### PR TITLE
Add PostHog telemetry for site, CLI, and MCP with opt-out controls

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,5 +18,12 @@ TIGRIS_BUCKET=relay-files
 STRIPE_SECRET_KEY=sk_test_xxx
 STRIPE_WEBHOOK_SECRET=whsec_xxx
 
+# Telemetry (optional)
+# POSTHOG_API_KEY=phc_override_key
+# POSTHOG_HOST=https://us.i.posthog.com
+# RELAYCAST_POSTHOG_KEY=phc_override_key
+RELAYCAST_POSTHOG_HOST=https://us.i.posthog.com
+RELAYCAST_TELEMETRY_DISABLED=0
+
 # Fly.io (production only)
 # FLY_MACHINE_ID=<auto-set by Fly>

--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ __pycache__/
 *.egg-info/
 .venv/
 .pytest_cache/
+.npm-cache/

--- a/README.md
+++ b/README.md
@@ -137,6 +137,14 @@ docker compose up -d   # Postgres, Redis, MinIO
 npm run dev            # Start the server on :3001
 ```
 
+## Telemetry
+
+Relaycast includes anonymous PostHog telemetry.
+
+- Opt out with `relaycast telemetry disable`
+- Env opt out: `DO_NOT_TRACK=1` or `RELAYCAST_TELEMETRY_DISABLED=1`
+- Details: [docs/TELEMETRY.md](./docs/TELEMETRY.md)
+
 ## API Reference
 
 Base URL: `https://api.relaycast.dev/v1`

--- a/docs/TELEMETRY.md
+++ b/docs/TELEMETRY.md
@@ -1,0 +1,32 @@
+# Telemetry
+
+Relaycast includes anonymous PostHog telemetry.
+
+## Opt Out
+
+### CLI command
+
+```bash
+relaycast telemetry disable
+```
+
+To re-enable:
+
+```bash
+relaycast telemetry enable
+```
+
+Check status:
+
+```bash
+relaycast telemetry status
+```
+
+### Environment variables
+
+Either of these disables telemetry:
+
+```bash
+DO_NOT_TRACK=1
+RELAYCAST_TELEMETRY_DISABLED=1
+```

--- a/package-lock.json
+++ b/package-lock.json
@@ -3381,6 +3381,7 @@
       "integrity": "sha512-Rs1bVAIdBs5gbTIKza/tgpMuG1k3U/UMJLWecIMxNdJFDMzcM5LOiLVRYh3PilWEYDIeUDv7bpiHPLPsbydGcw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -3499,6 +3500,7 @@
       "integrity": "sha512-BtE0k6cjwjLZoZixN0t5AKP0kSzlGu7FctRXYuPAm//aaiZhmfq1JwdYpYr1brzEspYyFeF+8XF5j2VK6oalrA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.54.0",
         "@typescript-eslint/types": "8.54.0",
@@ -3844,6 +3846,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4577,6 +4580,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -4650,6 +4654,7 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -4901,6 +4906,7 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -5383,6 +5389,7 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.11.9.tgz",
       "integrity": "sha512-Eaw2YTGM6WOxA6CXbckaEvslr2Ne4NFsKrvc0v97JD5awbmeBLO5w9Ho9L9kmKonrwF9RJlW6BxT1PVv/agBHQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -6170,6 +6177,7 @@
       "resolved": "https://registry.npmjs.org/postgres/-/postgres-3.4.8.tgz",
       "integrity": "sha512-d+JFcLM17njZaOLkv6SCev7uoLaBtfK86vMUXhW1Z4glPWh4jozno9APvW/XKFJ3CCxVoC7OL38BqRydtu5nGg==",
       "license": "Unlicense",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -6977,6 +6985,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -7057,6 +7066,7 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -7793,6 +7803,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/packages/cli/src/__tests__/index.test.ts
+++ b/packages/cli/src/__tests__/index.test.ts
@@ -20,8 +20,14 @@ vi.mock('commander', () => {
     action() {
       return this;
     }
+    hook() {
+      return this;
+    }
     parse() {
       return this;
+    }
+    parseAsync() {
+      return Promise.resolve(this);
     }
   }
   return { Command: MockCommand };
@@ -37,6 +43,14 @@ vi.mock('../commands/search.js', () => ({ registerSearchCommands: () => {} }));
 vi.mock('../commands/reactions.js', () => ({ registerReactionCommands: () => {} }));
 vi.mock('../commands/files.js', () => ({ registerFileCommands: () => {} }));
 vi.mock('../commands/billing.js', () => ({ registerBillingCommands: () => {} }));
+vi.mock('../commands/telemetry.js', () => ({ registerTelemetryCommands: () => {} }));
+vi.mock('../telemetry.js', () => ({
+  createCliTelemetry: () => ({
+    capture: () => {},
+    captureFirstRunIfNeeded: () => {},
+    flush: async () => {},
+  }),
+}));
 
 describe('relaycast', () => {
   it('exports CLI_VERSION', async () => {

--- a/packages/cli/src/__tests__/index.test.ts
+++ b/packages/cli/src/__tests__/index.test.ts
@@ -56,6 +56,6 @@ describe('relaycast', () => {
   it('exports CLI_VERSION', async () => {
     // Import after mocks are set so the CLI entrypoint does not call process.exit().
     const { CLI_VERSION } = await import('../index.js');
-    expect(CLI_VERSION).toBe('0.1.0');
+    expect(CLI_VERSION).toBe('0.1.2');
   });
 });

--- a/packages/cli/src/__tests__/telemetry.test.ts
+++ b/packages/cli/src/__tests__/telemetry.test.ts
@@ -29,21 +29,23 @@ describe('telemetry config', () => {
     vi.resetModules();
   });
 
-  it('can be disabled and re-enabled via telemetry command', async () => {
+  it('can be disabled and re-enabled via telemetry command using shared instance', async () => {
     const { registerTelemetryCommands } = await import('../commands/telemetry.js');
     const { createCliTelemetry } = await import('../telemetry.js');
     const program = new Command().exitOverride();
     const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const telemetry = createCliTelemetry();
 
-    registerTelemetryCommands(program);
+    registerTelemetryCommands(program, telemetry);
 
     await program.parseAsync(['telemetry', 'disable'], { from: 'user' });
-    expect(createCliTelemetry().status().enabled).toBe(false);
-    expect(createCliTelemetry().status().reason).toBe('user_opt_out');
+    // The same instance should reflect the change immediately
+    expect(telemetry.status().enabled).toBe(false);
+    expect(telemetry.status().reason).toBe('user_opt_out');
 
     await program.parseAsync(['telemetry', 'enable'], { from: 'user' });
-    expect(createCliTelemetry().status().enabled).toBe(true);
-    expect(createCliTelemetry().status().reason).toBe('enabled');
+    expect(telemetry.status().enabled).toBe(true);
+    expect(telemetry.status().reason).toBe('enabled');
 
     expect(logSpy).toHaveBeenCalled();
   });
@@ -55,5 +57,22 @@ describe('telemetry config', () => {
     const status = createCliTelemetry().status();
     expect(status.enabled).toBe(false);
     expect(status.reason).toBe('env_opt_out');
+  });
+
+  it('captureFirstRunIfNeeded does not mark captured when telemetry is disabled', async () => {
+    const { createCliTelemetry } = await import('../telemetry.js');
+    process.env.DO_NOT_TRACK = '1';
+
+    const telemetry = createCliTelemetry();
+    telemetry.captureFirstRunIfNeeded();
+
+    // After disabling DO_NOT_TRACK and creating a new instance,
+    // first-run should still fire because it was not marked as captured
+    delete process.env.DO_NOT_TRACK;
+    vi.resetModules();
+    const { createCliTelemetry: freshCreate } = await import('../telemetry.js');
+    const freshTelemetry = freshCreate();
+    // The status should be enabled now and first-run should not have been captured yet
+    expect(freshTelemetry.status().enabled).toBe(true);
   });
 });

--- a/packages/cli/src/__tests__/telemetry.test.ts
+++ b/packages/cli/src/__tests__/telemetry.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import { Command } from 'commander';
+
+describe('telemetry config', () => {
+  let homeDir: string;
+  let prevHome: string | undefined;
+  let prevDoNotTrack: string | undefined;
+  let prevDisabled: string | undefined;
+
+  beforeEach(() => {
+    vi.resetModules();
+    homeDir = fs.mkdtempSync(path.join(process.cwd(), 'relay-cli-telemetry-home-'));
+    prevHome = process.env.HOME;
+    prevDoNotTrack = process.env.DO_NOT_TRACK;
+    prevDisabled = process.env.RELAYCAST_TELEMETRY_DISABLED;
+    process.env.HOME = homeDir;
+    delete process.env.DO_NOT_TRACK;
+    delete process.env.RELAYCAST_TELEMETRY_DISABLED;
+  });
+
+  afterEach(() => {
+    fs.rmSync(homeDir, { recursive: true, force: true });
+    process.env.HOME = prevHome;
+    process.env.DO_NOT_TRACK = prevDoNotTrack;
+    process.env.RELAYCAST_TELEMETRY_DISABLED = prevDisabled;
+    vi.restoreAllMocks();
+    vi.resetModules();
+  });
+
+  it('can be disabled and re-enabled via telemetry command', async () => {
+    const { registerTelemetryCommands } = await import('../commands/telemetry.js');
+    const { createCliTelemetry } = await import('../telemetry.js');
+    const program = new Command().exitOverride();
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    registerTelemetryCommands(program);
+
+    await program.parseAsync(['telemetry', 'disable'], { from: 'user' });
+    expect(createCliTelemetry().status().enabled).toBe(false);
+    expect(createCliTelemetry().status().reason).toBe('user_opt_out');
+
+    await program.parseAsync(['telemetry', 'enable'], { from: 'user' });
+    expect(createCliTelemetry().status().enabled).toBe(true);
+    expect(createCliTelemetry().status().reason).toBe('enabled');
+
+    expect(logSpy).toHaveBeenCalled();
+  });
+
+  it('DO_NOT_TRACK env var forces telemetry off', async () => {
+    const { createCliTelemetry } = await import('../telemetry.js');
+    process.env.DO_NOT_TRACK = '1';
+
+    const status = createCliTelemetry().status();
+    expect(status.enabled).toBe(false);
+    expect(status.reason).toBe('env_opt_out');
+  });
+});

--- a/packages/cli/src/commands/telemetry.ts
+++ b/packages/cli/src/commands/telemetry.ts
@@ -1,5 +1,5 @@
 import { Command } from 'commander';
-import { createCliTelemetry, type TelemetryStatus } from '../telemetry.js';
+import type { CliTelemetry, TelemetryStatus } from '../telemetry.js';
 
 function reasonMessage(status: TelemetryStatus): string {
   if (status.reason === 'enabled') return 'Telemetry is enabled.';
@@ -25,7 +25,7 @@ function printStatus(status: TelemetryStatus): void {
   );
 }
 
-export function registerTelemetryCommands(program: Command): void {
+export function registerTelemetryCommands(program: Command, telemetryInstance: CliTelemetry): void {
   const telemetry = program
     .command('telemetry')
     .description('Anonymous usage telemetry settings (opt-out)');
@@ -34,15 +34,14 @@ export function registerTelemetryCommands(program: Command): void {
     .command('status')
     .description('Show telemetry status and opt-out source')
     .action(() => {
-      const status = createCliTelemetry().status();
-      printStatus(status);
+      printStatus(telemetryInstance.status());
     });
 
   telemetry
     .command('enable')
     .description('Enable telemetry')
     .action(() => {
-      const status = createCliTelemetry().setEnabled(true);
+      const status = telemetryInstance.setEnabled(true);
       printStatus(status);
     });
 
@@ -50,7 +49,7 @@ export function registerTelemetryCommands(program: Command): void {
     .command('disable')
     .description('Disable telemetry')
     .action(() => {
-      const status = createCliTelemetry().setEnabled(false);
+      const status = telemetryInstance.setEnabled(false);
       printStatus(status);
     });
 }

--- a/packages/cli/src/commands/telemetry.ts
+++ b/packages/cli/src/commands/telemetry.ts
@@ -1,0 +1,56 @@
+import { Command } from 'commander';
+import { createCliTelemetry, type TelemetryStatus } from '../telemetry.js';
+
+function reasonMessage(status: TelemetryStatus): string {
+  if (status.reason === 'enabled') return 'Telemetry is enabled.';
+  if (status.reason === 'env_opt_out') {
+    return 'Telemetry disabled by environment variable (DO_NOT_TRACK or RELAYCAST_TELEMETRY_DISABLED).';
+  }
+  return 'Telemetry disabled by user preference.';
+}
+
+function printStatus(status: TelemetryStatus): void {
+  console.log(
+    JSON.stringify(
+      {
+        enabled: status.enabled,
+        reason: status.reason,
+        env_opt_out: status.envOptOut,
+        user_opt_out: status.userOptOut,
+        message: reasonMessage(status),
+      },
+      null,
+      2,
+    ),
+  );
+}
+
+export function registerTelemetryCommands(program: Command): void {
+  const telemetry = program
+    .command('telemetry')
+    .description('Anonymous usage telemetry settings (opt-out)');
+
+  telemetry
+    .command('status')
+    .description('Show telemetry status and opt-out source')
+    .action(() => {
+      const status = createCliTelemetry().status();
+      printStatus(status);
+    });
+
+  telemetry
+    .command('enable')
+    .description('Enable telemetry')
+    .action(() => {
+      const status = createCliTelemetry().setEnabled(true);
+      printStatus(status);
+    });
+
+  telemetry
+    .command('disable')
+    .description('Disable telemetry')
+    .action(() => {
+      const status = createCliTelemetry().setEnabled(false);
+      printStatus(status);
+    });
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -14,7 +14,7 @@ import { registerBillingCommands } from './commands/billing.js';
 import { registerTelemetryCommands } from './commands/telemetry.js';
 import { createCliTelemetry } from './telemetry.js';
 
-export const CLI_VERSION = '0.1.0' as const;
+export const CLI_VERSION = '0.1.2' as const;
 
 const program = new Command();
 const telemetry = createCliTelemetry(CLI_VERSION);

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -11,10 +11,74 @@ import { registerSearchCommands } from './commands/search.js';
 import { registerReactionCommands } from './commands/reactions.js';
 import { registerFileCommands } from './commands/files.js';
 import { registerBillingCommands } from './commands/billing.js';
+import { registerTelemetryCommands } from './commands/telemetry.js';
+import { createCliTelemetry } from './telemetry.js';
 
 export const CLI_VERSION = '0.1.0' as const;
 
 const program = new Command();
+const telemetry = createCliTelemetry(CLI_VERSION);
+let activeCommandPath: string | null = null;
+let activeCommandStartedAt = 0;
+
+function getCommandPath(command: Command): string {
+  const names: string[] = [];
+  let current: Command | null = command;
+
+  while (current && current.parent) {
+    const name = current.name();
+    if (name) names.unshift(name);
+    current = current.parent;
+  }
+
+  return names.join(' ');
+}
+
+function captureDerivedEvents(commandPath: string, args: readonly unknown[]): void {
+  if (commandPath === 'workspace create') {
+    telemetry.capture('relaycast_workspace_created', { source_surface: 'cli' });
+    return;
+  }
+
+  if (commandPath === 'send') {
+    const target = typeof args[0] === 'string' ? args[0] : '';
+    telemetry.capture('relaycast_message_sent', {
+      source_surface: 'cli',
+      message_kind: target.startsWith('@') ? 'dm' : 'channel',
+      command: commandPath,
+    });
+    return;
+  }
+
+  if (commandPath === 'reply') {
+    telemetry.capture('relaycast_message_sent', {
+      source_surface: 'cli',
+      message_kind: 'thread_reply',
+      command: commandPath,
+    });
+    return;
+  }
+
+  if (commandPath === 'group-dm') {
+    const participants = Array.isArray(args[0]) ? args[0].length : undefined;
+    telemetry.capture('relaycast_message_sent', {
+      source_surface: 'cli',
+      message_kind: 'group_dm',
+      participants_count: participants,
+      command: commandPath,
+    });
+    return;
+  }
+
+  if (commandPath === 'inbox') {
+    telemetry.capture('relaycast_inbox_checked', { source_surface: 'cli' });
+    return;
+  }
+
+  if (commandPath === 'agent register') {
+    telemetry.capture('relaycast_agent_registered', { source_surface: 'cli' });
+  }
+}
 
 program
   .name('relay')
@@ -31,5 +95,61 @@ registerSearchCommands(program);
 registerReactionCommands(program);
 registerFileCommands(program);
 registerBillingCommands(program);
+registerTelemetryCommands(program);
 
-program.parse();
+program.hook('preAction', (_thisCommand, actionCommand) => {
+  const commandPath = getCommandPath(actionCommand);
+  if (!commandPath) return;
+
+  activeCommandPath = commandPath;
+  activeCommandStartedAt = Date.now();
+});
+
+program.hook('postAction', async (_thisCommand, actionCommand) => {
+  const commandPath = getCommandPath(actionCommand);
+  if (!commandPath) return;
+
+  const durationMs = Math.max(Date.now() - activeCommandStartedAt, 0);
+
+  telemetry.capture('relaycast_cli_command_completed', {
+    command: commandPath,
+    duration_ms: durationMs,
+    source_surface: 'cli',
+  });
+  captureDerivedEvents(commandPath, actionCommand.processedArgs);
+
+  activeCommandPath = null;
+  activeCommandStartedAt = 0;
+  await telemetry.flush();
+});
+
+telemetry.capture('relaycast_cli_started', {
+  source_surface: 'cli',
+  command_count: Math.max(process.argv.length - 2, 0),
+});
+telemetry.captureFirstRunIfNeeded();
+
+process.on('beforeExit', () => {
+  void telemetry.flush();
+});
+
+void program.parseAsync().catch(async (error: unknown) => {
+  if (activeCommandPath) {
+    const durationMs = Math.max(Date.now() - activeCommandStartedAt, 0);
+    telemetry.capture('relaycast_cli_command_failed', {
+      command: activeCommandPath,
+      duration_ms: durationMs,
+      source_surface: 'cli',
+      error_name: error instanceof Error ? error.name : 'UnknownError',
+    });
+  }
+
+  await telemetry.flush();
+
+  if (error instanceof Error) {
+    console.error(error.message);
+  } else {
+    console.error(String(error));
+  }
+  process.exit(1);
+});

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -81,8 +81,8 @@ function captureDerivedEvents(commandPath: string, args: readonly unknown[]): vo
 }
 
 program
-  .name('relay')
-  .description('Relay — agent-to-agent messaging CLI')
+  .name('relaycast')
+  .description('Relaycast — agent-to-agent messaging CLI')
   .version(CLI_VERSION);
 
 registerWorkspaceCommands(program);
@@ -95,7 +95,7 @@ registerSearchCommands(program);
 registerReactionCommands(program);
 registerFileCommands(program);
 registerBillingCommands(program);
-registerTelemetryCommands(program);
+registerTelemetryCommands(program, telemetry);
 
 program.hook('preAction', (_thisCommand, actionCommand) => {
   const commandPath = getCommandPath(actionCommand);

--- a/packages/cli/src/telemetry.ts
+++ b/packages/cli/src/telemetry.ts
@@ -76,9 +76,14 @@ function loadState(): TelemetryState {
 }
 
 function saveState(state: TelemetryState): void {
-  const dir = path.dirname(TELEMETRY_PATH);
-  fs.mkdirSync(dir, { recursive: true });
-  fs.writeFileSync(TELEMETRY_PATH, JSON.stringify(state, null, 2) + '\n', 'utf8');
+  try {
+    const dir = path.dirname(TELEMETRY_PATH);
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(TELEMETRY_PATH, JSON.stringify(state, null, 2) + '\n', 'utf8');
+  } catch {
+    // Best-effort persistence: if filesystem is read-only or unavailable,
+    // telemetry will still work with in-memory state
+  }
 }
 
 function getStatus(state: TelemetryState): TelemetryStatus {

--- a/packages/cli/src/telemetry.ts
+++ b/packages/cli/src/telemetry.ts
@@ -1,0 +1,232 @@
+import fs from 'node:fs';
+import http from 'node:http';
+import https from 'node:https';
+import os from 'node:os';
+import path from 'node:path';
+import { randomUUID } from 'node:crypto';
+
+interface TelemetryState {
+  anonymousId: string;
+  telemetryDisabled?: boolean;
+  firstRunCaptured?: boolean;
+}
+
+export interface TelemetryStatus {
+  enabled: boolean;
+  reason: 'enabled' | 'env_opt_out' | 'user_opt_out';
+  envOptOut: boolean;
+  userOptOut: boolean;
+}
+
+export interface CliTelemetry {
+  capture: (event: string, properties?: Record<string, unknown>) => void;
+  captureFirstRunIfNeeded: () => void;
+  flush: (timeoutMs?: number) => Promise<void>;
+  status: () => TelemetryStatus;
+  setEnabled: (enabled: boolean) => TelemetryStatus;
+  getAnonymousId: () => string;
+}
+
+const TELEMETRY_PATH = path.join(os.homedir(), '.relay', 'telemetry.json');
+const DEFAULT_POSTHOG_HOST = 'https://us.i.posthog.com';
+const DEFAULT_POSTHOG_KEY = 'phc_OAqBdey9pESZCcwaen9Fpyz6Ez8QKiMmLOnvFknXzg4';
+
+function isTruthy(value: string | undefined): boolean {
+  if (!value) return false;
+  const normalized = value.trim().toLowerCase();
+  return normalized === '1' || normalized === 'true' || normalized === 'yes' || normalized === 'on';
+}
+
+function getPostHogKey(): string {
+  return process.env.POSTHOG_API_KEY ??
+    process.env.RELAYCAST_POSTHOG_KEY ??
+    process.env.POSTHOG_KEY ??
+    DEFAULT_POSTHOG_KEY;
+}
+
+function getPostHogHost(): string {
+  const configured = process.env.POSTHOG_HOST ??
+    process.env.RELAYCAST_POSTHOG_HOST ??
+    DEFAULT_POSTHOG_HOST;
+  return configured.endsWith('/') ? configured.slice(0, -1) : configured;
+}
+
+function loadState(): TelemetryState {
+  try {
+    const raw = fs.readFileSync(TELEMETRY_PATH, 'utf8');
+    const parsed: unknown = JSON.parse(raw);
+    if (
+      parsed &&
+      typeof parsed === 'object' &&
+      'anonymousId' in parsed &&
+      typeof (parsed as { anonymousId: unknown }).anonymousId === 'string'
+    ) {
+      return parsed as TelemetryState;
+    }
+  } catch (err) {
+    const e = err as NodeJS.ErrnoException;
+    if (e.code !== 'ENOENT') {
+      // Ignore malformed telemetry files and overwrite with fresh state.
+    }
+  }
+
+  const state: TelemetryState = { anonymousId: randomUUID() };
+  saveState(state);
+  return state;
+}
+
+function saveState(state: TelemetryState): void {
+  const dir = path.dirname(TELEMETRY_PATH);
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(TELEMETRY_PATH, JSON.stringify(state, null, 2) + '\n', 'utf8');
+}
+
+function getStatus(state: TelemetryState): TelemetryStatus {
+  const envOptOut =
+    isTruthy(process.env.DO_NOT_TRACK) || isTruthy(process.env.RELAYCAST_TELEMETRY_DISABLED);
+  const userOptOut = state.telemetryDisabled === true;
+
+  if (envOptOut) {
+    return {
+      enabled: false,
+      reason: 'env_opt_out',
+      envOptOut,
+      userOptOut,
+    };
+  }
+
+  if (userOptOut) {
+    return {
+      enabled: false,
+      reason: 'user_opt_out',
+      envOptOut,
+      userOptOut,
+    };
+  }
+
+  return {
+    enabled: true,
+    reason: 'enabled',
+    envOptOut,
+    userOptOut,
+  };
+}
+
+function postJson(urlString: string, payload: Record<string, unknown>): Promise<void> {
+  return new Promise((resolve) => {
+    let resolved = false;
+    const finish = () => {
+      if (resolved) return;
+      resolved = true;
+      resolve();
+    };
+
+    try {
+      const url = new URL(urlString);
+      const body = JSON.stringify(payload);
+      const client = url.protocol === 'http:' ? http : https;
+      const req = client.request(
+        {
+          hostname: url.hostname,
+          port: url.port ? parseInt(url.port, 10) : undefined,
+          path: `${url.pathname}${url.search}`,
+          method: 'POST',
+          headers: {
+            'content-type': 'application/json',
+            'content-length': Buffer.byteLength(body),
+          },
+        },
+        (res) => {
+          res.resume();
+          res.on('end', finish);
+          res.on('error', finish);
+        },
+      );
+
+      req.on('error', finish);
+      req.setTimeout(1000, () => {
+        req.destroy();
+        finish();
+      });
+      req.write(body);
+      req.end();
+    } catch {
+      finish();
+    }
+  });
+}
+
+export function createCliTelemetry(cliVersion = 'unknown'): CliTelemetry {
+  const state = loadState();
+  const sessionId = randomUUID();
+  const pending = new Set<Promise<void>>();
+  const distinctId = process.env.RELAYCAST_TELEMETRY_DISTINCT_ID || state.anonymousId;
+  const distinctIdSource = process.env.RELAYCAST_TELEMETRY_DISTINCT_ID
+    ? 'env'
+    : 'generated';
+
+  const capture = (event: string, properties: Record<string, unknown> = {}) => {
+    const status = getStatus(state);
+    if (!status.enabled) return;
+
+    const payload = {
+      api_key: getPostHogKey(),
+      event,
+      distinct_id: distinctId,
+      properties: {
+        surface: 'cli',
+        cli_version: cliVersion,
+        session_id: sessionId,
+        node_version: process.version,
+        platform: process.platform,
+        arch: process.arch,
+        distinct_id_source: distinctIdSource,
+        ...properties,
+      },
+    };
+
+    const promise = postJson(`${getPostHogHost()}/capture/`, payload);
+    pending.add(promise);
+    void promise.finally(() => pending.delete(promise));
+  };
+
+  const captureFirstRunIfNeeded = () => {
+    if (state.firstRunCaptured) return;
+    state.firstRunCaptured = true;
+    saveState(state);
+
+    capture('relaycast_cli_first_run', {
+      install_source: process.env.RELAYCAST_INSTALL_SOURCE ?? 'unknown',
+      install_ref: process.env.RELAYCAST_INSTALL_REF ?? null,
+      command_count: Math.max(process.argv.length - 2, 0),
+    });
+  };
+
+  const flush = async (timeoutMs = 300) => {
+    const tasks = Array.from(pending);
+    if (tasks.length === 0) return;
+
+    await Promise.race([
+      Promise.allSettled(tasks).then(() => undefined),
+      new Promise<void>((resolve) => {
+        const timer = setTimeout(resolve, timeoutMs);
+        timer.unref?.();
+      }),
+    ]);
+  };
+
+  const setEnabled = (enabled: boolean): TelemetryStatus => {
+    state.telemetryDisabled = !enabled;
+    saveState(state);
+    return getStatus(state);
+  };
+
+  return {
+    capture,
+    captureFirstRunIfNeeded,
+    flush,
+    status: () => getStatus(state),
+    setEnabled,
+    getAnonymousId: () => state.anonymousId,
+  };
+}

--- a/packages/cli/src/telemetry.ts
+++ b/packages/cli/src/telemetry.ts
@@ -197,6 +197,10 @@ export function createCliTelemetry(cliVersion = 'unknown'): CliTelemetry {
 
   const captureFirstRunIfNeeded = () => {
     if (state.firstRunCaptured) return;
+
+    const status = getStatus(state);
+    if (!status.enabled) return;
+
     state.firstRunCaptured = true;
     saveState(state);
 

--- a/packages/mcp/src/__tests__/index.test.ts
+++ b/packages/mcp/src/__tests__/index.test.ts
@@ -3,7 +3,7 @@ import { MCP_VERSION } from '../index.js';
 
 describe('@relaycast/mcp', () => {
   it('exports MCP_VERSION', () => {
-    expect(MCP_VERSION).toBe('0.1.0');
+    expect(MCP_VERSION).toBe('0.1.2');
   });
 });
 

--- a/packages/mcp/src/__tests__/telemetry.test.ts
+++ b/packages/mcp/src/__tests__/telemetry.test.ts
@@ -42,13 +42,10 @@ describe('createMcpTelemetry', () => {
       vi.mocked(fs.writeFileSync).mockImplementation(() => undefined);
 
       const telemetry = createMcpTelemetry('1.0.0');
-      const captureSpy = vi.fn();
       
-      // Capture should be a no-op when telemetry is disabled
-      telemetry.capture('test_event', {});
-      
-      // Since capture is internal, we can't directly spy on it,
-      // but we can verify the state file was created (or not)
+      // Capture should return early (no-op) when telemetry is disabled
+      // We verify this doesn't throw and state file is still created for future use
+      expect(() => telemetry.capture('test_event', {})).not.toThrow();
       expect(fs.mkdirSync).toHaveBeenCalled();
     });
 
@@ -61,8 +58,9 @@ describe('createMcpTelemetry', () => {
       vi.mocked(fs.writeFileSync).mockImplementation(() => undefined);
 
       const telemetry = createMcpTelemetry('1.0.0');
-      telemetry.capture('test_event', {});
       
+      // Capture should return early (no-op) when telemetry is disabled
+      expect(() => telemetry.capture('test_event', {})).not.toThrow();
       expect(fs.mkdirSync).toHaveBeenCalled();
     });
 
@@ -74,7 +72,9 @@ describe('createMcpTelemetry', () => {
       vi.mocked(fs.readFileSync).mockReturnValue(JSON.stringify(stateWithOptOut));
 
       const telemetry = createMcpTelemetry('1.0.0');
-      telemetry.capture('test_event', {});
+      
+      // Capture should return early (no-op) when telemetry is disabled via state
+      expect(() => telemetry.capture('test_event', {})).not.toThrow();
       
       // Should read the file but not write a new one
       expect(fs.readFileSync).toHaveBeenCalledWith(mockTelemetryPath, 'utf8');
@@ -89,7 +89,9 @@ describe('createMcpTelemetry', () => {
       vi.mocked(fs.readFileSync).mockReturnValue(JSON.stringify(stateWithOptIn));
 
       const telemetry = createMcpTelemetry('1.0.0');
-      telemetry.capture('test_event', {});
+      
+      // Capture should return early because env opt-out takes precedence
+      expect(() => telemetry.capture('test_event', {})).not.toThrow();
       
       // Should still respect env opt-out
       expect(fs.readFileSync).toHaveBeenCalledWith(mockTelemetryPath, 'utf8');

--- a/packages/mcp/src/__tests__/telemetry.test.ts
+++ b/packages/mcp/src/__tests__/telemetry.test.ts
@@ -1,0 +1,228 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const mockHomedir = vi.hoisted(() => '/mock/home');
+
+vi.mock('node:os', () => ({
+  default: {
+    homedir: () => mockHomedir,
+  },
+}));
+
+vi.mock('node:fs');
+
+import { createMcpTelemetry } from '../telemetry.js';
+
+describe('createMcpTelemetry', () => {
+  const mockTelemetryPath = path.join(mockHomedir, '.relay', 'telemetry.json');
+  
+  beforeEach(() => {
+    delete process.env.DO_NOT_TRACK;
+    delete process.env.RELAYCAST_TELEMETRY_DISABLED;
+    delete process.env.POSTHOG_HOST;
+    delete process.env.RELAYCAST_POSTHOG_HOST;
+    delete process.env.POSTHOG_API_KEY;
+    delete process.env.POSTHOG_KEY;
+    delete process.env.RELAYCAST_POSTHOG_KEY;
+    delete process.env.RELAYCAST_TELEMETRY_DISTINCT_ID;
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('opt-out precedence', () => {
+    it('respects DO_NOT_TRACK=1', () => {
+      process.env.DO_NOT_TRACK = '1';
+      vi.mocked(fs.readFileSync).mockImplementation(() => {
+        throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
+      });
+      vi.mocked(fs.mkdirSync).mockImplementation(() => undefined);
+      vi.mocked(fs.writeFileSync).mockImplementation(() => undefined);
+
+      const telemetry = createMcpTelemetry('1.0.0');
+      const captureSpy = vi.fn();
+      
+      // Capture should be a no-op when telemetry is disabled
+      telemetry.capture('test_event', {});
+      
+      // Since capture is internal, we can't directly spy on it,
+      // but we can verify the state file was created (or not)
+      expect(fs.mkdirSync).toHaveBeenCalled();
+    });
+
+    it('respects RELAYCAST_TELEMETRY_DISABLED=true', () => {
+      process.env.RELAYCAST_TELEMETRY_DISABLED = 'true';
+      vi.mocked(fs.readFileSync).mockImplementation(() => {
+        throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
+      });
+      vi.mocked(fs.mkdirSync).mockImplementation(() => undefined);
+      vi.mocked(fs.writeFileSync).mockImplementation(() => undefined);
+
+      const telemetry = createMcpTelemetry('1.0.0');
+      telemetry.capture('test_event', {});
+      
+      expect(fs.mkdirSync).toHaveBeenCalled();
+    });
+
+    it('respects telemetryDisabled flag in state file', () => {
+      const stateWithOptOut = {
+        anonymousId: 'test-id-123',
+        telemetryDisabled: true,
+      };
+      vi.mocked(fs.readFileSync).mockReturnValue(JSON.stringify(stateWithOptOut));
+
+      const telemetry = createMcpTelemetry('1.0.0');
+      telemetry.capture('test_event', {});
+      
+      // Should read the file but not write a new one
+      expect(fs.readFileSync).toHaveBeenCalledWith(mockTelemetryPath, 'utf8');
+    });
+
+    it('prefers env opt-out over persisted flag', () => {
+      process.env.DO_NOT_TRACK = '1';
+      const stateWithOptIn = {
+        anonymousId: 'test-id-123',
+        telemetryDisabled: false,
+      };
+      vi.mocked(fs.readFileSync).mockReturnValue(JSON.stringify(stateWithOptIn));
+
+      const telemetry = createMcpTelemetry('1.0.0');
+      telemetry.capture('test_event', {});
+      
+      // Should still respect env opt-out
+      expect(fs.readFileSync).toHaveBeenCalledWith(mockTelemetryPath, 'utf8');
+    });
+  });
+
+  describe('host trimming', () => {
+    it('trims trailing slash from POSTHOG_HOST', () => {
+      process.env.POSTHOG_HOST = 'https://posthog.example.com/';
+      vi.mocked(fs.readFileSync).mockImplementation(() => {
+        throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
+      });
+      vi.mocked(fs.mkdirSync).mockImplementation(() => undefined);
+      vi.mocked(fs.writeFileSync).mockImplementation(() => undefined);
+
+      const telemetry = createMcpTelemetry('1.0.0');
+      telemetry.capture('test_event', {});
+      
+      // Host should be trimmed (we can't directly verify the HTTP call without mocking http/https)
+      expect(fs.mkdirSync).toHaveBeenCalled();
+    });
+
+    it('uses RELAYCAST_POSTHOG_HOST as fallback', () => {
+      process.env.RELAYCAST_POSTHOG_HOST = 'https://relay.posthog.com';
+      vi.mocked(fs.readFileSync).mockImplementation(() => {
+        throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
+      });
+      vi.mocked(fs.mkdirSync).mockImplementation(() => undefined);
+      vi.mocked(fs.writeFileSync).mockImplementation(() => undefined);
+
+      const telemetry = createMcpTelemetry('1.0.0');
+      telemetry.capture('test_event', {});
+      
+      expect(fs.mkdirSync).toHaveBeenCalled();
+    });
+  });
+
+  describe('error-tolerant state persistence', () => {
+    it('handles read-only filesystem gracefully on fresh state', () => {
+      vi.mocked(fs.readFileSync).mockImplementation(() => {
+        throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
+      });
+      vi.mocked(fs.mkdirSync).mockImplementation(() => {
+        throw Object.assign(new Error('EACCES'), { code: 'EACCES' });
+      });
+      vi.mocked(fs.writeFileSync).mockImplementation(() => undefined);
+
+      // Should not throw even if mkdir fails
+      expect(() => {
+        const telemetry = createMcpTelemetry('1.0.0');
+        telemetry.capture('test_event', {});
+      }).not.toThrow();
+    });
+
+    it('handles write errors gracefully', () => {
+      vi.mocked(fs.readFileSync).mockImplementation(() => {
+        throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
+      });
+      vi.mocked(fs.mkdirSync).mockImplementation(() => undefined);
+      vi.mocked(fs.writeFileSync).mockImplementation(() => {
+        throw Object.assign(new Error('EACCES'), { code: 'EACCES' });
+      });
+
+      // Should not throw even if writeFile fails
+      expect(() => {
+        const telemetry = createMcpTelemetry('1.0.0');
+        telemetry.capture('test_event', {});
+      }).not.toThrow();
+    });
+
+    it('handles malformed state file gracefully', () => {
+      vi.mocked(fs.readFileSync).mockReturnValue('invalid json{');
+      vi.mocked(fs.mkdirSync).mockImplementation(() => undefined);
+      vi.mocked(fs.writeFileSync).mockImplementation(() => undefined);
+
+      // Should not throw and should create fresh state
+      expect(() => {
+        const telemetry = createMcpTelemetry('1.0.0');
+        telemetry.capture('test_event', {});
+      }).not.toThrow();
+      
+      expect(fs.mkdirSync).toHaveBeenCalled();
+      expect(fs.writeFileSync).toHaveBeenCalled();
+    });
+
+    it('works with ephemeral anonymous ID when persistence fails', () => {
+      vi.mocked(fs.readFileSync).mockImplementation(() => {
+        throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
+      });
+      vi.mocked(fs.mkdirSync).mockImplementation(() => {
+        throw new Error('Cannot create directory');
+      });
+
+      // Should not throw and telemetry should still work
+      expect(() => {
+        const telemetry = createMcpTelemetry('1.0.0');
+        telemetry.capture('test_event', {});
+        void telemetry.flush();
+      }).not.toThrow();
+    });
+  });
+
+  describe('flush', () => {
+    it('completes without errors when no events are pending', async () => {
+      vi.mocked(fs.readFileSync).mockImplementation(() => {
+        throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
+      });
+      vi.mocked(fs.mkdirSync).mockImplementation(() => undefined);
+      vi.mocked(fs.writeFileSync).mockImplementation(() => undefined);
+
+      const telemetry = createMcpTelemetry('1.0.0');
+      await expect(telemetry.flush()).resolves.toBeUndefined();
+    });
+
+    it('respects timeout parameter', async () => {
+      vi.mocked(fs.readFileSync).mockImplementation(() => {
+        throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
+      });
+      vi.mocked(fs.mkdirSync).mockImplementation(() => undefined);
+      vi.mocked(fs.writeFileSync).mockImplementation(() => undefined);
+
+      const telemetry = createMcpTelemetry('1.0.0');
+      
+      // Capture an event (though HTTP call will be mocked/fail)
+      telemetry.capture('test_event', {});
+      
+      // Should timeout quickly with custom timeout
+      const start = Date.now();
+      await telemetry.flush(100);
+      const duration = Date.now() - start;
+      
+      // Should be around 100ms, with some tolerance
+      expect(duration).toBeLessThan(200);
+    });
+  });
+});

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -1,6 +1,4 @@
-export const MCP_VERSION = '0.1.0' as const;
-
-export { createRelayMcpServer } from './server.js';
+export { createRelayMcpServer, MCP_VERSION } from './server.js';
 export type { McpServerOptions } from './server.js';
 export { startStdio, createHttpHandler } from './transports.js';
 export { DEFAULT_SYSTEM_PROMPT } from './prompts.js';

--- a/packages/mcp/src/piggyback.ts
+++ b/packages/mcp/src/piggyback.ts
@@ -1,13 +1,23 @@
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import type { AgentClient } from '@relaycast/sdk';
 import type { SessionState } from './types.js';
+import type { McpTelemetry } from './telemetry.js';
 
 const SKIP_PIGGYBACK = new Set(['check_inbox', 'register']);
+const MESSAGE_TOOLS = new Set([
+  'post_message',
+  'reply_to_thread',
+  'send_dm',
+  'send_group_dm',
+  'trigger_webhook',
+  'invoke_command',
+]);
 
 export function enablePiggyback(
   mcpServer: McpServer,
   getSession: () => SessionState,
   getAgentClient: () => AgentClient,
+  telemetry?: McpTelemetry,
 ): void {
   const original = mcpServer.registerTool.bind(mcpServer);
 
@@ -16,14 +26,57 @@ export function enablePiggyback(
     config: any,
     handler: any,
   ) => {
-    if (SKIP_PIGGYBACK.has(name) || !handler) {
+    if (!handler) {
       return original(name, config, handler);
     }
 
-    const wrapped = async (...args: any[]) => {
-      const result = await handler(...args);
+    const shouldPiggybackInbox = !SKIP_PIGGYBACK.has(name);
 
-      if (!getSession().agentToken) return result;
+    const wrapped = async (...args: any[]) => {
+      const startedAt = Date.now();
+      telemetry?.capture('relaycast_mcp_tool_invoked', {
+        source_surface: 'mcp',
+        tool_name: name,
+      });
+
+      let result: any;
+      try {
+        result = await handler(...args);
+      } catch (error) {
+        telemetry?.capture('relaycast_mcp_tool_failed', {
+          source_surface: 'mcp',
+          tool_name: name,
+          duration_ms: Math.max(Date.now() - startedAt, 0),
+          error_name: error instanceof Error ? error.name : 'UnknownError',
+        });
+        throw error;
+      }
+
+      telemetry?.capture('relaycast_mcp_tool_completed', {
+        source_surface: 'mcp',
+        tool_name: name,
+        duration_ms: Math.max(Date.now() - startedAt, 0),
+      });
+
+      if (MESSAGE_TOOLS.has(name)) {
+        telemetry?.capture('relaycast_message_sent', {
+          source_surface: 'mcp',
+          tool_name: name,
+          message_kind: name,
+        });
+      } else if (name === 'check_inbox') {
+        telemetry?.capture('relaycast_inbox_checked', {
+          source_surface: 'mcp',
+          tool_name: name,
+        });
+      } else if (name === 'register') {
+        telemetry?.capture('relaycast_agent_registered', {
+          source_surface: 'mcp',
+          tool_name: name,
+        });
+      }
+
+      if (!shouldPiggybackInbox || !getSession().agentToken) return result;
 
       try {
         const client = getAgentClient();
@@ -34,7 +87,7 @@ export function enablePiggyback(
           (inbox.mentions?.length ?? 0) > 0 ||
           (inbox.unread_dms?.length ?? 0) > 0;
 
-        if (hasUnread) {
+        if (hasUnread && Array.isArray(result?.content)) {
           result.content.push({
             type: 'text' as const,
             text: formatInbox(inbox),

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -13,6 +13,8 @@ import { SubscriptionManager } from './resources/subscriptions.js';
 import { WsBridge } from './resources/ws-bridge.js';
 import { createMcpTelemetry, type McpTelemetry } from './telemetry.js';
 
+export const MCP_VERSION = '0.1.2';
+
 export interface McpServerOptions {
   apiKey: string;
   baseUrl?: string;
@@ -23,10 +25,10 @@ export interface McpServerOptions {
 export function createRelayMcpServer(options: McpServerOptions): McpServer {
   const relay = new Relay({ apiKey: options.apiKey, baseUrl: options.baseUrl });
   const session: SessionState = createInitialSession();
-  const telemetry = options.telemetry ?? createMcpTelemetry('0.1.0');
+  const telemetry = options.telemetry ?? createMcpTelemetry(MCP_VERSION);
 
   const mcpServer = new McpServer(
-    { name: 'agent-relay', version: '0.1.0' },
+    { name: 'agent-relay', version: MCP_VERSION },
     {
       capabilities: {
         resources: { subscribe: true, listChanged: true },

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -11,15 +11,18 @@ import { enablePiggyback } from './piggyback.js';
 import { registerResourceDefinitions } from './resources/definitions.js';
 import { SubscriptionManager } from './resources/subscriptions.js';
 import { WsBridge } from './resources/ws-bridge.js';
+import { createMcpTelemetry } from './telemetry.js';
 
 export interface McpServerOptions {
   apiKey: string;
   baseUrl?: string;
+  telemetryTransport?: 'stdio' | 'http';
 }
 
 export function createRelayMcpServer(options: McpServerOptions): McpServer {
   const relay = new Relay({ apiKey: options.apiKey, baseUrl: options.baseUrl });
   const session: SessionState = createInitialSession();
+  const telemetry = createMcpTelemetry('0.1.0');
 
   const mcpServer = new McpServer(
     { name: 'agent-relay', version: '0.1.0' },
@@ -31,6 +34,11 @@ export function createRelayMcpServer(options: McpServerOptions): McpServer {
       },
     },
   );
+
+  telemetry.capture('relaycast_mcp_server_started', {
+    source_surface: 'mcp',
+    transport: options.telemetryTransport ?? 'unknown',
+  });
 
   const getRelay = () => relay;
   const getSession = () => session;
@@ -53,6 +61,10 @@ export function createRelayMcpServer(options: McpServerOptions): McpServer {
       );
       wsBridge.start();
       Object.assign(session, partial, { wsBridge, subscriptions });
+      telemetry.capture('relaycast_mcp_session_authenticated', {
+        source_surface: 'mcp',
+        agent_name: partial.agentName ?? session.agentName ?? null,
+      });
     } else {
       Object.assign(session, partial);
     }
@@ -66,7 +78,7 @@ export function createRelayMcpServer(options: McpServerOptions): McpServer {
   };
 
   // Enable piggybacking of unread messages on all tool responses
-  enablePiggyback(mcpServer, getSession, getAgentClient);
+  enablePiggyback(mcpServer, getSession, getAgentClient, telemetry);
 
   // Register resource definitions (inbox, agents, channels, etc.)
   registerResourceDefinitions(mcpServer, getAgentClient, getRelay);
@@ -83,4 +95,3 @@ export function createRelayMcpServer(options: McpServerOptions): McpServer {
 
   return mcpServer;
 }
-

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -11,18 +11,19 @@ import { enablePiggyback } from './piggyback.js';
 import { registerResourceDefinitions } from './resources/definitions.js';
 import { SubscriptionManager } from './resources/subscriptions.js';
 import { WsBridge } from './resources/ws-bridge.js';
-import { createMcpTelemetry } from './telemetry.js';
+import { createMcpTelemetry, type McpTelemetry } from './telemetry.js';
 
 export interface McpServerOptions {
   apiKey: string;
   baseUrl?: string;
   telemetryTransport?: 'stdio' | 'http';
+  telemetry?: McpTelemetry;
 }
 
 export function createRelayMcpServer(options: McpServerOptions): McpServer {
   const relay = new Relay({ apiKey: options.apiKey, baseUrl: options.baseUrl });
   const session: SessionState = createInitialSession();
-  const telemetry = createMcpTelemetry('0.1.0');
+  const telemetry = options.telemetry ?? createMcpTelemetry('0.1.0');
 
   const mcpServer = new McpServer(
     { name: 'agent-relay', version: '0.1.0' },

--- a/packages/mcp/src/telemetry.ts
+++ b/packages/mcp/src/telemetry.ts
@@ -1,0 +1,163 @@
+import fs from 'node:fs';
+import http from 'node:http';
+import https from 'node:https';
+import os from 'node:os';
+import path from 'node:path';
+import { randomUUID } from 'node:crypto';
+
+interface TelemetryState {
+  anonymousId: string;
+  telemetryDisabled?: boolean;
+}
+
+export interface McpTelemetry {
+  capture: (event: string, properties?: Record<string, unknown>) => void;
+  flush: (timeoutMs?: number) => Promise<void>;
+}
+
+const TELEMETRY_PATH = path.join(os.homedir(), '.relay', 'telemetry.json');
+const DEFAULT_POSTHOG_HOST = 'https://us.i.posthog.com';
+const DEFAULT_POSTHOG_KEY = 'phc_OAqBdey9pESZCcwaen9Fpyz6Ez8QKiMmLOnvFknXzg4';
+
+function isTruthy(value: string | undefined): boolean {
+  if (!value) return false;
+  const normalized = value.trim().toLowerCase();
+  return normalized === '1' || normalized === 'true' || normalized === 'yes' || normalized === 'on';
+}
+
+function loadState(): TelemetryState {
+  try {
+    const raw = fs.readFileSync(TELEMETRY_PATH, 'utf8');
+    const parsed: unknown = JSON.parse(raw);
+    if (
+      parsed &&
+      typeof parsed === 'object' &&
+      'anonymousId' in parsed &&
+      typeof (parsed as { anonymousId: unknown }).anonymousId === 'string'
+    ) {
+      return parsed as TelemetryState;
+    }
+  } catch (err) {
+    const e = err as NodeJS.ErrnoException;
+    if (e.code !== 'ENOENT') {
+      // Fall through to fresh state.
+    }
+  }
+
+  const state: TelemetryState = { anonymousId: randomUUID() };
+  const dir = path.dirname(TELEMETRY_PATH);
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(TELEMETRY_PATH, JSON.stringify(state, null, 2) + '\n', 'utf8');
+  return state;
+}
+
+function telemetryEnabled(state: TelemetryState): boolean {
+  if (isTruthy(process.env.DO_NOT_TRACK) || isTruthy(process.env.RELAYCAST_TELEMETRY_DISABLED)) {
+    return false;
+  }
+  if (state.telemetryDisabled === true) return false;
+  return true;
+}
+
+function getPostHogHost(): string {
+  const configured = process.env.POSTHOG_HOST ??
+    process.env.RELAYCAST_POSTHOG_HOST ??
+    DEFAULT_POSTHOG_HOST;
+  return configured.endsWith('/') ? configured.slice(0, -1) : configured;
+}
+
+function getPostHogKey(): string {
+  return process.env.POSTHOG_API_KEY ??
+    process.env.RELAYCAST_POSTHOG_KEY ??
+    process.env.POSTHOG_KEY ??
+    DEFAULT_POSTHOG_KEY;
+}
+
+function postJson(urlString: string, payload: Record<string, unknown>): Promise<void> {
+  return new Promise((resolve) => {
+    let resolved = false;
+    const finish = () => {
+      if (resolved) return;
+      resolved = true;
+      resolve();
+    };
+
+    try {
+      const url = new URL(urlString);
+      const body = JSON.stringify(payload);
+      const client = url.protocol === 'http:' ? http : https;
+      const req = client.request(
+        {
+          hostname: url.hostname,
+          port: url.port ? parseInt(url.port, 10) : undefined,
+          path: `${url.pathname}${url.search}`,
+          method: 'POST',
+          headers: {
+            'content-type': 'application/json',
+            'content-length': Buffer.byteLength(body),
+          },
+        },
+        (res) => {
+          res.resume();
+          res.on('end', finish);
+          res.on('error', finish);
+        },
+      );
+
+      req.on('error', finish);
+      req.setTimeout(1000, () => {
+        req.destroy();
+        finish();
+      });
+      req.write(body);
+      req.end();
+    } catch {
+      finish();
+    }
+  });
+}
+
+export function createMcpTelemetry(version = 'unknown'): McpTelemetry {
+  const state = loadState();
+  const sessionId = randomUUID();
+  const pending = new Set<Promise<void>>();
+  const distinctId = process.env.RELAYCAST_TELEMETRY_DISTINCT_ID || state.anonymousId;
+
+  const capture = (event: string, properties: Record<string, unknown> = {}) => {
+    if (!telemetryEnabled(state)) return;
+
+    const payload = {
+      api_key: getPostHogKey(),
+      event,
+      distinct_id: distinctId,
+      properties: {
+        surface: 'mcp',
+        mcp_version: version,
+        session_id: sessionId,
+        node_version: process.version,
+        platform: process.platform,
+        arch: process.arch,
+        ...properties,
+      },
+    };
+
+    const promise = postJson(`${getPostHogHost()}/capture/`, payload);
+    pending.add(promise);
+    void promise.finally(() => pending.delete(promise));
+  };
+
+  const flush = async (timeoutMs = 300) => {
+    const tasks = Array.from(pending);
+    if (tasks.length === 0) return;
+
+    await Promise.race([
+      Promise.allSettled(tasks).then(() => undefined),
+      new Promise<void>((resolve) => {
+        const timer = setTimeout(resolve, timeoutMs);
+        timer.unref?.();
+      }),
+    ]);
+  };
+
+  return { capture, flush };
+}

--- a/packages/mcp/src/telemetry.ts
+++ b/packages/mcp/src/telemetry.ts
@@ -45,9 +45,14 @@ function loadState(): TelemetryState {
   }
 
   const state: TelemetryState = { anonymousId: randomUUID() };
-  const dir = path.dirname(TELEMETRY_PATH);
-  fs.mkdirSync(dir, { recursive: true });
-  fs.writeFileSync(TELEMETRY_PATH, JSON.stringify(state, null, 2) + '\n', 'utf8');
+  try {
+    const dir = path.dirname(TELEMETRY_PATH);
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(TELEMETRY_PATH, JSON.stringify(state, null, 2) + '\n', 'utf8');
+  } catch {
+    // Best-effort persistence: if filesystem is read-only or unavailable,
+    // telemetry will still work with ephemeral anonymous ID
+  }
   return state;
 }
 

--- a/packages/mcp/src/transports.ts
+++ b/packages/mcp/src/transports.ts
@@ -1,6 +1,6 @@
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
-import { createRelayMcpServer, type McpServerOptions } from './server.js';
+import { createRelayMcpServer, MCP_VERSION, type McpServerOptions } from './server.js';
 import { randomUUID } from 'node:crypto';
 import { createMcpTelemetry } from './telemetry.js';
 
@@ -40,7 +40,7 @@ export function createHttpHandler(baseOptions: McpServerOptions) {
       }
 
       // New session — create fresh MCP server + transport + telemetry
-      const telemetry = createMcpTelemetry('0.1.0');
+      const telemetry = createMcpTelemetry(MCP_VERSION);
       
       const transport = new StreamableHTTPServerTransport({
         sessionIdGenerator: () => randomUUID(),

--- a/packages/mcp/src/transports.ts
+++ b/packages/mcp/src/transports.ts
@@ -16,17 +16,15 @@ export async function startStdio(options: McpServerOptions): Promise<void> {
 
 /**
  * Session map for HTTP transport (multi-agent).
- * Each session gets its own MCP server + transport instance.
+ * Each session gets its own MCP server + transport + telemetry instance.
  */
 const sessions = new Map<string, { transport: StreamableHTTPServerTransport }>();
 
 /**
  * Create Express middleware for HTTP+SSE transport (multi-agent).
- * Each connecting client gets its own session with isolated state.
+ * Each connecting client gets its own session with isolated state and telemetry.
  */
 export function createHttpHandler(baseOptions: McpServerOptions) {
-  const telemetry = createMcpTelemetry('0.1.0');
-
   return {
     handleRequest: async (
       req: import('node:http').IncomingMessage,
@@ -41,7 +39,9 @@ export function createHttpHandler(baseOptions: McpServerOptions) {
         return;
       }
 
-      // New session — create fresh MCP server + transport
+      // New session — create fresh MCP server + transport + telemetry
+      const telemetry = createMcpTelemetry('0.1.0');
+      
       const transport = new StreamableHTTPServerTransport({
         sessionIdGenerator: () => randomUUID(),
       });
@@ -49,6 +49,7 @@ export function createHttpHandler(baseOptions: McpServerOptions) {
       const mcpServer = createRelayMcpServer({
         ...baseOptions,
         telemetryTransport: 'http',
+        telemetry,
       });
 
       transport.onclose = () => {
@@ -64,7 +65,7 @@ export function createHttpHandler(baseOptions: McpServerOptions) {
         telemetry.capture('relaycast_mcp_http_session_started', {
           source_surface: 'mcp',
           transport: 'http',
-          session_id: transport.sessionId,
+          mcp_transport_session_id: transport.sessionId,
         });
       }
 

--- a/packages/mcp/src/transports.ts
+++ b/packages/mcp/src/transports.ts
@@ -2,13 +2,14 @@ import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js'
 import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
 import { createRelayMcpServer, type McpServerOptions } from './server.js';
 import { randomUUID } from 'node:crypto';
+import { createMcpTelemetry } from './telemetry.js';
 
 /**
  * Start MCP server with stdio transport (single agent).
  * Reads from stdin, writes to stdout.
  */
 export async function startStdio(options: McpServerOptions): Promise<void> {
-  const mcpServer = createRelayMcpServer(options);
+  const mcpServer = createRelayMcpServer({ ...options, telemetryTransport: 'stdio' });
   const transport = new StdioServerTransport();
   await mcpServer.connect(transport);
 }
@@ -24,6 +25,8 @@ const sessions = new Map<string, { transport: StreamableHTTPServerTransport }>()
  * Each connecting client gets its own session with isolated state.
  */
 export function createHttpHandler(baseOptions: McpServerOptions) {
+  const telemetry = createMcpTelemetry('0.1.0');
+
   return {
     handleRequest: async (
       req: import('node:http').IncomingMessage,
@@ -43,7 +46,10 @@ export function createHttpHandler(baseOptions: McpServerOptions) {
         sessionIdGenerator: () => randomUUID(),
       });
 
-      const mcpServer = createRelayMcpServer(baseOptions);
+      const mcpServer = createRelayMcpServer({
+        ...baseOptions,
+        telemetryTransport: 'http',
+      });
 
       transport.onclose = () => {
         if (transport.sessionId) {
@@ -55,10 +61,14 @@ export function createHttpHandler(baseOptions: McpServerOptions) {
 
       if (transport.sessionId) {
         sessions.set(transport.sessionId, { transport });
+        telemetry.capture('relaycast_mcp_http_session_started', {
+          source_surface: 'mcp',
+          transport: 'http',
+          session_id: transport.sessionId,
+        });
       }
 
       await transport.handleRequest(req, res);
     },
   };
 }
-

--- a/site/index.html
+++ b/site/index.html
@@ -5,6 +5,8 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Relaycast — Headless Slack for AI Agents</title>
   <meta name="description" content="Give your AI agents channels, threads, DMs, and real-time events. Framework-agnostic messaging that works across any CLI, any language, any model.">
+  <meta name="relaycast-posthog-key" content="phc_OAqBdey9pESZCcwaen9Fpyz6Ez8QKiMmLOnvFknXzg4">
+  <meta name="relaycast-posthog-host" content="https://us.i.posthog.com">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
@@ -18,12 +20,12 @@
         <span class="logo-text">relaycast</span>
       </a>
       <div class="nav-links">
-        <a href="#features">Features</a>
-        <a href="#webhooks">Webhooks</a>
-        <a href="#pricing">Pricing</a>
-        <a href="#get-started">Docs</a>
-        <a href="https://github.com/AgentWorkforce/relaycast" target="_blank">GitHub</a>
-        <a href="#get-started" class="btn btn-sm">Get Started</a>
+        <a href="#features" data-telemetry-cta="nav_features">Features</a>
+        <a href="#webhooks" data-telemetry-cta="nav_webhooks">Webhooks</a>
+        <a href="#pricing" data-telemetry-cta="nav_pricing">Pricing</a>
+        <a href="#get-started" data-telemetry-cta="nav_docs">Docs</a>
+        <a href="https://github.com/AgentWorkforce/relaycast" target="_blank" data-telemetry-cta="nav_github">GitHub</a>
+        <a href="#get-started" class="btn btn-sm" data-telemetry-cta="nav_get_started">Get Started</a>
       </div>
     </div>
   </nav>
@@ -33,8 +35,8 @@
     <h1>Messaging infrastructure<br>for AI agents</h1>
     <p class="hero-sub">Channels, threads, DMs, reactions, and real-time events.<br>Two API calls to start. Zero infrastructure to manage.</p>
     <div class="hero-actions">
-      <a href="#get-started" class="btn btn-primary">Get Started</a>
-      <a href="https://github.com/AgentWorkforce/relaycast" class="btn btn-ghost" target="_blank">View on GitHub</a>
+      <a href="#get-started" class="btn btn-primary" data-telemetry-cta="hero_get_started">Get Started</a>
+      <a href="https://github.com/AgentWorkforce/relaycast" class="btn btn-ghost" target="_blank" data-telemetry-cta="hero_view_github">View on GitHub</a>
     </div>
 
     <div class="hero-code">
@@ -306,7 +308,7 @@ inbox = me.<span class="c-fn">inbox</span>()</code></pre>
           <li>MCP server included</li>
           <li>Community support</li>
         </ul>
-        <a href="#get-started" class="btn btn-ghost pricing-cta">Get Started</a>
+        <a href="#get-started" class="btn btn-ghost pricing-cta" data-pricing-plan="free" data-telemetry-cta="pricing_free">Get Started</a>
       </div>
       <div class="pricing-card pricing-card-featured">
         <div class="pricing-badge">Most popular</div>
@@ -325,7 +327,7 @@ inbox = me.<span class="c-fn">inbox</span>()</code></pre>
           <li>WebSocket streaming</li>
           <li>Priority support</li>
         </ul>
-        <a href="#get-started" class="btn btn-primary pricing-cta">Start Free Trial</a>
+        <a href="#get-started" class="btn btn-primary pricing-cta" data-pricing-plan="pro" data-telemetry-cta="pricing_pro">Start Free Trial</a>
       </div>
       <div class="pricing-card">
         <div class="pricing-plan">Enterprise</div>
@@ -344,7 +346,7 @@ inbox = me.<span class="c-fn">inbox</span>()</code></pre>
           <li>SSO &amp; audit logs</li>
           <li>Dedicated support &amp; SLA</li>
         </ul>
-        <a href="mailto:hello@relaycast.dev" class="btn btn-ghost pricing-cta">Contact Sales</a>
+        <a href="mailto:hello@relaycast.dev" class="btn btn-ghost pricing-cta" data-pricing-plan="enterprise" data-telemetry-cta="pricing_enterprise">Contact Sales</a>
       </div>
     </div>
   </section>
@@ -383,7 +385,7 @@ inbox = me.<span class="c-fn">inbox</span>()</code></pre>
       </div>
     </div>
     <div class="get-started-cta">
-      <a href="https://github.com/AgentWorkforce/relaycast" class="btn btn-primary btn-lg" target="_blank">Read the Docs</a>
+      <a href="https://github.com/AgentWorkforce/relaycast" class="btn btn-primary btn-lg" target="_blank" data-telemetry-cta="get_started_docs">Read the Docs</a>
     </div>
   </section>
 
@@ -394,9 +396,9 @@ inbox = me.<span class="c-fn">inbox</span>()</code></pre>
         <span class="logo-text">relaycast</span>
       </div>
       <div class="footer-links">
-        <a href="https://github.com/AgentWorkforce/relaycast" target="_blank">GitHub</a>
-        <a href="#get-started">Docs</a>
-        <a href="mailto:hello@relaycast.dev">Contact</a>
+        <a href="https://github.com/AgentWorkforce/relaycast" target="_blank" data-telemetry-cta="footer_github">GitHub</a>
+        <a href="#get-started" data-telemetry-cta="footer_docs">Docs</a>
+        <a href="mailto:hello@relaycast.dev" data-telemetry-cta="footer_contact">Contact</a>
       </div>
       <div class="footer-copy">&copy; 2026 Relaycast. Apache-2.0 License.</div>
     </div>

--- a/site/script.js
+++ b/site/script.js
@@ -1,29 +1,176 @@
+const POSTHOG_DEFAULT_HOST = 'https://us.i.posthog.com';
+const POSTHOG_PUBLIC_KEY = 'phc_OAqBdey9pESZCcwaen9Fpyz6Ez8QKiMmLOnvFknXzg4';
+const POSTHOG_DISTINCT_ID_KEY = 'relaycast_posthog_distinct_id';
+const POSTHOG_SESSION_ID = window.crypto?.randomUUID?.() ?? String(Date.now());
+
+function getMetaContent(name) {
+  return document.querySelector(`meta[name="${name}"]`)?.getAttribute('content')?.trim() ?? '';
+}
+
+function getOrCreateDistinctId() {
+  try {
+    const existing = localStorage.getItem(POSTHOG_DISTINCT_ID_KEY);
+    if (existing) return existing;
+    const next = window.crypto?.randomUUID?.() ?? `anon-${Date.now()}`;
+    localStorage.setItem(POSTHOG_DISTINCT_ID_KEY, next);
+    return next;
+  } catch {
+    return window.crypto?.randomUUID?.() ?? `anon-${Date.now()}`;
+  }
+}
+
+const telemetry = (() => {
+  const posthogKey =
+    window.POSTHOG_API_KEY ||
+    window.RELAYCAST_POSTHOG_KEY ||
+    getMetaContent('relaycast-posthog-key') ||
+    POSTHOG_PUBLIC_KEY;
+
+  const rawHost =
+    window.POSTHOG_HOST || window.RELAYCAST_POSTHOG_HOST || getMetaContent('relaycast-posthog-host');
+  const host = (rawHost || POSTHOG_DEFAULT_HOST).replace(/\/$/, '');
+  const distinctId = getOrCreateDistinctId();
+
+  const capture = (event, properties = {}) => {
+    const payload = {
+      api_key: posthogKey,
+      event,
+      distinct_id: distinctId,
+      properties: {
+        surface: 'site',
+        session_id: POSTHOG_SESSION_ID,
+        path: window.location.pathname,
+        hostname: window.location.hostname,
+        ...properties,
+      },
+    };
+
+    const body = JSON.stringify(payload);
+    const url = `${host}/capture/`;
+
+    if (navigator.sendBeacon) {
+      const sent = navigator.sendBeacon(url, new Blob([body], { type: 'application/json' }));
+      if (sent) return;
+    }
+
+    fetch(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body,
+      keepalive: true,
+    }).catch(() => {});
+  };
+
+  return {
+    enabled: true,
+    capture,
+  };
+})();
+
+function trackSiteView() {
+  telemetry.capture('relaycast_site_viewed', {
+    referrer: document.referrer || null,
+    query: window.location.search || null,
+  });
+}
+
+function trackCtaClick(anchor) {
+  const section = anchor.closest('section')?.id || anchor.closest('nav')?.className || 'unknown';
+  const destination = anchor.getAttribute('href') || '';
+  const ctaName = anchor.dataset.telemetryCta || anchor.textContent?.trim() || 'unknown';
+
+  telemetry.capture('relaycast_site_cta_clicked', {
+    cta_name: ctaName,
+    section,
+    destination,
+    is_external: anchor.target === '_blank' || destination.startsWith('http'),
+  });
+
+  const installIntent =
+    destination === '#get-started' ||
+    ctaName.includes('docs') ||
+    ctaName.includes('get_started') ||
+    ctaName.includes('github');
+
+  if (installIntent) {
+    telemetry.capture('relaycast_site_install_intent', {
+      cta_name: ctaName,
+      section,
+      destination,
+    });
+  }
+}
+
+document.addEventListener('click', (event) => {
+  const target = event.target;
+  if (!(target instanceof Element)) return;
+  const anchor = target.closest('a');
+  if (!anchor) return;
+
+  if (anchor.classList.contains('pricing-cta')) {
+    telemetry.capture('relaycast_site_pricing_clicked', {
+      plan: anchor.dataset.pricingPlan || 'unknown',
+      cta_text: anchor.textContent?.trim() || 'unknown',
+      destination: anchor.getAttribute('href') || '',
+    });
+  }
+
+  if (anchor.dataset.telemetryCta) {
+    trackCtaClick(anchor);
+  }
+});
+
+const viewedSections = new Set();
+const sectionObserver = new IntersectionObserver(
+  (entries) => {
+    entries.forEach((entry) => {
+      if (!entry.isIntersecting) return;
+      const sectionId = entry.target.id;
+      if (!sectionId || viewedSections.has(sectionId)) return;
+      viewedSections.add(sectionId);
+      telemetry.capture('relaycast_site_section_viewed', { section: sectionId });
+    });
+  },
+  { threshold: 0.35 },
+);
+
+document.querySelectorAll('section[id]').forEach((section) => {
+  sectionObserver.observe(section);
+});
+
 // SDK tab switching
-document.querySelectorAll('.sdk-tab').forEach(tab => {
+document.querySelectorAll('.sdk-tab').forEach((tab) => {
   tab.addEventListener('click', () => {
-    document.querySelectorAll('.sdk-tab').forEach(t => t.classList.remove('active'));
-    document.querySelectorAll('.code-panel').forEach(p => p.classList.remove('active'));
+    document.querySelectorAll('.sdk-tab').forEach((t) => t.classList.remove('active'));
+    document.querySelectorAll('.code-panel').forEach((panel) => panel.classList.remove('active'));
     tab.classList.add('active');
-    document.getElementById('code-' + tab.dataset.lang).classList.add('active');
+    const nextPanel = document.getElementById(`code-${tab.dataset.lang}`);
+    if (nextPanel) nextPanel.classList.add('active');
+
+    telemetry.capture('relaycast_site_sdk_tab_selected', {
+      tab: tab.dataset.lang ?? 'unknown',
+    });
   });
 });
 
 // Intersection observer for fade-in on scroll
 const observer = new IntersectionObserver(
-  entries => {
-    entries.forEach(entry => {
+  (entries) => {
+    entries.forEach((entry) => {
       if (entry.isIntersecting) {
         entry.target.style.opacity = '1';
         entry.target.style.transform = 'translateY(0)';
       }
     });
   },
-  { threshold: 0.1, rootMargin: '0px 0px -40px 0px' }
+  { threshold: 0.1, rootMargin: '0px 0px -40px 0px' },
 );
 
-document.querySelectorAll('.feature-card, .why-card, .step, .tool-badge, .webhook-card, .pricing-card').forEach(el => {
+document.querySelectorAll('.feature-card, .why-card, .step, .tool-badge, .webhook-card, .pricing-card').forEach((el) => {
   el.style.opacity = '0';
   el.style.transform = 'translateY(16px)';
   el.style.transition = 'opacity 0.5s ease, transform 0.5s ease';
   observer.observe(el);
 });
+
+trackSiteView();

--- a/site/script.js
+++ b/site/script.js
@@ -20,6 +20,19 @@ function getOrCreateDistinctId() {
 }
 
 const telemetry = (() => {
+  // Check for Do Not Track
+  const dnt = navigator.doNotTrack === '1' || 
+              navigator.doNotTrack === 'yes' ||
+              window.doNotTrack === '1' ||
+              navigator.msDoNotTrack === '1';
+
+  if (dnt) {
+    return {
+      enabled: false,
+      capture: () => {}, // no-op when DNT is enabled
+    };
+  }
+
   const posthogKey =
     window.POSTHOG_API_KEY ||
     window.RELAYCAST_POSTHOG_KEY ||
@@ -67,10 +80,39 @@ const telemetry = (() => {
   };
 })();
 
+function sanitizeUrl(url) {
+  if (!url) return null;
+  try {
+    const parsed = new URL(url, window.location.origin);
+    // Only keep UTM parameters and other safe tracking params
+    const safeParams = ['utm_source', 'utm_medium', 'utm_campaign', 'utm_term', 'utm_content', 'ref'];
+    const filteredParams = new URLSearchParams();
+    safeParams.forEach(param => {
+      const value = parsed.searchParams.get(param);
+      if (value) filteredParams.set(param, value);
+    });
+    const queryString = filteredParams.toString();
+    return queryString ? `?${queryString}` : null;
+  } catch {
+    return null;
+  }
+}
+
+function sanitizeReferrer(referrer) {
+  if (!referrer) return null;
+  try {
+    const parsed = new URL(referrer);
+    // Only send the origin (protocol + hostname), not the full URL
+    return parsed.origin;
+  } catch {
+    return null;
+  }
+}
+
 function trackSiteView() {
   telemetry.capture('relaycast_site_viewed', {
-    referrer: document.referrer || null,
-    query: window.location.search || null,
+    referrer: sanitizeReferrer(document.referrer),
+    query: sanitizeUrl(window.location.href),
   });
 }
 

--- a/site/script.js
+++ b/site/script.js
@@ -125,7 +125,7 @@ function trackCtaClick(anchor) {
     cta_name: ctaName,
     section,
     destination,
-    is_external: anchor.target === '_blank' || destination.startsWith('http'),
+    is_external: anchor.target === '_blank' || /^[a-z][a-z\d+.-]*:/i.test(destination),
   });
 
   const installIntent =

--- a/site/script.js
+++ b/site/script.js
@@ -112,7 +112,7 @@ function sanitizeReferrer(referrer) {
 function trackSiteView() {
   telemetry.capture('relaycast_site_viewed', {
     referrer: sanitizeReferrer(document.referrer),
-    query: sanitizeUrl(window.location.href),
+    query_params: sanitizeUrl(window.location.href),
   });
 }
 


### PR DESCRIPTION
## Summary
- add anonymous PostHog telemetry for the static site, CLI, and MCP server
- instrument funnel and usage events for: site views -> install intent, workspace creation, message sends, inbox checks, pricing CTA clicks, and CLI vs MCP usage
- add CLI telemetry controls (`relaycast telemetry status|enable|disable`) with opt-out precedence via `DO_NOT_TRACK=1` and `RELAYCAST_TELEMETRY_DISABLED=1`
- support local/staging telemetry overrides using Relay-compatible env vars (`POSTHOG_API_KEY`, `POSTHOG_HOST`) plus Relaycast aliases
- add focused telemetry documentation and update README/.env examples

## Validation
- `npm --prefix packages/cli test -- src/__tests__/index.test.ts src/__tests__/telemetry.test.ts`
- `npm --prefix packages/mcp test -- src/__tests__/piggyback.test.ts`
- `node --check site/script.js`

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/agentworkforce/relaycast/pull/2" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
