### PR TITLE
Add @relaycast/openclaw package for OpenClaw integration

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,6 +14,8 @@ on:
           - sdk
           - mcp
           - cli
+          - react
+          - openclaw
         default: "all"
       version:
         description: "Version bump type"
@@ -175,6 +177,8 @@ jobs:
           - sdk
           - mcp
           - cli
+          - react
+          - openclaw
 
     steps:
       - name: Checkout code
@@ -298,7 +302,9 @@ jobs:
             ### Install
             ```bash
             npm install @relaycast/sdk@${{ needs.build.outputs.new_version }}
+            npm install @relaycast/react@${{ needs.build.outputs.new_version }}
             npm install @relaycast/mcp@${{ needs.build.outputs.new_version }}
+            npm install @relaycast/openclaw@${{ needs.build.outputs.new_version }}
             npm install -g relaycast@${{ needs.build.outputs.new_version }}
             ```
 
@@ -309,6 +315,8 @@ jobs:
             | @relaycast/server | ${{ needs.build.outputs.new_version }} |
             | @relaycast/sdk | ${{ needs.build.outputs.new_version }} |
             | @relaycast/mcp | ${{ needs.build.outputs.new_version }} |
+            | @relaycast/react | ${{ needs.build.outputs.new_version }} |
+            | @relaycast/openclaw | ${{ needs.build.outputs.new_version }} |
             | relaycast (CLI) | ${{ needs.build.outputs.new_version }} |
           generate_release_notes: true
         env:

--- a/package-lock.json
+++ b/package-lock.json
@@ -2158,6 +2158,10 @@
       "resolved": "packages/mcp",
       "link": true
     },
+    "node_modules/@relaycast/openclaw": {
+      "resolved": "packages/openclaw",
+      "link": true
+    },
     "node_modules/@relaycast/sdk": {
       "resolved": "packages/sdk",
       "link": true
@@ -7811,6 +7815,7 @@
       "version": "0.1.2",
       "license": "Apache-2.0",
       "dependencies": {
+        "@relaycast/openclaw": "0.1.2",
         "@relaycast/sdk": "0.1.2",
         "@relaycast/types": "0.1.2",
         "commander": "^14.0.3"
@@ -8051,6 +8056,23 @@
         "jsdom": {
           "optional": true
         }
+      }
+    },
+    "packages/openclaw": {
+      "name": "@relaycast/openclaw",
+      "version": "0.1.2",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@relaycast/sdk": "0.1.2",
+        "@relaycast/types": "0.1.2"
+      },
+      "bin": {
+        "relaycast-openclaw": "dist/cli.js"
+      },
+      "devDependencies": {
+        "@types/node": "^20.0.0",
+        "typescript": "^5.7.0",
+        "vitest": "^3.0.0"
       }
     },
     "packages/sdk": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,20 @@
         "vitest": "^3.0.0"
       }
     },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-3.2.0.tgz",
+      "integrity": "sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^2.1.3",
+        "@csstools/css-color-parser": "^3.0.9",
+        "@csstools/css-parser-algorithms": "^3.0.4",
+        "@csstools/css-tokenizer": "^3.0.3",
+        "lru-cache": "^10.4.3"
+      }
+    },
     "node_modules/@aws-crypto/crc32": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-5.2.0.tgz",
@@ -946,6 +960,166 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
+      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.28.5",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/code-frame/node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.6.tgz",
+      "integrity": "sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.1.0.tgz",
+      "integrity": "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-2.1.4.tgz",
+      "integrity": "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-3.1.0.tgz",
+      "integrity": "sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^5.1.0",
+        "@csstools/css-calc": "^2.1.4"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
+      "integrity": "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz",
+      "integrity": "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@drizzle-team/brocli": {
@@ -2162,6 +2336,10 @@
       "resolved": "packages/openclaw",
       "link": true
     },
+    "node_modules/@relaycast/react": {
+      "resolved": "packages/react",
+      "link": true
+    },
     "node_modules/@relaycast/sdk": {
       "resolved": "packages/sdk",
       "link": true
@@ -3270,6 +3448,101 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
+      "integrity": "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/@types/body-parser": {
       "version": "1.19.6",
       "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.6.tgz",
@@ -3385,10 +3658,16 @@
       "integrity": "sha512-Rs1bVAIdBs5gbTIKza/tgpMuG1k3U/UMJLWecIMxNdJFDMzcM5LOiLVRYh3PilWEYDIeUDv7bpiHPLPsbydGcw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
+    },
+    "node_modules/@types/prop-types": {
+      "version": "15.7.15",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
+      "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/qs": {
       "version": "6.14.0",
@@ -3403,6 +3682,17 @@
       "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/react": {
+      "version": "18.3.28",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
+      "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/prop-types": "*",
+        "csstype": "^3.2.2"
+      }
     },
     "node_modules/@types/send": {
       "version": "1.2.1",
@@ -3504,7 +3794,6 @@
       "integrity": "sha512-BtE0k6cjwjLZoZixN0t5AKP0kSzlGu7FctRXYuPAm//aaiZhmfq1JwdYpYr1brzEspYyFeF+8XF5j2VK6oalrA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.54.0",
         "@typescript-eslint/types": "8.54.0",
@@ -3850,7 +4139,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3879,6 +4167,16 @@
       },
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/ajv": {
@@ -3914,6 +4212,17 @@
         }
       }
     },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/ansi-styles": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
@@ -3936,6 +4245,17 @@
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true,
       "license": "Python-2.0"
+    },
+    "node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
     },
     "node_modules/asap": {
       "version": "2.0.6",
@@ -4271,6 +4591,48 @@
         "node": ">= 8"
       }
     },
+    "node_modules/cssstyle": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-4.6.0.tgz",
+      "integrity": "sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^3.2.0",
+        "rrweb-cssom": "^0.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/cssstyle/node_modules/rrweb-cssom": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
+      "integrity": "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/data-urls": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
+      "integrity": "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -4287,6 +4649,13 @@
           "optional": true
         }
       }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/deep-eql": {
       "version": "5.0.2",
@@ -4333,6 +4702,17 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/dezalgo": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.4.tgz",
@@ -4353,6 +4733,14 @@
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
+    },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/drizzle-kit": {
       "version": "0.31.8",
@@ -4524,6 +4912,19 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
     "node_modules/es-define-property": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
@@ -4584,7 +4985,6 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -4658,7 +5058,6 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -4910,7 +5309,6 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -5393,9 +5791,21 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.11.9.tgz",
       "integrity": "sha512-Eaw2YTGM6WOxA6CXbckaEvslr2Ne4NFsKrvc0v97JD5awbmeBLO5w9Ho9L9kmKonrwF9RJlW6BxT1PVv/agBHQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=16.9.0"
+      }
+    },
+    "node_modules/html-encoding-sniffer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
+      "integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-encoding": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/http-errors": {
@@ -5416,6 +5826,34 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/human-signals": {
@@ -5552,6 +5990,13 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/is-promise": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
@@ -5604,6 +6049,47 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsdom": {
+      "version": "25.0.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-25.0.1.tgz",
+      "integrity": "sha512-8i7LzZj7BF8uplX+ZyOlIz86V6TAsSs+np6m1kpW9u0JWi4z/1t+FzcK1aek+ybTnAC4KhBL4uXCNT0wcUIeCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cssstyle": "^4.1.0",
+        "data-urls": "^5.0.0",
+        "decimal.js": "^10.4.3",
+        "form-data": "^4.0.0",
+        "html-encoding-sniffer": "^4.0.0",
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.5",
+        "is-potential-custom-element-name": "^1.0.1",
+        "nwsapi": "^2.2.12",
+        "parse5": "^7.1.2",
+        "rrweb-cssom": "^0.7.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^5.0.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^7.0.0",
+        "whatwg-encoding": "^3.1.1",
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0",
+        "ws": "^8.18.0",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "canvas": "^2.11.2"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
       }
     },
     "node_modules/json-buffer": {
@@ -5708,12 +6194,50 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
+    },
+    "node_modules/loose-envify/node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/loupe": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
       "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
     },
     "node_modules/magic-string": {
       "version": "0.30.21",
@@ -5919,6 +6443,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/nwsapi": {
+      "version": "2.2.23",
+      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.23.tgz",
+      "integrity": "sha512-7wfH4sLbt4M0gCDzGE6vzQBo0bfTKjU7Sfpqy/7gs1qBfYz2vEJH6vXcBKpO3+6Yu1telwd0t9HpyOoLEQQbIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -6051,6 +6582,19 @@
         "node": ">=6"
       }
     },
+    "node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
     "node_modules/parseurl": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
@@ -6181,7 +6725,6 @@
       "resolved": "https://registry.npmjs.org/postgres/-/postgres-3.4.8.tgz",
       "integrity": "sha512-d+JFcLM17njZaOLkv6SCev7uoLaBtfK86vMUXhW1Z4glPWh4jozno9APvW/XKFJ3CCxVoC7OL38BqRydtu5nGg==",
       "license": "Unlicense",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -6288,6 +6831,33 @@
       },
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/react": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
+      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
+      "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0",
+        "scheduler": "^0.23.2"
+      },
+      "peerDependencies": {
+        "react": "^18.3.1"
       }
     },
     "node_modules/react-is": {
@@ -6412,11 +6982,41 @@
         "node": ">= 18"
       }
     },
+    "node_modules/rrweb-cssom": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.7.1.tgz",
+      "integrity": "sha512-TrEMa7JGdVm0UThDJSx7ddw5nVm3UJS9o9CCIZ72B1vSyEZoziDqBYP3XIoi/12lKrJR8rE3jeFHMok2F/Mnsg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "license": "MIT"
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
+    },
+    "node_modules/scheduler": {
+      "version": "0.23.2",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
+      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      }
     },
     "node_modules/semver": {
       "version": "7.7.4",
@@ -6755,6 +7355,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tinybench": {
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
@@ -6816,6 +7423,26 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/tldts": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.86.tgz",
+      "integrity": "sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^6.1.86"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.86.tgz",
+      "integrity": "sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/toidentifier": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
@@ -6823,6 +7450,32 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.6"
+      }
+    },
+    "node_modules/tough-cookie": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.1.2.tgz",
+      "integrity": "sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^6.1.32"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
+      "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/ts-api-utils": {
@@ -6989,7 +7642,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -7070,7 +7722,6 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -7720,6 +8371,80 @@
         }
       }
     },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/whatwg-encoding": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+      "deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-encoding/node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
+      "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^5.1.0",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -7789,6 +8514,23 @@
         }
       }
     },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/yocto-queue": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
@@ -7807,7 +8549,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -8084,6 +8825,27 @@
         "@types/node": "^20.0.0",
         "typescript": "^5.7.0",
         "vitest": "^3.0.0"
+      }
+    },
+    "packages/react": {
+      "name": "@relaycast/react",
+      "version": "0.1.2",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@relaycast/sdk": "0.1.2",
+        "@relaycast/types": "0.1.2"
+      },
+      "devDependencies": {
+        "@testing-library/react": "^16.0.0",
+        "@types/react": "^18.3.0",
+        "jsdom": "^25.0.0",
+        "react": "^18.3.0",
+        "react-dom": "^18.3.0",
+        "typescript": "^5.7.0",
+        "vitest": "^3.0.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0"
       }
     },
     "packages/sdk": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -33,6 +33,7 @@
     "lint": "eslint src/"
   },
   "dependencies": {
+    "@relaycast/openclaw": "0.1.2",
     "@relaycast/sdk": "0.1.2",
     "@relaycast/types": "0.1.2",
     "commander": "^14.0.3"

--- a/packages/cli/src/commands/openclaw.ts
+++ b/packages/cli/src/commands/openclaw.ts
@@ -33,7 +33,7 @@ export function registerOpenClawCommands(program: Command): void {
       const apiKey = opts.apiKey ?? cfg.apiKey;
       if (!apiKey) {
         console.error(
-          'Missing API key. Provide --api-key or run: relay config set api-key <value>',
+          'Missing API key. Provide --api-key or run: relaycast config set api-key <value>',
         );
         process.exit(1);
       }

--- a/packages/cli/src/commands/openclaw.ts
+++ b/packages/cli/src/commands/openclaw.ts
@@ -1,0 +1,66 @@
+import { Command } from 'commander';
+import { detectOpenClaw, setupSkill } from '@relaycast/openclaw';
+import { loadConfig } from '../config.js';
+
+function printJson(value: unknown): void {
+  console.log(JSON.stringify(value, null, 2));
+}
+
+export function registerOpenClawCommands(program: Command): void {
+  const oc = program
+    .command('openclaw')
+    .description('OpenClaw integration — add Relaycast to your claw');
+
+  oc.command('status')
+    .description('Check OpenClaw installation and Relaycast skill status')
+    .action(async () => {
+      const detection = await detectOpenClaw();
+      printJson({
+        openclaw_installed: detection.installed,
+        config_dir: detection.configDir,
+        config_file: detection.configFile,
+        workspace_dir: detection.workspaceDir,
+        has_config: detection.config !== null,
+      });
+    });
+
+  oc.command('setup')
+    .description('Install Relaycast skill into OpenClaw workspace')
+    .option('-n, --name <name>', 'Name for this claw in Relaycast', 'my-claw')
+    .option('-k, --api-key <key>', 'Relaycast workspace API key')
+    .action(async (opts: { name: string; apiKey?: string }) => {
+      const cfg = loadConfig();
+      const apiKey = opts.apiKey ?? cfg.apiKey;
+      if (!apiKey) {
+        console.error(
+          'Missing API key. Provide --api-key or run: relay config set api-key <value>',
+        );
+        process.exit(1);
+      }
+
+      const detection = await detectOpenClaw();
+      if (!detection.installed) {
+        console.error(
+          'OpenClaw not detected at ~/.openclaw/\n' +
+            'Install OpenClaw first: https://github.com/openclaw/openclaw',
+        );
+        process.exit(1);
+      }
+
+      const result = await setupSkill({
+        apiKey,
+        clawName: opts.name,
+        baseUrl: cfg.endpoint,
+      });
+
+      console.log(result.message);
+      console.log('\nNext steps:');
+      console.log('  1. Restart your OpenClaw daemon to pick up the new skill');
+      console.log(
+        '  2. Your claw can now use Relaycast tools (send, read, search, etc.)',
+      );
+      console.log(
+        '  3. Other claws in the same workspace will see this claw online',
+      );
+    });
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -11,6 +11,7 @@ import { registerSearchCommands } from './commands/search.js';
 import { registerReactionCommands } from './commands/reactions.js';
 import { registerFileCommands } from './commands/files.js';
 import { registerBillingCommands } from './commands/billing.js';
+import { registerOpenClawCommands } from './commands/openclaw.js';
 
 export const CLI_VERSION = '0.1.0' as const;
 
@@ -31,5 +32,6 @@ registerSearchCommands(program);
 registerReactionCommands(program);
 registerFileCommands(program);
 registerBillingCommands(program);
+registerOpenClawCommands(program);
 
 program.parse();

--- a/packages/openclaw/package.json
+++ b/packages/openclaw/package.json
@@ -1,0 +1,51 @@
+{
+  "name": "@relaycast/openclaw",
+  "version": "0.1.2",
+  "description": "Drop-in Relaycast integration for OpenClaw — structured messaging for multi-claw setups.",
+  "keywords": [
+    "openclaw",
+    "relaycast",
+    "ai",
+    "agents",
+    "messaging",
+    "multi-agent"
+  ],
+  "author": "Relaycast",
+  "license": "Apache-2.0",
+  "homepage": "https://relaycast.dev",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/AgentWorkforce/relaycast",
+    "directory": "packages/openclaw"
+  },
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "bin": {
+    "relaycast-openclaw": "dist/cli.js"
+  },
+  "scripts": {
+    "build": "tsc",
+    "test": "vitest run",
+    "lint": "eslint src/"
+  },
+  "dependencies": {
+    "@relaycast/sdk": "0.1.2",
+    "@relaycast/types": "0.1.2"
+  },
+  "devDependencies": {
+    "@types/node": "^20.0.0",
+    "vitest": "^3.0.0",
+    "typescript": "^5.7.0"
+  },
+  "files": [
+    "dist",
+    "skill"
+  ]
+}

--- a/packages/openclaw/skill/SKILL.md
+++ b/packages/openclaw/skill/SKILL.md
@@ -7,6 +7,14 @@ summary: Structured messaging for multi-claw communication — channels, threads
 Structured messaging for multi-claw communication. Provides channels, threads,
 DMs, reactions, search, and persistent message history across OpenClaw instances.
 
+## Prerequisites
+
+Install the Relaycast CLI globally:
+
+```bash
+npm install -g relaycast
+```
+
 ## Environment
 
 - `RELAY_API_KEY` — Your Relaycast workspace key (required)
@@ -27,13 +35,13 @@ curl -X POST https://api.relaycast.dev/v1/workspaces \
 
 ```bash
 export RELAY_API_KEY="rk_live_YOUR_KEY"
-npx relaycast agent register "$RELAY_CLAW_NAME"
+relaycast agent register "$RELAY_CLAW_NAME"
 ```
 
 Or use the one-command installer:
 
 ```bash
-npx relaycast openclaw setup --api-key rk_live_YOUR_KEY --name my-claw
+relaycast openclaw setup --api-key rk_live_YOUR_KEY --name my-claw
 ```
 
 ## Tools
@@ -41,67 +49,70 @@ npx relaycast openclaw setup --api-key rk_live_YOUR_KEY --name my-claw
 ### Send a message to a channel
 
 ```bash
-npx relaycast send "#general" "your message"
+relaycast send "#general" "your message"
 ```
 
 ### Read recent messages from a channel
 
 ```bash
-npx relaycast read general
+relaycast read general
 ```
 
 ### Reply in a thread
 
 ```bash
-npx relaycast reply <message_id> "your reply"
+relaycast reply <message_id> "your reply"
 ```
 
 ### Send a direct message to another claw
 
 ```bash
-npx relaycast send "@other-claw" "your message"
+relaycast send "@other-claw" "your message"
 ```
 
 ### Check your inbox (unread messages, mentions, DMs)
 
 ```bash
-npx relaycast read inbox
+relaycast read inbox
 ```
 
 ### Search message history
 
 ```bash
-npx relaycast search "deployment error"
+relaycast search "deployment error"
 ```
 
 ### Add a reaction
 
 ```bash
-npx relaycast react <message_id> thumbsup
+relaycast react <message_id> thumbsup
 ```
 
 ### Create a channel
 
 ```bash
-npx relaycast channel create alerts --topic "System alerts and notifications"
+relaycast channel create alerts --topic "System alerts and notifications"
 ```
 
 ### List channels
 
 ```bash
-npx relaycast channel list
+relaycast channel list
 ```
 
 ## MCP Integration
 
-For richer integration, add Relaycast as an MCP server in your claw config:
+For richer integration, install the MCP package and add Relaycast as an MCP server in your claw config:
+
+```bash
+npm install -g @relaycast/mcp
+```
 
 ```json
 {
   "mcpServers": {
     "relaycast": {
-      "command": "npx",
-      "args": ["@relaycast/mcp"],
+      "command": "relaycast-mcp",
       "env": {
         "RELAY_API_KEY": "your_key_here"
       }

--- a/packages/openclaw/skill/SKILL.md
+++ b/packages/openclaw/skill/SKILL.md
@@ -1,0 +1,113 @@
+---
+summary: Structured messaging for multi-claw communication — channels, threads, DMs, reactions, search, and persistent history.
+---
+
+# Relaycast
+
+Structured messaging for multi-claw communication. Provides channels, threads,
+DMs, reactions, search, and persistent message history across OpenClaw instances.
+
+## Environment
+
+- `RELAY_API_KEY` — Your Relaycast workspace key (required)
+- `RELAY_CLAW_NAME` — This claw's agent name in Relaycast (required)
+- `RELAY_BASE_URL` — API endpoint (default: https://api.relaycast.dev)
+
+## Setup
+
+1. Create a free workspace:
+
+```bash
+curl -X POST https://api.relaycast.dev/v1/workspaces \
+  -H "Content-Type: application/json" \
+  -d '{"name": "my-project"}'
+```
+
+2. Set your API key and register this claw:
+
+```bash
+export RELAY_API_KEY="rk_live_YOUR_KEY"
+npx relaycast agent register "$RELAY_CLAW_NAME"
+```
+
+Or use the one-command installer:
+
+```bash
+npx relaycast openclaw setup --api-key rk_live_YOUR_KEY --name my-claw
+```
+
+## Tools
+
+### Send a message to a channel
+
+```bash
+npx relaycast send "#general" "your message"
+```
+
+### Read recent messages from a channel
+
+```bash
+npx relaycast read general
+```
+
+### Reply in a thread
+
+```bash
+npx relaycast reply <message_id> "your reply"
+```
+
+### Send a direct message to another claw
+
+```bash
+npx relaycast send "@other-claw" "your message"
+```
+
+### Check your inbox (unread messages, mentions, DMs)
+
+```bash
+npx relaycast read inbox
+```
+
+### Search message history
+
+```bash
+npx relaycast search "deployment error"
+```
+
+### Add a reaction
+
+```bash
+npx relaycast react <message_id> thumbsup
+```
+
+### Create a channel
+
+```bash
+npx relaycast channel create alerts --topic "System alerts and notifications"
+```
+
+### List channels
+
+```bash
+npx relaycast channel list
+```
+
+## MCP Integration
+
+For richer integration, add Relaycast as an MCP server in your claw config:
+
+```json
+{
+  "mcpServers": {
+    "relaycast": {
+      "command": "npx",
+      "args": ["@relaycast/mcp"],
+      "env": {
+        "RELAY_API_KEY": "your_key_here"
+      }
+    }
+  }
+}
+```
+
+This gives the claw 23 structured messaging tools with real-time event streaming.

--- a/packages/openclaw/src/__tests__/bridge.test.ts
+++ b/packages/openclaw/src/__tests__/bridge.test.ts
@@ -1,0 +1,191 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Mock the SDK before importing bridge
+const mockRegister = vi.fn();
+const mockJoin = vi.fn();
+const mockCreate = vi.fn();
+const mockSend = vi.fn();
+const mockDm = vi.fn();
+const mockInbox = vi.fn();
+const mockSearch = vi.fn();
+const mockReply = vi.fn();
+const mockReact = vi.fn();
+
+const mockAgentClient = {
+  channels: { join: mockJoin, create: mockCreate },
+  send: mockSend,
+  dm: mockDm,
+  inbox: mockInbox,
+  search: mockSearch,
+  reply: mockReply,
+  react: mockReact,
+};
+
+vi.mock('@relaycast/sdk', () => ({
+  Relay: vi.fn().mockImplementation(() => ({
+    agents: { register: mockRegister },
+    as: vi.fn().mockReturnValue(mockAgentClient),
+  })),
+  WsClient: vi.fn().mockImplementation(() => ({
+    connect: vi.fn(),
+    disconnect: vi.fn(),
+    subscribe: vi.fn(),
+  })),
+}));
+
+import { OpenClawBridge } from '../bridge.js';
+
+describe('OpenClawBridge', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRegister.mockResolvedValue({
+      id: '1',
+      name: 'test-claw',
+      token: 'at_live_test',
+      status: 'online',
+      created_at: new Date().toISOString(),
+    });
+    mockJoin.mockResolvedValue(undefined);
+  });
+
+  it('connects and registers as agent', async () => {
+    const bridge = new OpenClawBridge({
+      apiKey: 'rk_test_key',
+      claw: { name: 'test-claw', persona: 'Test bot' },
+    });
+
+    const agent = await bridge.connect();
+
+    expect(mockRegister).toHaveBeenCalledWith({
+      name: 'test-claw',
+      type: 'agent',
+      persona: 'Test bot',
+    });
+    expect(agent.name).toBe('test-claw');
+    expect(bridge.getToken()).toBe('at_live_test');
+  });
+
+  it('joins specified channels on connect', async () => {
+    const bridge = new OpenClawBridge({
+      apiKey: 'rk_test_key',
+      claw: { name: 'test-claw' },
+      channels: ['general', '#alerts'],
+    });
+
+    await bridge.connect();
+
+    expect(mockJoin).toHaveBeenCalledWith('general');
+    expect(mockJoin).toHaveBeenCalledWith('alerts');
+  });
+
+  it('creates channel when join fails', async () => {
+    mockJoin.mockRejectedValueOnce(new Error('not found'));
+    mockCreate.mockResolvedValue({ name: 'new-channel' });
+
+    const bridge = new OpenClawBridge({
+      apiKey: 'rk_test_key',
+      claw: { name: 'test-claw' },
+      channels: ['new-channel'],
+    });
+
+    await bridge.connect();
+
+    expect(mockJoin).toHaveBeenCalledWith('new-channel');
+    expect(mockCreate).toHaveBeenCalledWith({ name: 'new-channel' });
+  });
+
+  it('proxies send() to agent client', async () => {
+    const bridge = new OpenClawBridge({
+      apiKey: 'rk_test_key',
+      claw: { name: 'test-claw' },
+    });
+
+    await bridge.connect();
+    await bridge.send('#general', 'hello');
+
+    expect(mockSend).toHaveBeenCalledWith('#general', 'hello');
+  });
+
+  it('proxies dm() to agent client', async () => {
+    const bridge = new OpenClawBridge({
+      apiKey: 'rk_test_key',
+      claw: { name: 'test-claw' },
+    });
+
+    await bridge.connect();
+    await bridge.dm('other-claw', 'hey');
+
+    expect(mockDm).toHaveBeenCalledWith('other-claw', 'hey');
+  });
+
+  it('proxies reply() to agent client', async () => {
+    const bridge = new OpenClawBridge({
+      apiKey: 'rk_test_key',
+      claw: { name: 'test-claw' },
+    });
+
+    await bridge.connect();
+    await bridge.reply('msg123', 'replying');
+
+    expect(mockReply).toHaveBeenCalledWith('msg123', 'replying');
+  });
+
+  it('proxies react() to agent client', async () => {
+    const bridge = new OpenClawBridge({
+      apiKey: 'rk_test_key',
+      claw: { name: 'test-claw' },
+    });
+
+    await bridge.connect();
+    await bridge.react('msg123', 'thumbsup');
+
+    expect(mockReact).toHaveBeenCalledWith('msg123', 'thumbsup');
+  });
+
+  it('proxies search() to agent client', async () => {
+    const bridge = new OpenClawBridge({
+      apiKey: 'rk_test_key',
+      claw: { name: 'test-claw' },
+    });
+
+    await bridge.connect();
+    await bridge.search('deploy', { channel: 'ops' });
+
+    expect(mockSearch).toHaveBeenCalledWith('deploy', { channel: 'ops' });
+  });
+
+  it('proxies inbox() to agent client', async () => {
+    const bridge = new OpenClawBridge({
+      apiKey: 'rk_test_key',
+      claw: { name: 'test-claw' },
+    });
+
+    await bridge.connect();
+    await bridge.inbox();
+
+    expect(mockInbox).toHaveBeenCalled();
+  });
+
+  it('throws when using methods before connect()', () => {
+    const bridge = new OpenClawBridge({
+      apiKey: 'rk_test_key',
+      claw: { name: 'test-claw' },
+    });
+
+    expect(() => bridge.getAgent()).toThrow('Bridge not connected');
+  });
+
+  it('cleans up on disconnect()', async () => {
+    const bridge = new OpenClawBridge({
+      apiKey: 'rk_test_key',
+      claw: { name: 'test-claw' },
+    });
+
+    await bridge.connect();
+    expect(bridge.getToken()).toBe('at_live_test');
+
+    bridge.disconnect();
+    expect(bridge.getToken()).toBeNull();
+    expect(() => bridge.getAgent()).toThrow('Bridge not connected');
+  });
+});

--- a/packages/openclaw/src/__tests__/config.test.ts
+++ b/packages/openclaw/src/__tests__/config.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Mock fs modules before importing config
+const mocks = vi.hoisted(() => ({
+  readFile: vi.fn(),
+  existsSync: vi.fn(),
+}));
+
+vi.mock('node:fs/promises', () => ({
+  readFile: mocks.readFile,
+}));
+
+vi.mock('node:fs', () => ({
+  existsSync: mocks.existsSync,
+}));
+
+vi.mock('node:os', () => ({
+  homedir: () => '/home/testuser',
+}));
+
+import { detectOpenClaw, loadOpenClawConfig } from '../config.js';
+
+describe('detectOpenClaw', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('detects when openclaw is not installed', async () => {
+    mocks.existsSync.mockReturnValue(false);
+
+    const result = await detectOpenClaw();
+
+    expect(result.installed).toBe(false);
+    expect(result.configDir).toBe('/home/testuser/.openclaw');
+    expect(result.configFile).toBeNull();
+    expect(result.config).toBeNull();
+  });
+
+  it('detects installed openclaw with config', async () => {
+    mocks.existsSync.mockImplementation((path: string) => {
+      if (path === '/home/testuser/.openclaw') return true;
+      if (path === '/home/testuser/.openclaw/openclaw.json') return true;
+      return false;
+    });
+
+    const config = { agent: { model: 'anthropic/claude-opus-4-6' } };
+    mocks.readFile.mockResolvedValue(JSON.stringify(config));
+
+    const result = await detectOpenClaw();
+
+    expect(result.installed).toBe(true);
+    expect(result.configFile).toBe('/home/testuser/.openclaw/openclaw.json');
+    expect(result.config).toEqual(config);
+    expect(result.workspaceDir).toBe('/home/testuser/.openclaw/workspace');
+  });
+
+  it('handles invalid JSON config gracefully', async () => {
+    mocks.existsSync.mockReturnValue(true);
+    mocks.readFile.mockResolvedValue('not json{{{');
+
+    const result = await detectOpenClaw();
+
+    expect(result.installed).toBe(true);
+    expect(result.configFile).toBe('/home/testuser/.openclaw/openclaw.json');
+    expect(result.config).toBeNull();
+  });
+});
+
+describe('loadOpenClawConfig', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns null when openclaw not installed', async () => {
+    mocks.existsSync.mockReturnValue(false);
+
+    const config = await loadOpenClawConfig();
+    expect(config).toBeNull();
+  });
+
+  it('returns parsed config when available', async () => {
+    mocks.existsSync.mockReturnValue(true);
+
+    const expected = { agent: { model: 'anthropic/claude-opus-4-6' } };
+    mocks.readFile.mockResolvedValue(JSON.stringify(expected));
+
+    const config = await loadOpenClawConfig();
+    expect(config).toEqual(expected);
+  });
+});

--- a/packages/openclaw/src/__tests__/setup.test.ts
+++ b/packages/openclaw/src/__tests__/setup.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  mkdir: vi.fn(),
+  writeFile: vi.fn(),
+  readFile: vi.fn(),
+  existsSync: vi.fn(),
+}));
+
+vi.mock('node:fs/promises', () => ({
+  mkdir: mocks.mkdir,
+  writeFile: mocks.writeFile,
+  readFile: mocks.readFile,
+}));
+
+vi.mock('node:fs', () => ({
+  existsSync: mocks.existsSync,
+}));
+
+vi.mock('node:os', () => ({
+  homedir: () => '/home/testuser',
+}));
+
+import { setupSkill } from '../setup.js';
+
+describe('setupSkill', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.mkdir.mockResolvedValue(undefined);
+    mocks.writeFile.mockResolvedValue(undefined);
+  });
+
+  it('creates skill directory and writes files', async () => {
+    // OpenClaw installed but no config file
+    mocks.existsSync.mockImplementation((path: string) => {
+      if (path === '/home/testuser/.openclaw') return true;
+      return false;
+    });
+
+    const result = await setupSkill({
+      apiKey: 'rk_test_abc',
+      clawName: 'home-claw',
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.skillDir).toBe('/home/testuser/.openclaw/workspace/relaycast');
+
+    // Should create directory
+    expect(mocks.mkdir).toHaveBeenCalledWith(
+      '/home/testuser/.openclaw/workspace/relaycast',
+      { recursive: true },
+    );
+
+    // Should write SKILL.md
+    const skillMdCall = mocks.writeFile.mock.calls.find(
+      (c: string[]) => c[0].endsWith('SKILL.md'),
+    );
+    expect(skillMdCall).toBeDefined();
+    expect(skillMdCall[1]).toContain('Relaycast');
+    expect(skillMdCall[1]).toContain('npx relaycast send');
+
+    // Should write .env with correct values
+    const envCall = mocks.writeFile.mock.calls.find(
+      (c: string[]) => c[0].endsWith('.env'),
+    );
+    expect(envCall).toBeDefined();
+    expect(envCall[1]).toContain('rk_test_abc');
+    expect(envCall[1]).toContain('home-claw');
+  });
+
+  it('adds MCP config to openclaw.json when present', async () => {
+    const existingConfig = { agent: { model: 'anthropic/claude-opus-4-6' } };
+
+    mocks.existsSync.mockReturnValue(true);
+    mocks.readFile.mockResolvedValue(JSON.stringify(existingConfig));
+
+    await setupSkill({
+      apiKey: 'rk_test_xyz',
+      clawName: 'dev-claw',
+    });
+
+    // Should have written updated config
+    const configCall = mocks.writeFile.mock.calls.find(
+      (c: string[]) => c[0].endsWith('openclaw.json'),
+    );
+    expect(configCall).toBeDefined();
+    const written = JSON.parse(configCall[1]);
+    expect(written.mcpServers.relaycast).toBeDefined();
+    expect(written.mcpServers.relaycast.env.RELAY_API_KEY).toBe('rk_test_xyz');
+  });
+
+  it('defaults claw name to my-claw', async () => {
+    mocks.existsSync.mockImplementation((path: string) => {
+      if (path === '/home/testuser/.openclaw') return true;
+      return false;
+    });
+
+    await setupSkill({ apiKey: 'rk_test_abc' });
+
+    const envCall = mocks.writeFile.mock.calls.find(
+      (c: string[]) => c[0].endsWith('.env'),
+    );
+    expect(envCall[1]).toContain('my-claw');
+  });
+});

--- a/packages/openclaw/src/bridge.ts
+++ b/packages/openclaw/src/bridge.ts
@@ -1,0 +1,157 @@
+import { Relay, AgentClient, WsClient } from '@relaycast/sdk';
+import type { Agent } from '@relaycast/types';
+
+export interface ClawIdentity {
+  /** Name for this claw instance (used as Relaycast agent name). */
+  name: string;
+  /** Optional persona description. */
+  persona?: string;
+}
+
+export interface OpenClawBridgeOptions {
+  /** Relaycast workspace API key (rk_live_*). */
+  apiKey: string;
+  /** Relaycast API base URL. */
+  baseUrl?: string;
+  /** Identity for this claw instance. */
+  claw: ClawIdentity;
+  /** Auto-join these channels on connect. */
+  channels?: string[];
+  /** Enable real-time WebSocket events. */
+  realtime?: boolean;
+}
+
+/**
+ * OpenClawBridge connects an OpenClaw instance to a Relaycast workspace.
+ *
+ * Each claw registers as a Relaycast agent, gaining access to channels,
+ * threads, DMs, reactions, search, and persistent message history — things
+ * OpenClaw's built-in sessions_* tools don't provide.
+ *
+ * Usage:
+ * ```ts
+ * const bridge = new OpenClawBridge({
+ *   apiKey: 'rk_live_xxx',
+ *   claw: { name: 'my-claw', persona: 'Home automation assistant' },
+ *   channels: ['general', 'alerts'],
+ * });
+ * await bridge.connect();
+ * await bridge.send('#general', 'Online and ready.');
+ * ```
+ */
+export class OpenClawBridge {
+  private relay: Relay;
+  private agent: AgentClient | null = null;
+  private ws: WsClient | null = null;
+  private agentToken: string | null = null;
+  private options: OpenClawBridgeOptions;
+
+  constructor(options: OpenClawBridgeOptions) {
+    this.options = options;
+    this.relay = new Relay({
+      apiKey: options.apiKey,
+      baseUrl: options.baseUrl,
+    });
+  }
+
+  /**
+   * Register this claw as a Relaycast agent, join channels, and optionally
+   * open a WebSocket for real-time events.
+   */
+  async connect(): Promise<Agent> {
+    const result = await this.relay.agents.register({
+      name: this.options.claw.name,
+      type: 'agent',
+      persona: this.options.claw.persona,
+    });
+
+    this.agentToken = result.token;
+    this.agent = this.relay.as(result.token);
+
+    if (this.options.channels) {
+      for (const ch of this.options.channels) {
+        const name = ch.startsWith('#') ? ch.slice(1) : ch;
+        try {
+          await this.agent.channels.join(name);
+        } catch {
+          // Channel may not exist yet — create and join
+          await this.agent.channels.create({ name });
+        }
+      }
+    }
+
+    if (this.options.realtime) {
+      this.ws = new WsClient({
+        token: result.token,
+        baseUrl: this.options.baseUrl,
+      });
+      this.ws.connect();
+
+      if (this.options.channels) {
+        this.ws.subscribe(
+          this.options.channels.map((ch) =>
+            ch.startsWith('#') ? ch.slice(1) : ch,
+          ),
+        );
+      }
+    }
+
+    return result as unknown as Agent;
+  }
+
+  /** Get the underlying AgentClient for direct SDK access. */
+  getAgent(): AgentClient {
+    if (!this.agent) {
+      throw new Error(
+        'Bridge not connected. Call connect() first.',
+      );
+    }
+    return this.agent;
+  }
+
+  /** Get the WebSocket client (only available if realtime: true). */
+  getWs(): WsClient | null {
+    return this.ws;
+  }
+
+  /** Get the agent token for this claw (available after connect). */
+  getToken(): string | null {
+    return this.agentToken;
+  }
+
+  // ── Convenience methods that proxy to AgentClient ──
+
+  async send(channel: string, text: string) {
+    return this.getAgent().send(channel, text);
+  }
+
+  async dm(agent: string, text: string) {
+    return this.getAgent().dm(agent, text);
+  }
+
+  async reply(messageId: string, text: string) {
+    return this.getAgent().reply(messageId, text);
+  }
+
+  async react(messageId: string, emoji: string) {
+    return this.getAgent().react(messageId, emoji);
+  }
+
+  async search(query: string, opts?: { channel?: string; from?: string }) {
+    return this.getAgent().search(query, opts);
+  }
+
+  async inbox() {
+    return this.getAgent().inbox();
+  }
+
+  /** Disconnect WebSocket and clean up. */
+  disconnect() {
+    if (this.ws) {
+      this.ws.disconnect();
+      this.ws = null;
+    }
+    this.agent = null;
+    this.agentToken = null;
+  }
+}

--- a/packages/openclaw/src/cli.ts
+++ b/packages/openclaw/src/cli.ts
@@ -1,0 +1,45 @@
+#!/usr/bin/env node
+
+import { detectOpenClaw } from './config.js';
+import { setupSkill } from './setup.js';
+
+const args = process.argv.slice(2);
+const command = args[0];
+
+if (command === 'setup') {
+  const apiKey = args[1] ?? process.env.RELAY_API_KEY;
+  const clawName = args[2] ?? process.env.RELAY_CLAW_NAME ?? 'my-claw';
+
+  if (!apiKey) {
+    console.error(
+      'Usage: relaycast-openclaw setup <api-key> [claw-name]\n' +
+        '  Or set RELAY_API_KEY environment variable.',
+    );
+    process.exit(1);
+  }
+
+  const detection = await detectOpenClaw();
+  if (!detection.installed) {
+    console.error(
+      'OpenClaw not detected. Expected config at ~/.openclaw/\n' +
+        'Install OpenClaw first: https://github.com/openclaw/openclaw',
+    );
+    process.exit(1);
+  }
+
+  const result = await setupSkill({ apiKey, clawName });
+  console.log(result.message);
+} else if (command === 'status') {
+  const detection = await detectOpenClaw();
+  console.log(`OpenClaw installed: ${detection.installed}`);
+  console.log(`Config dir: ${detection.configDir}`);
+  console.log(`Config file: ${detection.configFile ?? 'not found'}`);
+  console.log(`Workspace: ${detection.workspaceDir}`);
+} else {
+  console.log(
+    'relaycast-openclaw — Relaycast integration for OpenClaw\n\n' +
+      'Commands:\n' +
+      '  setup <api-key> [claw-name]  Install Relaycast skill into OpenClaw\n' +
+      '  status                       Check OpenClaw installation\n',
+  );
+}

--- a/packages/openclaw/src/config.ts
+++ b/packages/openclaw/src/config.ts
@@ -1,0 +1,70 @@
+import { readFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { homedir } from 'node:os';
+import { existsSync } from 'node:fs';
+
+export interface OpenClawConfig {
+  agent?: {
+    model?: string;
+    [key: string]: unknown;
+  };
+  [key: string]: unknown;
+}
+
+export interface OpenClawDetection {
+  /** Whether OpenClaw appears to be installed. */
+  installed: boolean;
+  /** Path to the openclaw config directory. */
+  configDir: string;
+  /** Path to openclaw.json if it exists. */
+  configFile: string | null;
+  /** Path to the workspace directory. */
+  workspaceDir: string;
+  /** Parsed config if available. */
+  config: OpenClawConfig | null;
+}
+
+/** Default OpenClaw config directory. */
+function openclawHome(): string {
+  return join(homedir(), '.openclaw');
+}
+
+/**
+ * Detect whether OpenClaw is installed and return paths/config.
+ */
+export async function detectOpenClaw(): Promise<OpenClawDetection> {
+  const configDir = openclawHome();
+  const configPath = join(configDir, 'openclaw.json');
+  const workspaceDir = join(configDir, 'workspace');
+
+  const installed = existsSync(configDir);
+  let config: OpenClawConfig | null = null;
+  let configFile: string | null = null;
+
+  if (existsSync(configPath)) {
+    configFile = configPath;
+    try {
+      const raw = await readFile(configPath, 'utf-8');
+      config = JSON.parse(raw) as OpenClawConfig;
+    } catch {
+      // Config exists but isn't valid JSON — that's fine
+    }
+  }
+
+  return {
+    installed,
+    configDir,
+    configFile,
+    workspaceDir,
+    config,
+  };
+}
+
+/**
+ * Load and parse ~/.openclaw/openclaw.json.
+ * Returns null if not found or unparseable.
+ */
+export async function loadOpenClawConfig(): Promise<OpenClawConfig | null> {
+  const detection = await detectOpenClaw();
+  return detection.config;
+}

--- a/packages/openclaw/src/index.ts
+++ b/packages/openclaw/src/index.ts
@@ -1,0 +1,6 @@
+export { OpenClawBridge } from './bridge.js';
+export type { OpenClawBridgeOptions, ClawIdentity } from './bridge.js';
+export { detectOpenClaw, loadOpenClawConfig } from './config.js';
+export type { OpenClawConfig, OpenClawDetection } from './config.js';
+export { setupSkill } from './setup.js';
+export type { SetupOptions, SetupResult } from './setup.js';

--- a/packages/openclaw/src/setup.ts
+++ b/packages/openclaw/src/setup.ts
@@ -1,6 +1,5 @@
 import { mkdir, writeFile, readFile } from 'node:fs/promises';
 import { join } from 'node:path';
-import { existsSync } from 'node:fs';
 import { detectOpenClaw } from './config.js';
 
 export interface SetupOptions {
@@ -148,6 +147,7 @@ export async function setupSkill(options: SetupOptions): Promise<SetupResult> {
   await writeFile(join(skillDir, '.env'), env, 'utf-8');
 
   // If openclaw.json exists, add MCP server config
+  let mcpConfigAdded = false;
   if (detection.configFile && detection.config) {
     try {
       const raw = await readFile(detection.configFile, 'utf-8');
@@ -174,13 +174,14 @@ export async function setupSkill(options: SetupOptions): Promise<SetupResult> {
           JSON.stringify(config, null, 2) + '\n',
           'utf-8',
         );
+        mcpConfigAdded = true;
       }
     } catch {
       // Non-fatal — skill is still installed even if config update fails
     }
   }
 
-  const configNote = existsSync(detection.configFile ?? '')
+  const configNote = mcpConfigAdded
     ? ' MCP server added to openclaw.json.'
     : '';
 

--- a/packages/openclaw/src/setup.ts
+++ b/packages/openclaw/src/setup.ts
@@ -1,0 +1,192 @@
+import { mkdir, writeFile, readFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { existsSync } from 'node:fs';
+import { detectOpenClaw } from './config.js';
+
+export interface SetupOptions {
+  /** Relaycast workspace API key. */
+  apiKey: string;
+  /** Name for this claw in Relaycast. Defaults to hostname or 'my-claw'. */
+  clawName?: string;
+  /** Relaycast API base URL. Defaults to https://api.relaycast.dev. */
+  baseUrl?: string;
+}
+
+export interface SetupResult {
+  /** Whether setup succeeded. */
+  ok: boolean;
+  /** Path to the installed skill directory. */
+  skillDir: string;
+  /** Human-readable status message. */
+  message: string;
+}
+
+const SKILL_MD = `# Relaycast
+
+Structured messaging for multi-claw communication. Provides channels, threads,
+DMs, reactions, search, and persistent message history across OpenClaw instances.
+
+## Environment
+
+- \`RELAY_API_KEY\` — Your Relaycast workspace key (required)
+- \`RELAY_CLAW_NAME\` — This claw's agent name in Relaycast (required)
+- \`RELAY_BASE_URL\` — API endpoint (default: https://api.relaycast.dev)
+
+## Setup
+
+Run once to register this claw:
+
+\`\`\`bash
+npx relaycast agent register "$RELAY_CLAW_NAME"
+\`\`\`
+
+## Tools
+
+### Send a message to a channel
+
+\`\`\`bash
+npx relaycast send "#general" "your message"
+\`\`\`
+
+### Read recent messages from a channel
+
+\`\`\`bash
+npx relaycast read general
+\`\`\`
+
+### Reply in a thread
+
+\`\`\`bash
+npx relaycast reply <message_id> "your reply"
+\`\`\`
+
+### Send a direct message to another claw
+
+\`\`\`bash
+npx relaycast send "@other-claw" "your message"
+\`\`\`
+
+### Check your inbox (unread messages, mentions, DMs)
+
+\`\`\`bash
+npx relaycast read inbox
+\`\`\`
+
+### Search message history
+
+\`\`\`bash
+npx relaycast search "deployment error"
+\`\`\`
+
+### Add a reaction
+
+\`\`\`bash
+npx relaycast react <message_id> thumbsup
+\`\`\`
+
+### Create a channel
+
+\`\`\`bash
+npx relaycast channel create alerts --topic "System alerts and notifications"
+\`\`\`
+
+### List channels
+
+\`\`\`bash
+npx relaycast channel list
+\`\`\`
+
+## MCP Integration
+
+For richer integration, add Relaycast as an MCP server in your claw config:
+
+\`\`\`json
+{
+  "mcpServers": {
+    "relaycast": {
+      "command": "npx",
+      "args": ["@relaycast/mcp"],
+      "env": {
+        "RELAY_API_KEY": "your_key_here"
+      }
+    }
+  }
+}
+\`\`\`
+
+This gives the claw 23 structured messaging tools with real-time event streaming.
+`;
+
+const ENV_TEMPLATE = `# Relaycast configuration for this OpenClaw skill
+RELAY_API_KEY=__API_KEY__
+RELAY_CLAW_NAME=__CLAW_NAME__
+RELAY_BASE_URL=__BASE_URL__
+`;
+
+/**
+ * Install the Relaycast skill into an OpenClaw workspace.
+ *
+ * Creates ~/.openclaw/workspace/relaycast/ with:
+ * - SKILL.md (tool documentation for the claw agent)
+ * - .env (API key and claw identity)
+ */
+export async function setupSkill(options: SetupOptions): Promise<SetupResult> {
+  const detection = await detectOpenClaw();
+  const skillDir = join(detection.workspaceDir, 'relaycast');
+
+  // Create directories
+  await mkdir(skillDir, { recursive: true });
+
+  // Write SKILL.md
+  await writeFile(join(skillDir, 'SKILL.md'), SKILL_MD, 'utf-8');
+
+  // Write .env
+  const env = ENV_TEMPLATE
+    .replace('__API_KEY__', options.apiKey)
+    .replace('__CLAW_NAME__', options.clawName ?? 'my-claw')
+    .replace('__BASE_URL__', options.baseUrl ?? 'https://api.relaycast.dev');
+  await writeFile(join(skillDir, '.env'), env, 'utf-8');
+
+  // If openclaw.json exists, add MCP server config
+  if (detection.configFile && detection.config) {
+    try {
+      const raw = await readFile(detection.configFile, 'utf-8');
+      const config = JSON.parse(raw);
+
+      if (!config.mcpServers) {
+        config.mcpServers = {};
+      }
+
+      if (!config.mcpServers.relaycast) {
+        config.mcpServers.relaycast = {
+          command: 'npx',
+          args: ['@relaycast/mcp'],
+          env: {
+            RELAY_API_KEY: options.apiKey,
+            ...(options.baseUrl
+              ? { RELAY_BASE_URL: options.baseUrl }
+              : {}),
+          },
+        };
+
+        await writeFile(
+          detection.configFile,
+          JSON.stringify(config, null, 2) + '\n',
+          'utf-8',
+        );
+      }
+    } catch {
+      // Non-fatal — skill is still installed even if config update fails
+    }
+  }
+
+  const configNote = existsSync(detection.configFile ?? '')
+    ? ' MCP server added to openclaw.json.'
+    : '';
+
+  return {
+    ok: true,
+    skillDir,
+    message: `Relaycast skill installed at ${skillDir}.${configNote}`,
+  };
+}

--- a/packages/openclaw/tsconfig.json
+++ b/packages/openclaw/tsconfig.json
@@ -8,7 +8,6 @@
   "exclude": ["src/__tests__"],
   "references": [
     { "path": "../types" },
-    { "path": "../sdk" },
-    { "path": "../openclaw" }
+    { "path": "../sdk" }
   ]
 }

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,0 +1,45 @@
+{
+  "name": "@relaycast/react",
+  "version": "0.1.2",
+  "description": "Headless React hooks for Relaycast real-time agent messaging",
+  "keywords": ["relaycast", "react", "hooks", "ai", "agents", "messaging"],
+  "author": "Relaycast",
+  "license": "Apache-2.0",
+  "homepage": "https://relaycast.dev",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/AgentWorkforce/relaycast",
+    "directory": "packages/react"
+  },
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "scripts": {
+    "build": "tsc",
+    "test": "vitest run",
+    "lint": "eslint src/"
+  },
+  "dependencies": {
+    "@relaycast/sdk": "0.1.2",
+    "@relaycast/types": "0.1.2"
+  },
+  "peerDependencies": {
+    "react": "^18.0.0 || ^19.0.0"
+  },
+  "devDependencies": {
+    "@testing-library/react": "^16.0.0",
+    "@types/react": "^18.3.0",
+    "jsdom": "^25.0.0",
+    "react": "^18.3.0",
+    "react-dom": "^18.3.0",
+    "typescript": "^5.7.0",
+    "vitest": "^3.0.0"
+  },
+  "files": ["dist"]
+}

--- a/packages/react/src/__tests__/reducer.test.ts
+++ b/packages/react/src/__tests__/reducer.test.ts
@@ -1,0 +1,523 @@
+import { describe, it, expect } from 'vitest';
+import { createStore } from '../store.js';
+import { handleServerEvent } from '../reducer.js';
+import type { MessageWithMeta } from '@relaycast/types';
+
+function makeMessage(overrides: Partial<MessageWithMeta> = {}): MessageWithMeta {
+  return {
+    id: 'msg1',
+    agent_name: 'Alice',
+    agent_id: 'a1',
+    text: 'hello',
+    blocks: null,
+    attachments: [],
+    created_at: '2026-01-01T00:00:00Z',
+    reply_count: 0,
+    reactions: [],
+    read_by_count: 0,
+    ...overrides,
+  };
+}
+
+function makeChannel(overrides: Partial<{ id: string; workspace_id: string; name: string; channel_type: number; topic: string | null; created_by: string | null; created_at: string; is_archived: boolean }> = {}) {
+  return {
+    id: 'ch1',
+    workspace_id: 'ws1',
+    name: 'general',
+    channel_type: 0,
+    topic: null,
+    created_by: null,
+    created_at: '2026-01-01T00:00:00Z',
+    is_archived: false,
+    ...overrides,
+  };
+}
+
+function makeAgent(overrides: Partial<{ id: string; workspace_id: string; name: string; type: 'agent' | 'human'; token_hash: string; status: 'online' | 'offline' | 'away'; persona: string | null; metadata: Record<string, unknown>; created_at: string; last_seen: string }> = {}) {
+  return {
+    id: 'ag1',
+    workspace_id: 'ws1',
+    name: 'Alice',
+    type: 'agent' as const,
+    token_hash: '',
+    status: 'online' as const,
+    persona: null,
+    metadata: {},
+    created_at: '2026-01-01T00:00:00Z',
+    last_seen: '2026-01-01T00:00:00Z',
+    ...overrides,
+  };
+}
+
+describe('handleServerEvent', () => {
+  // ─── message.created ───────────────────────────────────────────
+
+  describe('message.created', () => {
+    it('appends message to correct channel', () => {
+      const store = createStore();
+
+      handleServerEvent(store, {
+        type: 'message.created',
+        channel: 'general',
+        message: { id: 'msg1', agent_name: 'Alice', text: 'hello', attachments: [] },
+      });
+
+      const state = store.getState();
+      expect(state.channelMessages['general'].messages).toHaveLength(1);
+      expect(state.channelMessages['general'].messages[0].id).toBe('msg1');
+      expect(state.channelMessages['general'].messages[0].agent_name).toBe('Alice');
+      expect(state.channelMessages['general'].messages[0].text).toBe('hello');
+    });
+
+    it('deduplicates by id', () => {
+      const store = createStore();
+
+      handleServerEvent(store, {
+        type: 'message.created',
+        channel: 'general',
+        message: { id: 'msg1', agent_name: 'Alice', text: 'hello', attachments: [] },
+      });
+      handleServerEvent(store, {
+        type: 'message.created',
+        channel: 'general',
+        message: { id: 'msg1', agent_name: 'Alice', text: 'hello again', attachments: [] },
+      });
+
+      const state = store.getState();
+      expect(state.channelMessages['general'].messages).toHaveLength(1);
+      expect(state.channelMessages['general'].messages[0].text).toBe('hello');
+    });
+  });
+
+  // ─── message.updated ───────────────────────────────────────────
+
+  describe('message.updated', () => {
+    it('updates text in matching message', () => {
+      const store = createStore();
+      store.updateChannelMessages('general', () => ({
+        messages: [makeMessage({ id: 'msg1', text: 'original' })],
+        loading: false,
+        error: null,
+      }));
+
+      handleServerEvent(store, {
+        type: 'message.updated',
+        channel: 'general',
+        message: { id: 'msg1', agent_name: 'Alice', text: 'edited' },
+      });
+
+      const state = store.getState();
+      expect(state.channelMessages['general'].messages[0].text).toBe('edited');
+    });
+
+    it('is a no-op if message not found', () => {
+      const store = createStore();
+      store.updateChannelMessages('general', () => ({
+        messages: [makeMessage({ id: 'msg1', text: 'original' })],
+        loading: false,
+        error: null,
+      }));
+
+      handleServerEvent(store, {
+        type: 'message.updated',
+        channel: 'general',
+        message: { id: 'msg999', agent_name: 'Alice', text: 'edited' },
+      });
+
+      const state = store.getState();
+      expect(state.channelMessages['general'].messages).toHaveLength(1);
+      expect(state.channelMessages['general'].messages[0].text).toBe('original');
+    });
+  });
+
+  // ─── thread.reply ──────────────────────────────────────────────
+
+  describe('thread.reply', () => {
+    it('appends reply to correct thread', () => {
+      const store = createStore();
+
+      handleServerEvent(store, {
+        type: 'thread.reply',
+        parent_id: 'msg1',
+        message: { id: 'reply1', agent_name: 'Bob', text: 'reply text' },
+      });
+
+      const state = store.getState();
+      expect(state.threads['msg1'].replies).toHaveLength(1);
+      expect(state.threads['msg1'].replies[0].id).toBe('reply1');
+      expect(state.threads['msg1'].replies[0].text).toBe('reply text');
+    });
+
+    it('deduplicates by id', () => {
+      const store = createStore();
+
+      handleServerEvent(store, {
+        type: 'thread.reply',
+        parent_id: 'msg1',
+        message: { id: 'reply1', agent_name: 'Bob', text: 'reply text' },
+      });
+      handleServerEvent(store, {
+        type: 'thread.reply',
+        parent_id: 'msg1',
+        message: { id: 'reply1', agent_name: 'Bob', text: 'reply text duplicate' },
+      });
+
+      const state = store.getState();
+      expect(state.threads['msg1'].replies).toHaveLength(1);
+      expect(state.threads['msg1'].replies[0].text).toBe('reply text');
+    });
+
+    it('increments parent reply_count in channel messages', () => {
+      const store = createStore();
+      store.updateChannelMessages('general', () => ({
+        messages: [makeMessage({ id: 'msg1', reply_count: 0 })],
+        loading: false,
+        error: null,
+      }));
+
+      handleServerEvent(store, {
+        type: 'thread.reply',
+        parent_id: 'msg1',
+        message: { id: 'reply1', agent_name: 'Bob', text: 'reply text' },
+      });
+
+      const state = store.getState();
+      expect(state.channelMessages['general'].messages[0].reply_count).toBe(1);
+    });
+  });
+
+  // ─── reaction.added ────────────────────────────────────────────
+
+  describe('reaction.added', () => {
+    it('creates new ReactionGroup if emoji not present', () => {
+      const store = createStore();
+      store.updateChannelMessages('general', () => ({
+        messages: [makeMessage({ id: 'msg1', reactions: [] })],
+        loading: false,
+        error: null,
+      }));
+
+      handleServerEvent(store, {
+        type: 'reaction.added',
+        message_id: 'msg1',
+        emoji: 'thumbsup',
+        agent_name: 'Alice',
+      });
+
+      const state = store.getState();
+      const reactions = state.channelMessages['general'].messages[0].reactions;
+      expect(reactions).toHaveLength(1);
+      expect(reactions[0]).toEqual({ emoji: 'thumbsup', count: 1, agents: ['Alice'] });
+    });
+
+    it('increments count on existing group', () => {
+      const store = createStore();
+      store.updateChannelMessages('general', () => ({
+        messages: [makeMessage({
+          id: 'msg1',
+          reactions: [{ emoji: 'thumbsup', count: 1, agents: ['Alice'] }],
+        })],
+        loading: false,
+        error: null,
+      }));
+
+      handleServerEvent(store, {
+        type: 'reaction.added',
+        message_id: 'msg1',
+        emoji: 'thumbsup',
+        agent_name: 'Bob',
+      });
+
+      const state = store.getState();
+      const reactions = state.channelMessages['general'].messages[0].reactions;
+      expect(reactions).toHaveLength(1);
+      expect(reactions[0].count).toBe(2);
+      expect(reactions[0].agents).toEqual(['Alice', 'Bob']);
+    });
+
+    it('deduplicates (same agent, same emoji)', () => {
+      const store = createStore();
+      store.updateChannelMessages('general', () => ({
+        messages: [makeMessage({
+          id: 'msg1',
+          reactions: [{ emoji: 'thumbsup', count: 1, agents: ['Alice'] }],
+        })],
+        loading: false,
+        error: null,
+      }));
+
+      handleServerEvent(store, {
+        type: 'reaction.added',
+        message_id: 'msg1',
+        emoji: 'thumbsup',
+        agent_name: 'Alice',
+      });
+
+      const state = store.getState();
+      const reactions = state.channelMessages['general'].messages[0].reactions;
+      expect(reactions).toHaveLength(1);
+      expect(reactions[0].count).toBe(1);
+      expect(reactions[0].agents).toEqual(['Alice']);
+    });
+  });
+
+  // ─── reaction.removed ──────────────────────────────────────────
+
+  describe('reaction.removed', () => {
+    it('decrements count', () => {
+      const store = createStore();
+      store.updateChannelMessages('general', () => ({
+        messages: [makeMessage({
+          id: 'msg1',
+          reactions: [{ emoji: 'thumbsup', count: 2, agents: ['Alice', 'Bob'] }],
+        })],
+        loading: false,
+        error: null,
+      }));
+
+      handleServerEvent(store, {
+        type: 'reaction.removed',
+        message_id: 'msg1',
+        emoji: 'thumbsup',
+        agent_name: 'Bob',
+      });
+
+      const state = store.getState();
+      const reactions = state.channelMessages['general'].messages[0].reactions;
+      expect(reactions).toHaveLength(1);
+      expect(reactions[0].count).toBe(1);
+      expect(reactions[0].agents).toEqual(['Alice']);
+    });
+
+    it('removes group when count reaches 0', () => {
+      const store = createStore();
+      store.updateChannelMessages('general', () => ({
+        messages: [makeMessage({
+          id: 'msg1',
+          reactions: [{ emoji: 'thumbsup', count: 1, agents: ['Alice'] }],
+        })],
+        loading: false,
+        error: null,
+      }));
+
+      handleServerEvent(store, {
+        type: 'reaction.removed',
+        message_id: 'msg1',
+        emoji: 'thumbsup',
+        agent_name: 'Alice',
+      });
+
+      const state = store.getState();
+      const reactions = state.channelMessages['general'].messages[0].reactions;
+      expect(reactions).toHaveLength(0);
+    });
+  });
+
+  // ─── agent.online / agent.offline ──────────────────────────────
+
+  describe('agent.online', () => {
+    it('updates agent status to online', () => {
+      const store = createStore();
+      const agent = makeAgent({ name: 'Alice', status: 'offline' });
+      store.setState({ agents: { data: [agent], loading: false, error: null } });
+
+      handleServerEvent(store, {
+        type: 'agent.online',
+        agent: { name: 'Alice' },
+      });
+
+      const state = store.getState();
+      expect(state.agents.data[0].status).toBe('online');
+    });
+  });
+
+  describe('agent.offline', () => {
+    it('updates agent status to offline', () => {
+      const store = createStore();
+      const agent = makeAgent({ name: 'Alice', status: 'online' });
+      store.setState({ agents: { data: [agent], loading: false, error: null } });
+
+      handleServerEvent(store, {
+        type: 'agent.offline',
+        agent: { name: 'Alice' },
+      });
+
+      const state = store.getState();
+      expect(state.agents.data[0].status).toBe('offline');
+    });
+  });
+
+  // ─── channel.created ───────────────────────────────────────────
+
+  describe('channel.created', () => {
+    it('appends to channel list', () => {
+      const store = createStore();
+      store.setState({ channels: { data: [], loading: false, error: null } });
+
+      handleServerEvent(store, {
+        type: 'channel.created',
+        channel: { name: 'new-channel', topic: 'A new channel' },
+      });
+
+      const state = store.getState();
+      expect(state.channels.data).toHaveLength(1);
+      expect(state.channels.data[0].name).toBe('new-channel');
+      expect(state.channels.data[0].topic).toBe('A new channel');
+      expect(state.channels.data[0].is_archived).toBe(false);
+    });
+
+    it('deduplicates by name', () => {
+      const store = createStore();
+      store.setState({
+        channels: { data: [makeChannel({ name: 'general' })], loading: false, error: null },
+      });
+
+      handleServerEvent(store, {
+        type: 'channel.created',
+        channel: { name: 'general', topic: 'duplicate' },
+      });
+
+      const state = store.getState();
+      expect(state.channels.data).toHaveLength(1);
+    });
+  });
+
+  // ─── channel.updated ───────────────────────────────────────────
+
+  describe('channel.updated', () => {
+    it('updates topic', () => {
+      const store = createStore();
+      store.setState({
+        channels: { data: [makeChannel({ name: 'general', topic: 'old topic' })], loading: false, error: null },
+      });
+
+      handleServerEvent(store, {
+        type: 'channel.updated',
+        channel: { name: 'general', topic: 'new topic' },
+      });
+
+      const state = store.getState();
+      expect(state.channels.data[0].topic).toBe('new topic');
+    });
+  });
+
+  // ─── channel.archived ──────────────────────────────────────────
+
+  describe('channel.archived', () => {
+    it('sets is_archived true', () => {
+      const store = createStore();
+      store.setState({
+        channels: { data: [makeChannel({ name: 'general', is_archived: false })], loading: false, error: null },
+      });
+
+      handleServerEvent(store, {
+        type: 'channel.archived',
+        channel: { name: 'general' },
+      });
+
+      const state = store.getState();
+      expect(state.channels.data[0].is_archived).toBe(true);
+    });
+  });
+
+  // ─── member.joined ─────────────────────────────────────────────
+
+  describe('member.joined', () => {
+    it('adds member to channel details', () => {
+      const store = createStore();
+
+      handleServerEvent(store, {
+        type: 'member.joined',
+        channel: 'general',
+        agent_name: 'Alice',
+      });
+
+      const state = store.getState();
+      expect(state.channelDetails['general'].members).toHaveLength(1);
+      expect(state.channelDetails['general'].members[0].agent_name).toBe('Alice');
+      expect(state.channelDetails['general'].members[0].role).toBe('member');
+    });
+
+    it('deduplicates by agent_name', () => {
+      const store = createStore();
+      store.updateChannelDetail('general', () => ({
+        channel: null,
+        members: [{ agent_id: '', agent_name: 'Alice', role: 'member' as const, joined_at: '2026-01-01T00:00:00Z' }],
+        loading: false,
+        error: null,
+      }));
+
+      handleServerEvent(store, {
+        type: 'member.joined',
+        channel: 'general',
+        agent_name: 'Alice',
+      });
+
+      const state = store.getState();
+      expect(state.channelDetails['general'].members).toHaveLength(1);
+    });
+  });
+
+  // ─── member.left ───────────────────────────────────────────────
+
+  describe('member.left', () => {
+    it('removes member from channel details', () => {
+      const store = createStore();
+      store.updateChannelDetail('general', () => ({
+        channel: null,
+        members: [
+          { agent_id: '', agent_name: 'Alice', role: 'member' as const, joined_at: '2026-01-01T00:00:00Z' },
+          { agent_id: '', agent_name: 'Bob', role: 'member' as const, joined_at: '2026-01-01T00:00:00Z' },
+        ],
+        loading: false,
+        error: null,
+      }));
+
+      handleServerEvent(store, {
+        type: 'member.left',
+        channel: 'general',
+        agent_name: 'Alice',
+      });
+
+      const state = store.getState();
+      expect(state.channelDetails['general'].members).toHaveLength(1);
+      expect(state.channelDetails['general'].members[0].agent_name).toBe('Bob');
+    });
+  });
+
+  // ─── dm.received ───────────────────────────────────────────────
+
+  describe('dm.received', () => {
+    it('flags dms as loading', () => {
+      const store = createStore();
+      store.setState({ dms: { data: [], loading: false, error: null } });
+
+      handleServerEvent(store, {
+        type: 'dm.received',
+        conversation_id: 'conv1',
+        message: { id: 'dm1', agent_name: 'Alice', text: 'hi' },
+      });
+
+      const state = store.getState();
+      expect(state.dms.loading).toBe(true);
+    });
+  });
+
+  // ─── group_dm.received ─────────────────────────────────────────
+
+  describe('group_dm.received', () => {
+    it('flags dms as loading', () => {
+      const store = createStore();
+      store.setState({ dms: { data: [], loading: false, error: null } });
+
+      handleServerEvent(store, {
+        type: 'group_dm.received',
+        conversation_id: 'conv1',
+        message: { id: 'dm1', agent_name: 'Alice', text: 'hi group' },
+      });
+
+      const state = store.getState();
+      expect(state.dms.loading).toBe(true);
+    });
+  });
+});

--- a/packages/react/src/context.ts
+++ b/packages/react/src/context.ts
@@ -1,0 +1,13 @@
+import { createContext } from 'react';
+import type { Relay, AgentClient, WsClient } from '@relaycast/sdk';
+import type { RelayStore } from './types.js';
+
+export interface ClientContextValue {
+  relay: Relay;
+  agent: AgentClient;
+  ws: WsClient;
+}
+
+export const ClientContext = createContext<ClientContextValue | null>(null);
+
+export const StoreContext = createContext<RelayStore | null>(null);

--- a/packages/react/src/hooks/useAgent.ts
+++ b/packages/react/src/hooks/useAgent.ts
@@ -1,0 +1,9 @@
+import { useContext } from 'react';
+import type { AgentClient } from '@relaycast/sdk';
+import { ClientContext } from '../context.js';
+
+export function useAgent(): AgentClient {
+  const ctx = useContext(ClientContext);
+  if (!ctx) throw new Error('useAgent must be used within <RelayProvider>');
+  return ctx.agent;
+}

--- a/packages/react/src/hooks/useChannel.ts
+++ b/packages/react/src/hooks/useChannel.ts
@@ -1,0 +1,40 @@
+import { useContext, useEffect, useSyncExternalStore } from 'react';
+import { ClientContext, StoreContext } from '../context.js';
+import type { UseChannelReturn, ChannelDetail } from '../types.js';
+
+const EMPTY: ChannelDetail = { channel: null, members: [], loading: true, error: null };
+
+export function useChannel(name: string): UseChannelReturn {
+  const ctx = useContext(ClientContext);
+  const store = useContext(StoreContext);
+  if (!ctx || !store) throw new Error('useChannel must be used within <RelayProvider>');
+
+  useEffect(() => {
+    store.updateChannelDetail(name, (prev) => ({ ...prev, loading: true }));
+
+    ctx.agent.channels.get(name)
+      .then((result) => {
+        const { members, ...channel } = result;
+        store.updateChannelDetail(name, () => ({ channel, members, loading: false, error: null }));
+      })
+      .catch((error: unknown) => {
+        store.updateChannelDetail(name, (prev) => ({
+          ...prev,
+          loading: false,
+          error: error instanceof Error ? error : new Error(String(error)),
+        }));
+      });
+  }, [name, ctx.agent, store]);
+
+  const data = useSyncExternalStore(
+    store.subscribe,
+    () => store.getState().channelDetails[name] ?? EMPTY,
+  );
+
+  return {
+    channel: data.channel,
+    members: data.members,
+    loading: data.loading,
+    error: data.error,
+  };
+}

--- a/packages/react/src/hooks/useChannels.ts
+++ b/packages/react/src/hooks/useChannels.ts
@@ -1,0 +1,38 @@
+import { useContext, useEffect, useSyncExternalStore } from 'react';
+import { ClientContext, StoreContext } from '../context.js';
+import type { UseChannelsReturn } from '../types.js';
+
+export function useChannels(): UseChannelsReturn {
+  const ctx = useContext(ClientContext);
+  const store = useContext(StoreContext);
+  if (!ctx || !store) throw new Error('useChannels must be used within <RelayProvider>');
+
+  useEffect(() => {
+    store.setState({ channels: { ...store.getState().channels, loading: true } });
+
+    ctx.agent.channels.list()
+      .then((data) => {
+        store.setState({ channels: { data, loading: false, error: null } });
+      })
+      .catch((error: unknown) => {
+        store.setState({
+          channels: {
+            ...store.getState().channels,
+            loading: false,
+            error: error instanceof Error ? error : new Error(String(error)),
+          },
+        });
+      });
+  }, [ctx.agent, store]);
+
+  const state = useSyncExternalStore(
+    store.subscribe,
+    () => store.getState().channels,
+  );
+
+  return {
+    channels: state.data,
+    loading: state.loading,
+    error: state.error,
+  };
+}

--- a/packages/react/src/hooks/useDMs.ts
+++ b/packages/react/src/hooks/useDMs.ts
@@ -1,0 +1,51 @@
+import { useContext, useEffect, useSyncExternalStore } from 'react';
+import { ClientContext, StoreContext } from '../context.js';
+import type { UseDMsReturn } from '../types.js';
+
+export function useDMs(): UseDMsReturn {
+  const ctx = useContext(ClientContext);
+  const store = useContext(StoreContext);
+  if (!ctx || !store) throw new Error('useDMs must be used within <RelayProvider>');
+
+  useEffect(() => {
+    store.setState({ dms: { ...store.getState().dms, loading: true } });
+
+    ctx.agent.dms.conversations()
+      .then((data) => {
+        store.setState({ dms: { data, loading: false, error: null } });
+      })
+      .catch((error: unknown) => {
+        store.setState({
+          dms: {
+            ...store.getState().dms,
+            loading: false,
+            error: error instanceof Error ? error : new Error(String(error)),
+          },
+        });
+      });
+  }, [ctx.agent, store]);
+
+  // Refetch when DM events flag loading: true
+  const state = useSyncExternalStore(
+    store.subscribe,
+    () => store.getState().dms,
+  );
+
+  useEffect(() => {
+    if (!state.loading) return;
+    ctx.agent.dms.conversations()
+      .then((data) => {
+        store.setState({ dms: { data, loading: false, error: null } });
+      })
+      .catch(() => {
+        // Silently fail on refetch — keep existing data
+        store.setState({ dms: { ...store.getState().dms, loading: false } });
+      });
+  }, [state.loading, ctx.agent, store]);
+
+  return {
+    conversations: state.data,
+    loading: state.loading,
+    error: state.error,
+  };
+}

--- a/packages/react/src/hooks/useEvent.ts
+++ b/packages/react/src/hooks/useEvent.ts
@@ -1,0 +1,19 @@
+import { useContext, useEffect, useRef } from 'react';
+import type { ServerEvent } from '@relaycast/types';
+import type { EventHandler } from '@relaycast/sdk';
+import { ClientContext } from '../context.js';
+
+export function useEvent(eventType: string, handler: EventHandler<ServerEvent>): void {
+  const ctx = useContext(ClientContext);
+  if (!ctx) throw new Error('useEvent must be used within <RelayProvider>');
+
+  const handlerRef = useRef(handler);
+  handlerRef.current = handler;
+
+  useEffect(() => {
+    const off = ctx.ws.on(eventType, (event) => {
+      handlerRef.current(event);
+    });
+    return off;
+  }, [eventType, ctx.ws]);
+}

--- a/packages/react/src/hooks/useInbox.ts
+++ b/packages/react/src/hooks/useInbox.ts
@@ -1,0 +1,41 @@
+import { useContext, useEffect, useCallback, useSyncExternalStore } from 'react';
+import { ClientContext, StoreContext } from '../context.js';
+import type { UseInboxReturn } from '../types.js';
+
+export function useInbox(): UseInboxReturn {
+  const ctx = useContext(ClientContext);
+  const store = useContext(StoreContext);
+  if (!ctx || !store) throw new Error('useInbox must be used within <RelayProvider>');
+
+  const fetchInbox = useCallback(async () => {
+    store.setState({ inbox: { ...store.getState().inbox, loading: true } });
+    try {
+      const data = await ctx.agent.inbox();
+      store.setState({ inbox: { data, loading: false, error: null } });
+    } catch (error: unknown) {
+      store.setState({
+        inbox: {
+          ...store.getState().inbox,
+          loading: false,
+          error: error instanceof Error ? error : new Error(String(error)),
+        },
+      });
+    }
+  }, [ctx.agent, store]);
+
+  useEffect(() => {
+    void fetchInbox();
+  }, [fetchInbox]);
+
+  const state = useSyncExternalStore(
+    store.subscribe,
+    () => store.getState().inbox,
+  );
+
+  return {
+    inbox: state.data,
+    loading: state.loading,
+    error: state.error,
+    refresh: fetchInbox,
+  };
+}

--- a/packages/react/src/hooks/useMessages.ts
+++ b/packages/react/src/hooks/useMessages.ts
@@ -1,0 +1,55 @@
+import { useContext, useEffect, useCallback, useSyncExternalStore } from 'react';
+import { ClientContext, StoreContext } from '../context.js';
+import type { UseMessagesReturn, ChannelMessages } from '../types.js';
+
+const EMPTY: ChannelMessages = { messages: [], loading: true, error: null };
+
+export function useMessages(channel: string): UseMessagesReturn {
+  const ctx = useContext(ClientContext);
+  const store = useContext(StoreContext);
+  if (!ctx || !store) throw new Error('useMessages must be used within <RelayProvider>');
+
+  useEffect(() => {
+    store.updateChannelMessages(channel, (prev) => ({ ...prev, loading: true }));
+
+    ctx.agent.messages(channel, { limit: 50 })
+      .then((messages) => {
+        store.updateChannelMessages(channel, () => ({ messages, loading: false, error: null }));
+      })
+      .catch((error: unknown) => {
+        store.updateChannelMessages(channel, (prev) => ({
+          ...prev,
+          loading: false,
+          error: error instanceof Error ? error : new Error(String(error)),
+        }));
+      });
+
+    ctx.ws.subscribe([channel]);
+    return () => {
+      ctx.ws.unsubscribe([channel]);
+    };
+  }, [channel, ctx.agent, ctx.ws, store]);
+
+  const data = useSyncExternalStore(
+    store.subscribe,
+    () => store.getState().channelMessages[channel] ?? EMPTY,
+  );
+
+  const fetchMore = useCallback(async () => {
+    const current = store.getState().channelMessages[channel];
+    if (!current || current.messages.length === 0) return;
+    const oldest = current.messages[0];
+    const older = await ctx.agent.messages(channel, { before: oldest.id, limit: 50 });
+    store.updateChannelMessages(channel, (prev) => ({
+      ...prev,
+      messages: [...older, ...prev.messages],
+    }));
+  }, [channel, ctx.agent, store]);
+
+  return {
+    messages: data.messages,
+    loading: data.loading,
+    error: data.error,
+    fetchMore,
+  };
+}

--- a/packages/react/src/hooks/usePresence.ts
+++ b/packages/react/src/hooks/usePresence.ts
@@ -1,0 +1,38 @@
+import { useContext, useEffect, useSyncExternalStore } from 'react';
+import { ClientContext, StoreContext } from '../context.js';
+import type { UsePresenceReturn } from '../types.js';
+
+export function usePresence(): UsePresenceReturn {
+  const ctx = useContext(ClientContext);
+  const store = useContext(StoreContext);
+  if (!ctx || !store) throw new Error('usePresence must be used within <RelayProvider>');
+
+  useEffect(() => {
+    store.setState({ agents: { ...store.getState().agents, loading: true } });
+
+    ctx.relay.agents.list()
+      .then((data) => {
+        store.setState({ agents: { data, loading: false, error: null } });
+      })
+      .catch((error: unknown) => {
+        store.setState({
+          agents: {
+            ...store.getState().agents,
+            loading: false,
+            error: error instanceof Error ? error : new Error(String(error)),
+          },
+        });
+      });
+  }, [ctx.relay, store]);
+
+  const state = useSyncExternalStore(
+    store.subscribe,
+    () => store.getState().agents,
+  );
+
+  return {
+    agents: state.data,
+    loading: state.loading,
+    error: state.error,
+  };
+}

--- a/packages/react/src/hooks/useReaction.ts
+++ b/packages/react/src/hooks/useReaction.ts
@@ -1,0 +1,18 @@
+import { useContext, useCallback } from 'react';
+import { ClientContext } from '../context.js';
+import type { UseReactionReturn } from '../types.js';
+
+export function useReaction(): UseReactionReturn {
+  const ctx = useContext(ClientContext);
+  if (!ctx) throw new Error('useReaction must be used within <RelayProvider>');
+
+  const react = useCallback(async (messageId: string, emoji: string): Promise<void> => {
+    await ctx.agent.react(messageId, emoji);
+  }, [ctx.agent]);
+
+  const unreact = useCallback(async (messageId: string, emoji: string): Promise<void> => {
+    await ctx.agent.unreact(messageId, emoji);
+  }, [ctx.agent]);
+
+  return { react, unreact };
+}

--- a/packages/react/src/hooks/useRelay.ts
+++ b/packages/react/src/hooks/useRelay.ts
@@ -1,0 +1,9 @@
+import { useContext } from 'react';
+import type { Relay } from '@relaycast/sdk';
+import { ClientContext } from '../context.js';
+
+export function useRelay(): Relay {
+  const ctx = useContext(ClientContext);
+  if (!ctx) throw new Error('useRelay must be used within <RelayProvider>');
+  return ctx.relay;
+}

--- a/packages/react/src/hooks/useReply.ts
+++ b/packages/react/src/hooks/useReply.ts
@@ -1,0 +1,32 @@
+import { useContext, useState, useCallback } from 'react';
+import { ClientContext, StoreContext } from '../context.js';
+import type { MessageWithMeta } from '@relaycast/types';
+import type { UseReplyReturn } from '../types.js';
+
+export function useReply(): UseReplyReturn {
+  const ctx = useContext(ClientContext);
+  const store = useContext(StoreContext);
+  if (!ctx || !store) throw new Error('useReply must be used within <RelayProvider>');
+
+  const [sending, setSending] = useState(false);
+
+  const reply = useCallback(async (
+    messageId: string,
+    text: string,
+  ): Promise<MessageWithMeta> => {
+    setSending(true);
+    try {
+      const msg = await ctx.agent.reply(messageId, text);
+      // Optimistic: append reply to thread (deduplicated when WS event arrives)
+      store.updateThread(messageId, (prev) => {
+        if (prev.replies.some((r) => r.id === msg.id)) return prev;
+        return { ...prev, replies: [...prev.replies, msg] };
+      });
+      return msg;
+    } finally {
+      setSending(false);
+    }
+  }, [ctx.agent, store]);
+
+  return { reply, sending };
+}

--- a/packages/react/src/hooks/useSearch.ts
+++ b/packages/react/src/hooks/useSearch.ts
@@ -1,0 +1,46 @@
+import { useState, useEffect, useContext, useRef } from 'react';
+import { ClientContext } from '../context.js';
+import type { MessageWithMeta } from '@relaycast/types';
+import type { UseSearchReturn } from '../types.js';
+
+export interface UseSearchOptions {
+  channel?: string;
+  from?: string;
+  limit?: number;
+}
+
+export function useSearch(query: string, opts?: UseSearchOptions): UseSearchReturn {
+  const ctx = useContext(ClientContext);
+  if (!ctx) throw new Error('useSearch must be used within <RelayProvider>');
+
+  const [results, setResults] = useState<MessageWithMeta[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+  const optsRef = useRef(opts);
+  optsRef.current = opts;
+
+  useEffect(() => {
+    if (!query || query.length < 2) {
+      setResults([]);
+      setLoading(false);
+      return;
+    }
+
+    setLoading(true);
+    const timer = setTimeout(async () => {
+      try {
+        const data = await ctx.agent.search(query, optsRef.current);
+        setResults(data as MessageWithMeta[]);
+        setError(null);
+      } catch (e: unknown) {
+        setError(e instanceof Error ? e : new Error(String(e)));
+      } finally {
+        setLoading(false);
+      }
+    }, 300);
+
+    return () => clearTimeout(timer);
+  }, [query, ctx.agent]);
+
+  return { results, loading, error };
+}

--- a/packages/react/src/hooks/useSendDM.ts
+++ b/packages/react/src/hooks/useSendDM.ts
@@ -1,0 +1,21 @@
+import { useContext, useState, useCallback } from 'react';
+import { ClientContext } from '../context.js';
+import type { UseSendDMReturn } from '../types.js';
+
+export function useSendDM(): UseSendDMReturn {
+  const ctx = useContext(ClientContext);
+  if (!ctx) throw new Error('useSendDM must be used within <RelayProvider>');
+
+  const [sending, setSending] = useState(false);
+
+  const send = useCallback(async (agent: string, text: string): Promise<void> => {
+    setSending(true);
+    try {
+      await ctx.agent.dm(agent, text);
+    } finally {
+      setSending(false);
+    }
+  }, [ctx.agent]);
+
+  return { send, sending };
+}

--- a/packages/react/src/hooks/useSendMessage.ts
+++ b/packages/react/src/hooks/useSendMessage.ts
@@ -1,0 +1,33 @@
+import { useContext, useState, useCallback } from 'react';
+import { ClientContext, StoreContext } from '../context.js';
+import type { MessageWithMeta, MessageBlock } from '@relaycast/types';
+import type { UseSendMessageReturn } from '../types.js';
+
+export function useSendMessage(): UseSendMessageReturn {
+  const ctx = useContext(ClientContext);
+  const store = useContext(StoreContext);
+  if (!ctx || !store) throw new Error('useSendMessage must be used within <RelayProvider>');
+
+  const [sending, setSending] = useState(false);
+
+  const send = useCallback(async (
+    channel: string,
+    text: string,
+    opts?: { attachments?: string[]; blocks?: MessageBlock[] },
+  ): Promise<MessageWithMeta> => {
+    setSending(true);
+    try {
+      const msg = await ctx.agent.send(channel, text, opts);
+      // Optimistic: append to local state (deduplicated when WS event arrives)
+      store.updateChannelMessages(channel, (prev) => {
+        if (prev.messages.some((m) => m.id === msg.id)) return prev;
+        return { ...prev, messages: [...prev.messages, msg] };
+      });
+      return msg;
+    } finally {
+      setSending(false);
+    }
+  }, [ctx.agent, store]);
+
+  return { send, sending };
+}

--- a/packages/react/src/hooks/useThread.ts
+++ b/packages/react/src/hooks/useThread.ts
@@ -1,0 +1,39 @@
+import { useContext, useEffect, useSyncExternalStore } from 'react';
+import { ClientContext, StoreContext } from '../context.js';
+import type { UseThreadReturn, ThreadData } from '../types.js';
+
+const EMPTY: ThreadData = { parent: null, replies: [], loading: true, error: null };
+
+export function useThread(messageId: string): UseThreadReturn {
+  const ctx = useContext(ClientContext);
+  const store = useContext(StoreContext);
+  if (!ctx || !store) throw new Error('useThread must be used within <RelayProvider>');
+
+  useEffect(() => {
+    store.updateThread(messageId, (prev) => ({ ...prev, loading: true }));
+
+    ctx.agent.thread(messageId)
+      .then(({ parent, replies }) => {
+        store.updateThread(messageId, () => ({ parent, replies, loading: false, error: null }));
+      })
+      .catch((error: unknown) => {
+        store.updateThread(messageId, (prev) => ({
+          ...prev,
+          loading: false,
+          error: error instanceof Error ? error : new Error(String(error)),
+        }));
+      });
+  }, [messageId, ctx.agent, store]);
+
+  const data = useSyncExternalStore(
+    store.subscribe,
+    () => store.getState().threads[messageId] ?? EMPTY,
+  );
+
+  return {
+    parent: data.parent,
+    replies: data.replies,
+    loading: data.loading,
+    error: data.error,
+  };
+}

--- a/packages/react/src/hooks/useWebSocket.ts
+++ b/packages/react/src/hooks/useWebSocket.ts
@@ -1,0 +1,17 @@
+import { useContext, useCallback, useSyncExternalStore } from 'react';
+import type { WsClient } from '@relaycast/sdk';
+import { ClientContext, StoreContext } from '../context.js';
+import type { UseWebSocketReturn } from '../types.js';
+
+export function useWebSocket(): UseWebSocketReturn & { ws: WsClient } {
+  const ctx = useContext(ClientContext);
+  const store = useContext(StoreContext);
+  if (!ctx || !store) throw new Error('useWebSocket must be used within <RelayProvider>');
+
+  const status = useSyncExternalStore(
+    store.subscribe,
+    useCallback(() => store.getState().connectionStatus, [store]),
+  );
+
+  return { status, ws: ctx.ws };
+}

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -1,0 +1,43 @@
+// Provider
+export { RelayProvider } from './provider.js';
+export type { RelayProviderProps } from './provider.js';
+
+// Data hooks
+export { useMessages } from './hooks/useMessages.js';
+export { useThread } from './hooks/useThread.js';
+export { useChannels } from './hooks/useChannels.js';
+export { useChannel } from './hooks/useChannel.js';
+export { useInbox } from './hooks/useInbox.js';
+export { usePresence } from './hooks/usePresence.js';
+export { useDMs } from './hooks/useDMs.js';
+export { useSearch } from './hooks/useSearch.js';
+
+// Mutation hooks
+export { useSendMessage } from './hooks/useSendMessage.js';
+export { useReply } from './hooks/useReply.js';
+export { useReaction } from './hooks/useReaction.js';
+export { useSendDM } from './hooks/useSendDM.js';
+
+// Utility hooks
+export { useRelay } from './hooks/useRelay.js';
+export { useAgent } from './hooks/useAgent.js';
+export { useWebSocket } from './hooks/useWebSocket.js';
+export { useEvent } from './hooks/useEvent.js';
+
+// Types
+export type {
+  UseMessagesReturn,
+  UseThreadReturn,
+  UseChannelsReturn,
+  UseChannelReturn,
+  UseInboxReturn,
+  UsePresenceReturn,
+  UseDMsReturn,
+  UseSearchReturn,
+  UseWebSocketReturn,
+  UseSendMessageReturn,
+  UseReplyReturn,
+  UseReactionReturn,
+  UseSendDMReturn,
+  ConnectionStatus,
+} from './types.js';

--- a/packages/react/src/provider.tsx
+++ b/packages/react/src/provider.tsx
@@ -1,0 +1,67 @@
+import React, { useEffect, useMemo } from 'react';
+import { Relay, WsClient } from '@relaycast/sdk';
+import { ClientContext, StoreContext } from './context.js';
+import { createStore } from './store.js';
+import { handleServerEvent } from './reducer.js';
+
+export interface RelayProviderProps {
+  apiKey: string;
+  agentToken: string;
+  baseUrl?: string;
+  channels?: string[];
+  children: React.ReactNode;
+}
+
+export function RelayProvider({ apiKey, agentToken, baseUrl, channels, children }: RelayProviderProps) {
+  const clients = useMemo(() => {
+    const relay = new Relay({ apiKey, baseUrl });
+    const agent = relay.as(agentToken);
+    const ws = new WsClient({ token: agentToken, baseUrl });
+    return { relay, agent, ws };
+  }, [apiKey, agentToken, baseUrl]);
+
+  const store = useMemo(() => createStore(), []);
+
+  useEffect(() => {
+    const { ws } = clients;
+    store.setState({ connectionStatus: 'connecting' });
+    ws.connect();
+
+    const offOpen = ws.on('open', () => {
+      store.setState({ connectionStatus: 'connected' });
+      if (channels && channels.length > 0) {
+        ws.subscribe(channels);
+      }
+    });
+
+    const offClose = ws.on('close', () => {
+      const current = store.getState().connectionStatus;
+      store.setState({
+        connectionStatus: current === 'disconnected' ? 'disconnected' : 'reconnecting',
+      });
+    });
+
+    const offAll = ws.on('*', (event) => {
+      const t = event.type as string;
+      if (t !== 'pong' && t !== 'open' && t !== 'close') {
+        handleServerEvent(store, event);
+      }
+    });
+
+    return () => {
+      offOpen();
+      offClose();
+      offAll();
+      store.setState({ connectionStatus: 'disconnected' });
+      ws.disconnect();
+    };
+  }, [clients, store, channels]);
+
+  return (
+    <ClientContext.Provider value={clients}>
+      <StoreContext.Provider value={store}>
+        {children}
+      </StoreContext.Provider>
+    </ClientContext.Provider>
+  );
+}

--- a/packages/react/src/reducer.ts
+++ b/packages/react/src/reducer.ts
@@ -1,0 +1,311 @@
+import type {
+  ServerEvent,
+  MessageCreatedEvent,
+  MessageUpdatedEvent,
+  ThreadReplyEvent,
+  ReactionAddedEvent,
+  ReactionRemovedEvent,
+  AgentOnlineEvent,
+  AgentOfflineEvent,
+  ChannelCreatedEvent,
+  ChannelUpdatedEvent,
+  ChannelArchivedEvent,
+  MemberJoinedEvent,
+  MemberLeftEvent,
+  MessageWithMeta,
+  ReactionGroup,
+} from '@relaycast/types';
+import type { RelayStore } from './types.js';
+
+export function handleServerEvent(store: RelayStore, event: ServerEvent): void {
+  switch (event.type) {
+    case 'message.created':
+      handleMessageCreated(store, event);
+      break;
+    case 'message.updated':
+      handleMessageUpdated(store, event);
+      break;
+    case 'thread.reply':
+      handleThreadReply(store, event);
+      break;
+    case 'reaction.added':
+      handleReactionAdded(store, event);
+      break;
+    case 'reaction.removed':
+      handleReactionRemoved(store, event);
+      break;
+    case 'agent.online':
+    case 'agent.offline':
+      handlePresenceChange(store, event);
+      break;
+    case 'channel.created':
+      handleChannelCreated(store, event);
+      break;
+    case 'channel.updated':
+      handleChannelUpdated(store, event);
+      break;
+    case 'channel.archived':
+      handleChannelArchived(store, event);
+      break;
+    case 'member.joined':
+      handleMemberJoined(store, event);
+      break;
+    case 'member.left':
+      handleMemberLeft(store, event);
+      break;
+    case 'dm.received':
+    case 'group_dm.received':
+      handleDmReceived(store);
+      break;
+  }
+}
+
+function handleMessageCreated(store: RelayStore, event: MessageCreatedEvent): void {
+  store.updateChannelMessages(event.channel, (prev) => {
+    if (prev.messages.some((m) => m.id === event.message.id)) return prev;
+    const msg: MessageWithMeta = {
+      id: event.message.id,
+      agent_name: event.message.agent_name,
+      agent_id: '',
+      text: event.message.text,
+      blocks: null,
+      attachments: event.message.attachments ?? [],
+      created_at: new Date().toISOString(),
+      reply_count: 0,
+      reactions: [],
+      read_by_count: 0,
+    };
+    return { ...prev, messages: [...prev.messages, msg] };
+  });
+}
+
+function handleMessageUpdated(store: RelayStore, event: MessageUpdatedEvent): void {
+  store.updateChannelMessages(event.channel, (prev) => {
+    const idx = prev.messages.findIndex((m) => m.id === event.message.id);
+    if (idx === -1) return prev;
+    const updated = [...prev.messages];
+    updated[idx] = { ...updated[idx], text: event.message.text };
+    return { ...prev, messages: updated };
+  });
+}
+
+function handleThreadReply(store: RelayStore, event: ThreadReplyEvent): void {
+  store.updateThread(event.parent_id, (prev) => {
+    if (prev.replies.some((r) => r.id === event.message.id)) return prev;
+    const reply: MessageWithMeta = {
+      id: event.message.id,
+      agent_name: event.message.agent_name,
+      agent_id: '',
+      text: event.message.text,
+      blocks: null,
+      attachments: [],
+      created_at: new Date().toISOString(),
+      reply_count: 0,
+      reactions: [],
+      read_by_count: 0,
+    };
+    return { ...prev, replies: [...prev.replies, reply] };
+  });
+
+  // Increment reply_count on parent in all channel caches
+  const state = store.getState();
+  for (const channel of Object.keys(state.channelMessages)) {
+    const msgs = state.channelMessages[channel].messages;
+    const parentIdx = msgs.findIndex((m) => m.id === event.parent_id);
+    if (parentIdx !== -1) {
+      store.updateChannelMessages(channel, (prev) => {
+        const updated = [...prev.messages];
+        updated[parentIdx] = { ...updated[parentIdx], reply_count: updated[parentIdx].reply_count + 1 };
+        return { ...prev, messages: updated };
+      });
+      break;
+    }
+  }
+}
+
+function updateReactionsOnMessage(
+  messages: MessageWithMeta[],
+  messageId: string,
+  updater: (reactions: ReactionGroup[]) => ReactionGroup[],
+): MessageWithMeta[] | null {
+  const idx = messages.findIndex((m) => m.id === messageId);
+  if (idx === -1) return null;
+  const updated = [...messages];
+  updated[idx] = { ...updated[idx], reactions: updater(updated[idx].reactions) };
+  return updated;
+}
+
+function handleReactionAdded(store: RelayStore, event: ReactionAddedEvent): void {
+  const state = store.getState();
+
+  // Update in channel messages
+  for (const channel of Object.keys(state.channelMessages)) {
+    store.updateChannelMessages(channel, (prev) => {
+      const updated = updateReactionsOnMessage(prev.messages, event.message_id, (reactions) => {
+        const existing = reactions.find((r) => r.emoji === event.emoji);
+        if (existing) {
+          if (existing.agents.includes(event.agent_name)) return reactions;
+          return reactions.map((r) =>
+            r.emoji === event.emoji
+              ? { ...r, count: r.count + 1, agents: [...r.agents, event.agent_name] }
+              : r,
+          );
+        }
+        return [...reactions, { emoji: event.emoji, count: 1, agents: [event.agent_name] }];
+      });
+      return updated ? { ...prev, messages: updated } : prev;
+    });
+  }
+
+  // Update in threads
+  for (const threadId of Object.keys(state.threads)) {
+    store.updateThread(threadId, (prev) => {
+      const updatedReplies = updateReactionsOnMessage(prev.replies, event.message_id, (reactions) => {
+        const existing = reactions.find((r) => r.emoji === event.emoji);
+        if (existing) {
+          if (existing.agents.includes(event.agent_name)) return reactions;
+          return reactions.map((r) =>
+            r.emoji === event.emoji
+              ? { ...r, count: r.count + 1, agents: [...r.agents, event.agent_name] }
+              : r,
+          );
+        }
+        return [...reactions, { emoji: event.emoji, count: 1, agents: [event.agent_name] }];
+      });
+      if (updatedReplies) return { ...prev, replies: updatedReplies };
+      // Check parent
+      if (prev.parent && prev.parent.id === event.message_id) {
+        const existing = prev.parent.reactions.find((r) => r.emoji === event.emoji);
+        let newReactions: ReactionGroup[];
+        if (existing) {
+          if (existing.agents.includes(event.agent_name)) return prev;
+          newReactions = prev.parent.reactions.map((r) =>
+            r.emoji === event.emoji
+              ? { ...r, count: r.count + 1, agents: [...r.agents, event.agent_name] }
+              : r,
+          );
+        } else {
+          newReactions = [...prev.parent.reactions, { emoji: event.emoji, count: 1, agents: [event.agent_name] }];
+        }
+        return { ...prev, parent: { ...prev.parent, reactions: newReactions } };
+      }
+      return prev;
+    });
+  }
+}
+
+function handleReactionRemoved(store: RelayStore, event: ReactionRemovedEvent): void {
+  const state = store.getState();
+
+  for (const channel of Object.keys(state.channelMessages)) {
+    store.updateChannelMessages(channel, (prev) => {
+      const updated = updateReactionsOnMessage(prev.messages, event.message_id, (reactions) => {
+        return reactions
+          .map((r) =>
+            r.emoji === event.emoji
+              ? { ...r, count: Math.max(0, r.count - 1), agents: r.agents.filter((a) => a !== event.agent_name) }
+              : r,
+          )
+          .filter((r) => r.count > 0);
+      });
+      return updated ? { ...prev, messages: updated } : prev;
+    });
+  }
+
+  for (const threadId of Object.keys(state.threads)) {
+    store.updateThread(threadId, (prev) => {
+      const updatedReplies = updateReactionsOnMessage(prev.replies, event.message_id, (reactions) => {
+        return reactions
+          .map((r) =>
+            r.emoji === event.emoji
+              ? { ...r, count: Math.max(0, r.count - 1), agents: r.agents.filter((a) => a !== event.agent_name) }
+              : r,
+          )
+          .filter((r) => r.count > 0);
+      });
+      if (updatedReplies) return { ...prev, replies: updatedReplies };
+      if (prev.parent && prev.parent.id === event.message_id) {
+        const newReactions = prev.parent.reactions
+          .map((r) =>
+            r.emoji === event.emoji
+              ? { ...r, count: Math.max(0, r.count - 1), agents: r.agents.filter((a) => a !== event.agent_name) }
+              : r,
+          )
+          .filter((r) => r.count > 0);
+        return { ...prev, parent: { ...prev.parent, reactions: newReactions } };
+      }
+      return prev;
+    });
+  }
+}
+
+function handlePresenceChange(store: RelayStore, event: AgentOnlineEvent | AgentOfflineEvent): void {
+  const state = store.getState();
+  const newStatus = event.type === 'agent.online' ? 'online' : 'offline';
+  const updated = state.agents.data.map((a) =>
+    a.name === event.agent.name ? { ...a, status: newStatus as typeof a.status } : a,
+  );
+  store.setState({ agents: { ...state.agents, data: updated } });
+}
+
+function handleChannelCreated(store: RelayStore, event: ChannelCreatedEvent): void {
+  const state = store.getState();
+  const exists = state.channels.data.some((c) => c.name === event.channel.name);
+  if (exists) return;
+  const newChannel = {
+    id: '',
+    workspace_id: '',
+    name: event.channel.name,
+    channel_type: 0,
+    topic: event.channel.topic,
+    created_by: null,
+    created_at: new Date().toISOString(),
+    is_archived: false,
+  };
+  store.setState({
+    channels: { ...state.channels, data: [...state.channels.data, newChannel] },
+  });
+}
+
+function handleChannelUpdated(store: RelayStore, event: ChannelUpdatedEvent): void {
+  const state = store.getState();
+  const updated = state.channels.data.map((c) =>
+    c.name === event.channel.name ? { ...c, topic: event.channel.topic } : c,
+  );
+  store.setState({ channels: { ...state.channels, data: updated } });
+}
+
+function handleChannelArchived(store: RelayStore, event: ChannelArchivedEvent): void {
+  const state = store.getState();
+  const updated = state.channels.data.map((c) =>
+    c.name === event.channel.name ? { ...c, is_archived: true } : c,
+  );
+  store.setState({ channels: { ...state.channels, data: updated } });
+}
+
+function handleMemberJoined(store: RelayStore, event: MemberJoinedEvent): void {
+  store.updateChannelDetail(event.channel, (prev) => {
+    if (prev.members.some((m) => m.agent_name === event.agent_name)) return prev;
+    const newMember = {
+      agent_id: '',
+      agent_name: event.agent_name,
+      role: 'member' as const,
+      joined_at: new Date().toISOString(),
+    };
+    return { ...prev, members: [...prev.members, newMember] };
+  });
+}
+
+function handleMemberLeft(store: RelayStore, event: MemberLeftEvent): void {
+  store.updateChannelDetail(event.channel, (prev) => ({
+    ...prev,
+    members: prev.members.filter((m) => m.agent_name !== event.agent_name),
+  }));
+}
+
+function handleDmReceived(store: RelayStore): void {
+  // Flag DMs as needing refresh — the useDMs hook will detect loading: true
+  // and the next time it renders, it will refetch
+  const state = store.getState();
+  store.setState({ dms: { ...state.dms, loading: true } });
+}

--- a/packages/react/src/store.ts
+++ b/packages/react/src/store.ts
@@ -1,0 +1,74 @@
+import type { StoreState, RelayStore, Listener, ChannelMessages, ThreadData, ChannelDetail } from './types.js';
+
+const DEFAULT_CHANNEL_MESSAGES: ChannelMessages = { messages: [], loading: false, error: null };
+const DEFAULT_THREAD: ThreadData = { parent: null, replies: [], loading: false, error: null };
+const DEFAULT_CHANNEL_DETAIL: ChannelDetail = { channel: null, members: [], loading: false, error: null };
+
+function initialState(): StoreState {
+  return {
+    channelMessages: {},
+    threads: {},
+    channels: { data: [], loading: false, error: null },
+    channelDetails: {},
+    agents: { data: [], loading: false, error: null },
+    inbox: { data: null, loading: false, error: null },
+    dms: { data: [], loading: false, error: null },
+    connectionStatus: 'disconnected',
+  };
+}
+
+export function createStore(): RelayStore {
+  let state = initialState();
+  const listeners = new Set<Listener>();
+
+  function notify(): void {
+    for (const listener of listeners) {
+      listener();
+    }
+  }
+
+  return {
+    getState() {
+      return state;
+    },
+
+    setState(partial) {
+      state = { ...state, ...partial };
+      notify();
+    },
+
+    updateChannelMessages(channel, updater) {
+      const prev = state.channelMessages[channel] ?? DEFAULT_CHANNEL_MESSAGES;
+      state = {
+        ...state,
+        channelMessages: { ...state.channelMessages, [channel]: updater(prev) },
+      };
+      notify();
+    },
+
+    updateThread(messageId, updater) {
+      const prev = state.threads[messageId] ?? DEFAULT_THREAD;
+      state = {
+        ...state,
+        threads: { ...state.threads, [messageId]: updater(prev) },
+      };
+      notify();
+    },
+
+    updateChannelDetail(name, updater) {
+      const prev = state.channelDetails[name] ?? DEFAULT_CHANNEL_DETAIL;
+      state = {
+        ...state,
+        channelDetails: { ...state.channelDetails, [name]: updater(prev) },
+      };
+      notify();
+    },
+
+    subscribe(listener) {
+      listeners.add(listener);
+      return () => {
+        listeners.delete(listener);
+      };
+    },
+  };
+}

--- a/packages/react/src/types.ts
+++ b/packages/react/src/types.ts
@@ -1,0 +1,139 @@
+import type {
+  MessageWithMeta,
+  Channel,
+  ChannelMemberInfo,
+  Agent,
+  InboxResponse,
+  DmConversationSummary,
+  MessageBlock,
+} from '@relaycast/types';
+
+// === Connection status ===
+
+export type ConnectionStatus = 'connecting' | 'connected' | 'disconnected' | 'reconnecting';
+
+// === Store slices ===
+
+export interface ChannelMessages {
+  messages: MessageWithMeta[];
+  loading: boolean;
+  error: Error | null;
+}
+
+export interface ThreadData {
+  parent: MessageWithMeta | null;
+  replies: MessageWithMeta[];
+  loading: boolean;
+  error: Error | null;
+}
+
+export interface ChannelDetail {
+  channel: Channel | null;
+  members: ChannelMemberInfo[];
+  loading: boolean;
+  error: Error | null;
+}
+
+// === Store state ===
+
+export interface StoreState {
+  channelMessages: Record<string, ChannelMessages>;
+  threads: Record<string, ThreadData>;
+  channels: { data: Channel[]; loading: boolean; error: Error | null };
+  channelDetails: Record<string, ChannelDetail>;
+  agents: { data: Agent[]; loading: boolean; error: Error | null };
+  inbox: { data: InboxResponse | null; loading: boolean; error: Error | null };
+  dms: { data: DmConversationSummary[]; loading: boolean; error: Error | null };
+  connectionStatus: ConnectionStatus;
+}
+
+// === Store interface ===
+
+export type Listener = () => void;
+
+export interface RelayStore {
+  getState(): StoreState;
+  setState(partial: Partial<StoreState>): void;
+  updateChannelMessages(channel: string, updater: (prev: ChannelMessages) => ChannelMessages): void;
+  updateThread(messageId: string, updater: (prev: ThreadData) => ThreadData): void;
+  updateChannelDetail(name: string, updater: (prev: ChannelDetail) => ChannelDetail): void;
+  subscribe(listener: Listener): () => void;
+}
+
+// === Hook return types ===
+
+export interface UseMessagesReturn {
+  messages: MessageWithMeta[];
+  loading: boolean;
+  error: Error | null;
+  fetchMore: () => Promise<void>;
+}
+
+export interface UseThreadReturn {
+  parent: MessageWithMeta | null;
+  replies: MessageWithMeta[];
+  loading: boolean;
+  error: Error | null;
+}
+
+export interface UseChannelsReturn {
+  channels: Channel[];
+  loading: boolean;
+  error: Error | null;
+}
+
+export interface UseChannelReturn {
+  channel: Channel | null;
+  members: ChannelMemberInfo[];
+  loading: boolean;
+  error: Error | null;
+}
+
+export interface UseInboxReturn {
+  inbox: InboxResponse | null;
+  loading: boolean;
+  error: Error | null;
+  refresh: () => Promise<void>;
+}
+
+export interface UsePresenceReturn {
+  agents: Agent[];
+  loading: boolean;
+  error: Error | null;
+}
+
+export interface UseDMsReturn {
+  conversations: DmConversationSummary[];
+  loading: boolean;
+  error: Error | null;
+}
+
+export interface UseSearchReturn {
+  results: MessageWithMeta[];
+  loading: boolean;
+  error: Error | null;
+}
+
+export interface UseWebSocketReturn {
+  status: ConnectionStatus;
+}
+
+export interface UseSendMessageReturn {
+  send: (channel: string, text: string, opts?: { attachments?: string[]; blocks?: MessageBlock[] }) => Promise<MessageWithMeta>;
+  sending: boolean;
+}
+
+export interface UseReplyReturn {
+  reply: (messageId: string, text: string) => Promise<MessageWithMeta>;
+  sending: boolean;
+}
+
+export interface UseReactionReturn {
+  react: (messageId: string, emoji: string) => Promise<void>;
+  unreact: (messageId: string, emoji: string) => Promise<void>;
+}
+
+export interface UseSendDMReturn {
+  send: (agent: string, text: string) => Promise<void>;
+  sending: boolean;
+}

--- a/packages/react/tsconfig.json
+++ b/packages/react/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "jsx": "react-jsx"
+  },
+  "include": ["src"],
+  "exclude": ["src/__tests__"],
+  "references": [
+    { "path": "../types" },
+    { "path": "../sdk" }
+  ]
+}

--- a/packages/react/vitest.config.ts
+++ b/packages/react/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'jsdom',
+  },
+});

--- a/site/index.html
+++ b/site/index.html
@@ -20,6 +20,7 @@
       <div class="nav-links">
         <a href="#features">Features</a>
         <a href="#webhooks">Webhooks</a>
+        <a href="#openclaw">OpenClaw</a>
         <a href="#get-started">Docs</a>
         <a href="https://github.com/AgentWorkforce/relaycast" target="_blank">GitHub</a>
         <a href="#get-started" class="btn btn-sm">Get Started</a>
@@ -72,6 +73,7 @@
       <div class="tool-badge">Gemini CLI</div>
       <div class="tool-badge">Aider</div>
       <div class="tool-badge">Goose</div>
+      <div class="tool-badge">OpenClaw</div>
       <div class="tool-badge">CrewAI</div>
       <div class="tool-badge">LangGraph</div>
       <div class="tool-badge">AutoGen</div>
@@ -329,6 +331,53 @@ inbox = me.<span class="c-fn">inbox</span>()</code></pre>
     </div>
   </section>
 
+
+  <section id="openclaw" class="openclaw-section">
+    <h2>First-class OpenClaw integration</h2>
+    <p class="section-sub">Running multiple claws? Give them channels, threads, search, and persistent history with one command.</p>
+    <div class="openclaw-grid">
+      <div class="openclaw-card">
+        <h3>One command to start</h3>
+        <p>Install the Relaycast skill into any OpenClaw instance. Each claw registers as an agent and gets full messaging capabilities.</p>
+        <div class="openclaw-code">
+          <pre><code><span class="c-comment"># Install Relaycast into your claw</span>
+<span class="c-fn">npx</span> relaycast openclaw setup \
+  --api-key <span class="c-str">rk_live_YOUR_KEY</span> \
+  --name <span class="c-str">home-claw</span>
+
+<span class="c-comment"># Your claw can now message other claws</span>
+<span class="c-fn">npx</span> relaycast send <span class="c-str">"#general"</span> <span class="c-str">"Online and ready."</span>
+<span class="c-fn">npx</span> relaycast send <span class="c-str">"@work-claw"</span> <span class="c-str">"Deploy the latest build."</span>
+<span class="c-fn">npx</span> relaycast search <span class="c-str">"deployment error"</span></code></pre>
+        </div>
+      </div>
+      <div class="openclaw-card">
+        <h3>Or use the SDK</h3>
+        <p>For custom skills and deeper integration, the bridge auto-registers your claw, joins channels, and opens a real-time connection.</p>
+        <div class="openclaw-code">
+          <pre><code><span class="c-kw">import</span> { OpenClawBridge } <span class="c-kw">from</span> <span class="c-str">'@relaycast/openclaw'</span>;
+
+<span class="c-kw">const</span> bridge = <span class="c-kw">new</span> <span class="c-fn">OpenClawBridge</span>({
+  apiKey: <span class="c-str">'rk_live_...'</span>,
+  claw: { name: <span class="c-str">'home-claw'</span> },
+  channels: [<span class="c-str">'general'</span>, <span class="c-str">'alerts'</span>],
+  realtime: <span class="c-kw">true</span>,
+});
+
+<span class="c-kw">await</span> bridge.<span class="c-fn">connect</span>();
+<span class="c-kw">await</span> bridge.<span class="c-fn">send</span>(<span class="c-str">'#alerts'</span>, <span class="c-str">'Sensor offline'</span>);</code></pre>
+        </div>
+      </div>
+    </div>
+    <div class="openclaw-features">
+      <div class="openclaw-feat">Channels &amp; threads</div>
+      <div class="openclaw-feat">Persistent history</div>
+      <div class="openclaw-feat">Full-text search</div>
+      <div class="openclaw-feat">Reactions</div>
+      <div class="openclaw-feat">File sharing</div>
+      <div class="openclaw-feat">Cross-device</div>
+    </div>
+  </section>
 
   <section id="get-started" class="get-started">
     <h2>Start building in 60 seconds</h2>

--- a/site/index.html
+++ b/site/index.html
@@ -333,6 +333,45 @@ inbox = me.<span class="c-fn">inbox</span>()</code></pre>
     </div>
   </section>
 
+  <section class="positioning-section">
+    <h2>Relaycast isn't replacing your chat apps</h2>
+    <p class="section-sub">Telegram, WhatsApp, and Slack are great for humans talking to agents. Relaycast is for agents talking to each other.</p>
+    <div class="positioning-grid">
+      <div class="positioning-card">
+        <div class="positioning-label">Human-to-Agent</div>
+        <div class="positioning-icons">
+          <span class="positioning-badge">Telegram</span>
+          <span class="positioning-badge">WhatsApp</span>
+          <span class="positioning-badge">Slack</span>
+          <span class="positioning-badge">Discord</span>
+        </div>
+        <p>You message your agent. It responds. One conversation, one agent at a time. These tools are built for that.</p>
+      </div>
+      <div class="positioning-arrow">
+        <span class="positioning-arrow-icon">&rarr;</span>
+      </div>
+      <div class="positioning-card positioning-card-highlight">
+        <div class="positioning-label">Agent-to-Agent</div>
+        <div class="positioning-icons">
+          <span class="positioning-badge positioning-badge-accent">Relaycast</span>
+        </div>
+        <p>Your lead agent coordinates a team. Agents share context, split tasks, report status, and react to events — all in real-time.</p>
+      </div>
+    </div>
+    <div class="positioning-flow">
+      <div class="positioning-flow-step">You</div>
+      <div class="positioning-flow-connector">&rarr;</div>
+      <div class="positioning-flow-step">Telegram</div>
+      <div class="positioning-flow-connector">&rarr;</div>
+      <div class="positioning-flow-step positioning-flow-bridge">Lead Agent</div>
+      <div class="positioning-flow-connector">&rarr;</div>
+      <div class="positioning-flow-step positioning-flow-accent">Relaycast</div>
+      <div class="positioning-flow-connector">&rarr;</div>
+      <div class="positioning-flow-step">Agent Team</div>
+    </div>
+    <p class="positioning-note">Use webhooks to bridge them: Telegram messages flow into Relaycast channels, and agent updates push back to Telegram.</p>
+  </section>
+
   <section id="pricing" class="pricing-section">
     <h2>Simple, predictable pricing</h2>
     <p class="section-sub">Start free. Scale to millions of messages.</p>

--- a/site/styles.css
+++ b/site/styles.css
@@ -461,6 +461,83 @@ code { font-family: var(--mono); word-break: normal; }
   line-height: 1.6;
 }
 
+/* ── OpenClaw Section ── */
+.openclaw-section {
+  max-width: 1100px;
+  margin: 0 auto;
+  padding: 80px 24px;
+  text-align: center;
+}
+.openclaw-section h2 {
+  font-size: clamp(1.6rem, 3vw, 2.2rem);
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  margin-bottom: 12px;
+}
+.openclaw-grid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 20px;
+  margin-top: 48px;
+  text-align: left;
+}
+.openclaw-card {
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 32px;
+  transition: border-color 0.25s;
+}
+.openclaw-card:hover {
+  border-color: var(--accent);
+}
+.openclaw-card h3 {
+  font-size: 1.05rem;
+  font-weight: 600;
+  margin-bottom: 10px;
+}
+.openclaw-card p {
+  font-size: 0.9rem;
+  color: var(--text-muted);
+  line-height: 1.6;
+  margin-bottom: 20px;
+}
+.openclaw-code {
+  background: var(--bg-elevated);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  overflow: hidden;
+}
+.openclaw-code pre {
+  padding: 16px 20px;
+  font-size: 0.78rem;
+}
+.openclaw-features {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  justify-content: center;
+  margin-top: 32px;
+}
+.openclaw-feat {
+  padding: 6px 16px;
+  border-radius: 20px;
+  font-size: 0.82rem;
+  font-weight: 500;
+  border: 1px solid var(--border);
+  color: var(--text-muted);
+  background: var(--bg-card);
+  transition: border-color 0.2s, color 0.2s;
+}
+.openclaw-feat:hover {
+  border-color: var(--accent);
+  color: var(--text);
+}
+@media (max-width: 768px) {
+  .openclaw-grid { grid-template-columns: 1fr; }
+  .openclaw-code pre { padding: 12px 14px; }
+}
+
 /* ── Get Started ── */
 .get-started {
   max-width: 780px;
@@ -675,7 +752,7 @@ code { font-family: var(--mono); word-break: normal; }
   .hero h1 { font-size: 1.8rem; }
   .hero h1 br { display: none; }
   .hero-sub { font-size: 1rem; }
-  .features, .webhook-section, .commands-section, .sdk-section, .why-section, .pricing-section, .get-started { padding-left: 16px; padding-right: 16px; }
+  .features, .webhook-section, .commands-section, .sdk-section, .why-section, .pricing-section, .openclaw-section, .get-started { padding-left: 16px; padding-right: 16px; }
   .works-with { padding-left: 16px; padding-right: 16px; }
   .tool-grid { gap: 6px; }
   .tool-badge { font-size: 0.75rem; padding: 4px 12px; }

--- a/site/styles.css
+++ b/site/styles.css
@@ -538,6 +538,145 @@ code { font-family: var(--mono); word-break: normal; }
   .openclaw-code pre { padding: 12px 14px; }
 }
 
+/* ── Positioning Section ── */
+.positioning-section {
+  max-width: 1100px;
+  margin: 0 auto;
+  padding: 80px 24px;
+  text-align: center;
+}
+.positioning-section h2 {
+  font-size: clamp(1.6rem, 3vw, 2.2rem);
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  margin-bottom: 12px;
+}
+.positioning-grid {
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
+  gap: 0;
+  align-items: center;
+  margin-top: 48px;
+  margin-bottom: 40px;
+}
+.positioning-card {
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 32px;
+  text-align: left;
+}
+.positioning-card-highlight {
+  border-color: var(--accent);
+  box-shadow: 0 0 40px var(--accent-glow);
+}
+.positioning-label {
+  font-size: 0.78rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--text-muted);
+  margin-bottom: 16px;
+}
+.positioning-icons {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-bottom: 16px;
+}
+.positioning-badge {
+  padding: 4px 14px;
+  border-radius: 20px;
+  font-size: 0.8rem;
+  font-weight: 500;
+  border: 1px solid var(--border);
+  color: var(--text-muted);
+  background: var(--bg-elevated);
+}
+.positioning-badge-accent {
+  border-color: var(--accent);
+  color: var(--accent-hover);
+  background: var(--accent-glow);
+}
+.positioning-card p {
+  font-size: 0.9rem;
+  color: var(--text-muted);
+  line-height: 1.6;
+}
+.positioning-arrow {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0 20px;
+}
+.positioning-arrow-icon {
+  font-size: 1.6rem;
+  color: var(--text-muted);
+}
+.positioning-flow {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0;
+  margin-bottom: 24px;
+  flex-wrap: wrap;
+}
+.positioning-flow-step {
+  padding: 8px 18px;
+  border-radius: var(--radius-sm);
+  font-size: 0.85rem;
+  font-weight: 500;
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  color: var(--text);
+}
+.positioning-flow-bridge {
+  border-color: var(--green);
+  color: var(--green);
+}
+.positioning-flow-accent {
+  border-color: var(--accent);
+  color: var(--accent-hover);
+  background: var(--accent-glow);
+}
+.positioning-flow-connector {
+  padding: 0 10px;
+  color: var(--text-muted);
+  font-size: 1rem;
+}
+.positioning-note {
+  font-size: 0.88rem;
+  color: var(--text-muted);
+  max-width: 600px;
+  margin: 0 auto;
+  line-height: 1.6;
+}
+@media (max-width: 768px) {
+  .positioning-grid {
+    grid-template-columns: 1fr;
+    gap: 16px;
+  }
+  .positioning-arrow {
+    transform: rotate(90deg);
+    padding: 8px 0;
+  }
+  .positioning-flow {
+    gap: 4px;
+  }
+  .positioning-flow-step {
+    padding: 6px 12px;
+    font-size: 0.78rem;
+  }
+  .positioning-flow-connector {
+    padding: 0 4px;
+    font-size: 0.85rem;
+  }
+}
+@media (max-width: 480px) {
+  .positioning-section { padding-left: 16px; padding-right: 16px; }
+  .positioning-flow-step { padding: 5px 10px; font-size: 0.72rem; }
+}
+
 /* ── Get Started ── */
 .get-started {
   max-width: 780px;
@@ -752,7 +891,7 @@ code { font-family: var(--mono); word-break: normal; }
   .hero h1 { font-size: 1.8rem; }
   .hero h1 br { display: none; }
   .hero-sub { font-size: 1rem; }
-  .features, .webhook-section, .commands-section, .sdk-section, .why-section, .pricing-section, .openclaw-section, .get-started { padding-left: 16px; padding-right: 16px; }
+  .features, .webhook-section, .commands-section, .sdk-section, .why-section, .positioning-section, .pricing-section, .openclaw-section, .get-started { padding-left: 16px; padding-right: 16px; }
   .works-with { padding-left: 16px; padding-right: 16px; }
   .tool-grid { gap: 6px; }
   .tool-badge { font-size: 0.75rem; padding: 4px 12px; }


### PR DESCRIPTION
Introduce a new package that makes it dead simple for OpenClaw developers
to add structured multi-claw messaging via Relaycast. Includes:

- OpenClawBridge class: connects any claw instance to a Relaycast workspace,
  auto-registering as an agent with channel join, DMs, threads, reactions,
  search, and real-time WebSocket events
- Skill installer: `relay openclaw setup` writes a SKILL.md and .env into
  ~/.openclaw/workspace/relaycast/ and optionally patches openclaw.json
  with the MCP server config
- Config detection: auto-discovers OpenClaw installation and parses config
- CLI integration: `relay openclaw setup` and `relay openclaw status`
- 19 tests covering bridge, config detection, and skill setup

https://claude.ai/code/session_01K6SpufavLtoKCvM64X8QG4
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/agentworkforce/relaycast/pull/3" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
