### PR TITLE
api/sdk: optional Idempotency-Key support for messaging writes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,5 @@ __pycache__/
 *.egg-info/
 .venv/
 .pytest_cache/
+
+.npm-cache

--- a/README.md
+++ b/README.md
@@ -152,6 +152,17 @@ Two token types:
 
 Header: `Authorization: Bearer <token>`
 
+Optional for safe retries on write endpoints:
+`Idempotency-Key: <client-generated-key>`
+
+Idempotency keys are supported for:
+- `POST /v1/channels/:name/messages`
+- `POST /v1/messages/:id/replies`
+- `POST /v1/dm`
+- `POST /v1/dm/:conversation_id/messages`
+
+If the same key is retried with the same payload, Relaycast returns the original response and sets `Idempotency-Replayed: true`. If reused with a different payload, Relaycast returns `409 idempotency_key_reused`.
+
 ### Core Endpoints
 
 ```

--- a/packages/sdk/src/__tests__/agent-messaging.test.ts
+++ b/packages/sdk/src/__tests__/agent-messaging.test.ts
@@ -60,6 +60,15 @@ describe('AgentClient', () => {
       const [, init] = mockFetch.mock.calls[0]!;
       expect(init.body).toBe(JSON.stringify({ text: 'hello', attachments: ['att_1', 'att_2'] }));
     });
+
+    it('forwards Idempotency-Key when provided', async () => {
+      mockFetch.mockImplementation(() => mockResponse({ id: 'm_1' }));
+
+      await me.send('#general', 'hello', { idempotencyKey: 'msg-key-1' });
+
+      const [, init] = mockFetch.mock.calls[0]!;
+      expect((init.headers as Record<string, string>)['Idempotency-Key']).toBe('msg-key-1');
+    });
   });
 
   describe('messages()', () => {
@@ -118,6 +127,15 @@ describe('AgentClient', () => {
       expect(init.method).toBe('POST');
       expect(init.body).toBe(JSON.stringify({ text: 'reply' }));
     });
+
+    it('forwards Idempotency-Key when provided', async () => {
+      mockFetch.mockImplementation(() => mockResponse({ id: 'm_2' }));
+
+      await me.reply('m_1', 'reply', { idempotencyKey: 'reply-key-1' });
+
+      const [, init] = mockFetch.mock.calls[0]!;
+      expect((init.headers as Record<string, string>)['Idempotency-Key']).toBe('reply-key-1');
+    });
   });
 
   describe('thread()', () => {
@@ -153,6 +171,15 @@ describe('AgentClient', () => {
       expect(url).toBe('https://api.agentrelay.dev/v1/dm');
       expect(init.method).toBe('POST');
       expect(init.body).toBe(JSON.stringify({ to: 'Worker-1', text: 'hi' }));
+    });
+
+    it('forwards Idempotency-Key when provided', async () => {
+      mockFetch.mockImplementation(() => mockResponse({ id: 'dm_1' }));
+
+      await me.dm('Worker-1', 'hi', { idempotencyKey: 'dm-key-1' });
+
+      const [, init] = mockFetch.mock.calls[0]!;
+      expect((init.headers as Record<string, string>)['Idempotency-Key']).toBe('dm-key-1');
     });
   });
 
@@ -210,6 +237,15 @@ describe('AgentClient', () => {
       expect(init.body).toBe(JSON.stringify({ text: 'hello' }));
     });
 
+    it('sendMessage() forwards Idempotency-Key when provided', async () => {
+      mockFetch.mockImplementation(() => mockResponse({ id: 'm_2' }));
+
+      await me.dms.sendMessage('c_1', 'hello', { idempotencyKey: 'gdm-key-1' });
+
+      const [, init] = mockFetch.mock.calls[0]!;
+      expect((init.headers as Record<string, string>)['Idempotency-Key']).toBe('gdm-key-1');
+    });
+
     it('addParticipant() adds agent', async () => {
       mockFetch.mockImplementation(() => mockResponse({ ok: true }));
 
@@ -233,4 +269,3 @@ describe('AgentClient', () => {
     });
   });
 });
-

--- a/packages/sdk/src/agent.ts
+++ b/packages/sdk/src/agent.ts
@@ -20,10 +20,19 @@ import type {
   InvokeCommandRequest,
   CommandInvocation,
 } from '@relaycast/types';
-import { HttpClient } from './client.js';
+import { HttpClient, type RequestOptions } from './client.js';
 
 function stripHash(channel: string): string {
   return channel.startsWith('#') ? channel.slice(1) : channel;
+}
+
+interface IdempotencyOption {
+  idempotencyKey?: string;
+}
+
+function idempotencyHeaders(opts?: IdempotencyOption): RequestOptions | undefined {
+  if (!opts?.idempotencyKey) return undefined;
+  return { headers: { 'Idempotency-Key': opts.idempotencyKey } };
 }
 
 export class AgentClient {
@@ -38,13 +47,18 @@ export class AgentClient {
   async send(
     channel: string,
     text: string,
-    opts?: { attachments?: string[]; blocks?: MessageBlock[] },
+    opts?: { attachments?: string[]; blocks?: MessageBlock[]; idempotencyKey?: string },
   ): Promise<MessageWithMeta> {
     const name = stripHash(channel);
-    const body: PostMessageRequest = { text, ...opts };
+    const body: PostMessageRequest = {
+      text,
+      ...(opts?.attachments ? { attachments: opts.attachments } : {}),
+      ...(opts?.blocks ? { blocks: opts.blocks } : {}),
+    };
     return this.client.post(
       `/v1/channels/${encodeURIComponent(name)}/messages`,
       body,
+      idempotencyHeaders(opts),
     );
   }
 
@@ -70,12 +84,16 @@ export class AgentClient {
   async reply(
     id: string,
     text: string,
-    opts?: { blocks?: MessageBlock[] },
+    opts?: { blocks?: MessageBlock[]; idempotencyKey?: string },
   ): Promise<MessageWithMeta> {
-    const body: ThreadReplyRequest = { text, ...opts };
+    const body: ThreadReplyRequest = {
+      text,
+      ...(opts?.blocks ? { blocks: opts.blocks } : {}),
+    };
     return this.client.post(
       `/v1/messages/${encodeURIComponent(id)}/replies`,
       body,
+      idempotencyHeaders(opts),
     );
   }
 
@@ -95,9 +113,9 @@ export class AgentClient {
 
   // === DMs ===
 
-  async dm(agent: string, text: string): Promise<unknown> {
+  async dm(agent: string, text: string, opts?: IdempotencyOption): Promise<unknown> {
     const body: SendDmRequest = { to: agent, text };
-    return this.client.post('/v1/dm', body);
+    return this.client.post('/v1/dm', body, idempotencyHeaders(opts));
   }
 
   dms = {
@@ -121,10 +139,15 @@ export class AgentClient {
     createGroup: (opts: CreateGroupDmRequest): Promise<unknown> =>
       this.client.post('/v1/dm/group', opts),
 
-    sendMessage: (conversationId: string, text: string): Promise<unknown> =>
+    sendMessage: (
+      conversationId: string,
+      text: string,
+      opts?: IdempotencyOption,
+    ): Promise<unknown> =>
       this.client.post(
         `/v1/dm/${encodeURIComponent(conversationId)}/messages`,
         { text },
+        idempotencyHeaders(opts),
       ),
 
     addParticipant: (

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -5,6 +5,10 @@ export interface ClientOptions {
   baseUrl?: string;
 }
 
+export interface RequestOptions {
+  headers?: Record<string, string>;
+}
+
 export class RelayError extends Error {
   code: string;
   status: number;
@@ -42,6 +46,7 @@ export class HttpClient {
     path: string,
     body?: unknown,
     query?: Record<string, string>,
+    options?: RequestOptions,
   ): Promise<T> {
     const url = new URL(path, this._baseUrl);
     if (query) {
@@ -53,6 +58,7 @@ export class HttpClient {
     const headers: Record<string, string> = {
       Authorization: `Bearer ${this.apiKey}`,
       'X-SDK-Version': SDK_VERSION,
+      ...(options?.headers || {}),
     };
 
     const hasBody = body !== undefined && method.toUpperCase() !== 'GET';
@@ -96,20 +102,19 @@ export class HttpClient {
     }
   }
 
-  get<T>(path: string, query?: Record<string, string>): Promise<T> {
-    return this.request<T>('GET', path, undefined, query);
+  get<T>(path: string, query?: Record<string, string>, options?: RequestOptions): Promise<T> {
+    return this.request<T>('GET', path, undefined, query, options);
   }
 
-  post<T>(path: string, body?: unknown): Promise<T> {
-    return this.request<T>('POST', path, body);
+  post<T>(path: string, body?: unknown, options?: RequestOptions): Promise<T> {
+    return this.request<T>('POST', path, body, undefined, options);
   }
 
-  patch<T>(path: string, body?: unknown): Promise<T> {
-    return this.request<T>('PATCH', path, body);
+  patch<T>(path: string, body?: unknown, options?: RequestOptions): Promise<T> {
+    return this.request<T>('PATCH', path, body, undefined, options);
   }
 
-  async delete(path: string): Promise<void> {
-    await this.request<unknown>('DELETE', path);
+  async delete(path: string, options?: RequestOptions): Promise<void> {
+    await this.request<unknown>('DELETE', path, undefined, undefined, options);
   }
 }
-

--- a/packages/server/src/middleware/__tests__/idempotency.test.ts
+++ b/packages/server/src/middleware/__tests__/idempotency.test.ts
@@ -1,0 +1,139 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { parseIdempotencyKey, runIdempotent } from '../idempotency.js';
+
+const store = new Map<string, string>();
+
+const mockRedis = {
+  get: vi.fn(async (key: string) => store.get(key) ?? null),
+  set: vi.fn(async (key: string, value: string, ...args: unknown[]) => {
+    const useNx = args.includes('NX');
+    if (useNx && store.has(key)) {
+      return null;
+    }
+    store.set(key, value);
+    return 'OK';
+  }),
+  del: vi.fn(async (key: string) => {
+    store.delete(key);
+    return 1;
+  }),
+};
+
+vi.mock('../../redis/index.js', () => ({
+  getRedis: vi.fn(() => mockRedis),
+}));
+
+describe('idempotency middleware helpers', () => {
+  beforeEach(() => {
+    store.clear();
+    vi.clearAllMocks();
+  });
+
+  describe('parseIdempotencyKey()', () => {
+    it('returns undefined when header is absent', () => {
+      const req = { header: vi.fn(() => undefined) } as any;
+      expect(parseIdempotencyKey(req)).toEqual({});
+    });
+
+    it('rejects empty key', () => {
+      const req = { header: vi.fn(() => '   ') } as any;
+      expect(parseIdempotencyKey(req).error).toContain('cannot be empty');
+    });
+
+    it('accepts visible ASCII key', () => {
+      const req = { header: vi.fn(() => 'abc-123:_KEY') } as any;
+      expect(parseIdempotencyKey(req)).toEqual({ key: 'abc-123:_KEY' });
+    });
+  });
+
+  describe('runIdempotent()', () => {
+    it('runs operation directly when no key is provided', async () => {
+      const op = vi.fn(async () => ({ id: 'm1' }));
+
+      const a = await runIdempotent({
+        workspaceId: 'ws1',
+        actorId: 'a1',
+        scope: 'dm:direct',
+        operation: op,
+      });
+      const b = await runIdempotent({
+        workspaceId: 'ws1',
+        actorId: 'a1',
+        scope: 'dm:direct',
+        operation: op,
+      });
+
+      expect(a.replayed).toBe(false);
+      expect(b.replayed).toBe(false);
+      expect(op).toHaveBeenCalledTimes(2);
+    });
+
+    it('replays stored response for same key and fingerprint', async () => {
+      const op = vi.fn(async () => ({ id: 'm1' }));
+
+      const first = await runIdempotent({
+        workspaceId: 'ws1',
+        actorId: 'a1',
+        scope: 'channel:general',
+        key: 'idem-1',
+        fingerprint: '{"text":"hello"}',
+        operation: op,
+      });
+
+      const second = await runIdempotent({
+        workspaceId: 'ws1',
+        actorId: 'a1',
+        scope: 'channel:general',
+        key: 'idem-1',
+        fingerprint: '{"text":"hello"}',
+        operation: op,
+      });
+
+      expect(first.replayed).toBe(false);
+      expect(second.replayed).toBe(true);
+      expect(second.data).toEqual(first.data);
+      expect(op).toHaveBeenCalledTimes(1);
+    });
+
+    it('rejects same key reused with different fingerprint', async () => {
+      const op = vi.fn(async () => ({ id: 'm1' }));
+
+      await runIdempotent({
+        workspaceId: 'ws1',
+        actorId: 'a1',
+        scope: 'channel:general',
+        key: 'idem-1',
+        fingerprint: '{"text":"hello"}',
+        operation: op,
+      });
+
+      await expect(
+        runIdempotent({
+          workspaceId: 'ws1',
+          actorId: 'a1',
+          scope: 'channel:general',
+          key: 'idem-1',
+          fingerprint: '{"text":"different"}',
+          operation: op,
+        }),
+      ).rejects.toMatchObject({ code: 'idempotency_key_reused', status: 409 });
+    });
+
+    it('returns conflict when same key is currently processing', async () => {
+      const setSpy = vi.spyOn(mockRedis, 'set');
+      // First SET is lock acquisition, force lock miss (already in progress)
+      setSpy.mockResolvedValueOnce(null as any);
+
+      await expect(
+        runIdempotent({
+          workspaceId: 'ws1',
+          actorId: 'a1',
+          scope: 'channel:general',
+          key: 'idem-1',
+          fingerprint: '{"text":"hello"}',
+          operation: async () => ({ id: 'm1' }),
+        }),
+      ).rejects.toMatchObject({ code: 'idempotency_in_progress', status: 409 });
+    });
+  });
+});

--- a/packages/server/src/middleware/idempotency.ts
+++ b/packages/server/src/middleware/idempotency.ts
@@ -1,0 +1,193 @@
+import type { Request } from 'express';
+import { createHash } from 'node:crypto';
+import { getRedis } from '../redis/index.js';
+
+const IDEMPOTENCY_TTL_SECONDS = 24 * 60 * 60;
+const IDEMPOTENCY_LOCK_TTL_SECONDS = 30;
+const IDEMPOTENCY_KEY_MAX_LENGTH = 255;
+
+interface StoredIdempotencyRecord<T> {
+  status: number;
+  data: T;
+  fingerprint?: string;
+}
+
+export interface IdempotentResult<T> {
+  status: number;
+  data: T;
+  replayed: boolean;
+}
+
+interface RunIdempotentOptions<T> {
+  workspaceId: string;
+  actorId: string;
+  scope: string;
+  key?: string;
+  status?: number;
+  fingerprint?: string;
+  ttlSeconds?: number;
+  operation: () => Promise<T>;
+}
+
+function buildKey(workspaceId: string, actorId: string, scope: string, key: string): string {
+  const digest = createHash('sha256').update(key).digest('hex');
+  const scopeDigest = createHash('sha256').update(scope).digest('hex').slice(0, 16);
+  return `idem:v1:${workspaceId}:${actorId}:${scopeDigest}:${digest}`;
+}
+
+export function parseIdempotencyKey(req: Request): { key?: string; error?: string } {
+  const raw = req.header('Idempotency-Key');
+  if (raw === undefined) {
+    return {};
+  }
+
+  const key = raw.trim();
+  if (!key) {
+    return { error: 'Idempotency-Key cannot be empty' };
+  }
+
+  if (key.length > IDEMPOTENCY_KEY_MAX_LENGTH) {
+    return {
+      error: `Idempotency-Key must be ${IDEMPOTENCY_KEY_MAX_LENGTH} characters or fewer`,
+    };
+  }
+
+  // Restrict to visible ASCII (no whitespace/control chars)
+  if (/[^\x21-\x7E]/.test(key)) {
+    return {
+      error: 'Idempotency-Key must contain only visible ASCII characters',
+    };
+  }
+
+  return { key };
+}
+
+export async function runIdempotent<T>(
+  options: RunIdempotentOptions<T>,
+): Promise<IdempotentResult<T>> {
+  const {
+    workspaceId,
+    actorId,
+    scope,
+    key,
+    fingerprint,
+    operation,
+    status = 201,
+    ttlSeconds = IDEMPOTENCY_TTL_SECONDS,
+  } = options;
+
+  if (!key) {
+    const data = await operation();
+    return { status, data, replayed: false };
+  }
+
+  let redis: ReturnType<typeof getRedis> | null = null;
+  let redisKey: string | null = null;
+  let lockKey: string | null = null;
+  let lockAcquired = false;
+
+  try {
+    redis = getRedis();
+    // In tests/mocks this can be a partial object. If core methods don't exist,
+    // degrade gracefully to non-idempotent behavior.
+    if (
+      typeof (redis as any).get !== 'function'
+      || typeof (redis as any).set !== 'function'
+      || typeof (redis as any).del !== 'function'
+    ) {
+      redis = null;
+    }
+  } catch {
+    redis = null;
+  }
+
+  if (redis) {
+    redisKey = buildKey(workspaceId, actorId, scope, key);
+    lockKey = `${redisKey}:lock`;
+
+    try {
+      const existingRaw = await redis.get(redisKey);
+      if (existingRaw) {
+        const parsed = JSON.parse(existingRaw) as StoredIdempotencyRecord<T>;
+        if (fingerprint && parsed.fingerprint && parsed.fingerprint !== fingerprint) {
+          const err = new Error('Idempotency-Key was reused with a different request payload');
+          Object.assign(err, { code: 'idempotency_key_reused', status: 409 });
+          throw err;
+        }
+
+        return {
+          status: parsed.status || status,
+          data: parsed.data,
+          replayed: true,
+        };
+      }
+
+      const lockResult = await redis.set(
+        lockKey,
+        '1',
+        'EX',
+        IDEMPOTENCY_LOCK_TTL_SECONDS,
+        'NX',
+      );
+
+      if (!lockResult) {
+        const concurrentRaw = await redis.get(redisKey);
+        if (concurrentRaw) {
+          const parsed = JSON.parse(concurrentRaw) as StoredIdempotencyRecord<T>;
+          if (fingerprint && parsed.fingerprint && parsed.fingerprint !== fingerprint) {
+            const err = new Error('Idempotency-Key was reused with a different request payload');
+            Object.assign(err, { code: 'idempotency_key_reused', status: 409 });
+            throw err;
+          }
+
+          return {
+            status: parsed.status || status,
+            data: parsed.data,
+            replayed: true,
+          };
+        }
+
+        const err = new Error('Another request with this Idempotency-Key is still processing');
+        Object.assign(err, { code: 'idempotency_in_progress', status: 409 });
+        throw err;
+      }
+
+      lockAcquired = true;
+    } catch (err) {
+      if (err instanceof Error && (err as any).code) {
+        throw err;
+      }
+      // Redis unavailable or decode failure: proceed without idempotency.
+      redis = null;
+      redisKey = null;
+      lockKey = null;
+      lockAcquired = false;
+    }
+  }
+
+  try {
+    const data = await operation();
+
+    if (redis && redisKey && lockAcquired) {
+      const record: StoredIdempotencyRecord<T> = {
+        status,
+        data,
+        fingerprint,
+      };
+      try {
+        await redis.set(redisKey, JSON.stringify(record), 'EX', ttlSeconds);
+      } finally {
+        if (lockKey) {
+          await redis.del(lockKey).catch(() => {});
+        }
+      }
+    }
+
+    return { status, data, replayed: false };
+  } catch (err) {
+    if (redis && lockKey && lockAcquired) {
+      await redis.del(lockKey).catch(() => {});
+    }
+    throw err;
+  }
+}

--- a/packages/server/src/middleware/idempotency.ts
+++ b/packages/server/src/middleware/idempotency.ts
@@ -153,6 +153,23 @@ export async function runIdempotent<T>(
       }
 
       lockAcquired = true;
+
+      // Re-check record after acquiring lock to handle race with completed request
+      const recheckRaw = await redis.get(redisKey);
+      if (recheckRaw) {
+        await redis.del(lockKey).catch(() => {});
+        const parsed = JSON.parse(recheckRaw) as StoredIdempotencyRecord<T>;
+        if (fingerprint && parsed.fingerprint && parsed.fingerprint !== fingerprint) {
+          const err = new Error('Idempotency-Key was reused with a different request payload');
+          Object.assign(err, { code: 'idempotency_key_reused', status: 409 });
+          throw err;
+        }
+        return {
+          status: parsed.status || status,
+          data: parsed.data,
+          replayed: true,
+        };
+      }
     } catch (err) {
       if (err instanceof Error && ['idempotency_key_reused', 'idempotency_in_progress'].includes((err as any).code)) {
         throw err;

--- a/packages/server/src/middleware/idempotency.ts
+++ b/packages/server/src/middleware/idempotency.ts
@@ -154,7 +154,7 @@ export async function runIdempotent<T>(
 
       lockAcquired = true;
     } catch (err) {
-      if (err instanceof Error && (err as any).code) {
+      if (err instanceof Error && ['idempotency_key_reused', 'idempotency_in_progress'].includes((err as any).code)) {
         throw err;
       }
       // Redis unavailable or decode failure: proceed without idempotency.
@@ -176,6 +176,8 @@ export async function runIdempotent<T>(
       };
       try {
         await redis.set(redisKey, JSON.stringify(record), 'EX', ttlSeconds);
+      } catch {
+        // Redis failure during record storage — proceed without idempotency record.
       } finally {
         if (lockKey) {
           await redis.del(lockKey).catch(() => {});

--- a/packages/server/src/routes/dm.ts
+++ b/packages/server/src/routes/dm.ts
@@ -4,6 +4,7 @@ import {
   type AuthenticatedRequest,
 } from '../middleware/auth.js';
 import { rateLimit } from '../middleware/rateLimit.js';
+import { parseIdempotencyKey, runIdempotent } from '../middleware/idempotency.js';
 import * as dmEngine from '../engine/dm.js';
 import { publishEvent } from '../ws/pubsub.js';
 import { deliverEvent } from '../engine/eventDelivery.js';
@@ -36,16 +37,37 @@ dmRouter.post(
         return;
       }
 
-      const result = await dmEngine.sendDm(req.workspace!.id, req.agent!.id, {
-        to,
-        text,
-      });
-      res.status(201).json({ ok: true, data: result });
+      const { key: idempotencyKey, error: idempotencyError } = parseIdempotencyKey(req);
+      if (idempotencyError) {
+        res.status(400).json({
+          ok: false,
+          error: { code: 'invalid_idempotency_key', message: idempotencyError },
+        });
+        return;
+      }
 
-      // Fire-and-forget event publishing
-      const eventData = { ...result };
-      publishEvent({ type: 'dm.received', workspace_id: req.workspace!.id, data: eventData, timestamp: new Date().toISOString() }).catch(() => {});
-      deliverEvent(req.workspace!.id, 'dm.received', eventData).catch(() => {});
+      const idempotent = await runIdempotent({
+        workspaceId: req.workspace!.id,
+        actorId: req.agent!.id,
+        scope: 'dm:direct',
+        key: idempotencyKey,
+        status: 201,
+        fingerprint: JSON.stringify({ to, text }),
+        operation: () => dmEngine.sendDm(req.workspace!.id, req.agent!.id, { to, text }),
+      });
+
+      if (idempotent.replayed) {
+        res.setHeader('Idempotency-Replayed', 'true');
+      }
+
+      res.status(idempotent.status).json({ ok: true, data: idempotent.data });
+
+      // Fire-and-forget event publishing only for fresh writes.
+      if (!idempotent.replayed) {
+        const eventData = { ...idempotent.data };
+        publishEvent({ type: 'dm.received', workspace_id: req.workspace!.id, data: eventData, timestamp: new Date().toISOString() }).catch(() => {});
+        deliverEvent(req.workspace!.id, 'dm.received', eventData).catch(() => {});
+      }
     } catch (err: unknown) {
       if (!res.headersSent) {
         const error = err as Error & { code?: string; status?: number };
@@ -110,4 +132,3 @@ dmRouter.get(
     }
   },
 );
-

--- a/packages/server/src/routes/groupDm.ts
+++ b/packages/server/src/routes/groupDm.ts
@@ -4,6 +4,7 @@ import {
   type AuthenticatedRequest,
 } from '../middleware/auth.js';
 import { rateLimit } from '../middleware/rateLimit.js';
+import { parseIdempotencyKey, runIdempotent } from '../middleware/idempotency.js';
 import * as groupDmEngine from '../engine/groupDm.js';
 import { publishEvent } from '../ws/pubsub.js';
 import { deliverEvent } from '../engine/eventDelivery.js';
@@ -58,19 +59,44 @@ groupDmRouter.post(
         return;
       }
 
-      const conversationId = req.params.conversation_id as string;
-      const result = await groupDmEngine.postGroupMessage(
-        req.workspace!.id,
-        conversationId,
-        req.agent!.id,
-        { text },
-      );
-      res.status(201).json({ ok: true, data: result });
+      const { key: idempotencyKey, error: idempotencyError } = parseIdempotencyKey(req);
+      if (idempotencyError) {
+        res.status(400).json({
+          ok: false,
+          error: { code: 'invalid_idempotency_key', message: idempotencyError },
+        });
+        return;
+      }
 
-      // Fire-and-forget event publishing
-      const eventData = { ...result };
-      publishEvent({ type: 'group_dm.received', workspace_id: req.workspace!.id, data: eventData, timestamp: new Date().toISOString() }).catch(() => {});
-      deliverEvent(req.workspace!.id, 'group_dm.received', eventData).catch(() => {});
+      const conversationId = req.params.conversation_id as string;
+      const idempotent = await runIdempotent({
+        workspaceId: req.workspace!.id,
+        actorId: req.agent!.id,
+        scope: `dm-group-message:${conversationId}`,
+        key: idempotencyKey,
+        status: 201,
+        fingerprint: JSON.stringify({ conversationId, text }),
+        operation: () =>
+          groupDmEngine.postGroupMessage(
+            req.workspace!.id,
+            conversationId,
+            req.agent!.id,
+            { text },
+          ),
+      });
+
+      if (idempotent.replayed) {
+        res.setHeader('Idempotency-Replayed', 'true');
+      }
+
+      res.status(idempotent.status).json({ ok: true, data: idempotent.data });
+
+      // Fire-and-forget event publishing only for fresh writes.
+      if (!idempotent.replayed) {
+        const eventData = { ...idempotent.data };
+        publishEvent({ type: 'group_dm.received', workspace_id: req.workspace!.id, data: eventData, timestamp: new Date().toISOString() }).catch(() => {});
+        deliverEvent(req.workspace!.id, 'group_dm.received', eventData).catch(() => {});
+      }
     } catch (err: unknown) {
       if (!res.headersSent) {
         const error = err as Error & { code?: string; status?: number };

--- a/packages/server/src/routes/message.ts
+++ b/packages/server/src/routes/message.ts
@@ -4,6 +4,7 @@ import {
   type AuthenticatedRequest,
 } from '../middleware/auth.js';
 import { rateLimit } from '../middleware/rateLimit.js';
+import { parseIdempotencyKey, runIdempotent } from '../middleware/idempotency.js';
 import * as messageEngine from '../engine/message.js';
 import * as channelEngine from '../engine/channel.js';
 import { publishEvent } from '../ws/pubsub.js';
@@ -23,6 +24,15 @@ messageRouter.post(
         res.status(400).json({
           ok: false,
           error: { code: 'invalid_request', message: 'text is required' },
+        });
+        return;
+      }
+
+      const { key: idempotencyKey, error: idempotencyError } = parseIdempotencyKey(req);
+      if (idempotencyError) {
+        res.status(400).json({
+          ok: false,
+          error: { code: 'invalid_idempotency_key', message: idempotencyError },
         });
         return;
       }
@@ -52,18 +62,34 @@ messageRouter.post(
         return;
       }
 
-      const result = await messageEngine.postMessage(
-        req.workspace!.id,
-        channel.id,
-        agentId,
-        { text, blocks, attachments, data, content_type },
-      );
-      res.status(201).json({ ok: true, data: result });
+      const idempotent = await runIdempotent({
+        workspaceId: req.workspace!.id,
+        actorId: agentId,
+        scope: `channel-message:${channel.id}`,
+        key: idempotencyKey,
+        status: 201,
+        fingerprint: JSON.stringify({ channelId: channel.id, text, blocks, attachments, data, content_type }),
+        operation: () =>
+          messageEngine.postMessage(
+            req.workspace!.id,
+            channel.id,
+            agentId,
+            { text, blocks, attachments, data, content_type },
+          ),
+      });
 
-      // Fire-and-forget event publishing
-      const eventData = { ...result, channel_name: channelName };
-      publishEvent({ type: 'message.created', workspace_id: req.workspace!.id, channel_id: channel.id, data: eventData, timestamp: new Date().toISOString() }).catch(() => {});
-      deliverEvent(req.workspace!.id, 'message.created', eventData).catch(() => {});
+      if (idempotent.replayed) {
+        res.setHeader('Idempotency-Replayed', 'true');
+      }
+
+      res.status(idempotent.status).json({ ok: true, data: idempotent.data });
+
+      // Fire-and-forget event publishing only for fresh writes.
+      if (!idempotent.replayed) {
+        const eventData = { ...idempotent.data, channel_name: channelName };
+        publishEvent({ type: 'message.created', workspace_id: req.workspace!.id, channel_id: channel.id, data: eventData, timestamp: new Date().toISOString() }).catch(() => {});
+        deliverEvent(req.workspace!.id, 'message.created', eventData).catch(() => {});
+      }
     } catch (err: unknown) {
       if (!res.headersSent) {
         const error = err as Error & { code?: string; status?: number };

--- a/packages/server/src/routes/thread.ts
+++ b/packages/server/src/routes/thread.ts
@@ -4,6 +4,7 @@ import {
   type AuthenticatedRequest,
 } from '../middleware/auth.js';
 import { rateLimit } from '../middleware/rateLimit.js';
+import { parseIdempotencyKey, runIdempotent } from '../middleware/idempotency.js';
 import * as threadEngine from '../engine/thread.js';
 import { publishEvent } from '../ws/pubsub.js';
 import { deliverEvent } from '../engine/eventDelivery.js';
@@ -26,6 +27,15 @@ threadRouter.post(
         return;
       }
 
+      const { key: idempotencyKey, error: idempotencyError } = parseIdempotencyKey(req);
+      if (idempotencyError) {
+        res.status(400).json({
+          ok: false,
+          error: { code: 'invalid_idempotency_key', message: idempotencyError },
+        });
+        return;
+      }
+
       const agentId = req.agent?.id;
       if (!agentId) {
         res.status(403).json({
@@ -36,18 +46,35 @@ threadRouter.post(
       }
 
       const parentId = req.params.id as string;
-      const result = await threadEngine.postReply(
-        req.workspace!.id,
-        parentId,
-        agentId,
-        { text },
-      );
-      res.status(201).json({ ok: true, data: result });
+      const idempotent = await runIdempotent({
+        workspaceId: req.workspace!.id,
+        actorId: agentId,
+        scope: `thread-reply:${parentId}`,
+        key: idempotencyKey,
+        status: 201,
+        fingerprint: JSON.stringify({ parentId, text }),
+        operation: () =>
+          threadEngine.postReply(
+            req.workspace!.id,
+            parentId,
+            agentId,
+            { text },
+          ),
+      });
 
-      // Fire-and-forget event publishing
-      const eventData = { ...result };
-      publishEvent({ type: 'thread.reply', workspace_id: req.workspace!.id, channel_id: result.channel_id, data: eventData, timestamp: new Date().toISOString() }).catch(() => {});
-      deliverEvent(req.workspace!.id, 'thread.reply', eventData).catch(() => {});
+      if (idempotent.replayed) {
+        res.setHeader('Idempotency-Replayed', 'true');
+      }
+
+      res.status(idempotent.status).json({ ok: true, data: idempotent.data });
+
+      // Fire-and-forget event publishing only for fresh writes.
+      if (!idempotent.replayed) {
+        const eventData = { ...idempotent.data } as Record<string, unknown>;
+        const channelId = typeof eventData.channel_id === 'string' ? eventData.channel_id : undefined;
+        publishEvent({ type: 'thread.reply', workspace_id: req.workspace!.id, channel_id: channelId, data: eventData, timestamp: new Date().toISOString() }).catch(() => {});
+        deliverEvent(req.workspace!.id, 'thread.reply', eventData).catch(() => {});
+      }
     } catch (err: unknown) {
       if (!res.headersSent) {
         const error = err as Error & { code?: string; status?: number };


### PR DESCRIPTION
## Summary
- add server-side idempotency handling via `Idempotency-Key` for write endpoints:
  - `POST /v1/channels/:name/messages`
  - `POST /v1/messages/:id/replies`
  - `POST /v1/dm`
  - `POST /v1/dm/:conversation_id/messages`
- introduce shared middleware helper (`runIdempotent`) backed by Redis with:
  - replayed response return + `Idempotency-Replayed: true`
  - conflict on same key with different payload (`409 idempotency_key_reused`)
  - conflict while in-flight (`409 idempotency_in_progress`)
  - graceful degradation when Redis methods are unavailable
- extend SDK HTTP client to accept per-request headers and expose optional `idempotencyKey` on agent messaging APIs (`send`, `reply`, `dm`, `dms.sendMessage`)
- add server middleware tests and SDK header-propagation tests
- document idempotency usage in README authentication section
- include existing `.gitignore` update (`.npm-cache`) per request

## Validation
- `npm --prefix /Users/will/Projects/relaycast/packages/server test -- src/middleware/__tests__/idempotency.test.ts src/routes/__tests__/message.test.ts src/routes/__tests__/dm.test.ts src/routes/__tests__/thread.test.ts src/routes/__tests__/groupDm.test.ts`
  - passed (33/33)
- `npm --prefix /Users/will/Projects/relaycast/packages/sdk test -- src/__tests__/agent-messaging.test.ts`
  - passed (23/23)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/agentworkforce/relaycast/pull/5" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
