### PR TITLE
Add DO_NOT_TRACK env and mock http/https in tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,3 +36,5 @@ jobs:
 
       - name: Test
         run: npx turbo test
+        env:
+          DO_NOT_TRACK: '1'

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -34,6 +34,8 @@ jobs:
 
       - name: Test
         run: npx turbo test
+        env:
+          DO_NOT_TRACK: '1'
 
   deploy:
     name: Deploy to Fly.io

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -149,6 +149,8 @@ jobs:
 
       - name: Run tests
         run: npx turbo test
+        env:
+          DO_NOT_TRACK: '1'
 
       - name: Upload build artifacts
         uses: actions/upload-artifact@v4

--- a/packages/mcp/src/__tests__/telemetry.test.ts
+++ b/packages/mcp/src/__tests__/telemetry.test.ts
@@ -3,6 +3,36 @@ import fs from 'node:fs';
 import path from 'node:path';
 
 const mockHomedir = vi.hoisted(() => '/mock/home');
+const posthogRequestMock = vi.hoisted(() =>
+  vi.fn(
+    (
+      _options: unknown,
+      callback?: (res: { resume: () => void; on: (event: string, listener: () => void) => void }) => void,
+    ) => {
+      const endListeners: Array<() => void> = [];
+      callback?.({
+        resume: () => undefined,
+        on: (event: string, listener: () => void) => {
+          if (event === 'end') {
+            endListeners.push(listener);
+          }
+        },
+      });
+
+      return {
+        on: vi.fn(),
+        setTimeout: vi.fn(),
+        destroy: vi.fn(),
+        write: vi.fn(),
+        end: vi.fn(() => {
+          for (const listener of endListeners) {
+            listener();
+          }
+        }),
+      };
+    },
+  ),
+);
 
 vi.mock('node:os', () => ({
   default: {
@@ -11,6 +41,16 @@ vi.mock('node:os', () => ({
 }));
 
 vi.mock('node:fs');
+vi.mock('node:http', () => ({
+  default: {
+    request: posthogRequestMock,
+  },
+}));
+vi.mock('node:https', () => ({
+  default: {
+    request: posthogRequestMock,
+  },
+}));
 
 import { createMcpTelemetry } from '../telemetry.js';
 


### PR DESCRIPTION
Set DO_NOT_TRACK='1' for the Test steps in CI, deploy, and publish workflows to disable telemetry during CI runs. Update telemetry unit test to add a posthog request mock and mock node:http/node:https so tests don't perform real network requests and can simulate request end events for deterministic behavior.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/agentworkforce/relaycast/pull/8" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
