### PR TITLE
Fix self-echo in MCP piggyback notifications

### DIFF
--- a/packages/mcp/src/__tests__/piggyback.test.ts
+++ b/packages/mcp/src/__tests__/piggyback.test.ts
@@ -171,6 +171,92 @@ describe('piggyback unread messages', () => {
     expect(mockInbox).not.toHaveBeenCalled();
   });
 
+  it('filters out self-sent DMs from piggyback', async () => {
+    mockInbox.mockResolvedValue({
+      unread_channels: [],
+      mentions: [],
+      unread_dms: [
+        { from: 'bot1', unread_count: 1 },
+        { from: 'alice', unread_count: 2 },
+      ],
+    });
+
+    const result = await client.callTool({
+      name: 'dummy_tool',
+      arguments: { arg: 'test' },
+    });
+
+    expect(result.content).toHaveLength(2);
+    const piggyback = (result.content as any[])[1];
+    expect(piggyback.text).toContain('From alice: 2 unread');
+    expect(piggyback.text).not.toContain('From bot1');
+  });
+
+  it('filters out self-mentions from piggyback', async () => {
+    mockInbox.mockResolvedValue({
+      unread_channels: [],
+      mentions: [
+        { agent_name: 'bot1', channel_name: 'general', text: 'my own msg' },
+        { agent_name: 'alice', channel_name: 'dev', text: 'hey there' },
+      ],
+      unread_dms: [],
+    });
+
+    const result = await client.callTool({
+      name: 'dummy_tool',
+      arguments: { arg: 'test' },
+    });
+
+    expect(result.content).toHaveLength(2);
+    const piggyback = (result.content as any[])[1];
+    expect(piggyback.text).toContain('@alice in #dev');
+    expect(piggyback.text).not.toContain('@bot1');
+  });
+
+  it('filters self-sent DMs with case and @ prefix differences', async () => {
+    mockInbox.mockResolvedValue({
+      unread_channels: [],
+      mentions: [
+        { agent_name: '@Bot1', channel_name: 'general', text: 'echo' },
+        { agent_name: 'alice', channel_name: 'dev', text: 'real mention' },
+      ],
+      unread_dms: [
+        { from: 'BOT1', unread_count: 1 },
+        { from: ' @bot1 ', unread_count: 1 },
+        { from: 'carol', unread_count: 3 },
+      ],
+    });
+
+    const result = await client.callTool({
+      name: 'dummy_tool',
+      arguments: { arg: 'test' },
+    });
+
+    expect(result.content).toHaveLength(2);
+    const piggyback = (result.content as any[])[1];
+    expect(piggyback.text).toContain('From carol: 3 unread');
+    expect(piggyback.text).not.toContain('BOT1');
+    expect(piggyback.text).not.toContain('@bot1');
+    expect(piggyback.text).toContain('@alice in #dev');
+    expect(piggyback.text).not.toContain('@Bot1');
+  });
+
+  it('suppresses piggyback entirely when all messages are self-sent', async () => {
+    mockInbox.mockResolvedValue({
+      unread_channels: [],
+      mentions: [],
+      unread_dms: [{ from: 'bot1', unread_count: 3 }],
+    });
+
+    const result = await client.callTool({
+      name: 'dummy_tool',
+      arguments: { arg: 'test' },
+    });
+
+    expect(result.content).toHaveLength(1);
+    expect((result.content as any[])[0].text).toBe('original result');
+  });
+
   it('handles inbox error gracefully', async () => {
     mockInbox.mockRejectedValue(new Error('Network error'));
 

--- a/packages/mcp/src/piggyback.ts
+++ b/packages/mcp/src/piggyback.ts
@@ -93,10 +93,14 @@ export function enablePiggyback(
           (inbox.unread_dms?.length ?? 0) > 0;
 
         if (hasUnread && Array.isArray(result?.content)) {
-          result.content.push({
-            type: 'text' as const,
-            text: formatInbox(inbox),
-          });
+          const selfName = getSession().agentName;
+          const inboxText = formatInbox(inbox, selfName);
+          if (inboxText) {
+            result.content.push({
+              type: 'text' as const,
+              text: inboxText,
+            });
+          }
         }
       } catch {
         // Silently ignore — never break the original tool response
@@ -113,7 +117,11 @@ function formatInbox(inbox: {
   unread_channels?: Array<{ channel_name: string; unread_count: number }>;
   mentions?: Array<{ agent_name: string; channel_name: string; text: string }>;
   unread_dms?: Array<{ from: string; unread_count: number }>;
-}): string {
+}, selfName?: string | null): string {
+  const norm = (s: string) => s.trim().replace(/^@/, '').toLowerCase();
+  const selfNorm = selfName ? norm(selfName) : null;
+  const isSelf = (name: string) => selfNorm != null && norm(name) === selfNorm;
+
   const lines: string[] = ['--- Pending Messages ---'];
 
   if (inbox.unread_channels?.length) {
@@ -123,19 +131,27 @@ function formatInbox(inbox: {
     }
   }
 
-  if (inbox.mentions?.length) {
+  const mentions = selfNorm
+    ? inbox.mentions?.filter((m) => !isSelf(m.agent_name))
+    : inbox.mentions;
+  if (mentions?.length) {
     lines.push('Mentions:');
-    for (const m of inbox.mentions) {
+    for (const m of mentions) {
       lines.push(`  @${m.agent_name} in #${m.channel_name}: "${m.text}"`);
     }
   }
 
-  if (inbox.unread_dms?.length) {
+  const dms = selfNorm
+    ? inbox.unread_dms?.filter((dm) => !isSelf(dm.from))
+    : inbox.unread_dms;
+  if (dms?.length) {
     lines.push('Unread DMs:');
-    for (const dm of inbox.unread_dms) {
+    for (const dm of dms) {
       lines.push(`  From ${dm.from}: ${dm.unread_count} unread`);
     }
   }
+
+  if (lines.length === 1) return '';
 
   return lines.join('\n');
 }


### PR DESCRIPTION
Filter out messages sent by the current agent from inbox piggyback notifications. Normalizes identity comparison (trim, strip @, lowercase) to handle case mismatches and @-prefix variants.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/agentworkforce/relaycast/pull/14" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
