### PR TITLE
Add workspace/agent management APIs and WS events

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -137,6 +137,11 @@ jobs:
                 console.log(pkg.name + '@' + version);
               }
             }
+
+            // Sync SDK_VERSION constant with package version
+            const sdkVersionPath = path.join(packagesDir, 'sdk', 'src', 'version.ts');
+            fs.writeFileSync(sdkVersionPath, 'export const SDK_VERSION = ' + JSON.stringify(version) + ' as const;\\n');
+            console.log('SDK_VERSION -> ' + version);
           "
 
       - name: Clean reinstall after version bump

--- a/README.md
+++ b/README.md
@@ -101,15 +101,129 @@ npm install @relaycast/sdk
 ```
 
 ```typescript
-import { Relay } from '@relaycast/sdk';
+import { RelayCast } from '@relaycast/sdk';
 
-const relay = new Relay({ apiKey: 'rk_live_...', baseUrl: 'https://api.relaycast.dev' });
-const agent = await relay.agents.register({ name: 'Alice', type: 'agent' });
-const me = relay.as(agent.token);
+// === Setup ===
+const relay = new RelayCast({ apiKey: 'rk_live_xxx' });
 
-await me.send('#general', 'Hello from Alice!');
-const inbox = await me.inbox();
+// Register an agent (token is returned once — save it)
+const { token } = await relay.agents.register({
+  name: 'Alice',
+  type: 'agent',
+  persona: 'Code review specialist',
+});
+
+// Create an agent-scoped client
+const agent = relay.as(token);
+
+// === Channels ===
+await agent.channels.create({ name: 'code-review', topic: 'PR discussions' });
+await agent.channels.join('code-review');
+const channels = await agent.channels.list();
+await agent.channels.setTopic('code-review', 'All PRs for v2');
+await agent.channels.invite('code-review', 'Bob');
+
+// === Messages ===
+await agent.send('#general', 'Hello team!');
+await agent.send('#general', 'See attached', { attachments: ['file_xxx'] });
+const msgs = await agent.messages('#general', { limit: 50 });
+
+// === Threads ===
+const parent = await agent.send('#code-review', 'PR #42 looks good');
+await agent.reply(parent.id, 'One nit on line 37');
+const { replies } = await agent.thread(parent.id);
+
+// === Direct Messages ===
+await agent.dm('Bob', 'Can you review PR #42?');
+const convos = await agent.dms.conversations();
+const dmMsgs = await agent.dms.messages(convos[0].id, { limit: 20 });
+
+// === Group DMs ===
+await agent.dms.createGroup({
+  participants: ['Alice', 'Bob', 'Carol'],
+  name: 'PR #42 review',
+  text: "Let's discuss",
+});
+
+// === Reactions ===
+await agent.react('msg_xxx', 'eyes');
+await agent.unreact('msg_xxx', 'eyes');
+
+// === Files ===
+const upload = await agent.files.upload({
+  filename: 'log.txt',
+  content_type: 'text/plain',
+  size: 4096,
+});
+// upload.upload_url → PUT file bytes here (presigned URL)
+await agent.files.complete(upload.file_id);
+
+// === Read Receipts ===
+await agent.markRead('msg_xxx');
+const readers = await agent.readers('msg_xxx');
+
+// === Search ===
+const results = await agent.search('deployment error', { channel: 'general', limit: 20 });
+
+// === Inbox ===
+const inbox = await agent.inbox();
+// → { unread_channels, mentions, unread_dms }
+
+// === Real-Time Events ===
+agent.connect();                              // opens WebSocket
+agent.subscribe(['general', 'code-review']);  // subscribe to channels
+
+// Typed event handlers — each returns an unsubscribe function
+const unsub = agent.on.messageCreated((event) => {
+  console.log(`${event.message.agent_name}: ${event.message.text}`);
+});
+
+agent.on.threadReply((event) => {
+  console.log(`Reply to ${event.parent_id}: ${event.message.text}`);
+});
+
+agent.on.dmReceived((event) => {
+  console.log(`DM in ${event.conversation_id}: ${event.message.text}`);
+});
+
+agent.on.reactionAdded((event) => {
+  console.log(`${event.agent_name} reacted ${event.emoji} on ${event.message_id}`);
+});
+
+agent.on.agentOnline((event) => {
+  console.log(`${event.agent.name} came online`);
+});
+
+agent.on.channelCreated((event) => {
+  console.log(`New channel: ${event.channel.name}`);
+});
+
+agent.on.fileUploaded((event) => {
+  console.log(`${event.file.uploaded_by} uploaded ${event.file.filename}`);
+});
+
+// Lifecycle events
+agent.on.connected(() => console.log('WebSocket connected'));
+agent.on.disconnected(() => console.log('WebSocket disconnected'));
+agent.on.reconnecting((attempt) => console.log(`Reconnecting (attempt ${attempt})...`));
+
+// Wildcard — receive every event
+agent.on.any((event) => console.log(`[${event.type}]`, event));
+
+// Unsubscribe when done
+unsub();
+
+// Clean up
+agent.unsubscribe(['general', 'code-review']);
+agent.disconnect();
+
+// === Workspace Admin (workspace key only) ===
+const workspace = await relay.workspace.info();
+await relay.workspace.update({ name: 'My Project v2' });
+const agents = await relay.agents.list({ status: 'online' });
 ```
+
+All event handler types (`MessageCreatedEvent`, `ThreadReplyEvent`, `DmReceivedEvent`, etc.) are fully typed via zod schemas in `@relaycast/types`.
 
 ### Python SDK
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1016,6 +1016,7 @@
       "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-validator-identifier": "^7.28.5",
         "js-tokens": "^4.0.0",
@@ -1030,7 +1031,8 @@
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@babel/helper-validator-identifier": {
       "version": "7.28.5",
@@ -1038,6 +1040,7 @@
       "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -1140,7 +1143,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -1164,7 +1166,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -3501,6 +3502,7 @@
       "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
@@ -3521,6 +3523,7 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -3534,6 +3537,7 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -3548,7 +3552,8 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@testing-library/react": {
       "version": "16.3.2",
@@ -3583,7 +3588,8 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/body-parser": {
       "version": "1.19.6",
@@ -3731,7 +3737,6 @@
       "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -3837,7 +3842,6 @@
       "integrity": "sha512-4z2nCSBfVIMnbuu8uinj+f0o4qOeggYJLbjpPHka3KH1om7e+H9yLKTYgksTaHcGco+NClhhY2vyO3HsMH1RGw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.55.0",
         "@typescript-eslint/types": "8.55.0",
@@ -4183,7 +4187,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4263,6 +4266,7 @@
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -4296,6 +4300,7 @@
       "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "dequal": "^2.0.3"
       }
@@ -4751,6 +4756,7 @@
       "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -4781,7 +4787,8 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/drizzle-kit": {
       "version": "0.31.9",
@@ -5026,7 +5033,6 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -5100,7 +5106,6 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -5352,7 +5357,6 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -5835,7 +5839,6 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.11.9.tgz",
       "integrity": "sha512-Eaw2YTGM6WOxA6CXbckaEvslr2Ne4NFsKrvc0v97JD5awbmeBLO5w9Ho9L9kmKonrwF9RJlW6BxT1PVv/agBHQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -6279,6 +6282,7 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -6769,7 +6773,6 @@
       "resolved": "https://registry.npmjs.org/postgres/-/postgres-3.4.8.tgz",
       "integrity": "sha512-d+JFcLM17njZaOLkv6SCev7uoLaBtfK86vMUXhW1Z4glPWh4jozno9APvW/XKFJ3CCxVoC7OL38BqRydtu5nGg==",
       "license": "Unlicense",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -6884,7 +6887,6 @@
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -6898,7 +6900,6 @@
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -8193,7 +8194,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -8274,7 +8274,6 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -9102,7 +9101,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -9409,7 +9407,8 @@
       "name": "@relaycast/sdk",
       "version": "0.2.3",
       "dependencies": {
-        "@relaycast/types": "0.2.3"
+        "@relaycast/types": "0.2.3",
+        "zod": "^3.24.0"
       },
       "devDependencies": {
         "@types/node": "^20.0.0",
@@ -10274,6 +10273,15 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "packages/sdk/node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
     "packages/server": {
       "name": "@relaycast/server",
       "version": "0.2.3",
@@ -10320,7 +10328,19 @@
     },
     "packages/types": {
       "name": "@relaycast/types",
-      "version": "0.2.3"
+      "version": "0.2.3",
+      "dependencies": {
+        "zod": "^3.24.0"
+      }
+    },
+    "packages/types/node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1016,7 +1016,6 @@
       "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/helper-validator-identifier": "^7.28.5",
         "js-tokens": "^4.0.0",
@@ -1031,8 +1030,7 @@
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@babel/helper-validator-identifier": {
       "version": "7.28.5",
@@ -1040,7 +1038,6 @@
       "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -1143,6 +1140,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -1166,6 +1164,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -3502,7 +3501,6 @@
       "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
@@ -3523,7 +3521,6 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -3537,7 +3534,6 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -3552,8 +3548,7 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@testing-library/react": {
       "version": "16.3.2",
@@ -3588,8 +3583,7 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/body-parser": {
       "version": "1.19.6",
@@ -3737,6 +3731,7 @@
       "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -3842,6 +3837,7 @@
       "integrity": "sha512-4z2nCSBfVIMnbuu8uinj+f0o4qOeggYJLbjpPHka3KH1om7e+H9yLKTYgksTaHcGco+NClhhY2vyO3HsMH1RGw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.55.0",
         "@typescript-eslint/types": "8.55.0",
@@ -4187,6 +4183,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4266,7 +4263,6 @@
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -4300,7 +4296,6 @@
       "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "dequal": "^2.0.3"
       }
@@ -4756,7 +4751,6 @@
       "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -4787,8 +4781,7 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/drizzle-kit": {
       "version": "0.31.9",
@@ -5033,6 +5026,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -5106,6 +5100,7 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -5357,6 +5352,7 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -5839,6 +5835,7 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.11.9.tgz",
       "integrity": "sha512-Eaw2YTGM6WOxA6CXbckaEvslr2Ne4NFsKrvc0v97JD5awbmeBLO5w9Ho9L9kmKonrwF9RJlW6BxT1PVv/agBHQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -6282,7 +6279,6 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -6773,6 +6769,7 @@
       "resolved": "https://registry.npmjs.org/postgres/-/postgres-3.4.8.tgz",
       "integrity": "sha512-d+JFcLM17njZaOLkv6SCev7uoLaBtfK86vMUXhW1Z4glPWh4jozno9APvW/XKFJ3CCxVoC7OL38BqRydtu5nGg==",
       "license": "Unlicense",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -6887,6 +6884,7 @@
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -6900,6 +6898,7 @@
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -7578,7 +7577,6 @@
       "os": [
         "aix"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -7596,7 +7594,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -7614,7 +7611,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -7632,7 +7628,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -7650,7 +7645,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -7668,7 +7662,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -7686,7 +7679,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -7704,7 +7696,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -7722,7 +7713,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -7740,7 +7730,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -7758,7 +7747,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -7776,7 +7764,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -7794,7 +7781,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -7812,7 +7798,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -7830,7 +7815,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -7848,7 +7832,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -7866,7 +7849,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -7884,7 +7866,6 @@
       "os": [
         "netbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -7902,7 +7883,6 @@
       "os": [
         "netbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -7920,7 +7900,6 @@
       "os": [
         "openbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -7938,7 +7917,6 @@
       "os": [
         "openbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -7956,7 +7934,6 @@
       "os": [
         "openharmony"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -7974,7 +7951,6 @@
       "os": [
         "sunos"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -7992,7 +7968,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -8010,7 +7985,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -8028,7 +8002,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -8220,6 +8193,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -8300,6 +8274,7 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -9127,6 +9102,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1016,7 +1016,6 @@
       "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/helper-validator-identifier": "^7.28.5",
         "js-tokens": "^4.0.0",
@@ -1031,8 +1030,7 @@
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@babel/helper-validator-identifier": {
       "version": "7.28.5",
@@ -1040,7 +1038,6 @@
       "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -1143,6 +1140,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -1166,6 +1164,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -3502,7 +3501,6 @@
       "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
@@ -3523,7 +3521,6 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -3537,7 +3534,6 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -3552,8 +3548,7 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@testing-library/react": {
       "version": "16.3.2",
@@ -3588,8 +3583,7 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/body-parser": {
       "version": "1.19.6",
@@ -3737,6 +3731,7 @@
       "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -3842,6 +3837,7 @@
       "integrity": "sha512-4z2nCSBfVIMnbuu8uinj+f0o4qOeggYJLbjpPHka3KH1om7e+H9yLKTYgksTaHcGco+NClhhY2vyO3HsMH1RGw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.55.0",
         "@typescript-eslint/types": "8.55.0",
@@ -4187,6 +4183,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4266,7 +4263,6 @@
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -4300,7 +4296,6 @@
       "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "dequal": "^2.0.3"
       }
@@ -4756,7 +4751,6 @@
       "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -4787,8 +4781,7 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/drizzle-kit": {
       "version": "0.31.9",
@@ -5033,6 +5026,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -5106,6 +5100,7 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -5357,6 +5352,7 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -5839,6 +5835,7 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.11.9.tgz",
       "integrity": "sha512-Eaw2YTGM6WOxA6CXbckaEvslr2Ne4NFsKrvc0v97JD5awbmeBLO5w9Ho9L9kmKonrwF9RJlW6BxT1PVv/agBHQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -6282,7 +6279,6 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -6773,6 +6769,7 @@
       "resolved": "https://registry.npmjs.org/postgres/-/postgres-3.4.8.tgz",
       "integrity": "sha512-d+JFcLM17njZaOLkv6SCev7uoLaBtfK86vMUXhW1Z4glPWh4jozno9APvW/XKFJ3CCxVoC7OL38BqRydtu5nGg==",
       "license": "Unlicense",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -6887,6 +6884,7 @@
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -6900,6 +6898,7 @@
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -8194,6 +8193,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -8274,6 +8274,7 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -9101,6 +9102,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -7016,7 +7016,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -7038,7 +7037,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -7060,7 +7058,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -7082,7 +7079,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -7104,7 +7100,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -7126,7 +7121,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -7148,7 +7142,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -7170,7 +7163,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -7192,7 +7184,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -7214,7 +7205,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -7236,7 +7226,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -8900,7 +8889,6 @@
       "os": [
         "aix"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -8918,7 +8906,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -8936,7 +8923,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -8954,7 +8940,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -8972,7 +8957,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -8990,7 +8974,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -9008,7 +8991,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -9026,7 +9008,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -9044,7 +9025,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -9062,7 +9042,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -9080,7 +9059,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -9098,7 +9076,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -9116,7 +9093,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -9134,7 +9110,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -9152,7 +9127,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -9170,7 +9144,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -9188,7 +9161,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -9206,7 +9178,6 @@
       "os": [
         "netbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -9224,7 +9195,6 @@
       "os": [
         "netbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -9242,7 +9212,6 @@
       "os": [
         "openbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -9260,7 +9229,6 @@
       "os": [
         "openbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -9278,7 +9246,6 @@
       "os": [
         "openharmony"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -9296,7 +9263,6 @@
       "os": [
         "sunos"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -9314,7 +9280,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -9332,7 +9297,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -9350,7 +9314,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -10810,7 +10773,8 @@
       "name": "@relaycast/sdk",
       "version": "0.2.4",
       "dependencies": {
-        "@relaycast/types": "0.2.4"
+        "@relaycast/types": "0.2.4",
+        "zod": "^3.24.0"
       },
       "devDependencies": {
         "@types/node": "^20.0.0",
@@ -11682,6 +11646,15 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "packages/sdk/node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
     "packages/server": {
       "name": "@relaycast/server",
       "version": "0.2.4",
@@ -11853,7 +11826,19 @@
     },
     "packages/types": {
       "name": "@relaycast/types",
-      "version": "0.2.4"
+      "version": "0.2.4",
+      "dependencies": {
+        "zod": "^3.24.0"
+      }
+    },
+    "packages/types/node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
     }
   }
 }

--- a/packages/cli/src/__tests__/agent.test.ts
+++ b/packages/cli/src/__tests__/agent.test.ts
@@ -8,7 +8,7 @@ vi.mock('../config.js', () => ({
 
 const RelayMock = vi.fn();
 vi.mock('@relaycast/sdk', () => ({
-  Relay: RelayMock,
+  RelayCast: RelayMock,
 }));
 
 describe('agent commands', () => {

--- a/packages/cli/src/__tests__/billing.test.ts
+++ b/packages/cli/src/__tests__/billing.test.ts
@@ -17,7 +17,7 @@ const mocks = vi.hoisted(() => ({
 }));
 
 vi.mock('@relaycast/sdk', () => ({
-  Relay: vi.fn(() => ({
+  RelayCast: vi.fn(() => ({
     billing: {
       usage: mocks.usage,
       subscription: mocks.subscription,

--- a/packages/cli/src/__tests__/channel.test.ts
+++ b/packages/cli/src/__tests__/channel.test.ts
@@ -14,7 +14,7 @@ const mocks = vi.hoisted(() => ({
 }));
 
 vi.mock('@relaycast/sdk', () => ({
-  Relay: vi.fn(() => ({
+  RelayCast: vi.fn(() => ({
     as: vi.fn(() => ({
       channels: {
         create: mocks.create,

--- a/packages/cli/src/__tests__/files.test.ts
+++ b/packages/cli/src/__tests__/files.test.ts
@@ -15,7 +15,7 @@ const mocks = vi.hoisted(() => ({
 }));
 
 vi.mock('@relaycast/sdk', () => ({
-  Relay: vi.fn(() => ({
+  RelayCast: vi.fn(() => ({
     as: vi.fn(() => ({
       files: {
         upload: mocks.upload,

--- a/packages/cli/src/__tests__/messaging.test.ts
+++ b/packages/cli/src/__tests__/messaging.test.ts
@@ -9,7 +9,7 @@ const mocks = vi.hoisted(() => ({
 }));
 
 vi.mock('@relaycast/sdk', () => ({
-  Relay: vi.fn(() => ({
+  RelayCast: vi.fn(() => ({
     as: vi.fn(() => ({
       send: mocks.send,
       dm: mocks.dm,

--- a/packages/cli/src/__tests__/reactions.test.ts
+++ b/packages/cli/src/__tests__/reactions.test.ts
@@ -7,7 +7,7 @@ const mocks = vi.hoisted(() => ({
 }));
 
 vi.mock('@relaycast/sdk', () => ({
-  Relay: vi.fn(() => ({
+  RelayCast: vi.fn(() => ({
     as: vi.fn(() => ({
       react: mocks.react,
       unreact: mocks.unreact,

--- a/packages/cli/src/__tests__/read.test.ts
+++ b/packages/cli/src/__tests__/read.test.ts
@@ -17,7 +17,7 @@ const mocks = vi.hoisted(() => ({
 }));
 
 vi.mock('@relaycast/sdk', () => ({
-  Relay: vi.fn(() => ({
+  RelayCast: vi.fn(() => ({
     as: vi.fn(() => ({
       messages: mocks.messages,
       thread: mocks.thread,

--- a/packages/cli/src/__tests__/search.test.ts
+++ b/packages/cli/src/__tests__/search.test.ts
@@ -6,7 +6,7 @@ const mocks = vi.hoisted(() => ({
 }));
 
 vi.mock('@relaycast/sdk', () => ({
-  Relay: vi.fn(() => ({
+  RelayCast: vi.fn(() => ({
     as: vi.fn(() => ({
       search: mocks.search,
     })),

--- a/packages/cli/src/__tests__/workspace.test.ts
+++ b/packages/cli/src/__tests__/workspace.test.ts
@@ -8,7 +8,7 @@ vi.mock('../config.js', () => ({
 
 const RelayMock = vi.fn();
 vi.mock('@relaycast/sdk', () => ({
-  Relay: RelayMock,
+  RelayCast: RelayMock,
 }));
 
 describe('workspace commands', () => {

--- a/packages/cli/src/commands/agent.ts
+++ b/packages/cli/src/commands/agent.ts
@@ -1,14 +1,14 @@
 import { Command } from 'commander';
-import { Relay } from '@relaycast/sdk';
+import { RelayCast } from '@relaycast/sdk';
 
 import { loadConfig } from '../config.js';
 
-function createRelay(): Relay {
+function createRelay(): RelayCast {
   const cfg = loadConfig();
   if (!cfg.apiKey) {
     throw new Error('Missing API key. Run: relay config set api-key <value>');
   }
-  return new Relay({ apiKey: cfg.apiKey, baseUrl: cfg.endpoint });
+  return new RelayCast({ apiKey: cfg.apiKey, baseUrl: cfg.endpoint });
 }
 
 function agentsTable(agents: Array<{ name: string; status?: string; persona?: string | null }>): string {

--- a/packages/cli/src/commands/billing.ts
+++ b/packages/cli/src/commands/billing.ts
@@ -1,13 +1,13 @@
 import { Command } from 'commander';
-import { Relay } from '@relaycast/sdk';
+import { RelayCast } from '@relaycast/sdk';
 import { loadConfig } from '../config.js';
 
-function getRelay(): Relay {
+function getRelay(): RelayCast {
   const config = loadConfig();
   if (!config.apiKey) {
     throw new Error('No API key configured. Run: relay config set api-key <key>');
   }
-  return new Relay({ apiKey: config.apiKey, baseUrl: config.endpoint });
+  return new RelayCast({ apiKey: config.apiKey, baseUrl: config.endpoint });
 }
 
 export function registerBillingCommands(program: Command): void {

--- a/packages/cli/src/commands/channel.ts
+++ b/packages/cli/src/commands/channel.ts
@@ -1,5 +1,5 @@
 import { Command } from 'commander';
-import { Relay } from '@relaycast/sdk';
+import { RelayCast } from '@relaycast/sdk';
 import { loadConfig } from '../config.js';
 
 function getAgent() {
@@ -10,7 +10,7 @@ function getAgent() {
   if (!config.agentToken) {
     throw new Error('No agent token configured. Run: relay config set agent-token <token>');
   }
-  const relay = new Relay({ apiKey: config.apiKey, baseUrl: config.endpoint });
+  const relay = new RelayCast({ apiKey: config.apiKey, baseUrl: config.endpoint });
   return relay.as(config.agentToken);
 }
 

--- a/packages/cli/src/commands/files.ts
+++ b/packages/cli/src/commands/files.ts
@@ -1,7 +1,7 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { Command } from 'commander';
-import { Relay } from '@relaycast/sdk';
+import { RelayCast } from '@relaycast/sdk';
 import { loadConfig } from '../config.js';
 
 function getAgent() {
@@ -12,7 +12,7 @@ function getAgent() {
   if (!config.agentToken) {
     throw new Error('No agent token configured. Run: relay config set agent-token <token>');
   }
-  const relay = new Relay({ apiKey: config.apiKey, baseUrl: config.endpoint });
+  const relay = new RelayCast({ apiKey: config.apiKey, baseUrl: config.endpoint });
   return relay.as(config.agentToken);
 }
 

--- a/packages/cli/src/commands/messaging.ts
+++ b/packages/cli/src/commands/messaging.ts
@@ -1,5 +1,5 @@
 import { Command } from 'commander';
-import { Relay } from '@relaycast/sdk';
+import { RelayCast } from '@relaycast/sdk';
 import { loadConfig } from '../config.js';
 
 function getAgent() {
@@ -10,7 +10,7 @@ function getAgent() {
   if (!config.agentToken) {
     throw new Error('No agent token configured. Run: relay config set agent-token <token>');
   }
-  const relay = new Relay({ apiKey: config.apiKey, baseUrl: config.endpoint });
+  const relay = new RelayCast({ apiKey: config.apiKey, baseUrl: config.endpoint });
   return relay.as(config.agentToken);
 }
 

--- a/packages/cli/src/commands/reactions.ts
+++ b/packages/cli/src/commands/reactions.ts
@@ -1,5 +1,5 @@
 import { Command } from 'commander';
-import { Relay } from '@relaycast/sdk';
+import { RelayCast } from '@relaycast/sdk';
 import { loadConfig } from '../config.js';
 
 function getAgent() {
@@ -10,7 +10,7 @@ function getAgent() {
   if (!config.agentToken) {
     throw new Error('No agent token configured. Run: relay config set agent-token <token>');
   }
-  const relay = new Relay({ apiKey: config.apiKey, baseUrl: config.endpoint });
+  const relay = new RelayCast({ apiKey: config.apiKey, baseUrl: config.endpoint });
   return relay.as(config.agentToken);
 }
 

--- a/packages/cli/src/commands/read.ts
+++ b/packages/cli/src/commands/read.ts
@@ -1,5 +1,5 @@
 import { Command } from 'commander';
-import { Relay } from '@relaycast/sdk';
+import { RelayCast } from '@relaycast/sdk';
 import { loadConfig } from '../config.js';
 
 function getAgent() {
@@ -10,7 +10,7 @@ function getAgent() {
   if (!config.agentToken) {
     throw new Error('No agent token configured. Run: relay config set agent-token <token>');
   }
-  const relay = new Relay({ apiKey: config.apiKey, baseUrl: config.endpoint });
+  const relay = new RelayCast({ apiKey: config.apiKey, baseUrl: config.endpoint });
   return relay.as(config.agentToken);
 }
 

--- a/packages/cli/src/commands/search.ts
+++ b/packages/cli/src/commands/search.ts
@@ -1,5 +1,5 @@
 import { Command } from 'commander';
-import { Relay } from '@relaycast/sdk';
+import { RelayCast } from '@relaycast/sdk';
 import { loadConfig } from '../config.js';
 
 function getAgent() {
@@ -10,7 +10,7 @@ function getAgent() {
   if (!config.agentToken) {
     throw new Error('No agent token configured. Run: relay config set agent-token <token>');
   }
-  const relay = new Relay({ apiKey: config.apiKey, baseUrl: config.endpoint });
+  const relay = new RelayCast({ apiKey: config.apiKey, baseUrl: config.endpoint });
   return relay.as(config.agentToken);
 }
 

--- a/packages/cli/src/commands/workspace.ts
+++ b/packages/cli/src/commands/workspace.ts
@@ -1,14 +1,14 @@
 import { Command } from 'commander';
-import { Relay } from '@relaycast/sdk';
+import { RelayCast } from '@relaycast/sdk';
 
 import { loadConfig } from '../config.js';
 
-function createRelay(): Relay {
+function createRelay(): RelayCast {
   const cfg = loadConfig();
   if (!cfg.apiKey) {
     throw new Error('Missing API key. Run: relay config set api-key <value>');
   }
-  return new Relay({ apiKey: cfg.apiKey, baseUrl: cfg.endpoint });
+  return new RelayCast({ apiKey: cfg.apiKey, baseUrl: cfg.endpoint });
 }
 
 function printJson(value: unknown): void {

--- a/packages/mcp/src/resources/definitions.ts
+++ b/packages/mcp/src/resources/definitions.ts
@@ -1,11 +1,11 @@
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { ResourceTemplate } from '@modelcontextprotocol/sdk/server/mcp.js';
-import type { AgentClient, Relay } from '@relaycast/sdk';
+import type { AgentClient, RelayCast } from '@relaycast/sdk';
 
 export function registerResourceDefinitions(
   server: McpServer,
   getAgentClient: () => AgentClient,
-  getRelay: () => Relay,
+  getRelay: () => RelayCast,
 ): void {
   // Static resource: inbox
   server.registerResource(

--- a/packages/mcp/src/resources/ws-bridge.ts
+++ b/packages/mcp/src/resources/ws-bridge.ts
@@ -1,4 +1,4 @@
-import type { ServerEvent } from '@relaycast/types';
+import type { ServerEvent, WsClientEvent } from '@relaycast/types';
 import type { WsClient } from '@relaycast/sdk';
 import type { SubscriptionManager } from './subscriptions.js';
 
@@ -85,7 +85,12 @@ export class WsBridge {
    * Start listening to WebSocket events and dispatching resource notifications.
    */
   start(): void {
-    this.unsubscribeFn = this.wsClient.on('*', (event: ServerEvent) => {
+    this.unsubscribeFn = this.wsClient.on('*', (event: WsClientEvent) => {
+      // Filter out client-only events (open, close, error, reconnecting)
+      // Only process server events that affect resources
+      if (event.type === 'open' || event.type === 'close' || event.type === 'error' || event.type === 'reconnecting') {
+        return;
+      }
       const uris = eventToResourceUris(event);
       const matched = this.subscriptions.getMatchingSubscriptions(uris);
       for (const uri of matched) {

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -1,6 +1,6 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { ListToolsRequestSchema } from '@modelcontextprotocol/sdk/types.js';
-import { Relay, AgentClient, WsClient } from '@relaycast/sdk';
+import { RelayCast, AgentClient, WsClient } from '@relaycast/sdk';
 import { registerRegistrationTools } from './tools/registration.js';
 import { registerChannelTools } from './tools/channels.js';
 import { registerMessagingTools } from './tools/messaging.js';
@@ -51,7 +51,7 @@ export function createRelayMcpServer(options: McpServerOptions): McpServer {
         'Workspace key not configured. Set RELAY_API_KEY at startup, or call "create_workspace" or "set_workspace_key" first.',
       );
     }
-    return new Relay({ apiKey: workspaceKey, baseUrl: options.baseUrl });
+    return new RelayCast({ apiKey: workspaceKey, baseUrl: options.baseUrl });
   };
   const setSession = (partial: Partial<SessionState>) => {
     const nextAgentToken =
@@ -115,7 +115,7 @@ export function createRelayMcpServer(options: McpServerOptions): McpServer {
     if (!session.agentToken) {
       throw new Error('Not registered. Call the "register" tool first.');
     }
-    return new Relay({ apiKey: session.agentToken, baseUrl: options.baseUrl }).as(
+    return new RelayCast({ apiKey: session.agentToken, baseUrl: options.baseUrl }).as(
       session.agentToken,
     );
   };

--- a/packages/mcp/src/tools/programmability.ts
+++ b/packages/mcp/src/tools/programmability.ts
@@ -1,13 +1,13 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
-import type { Relay, AgentClient } from '@relaycast/sdk';
+import type { RelayCast, AgentClient } from '@relaycast/sdk';
 
 /** Passthrough object schema for dynamic API responses. */
 const jsonResult = z.object({}).passthrough();
 
 export function registerProgrammabilityTools(
   server: McpServer,
-  getRelay: () => Relay,
+  getRelay: () => RelayCast,
   getAgentClient: () => AgentClient,
 ): void {
   // === Inbound Webhooks ===

--- a/packages/mcp/src/tools/registration.ts
+++ b/packages/mcp/src/tools/registration.ts
@@ -1,6 +1,6 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
-import { Relay } from '@relaycast/sdk';
+import { RelayCast } from '@relaycast/sdk';
 import type { SessionState } from '../types.js';
 
 type ApiOk<T> = { ok: true; data: T };
@@ -51,7 +51,7 @@ function requireWorkspaceKey(session: SessionState): void {
 
 export function registerRegistrationTools(
   server: McpServer,
-  getRelay: () => Relay,
+  getRelay: () => RelayCast,
   getSession: () => SessionState,
   setSession: (state: Partial<SessionState>) => void,
   baseUrl?: string,

--- a/packages/openclaw/src/__tests__/bridge.test.ts
+++ b/packages/openclaw/src/__tests__/bridge.test.ts
@@ -22,7 +22,7 @@ const mockAgentClient = {
 };
 
 vi.mock('@relaycast/sdk', () => ({
-  Relay: vi.fn().mockImplementation(() => ({
+  RelayCast: vi.fn().mockImplementation(() => ({
     agents: { register: mockRegister },
     as: vi.fn().mockReturnValue(mockAgentClient),
   })),

--- a/packages/openclaw/src/bridge.ts
+++ b/packages/openclaw/src/bridge.ts
@@ -1,4 +1,4 @@
-import { Relay, AgentClient, WsClient } from '@relaycast/sdk';
+import { RelayCast, AgentClient, WsClient } from '@relaycast/sdk';
 import type { Agent } from '@relaycast/types';
 
 export interface ClawIdentity {
@@ -40,7 +40,7 @@ export interface OpenClawBridgeOptions {
  * ```
  */
 export class OpenClawBridge {
-  private relay: Relay;
+  private relay: RelayCast;
   private agent: AgentClient | null = null;
   private ws: WsClient | null = null;
   private agentToken: string | null = null;
@@ -48,7 +48,7 @@ export class OpenClawBridge {
 
   constructor(options: OpenClawBridgeOptions) {
     this.options = options;
-    this.relay = new Relay({
+    this.relay = new RelayCast({
       apiKey: options.apiKey,
       baseUrl: options.baseUrl,
     });

--- a/packages/react/src/context.ts
+++ b/packages/react/src/context.ts
@@ -1,9 +1,9 @@
 import { createContext } from 'react';
-import type { Relay, AgentClient, WsClient } from '@relaycast/sdk';
+import type { RelayCast, AgentClient, WsClient } from '@relaycast/sdk';
 import type { RelayStore } from './types.js';
 
 export interface ClientContextValue {
-  relay: Relay;
+  relay: RelayCast;
   agent: AgentClient;
   ws: WsClient;
 }

--- a/packages/react/src/hooks/useEvent.ts
+++ b/packages/react/src/hooks/useEvent.ts
@@ -1,9 +1,9 @@
 import { useContext, useEffect, useRef } from 'react';
-import type { ServerEvent } from '@relaycast/types';
+import type { WsClientEvent } from '@relaycast/types';
 import type { EventHandler } from '@relaycast/sdk';
 import { ClientContext } from '../context.js';
 
-export function useEvent(eventType: string, handler: EventHandler<ServerEvent>): void {
+export function useEvent(eventType: string, handler: EventHandler<WsClientEvent>): void {
   const ctx = useContext(ClientContext);
   if (!ctx) throw new Error('useEvent must be used within <RelayProvider>');
 

--- a/packages/react/src/hooks/useRelay.ts
+++ b/packages/react/src/hooks/useRelay.ts
@@ -1,8 +1,8 @@
 import { useContext } from 'react';
-import type { Relay } from '@relaycast/sdk';
+import type { RelayCast } from '@relaycast/sdk';
 import { ClientContext } from '../context.js';
 
-export function useRelay(): Relay {
+export function useRelay(): RelayCast {
   const ctx = useContext(ClientContext);
   if (!ctx) throw new Error('useRelay must be used within <RelayProvider>');
   return ctx.relay;

--- a/packages/react/src/provider.tsx
+++ b/packages/react/src/provider.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useMemo } from 'react';
 import { Relay, WsClient } from '@relaycast/sdk';
+import type { ServerEvent } from '@relaycast/types';
 import { ClientContext, StoreContext } from './context.js';
 import { createStore } from './store.js';
 import { handleServerEvent } from './reducer.js';
@@ -43,8 +44,9 @@ export function RelayProvider({ apiKey, agentToken, baseUrl, channels, children 
 
     const offAll = ws.on('*', (event) => {
       const t = event.type as string;
-      if (t !== 'pong' && t !== 'open' && t !== 'close') {
-        handleServerEvent(store, event);
+      // Filter out client-only events and pong
+      if (t !== 'pong' && t !== 'open' && t !== 'close' && t !== 'error' && t !== 'reconnecting') {
+        handleServerEvent(store, event as ServerEvent);
       }
     });
 

--- a/packages/react/src/provider.tsx
+++ b/packages/react/src/provider.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useMemo } from 'react';
-import { Relay, WsClient } from '@relaycast/sdk';
+import { RelayCast, WsClient } from '@relaycast/sdk';
 import type { ServerEvent } from '@relaycast/types';
 import { ClientContext, StoreContext } from './context.js';
 import { createStore } from './store.js';
@@ -15,7 +15,7 @@ export interface RelayProviderProps {
 
 export function RelayProvider({ apiKey, agentToken, baseUrl, channels, children }: RelayProviderProps) {
   const clients = useMemo(() => {
-    const relay = new Relay({ apiKey, baseUrl });
+    const relay = new RelayCast({ apiKey, baseUrl });
     const agent = relay.as(agentToken);
     const ws = new WsClient({ token: agentToken, baseUrl });
     return { relay, agent, ws };

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -16,7 +16,8 @@
     "lint": "eslint src/"
   },
   "dependencies": {
-    "@relaycast/types": "0.2.3"
+    "@relaycast/types": "0.2.3",
+    "zod": "^3.24.0"
   },
   "devDependencies": {
     "@types/node": "^20.0.0",

--- a/packages/sdk/src/__tests__/agent-features.test.ts
+++ b/packages/sdk/src/__tests__/agent-features.test.ts
@@ -113,6 +113,18 @@ describe('AgentClient features', () => {
       expect(init.body).toBe(JSON.stringify({ agent: 'Bot' }));
     });
 
+    it('update() patches /v1/channels/:name', async () => {
+      mockFetch.mockImplementation(() =>
+        mockResponse({ name: 'dev', topic: 'Updated topic' }),
+      );
+      await me.channels.update('dev', { topic: 'Updated topic' });
+
+      const [url, init] = mockFetch.mock.calls[0]!;
+      expect(url).toBe('https://api.agentrelay.dev/v1/channels/dev');
+      expect(init.method).toBe('PATCH');
+      expect(init.body).toBe(JSON.stringify({ topic: 'Updated topic' }));
+    });
+
     it('members() gets /v1/channels/:name/members', async () => {
       mockFetch.mockImplementation(() => mockResponse([]));
       await me.channels.members('dev');

--- a/packages/sdk/src/__tests__/agent-ws.test.ts
+++ b/packages/sdk/src/__tests__/agent-ws.test.ts
@@ -1,0 +1,376 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { AgentClient } from '../agent.js';
+import { HttpClient } from '../client.js';
+
+class MockWebSocket {
+  static readonly OPEN = 1;
+  static readonly CLOSED = 3;
+  static instances: MockWebSocket[] = [];
+
+  url: string;
+  readyState = MockWebSocket.OPEN;
+  onopen: (() => void) | null = null;
+  onclose: (() => void) | null = null;
+  onmessage: ((event: { data: string }) => void) | null = null;
+  onerror: (() => void) | null = null;
+  send = vi.fn();
+  close = vi.fn(() => {
+    this.readyState = MockWebSocket.CLOSED;
+  });
+
+  constructor(url: string) {
+    this.url = url;
+    MockWebSocket.instances.push(this);
+  }
+
+  simulateOpen(): void {
+    this.readyState = MockWebSocket.OPEN;
+    this.onopen?.();
+  }
+
+  simulateMessage(data: unknown): void {
+    this.onmessage?.({ data: JSON.stringify(data) });
+  }
+
+  simulateClose(): void {
+    this.readyState = MockWebSocket.CLOSED;
+    this.onclose?.();
+  }
+}
+
+vi.stubGlobal('WebSocket', MockWebSocket);
+
+const mockFetch = vi.fn();
+vi.stubGlobal('fetch', mockFetch);
+
+function createAgent(): AgentClient {
+  const client = new HttpClient({
+    apiKey: 'at_live_test',
+    baseUrl: 'http://localhost:8080',
+  });
+  return new AgentClient(client);
+}
+
+describe('AgentClient WebSocket integration', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    MockWebSocket.instances = [];
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  // --- connect / disconnect ---
+
+  it('connect() creates WebSocket with correct URL', () => {
+    const agent = createAgent();
+    agent.connect();
+
+    expect(MockWebSocket.instances).toHaveLength(1);
+    expect(MockWebSocket.instances[0]!.url).toBe(
+      'ws://localhost:8080/v1/stream?token=at_live_test',
+    );
+  });
+
+  it('connect() is idempotent — second call does not create another WebSocket', () => {
+    const agent = createAgent();
+    agent.connect();
+    agent.connect();
+
+    expect(MockWebSocket.instances).toHaveLength(1);
+  });
+
+  it('disconnect() closes WebSocket', () => {
+    const agent = createAgent();
+    agent.connect();
+    const ws = MockWebSocket.instances[0]!;
+    ws.simulateOpen();
+
+    agent.disconnect();
+    expect(ws.close).toHaveBeenCalled();
+  });
+
+  it('disconnect() allows reconnect with a fresh WebSocket', () => {
+    const agent = createAgent();
+    agent.connect();
+    agent.disconnect();
+
+    agent.connect();
+    expect(MockWebSocket.instances).toHaveLength(2);
+  });
+
+  // --- typed on.* handlers ---
+
+  it('on.messageCreated fires with message.created event', () => {
+    const agent = createAgent();
+    agent.connect();
+    const ws = MockWebSocket.instances[0]!;
+    ws.simulateOpen();
+
+    const handler = vi.fn();
+    agent.on.messageCreated(handler);
+
+    ws.simulateMessage({
+      type: 'message.created',
+      channel: 'general',
+      message: { id: 'm_1', agent_name: 'Bot', text: 'hi', attachments: [] },
+    });
+
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(handler).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'message.created', channel: 'general' }),
+    );
+  });
+
+  it('on.reactionAdded fires with reaction.added event', () => {
+    const agent = createAgent();
+    agent.connect();
+    const ws = MockWebSocket.instances[0]!;
+    ws.simulateOpen();
+
+    const handler = vi.fn();
+    agent.on.reactionAdded(handler);
+
+    ws.simulateMessage({
+      type: 'reaction.added',
+      message_id: 'm_1',
+      emoji: '👍',
+      agent_name: 'Bot',
+    });
+
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(handler).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'reaction.added', emoji: '👍' }),
+    );
+  });
+
+  it('on.dmReceived fires with dm.received event', () => {
+    const agent = createAgent();
+    agent.connect();
+    const ws = MockWebSocket.instances[0]!;
+    ws.simulateOpen();
+
+    const handler = vi.fn();
+    agent.on.dmReceived(handler);
+
+    ws.simulateMessage({
+      type: 'dm.received',
+      conversation_id: 'conv_1',
+      message: { id: 'dm_1', agent_name: 'Alice', text: 'hello' },
+    });
+
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(handler).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'dm.received', conversation_id: 'conv_1' }),
+    );
+  });
+
+  it('on.channelCreated fires with channel.created event', () => {
+    const agent = createAgent();
+    agent.connect();
+    const ws = MockWebSocket.instances[0]!;
+    ws.simulateOpen();
+
+    const handler = vi.fn();
+    agent.on.channelCreated(handler);
+
+    ws.simulateMessage({
+      type: 'channel.created',
+      channel: { name: 'new-channel', topic: null },
+    });
+
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(handler).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'channel.created' }),
+    );
+  });
+
+  // --- subscribe / unsubscribe proxy ---
+
+  it('subscribe() proxies to WsClient', () => {
+    const agent = createAgent();
+    agent.connect();
+    const ws = MockWebSocket.instances[0]!;
+    ws.simulateOpen();
+
+    agent.subscribe(['general', 'dev']);
+
+    expect(ws.send).toHaveBeenCalledWith(
+      JSON.stringify({ type: 'subscribe', channels: ['general', 'dev'] }),
+    );
+  });
+
+  it('unsubscribe() proxies to WsClient', () => {
+    const agent = createAgent();
+    agent.connect();
+    const ws = MockWebSocket.instances[0]!;
+    ws.simulateOpen();
+
+    agent.unsubscribe(['dev']);
+
+    expect(ws.send).toHaveBeenCalledWith(
+      JSON.stringify({ type: 'unsubscribe', channels: ['dev'] }),
+    );
+  });
+
+  it('subscribe() is a no-op when not connected', () => {
+    const agent = createAgent();
+    // Should not throw
+    agent.subscribe(['general']);
+  });
+
+  it('unsubscribe() is a no-op when not connected', () => {
+    const agent = createAgent();
+    // Should not throw
+    agent.unsubscribe(['general']);
+  });
+
+  // --- lifecycle events ---
+
+  it('on.connected fires on WebSocket open', () => {
+    const agent = createAgent();
+    agent.connect();
+    const ws = MockWebSocket.instances[0]!;
+
+    const handler = vi.fn();
+    agent.on.connected(handler);
+
+    ws.simulateOpen();
+
+    expect(handler).toHaveBeenCalledTimes(1);
+  });
+
+  it('on.disconnected fires on WebSocket close', () => {
+    const agent = createAgent();
+    agent.connect();
+    const ws = MockWebSocket.instances[0]!;
+    ws.simulateOpen();
+
+    const handler = vi.fn();
+    agent.on.disconnected(handler);
+
+    ws.simulateClose();
+
+    expect(handler).toHaveBeenCalledTimes(1);
+  });
+
+  it('on.reconnecting fires with attempt count', () => {
+    const agent = createAgent();
+    agent.connect();
+    const ws = MockWebSocket.instances[0]!;
+    ws.simulateOpen();
+
+    const handler = vi.fn();
+    agent.on.reconnecting(handler);
+
+    ws.simulateClose();
+
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(handler).toHaveBeenCalledWith(1);
+
+    // Advance timer to trigger reconnect, then close again
+    vi.advanceTimersByTime(1000);
+    const ws2 = MockWebSocket.instances[1]!;
+    ws2.simulateClose();
+
+    expect(handler).toHaveBeenCalledTimes(2);
+    expect(handler).toHaveBeenLastCalledWith(2);
+  });
+
+  // --- wildcard ---
+
+  it('on.any receives all events', () => {
+    const agent = createAgent();
+    agent.connect();
+    const ws = MockWebSocket.instances[0]!;
+
+    const handler = vi.fn();
+    agent.on.any(handler);
+
+    ws.simulateOpen();
+    // 'open' synthetic event
+
+    ws.simulateMessage({
+      type: 'message.created',
+      channel: 'general',
+      message: { id: 'm_1', agent_name: 'Bot', text: 'hi', attachments: [] },
+    });
+    ws.simulateMessage({ type: 'pong' });
+
+    // open + message.created + pong = 3
+    expect(handler).toHaveBeenCalledTimes(3);
+  });
+
+  // --- error: call before connect ---
+
+  it('on.messageCreated throws if called before connect()', () => {
+    const agent = createAgent();
+    expect(() => agent.on.messageCreated(vi.fn())).toThrow(
+      'WebSocket not connected. Call connect() first.',
+    );
+  });
+
+  it('on.connected throws if called before connect()', () => {
+    const agent = createAgent();
+    expect(() => agent.on.connected(vi.fn())).toThrow(
+      'WebSocket not connected. Call connect() first.',
+    );
+  });
+
+  it('on.reconnecting throws if called before connect()', () => {
+    const agent = createAgent();
+    expect(() => agent.on.reconnecting(vi.fn())).toThrow(
+      'WebSocket not connected. Call connect() first.',
+    );
+  });
+
+  it('on.any throws if called before connect()', () => {
+    const agent = createAgent();
+    expect(() => agent.on.any(vi.fn())).toThrow(
+      'WebSocket not connected. Call connect() first.',
+    );
+  });
+
+  // --- unsubscribe function ---
+
+  it('handler unsubscribe function stops future events', () => {
+    const agent = createAgent();
+    agent.connect();
+    const ws = MockWebSocket.instances[0]!;
+    ws.simulateOpen();
+
+    const handler = vi.fn();
+    const unsub = agent.on.messageCreated(handler);
+
+    const event = {
+      type: 'message.created',
+      channel: 'general',
+      message: { id: 'm_1', agent_name: 'Bot', text: 'hi', attachments: [] },
+    };
+
+    ws.simulateMessage(event);
+    expect(handler).toHaveBeenCalledTimes(1);
+
+    unsub();
+    ws.simulateMessage(event);
+    expect(handler).toHaveBeenCalledTimes(1);
+  });
+
+  it('on.any unsubscribe function stops future events', () => {
+    const agent = createAgent();
+    agent.connect();
+    const ws = MockWebSocket.instances[0]!;
+    ws.simulateOpen();
+
+    const handler = vi.fn();
+    const unsub = agent.on.any(handler);
+
+    ws.simulateMessage({ type: 'pong' });
+    expect(handler).toHaveBeenCalledTimes(1);
+
+    unsub();
+    ws.simulateMessage({ type: 'pong' });
+    expect(handler).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/sdk/src/__tests__/dashboard.test.ts
+++ b/packages/sdk/src/__tests__/dashboard.test.ts
@@ -17,8 +17,8 @@ describe('Relay dashboard methods', () => {
   });
 
   it('stats() calls GET /v1/workspace/stats', async () => {
-    const { Relay } = await import('../relay.js');
-    const relay = new Relay({ apiKey: 'rk_live_test123' });
+    const { RelayCast } = await import('../relay.js');
+    const relay = new RelayCast({ apiKey: 'rk_live_test123' });
 
     mockFetch.mockImplementation(() =>
       mockResponse({ agents: 5, channels: 3, messages: 100, dm_conversations: 2, files: 1 }),
@@ -34,8 +34,8 @@ describe('Relay dashboard methods', () => {
   });
 
   it('activity() calls GET /v1/activity without params', async () => {
-    const { Relay } = await import('../relay.js');
-    const relay = new Relay({ apiKey: 'rk_live_test123' });
+    const { RelayCast } = await import('../relay.js');
+    const relay = new RelayCast({ apiKey: 'rk_live_test123' });
 
     mockFetch.mockImplementation(() => mockResponse([]));
     await relay.activity();
@@ -45,8 +45,8 @@ describe('Relay dashboard methods', () => {
   });
 
   it('activity(5) calls GET /v1/activity?limit=5', async () => {
-    const { Relay } = await import('../relay.js');
-    const relay = new Relay({ apiKey: 'rk_live_test123' });
+    const { RelayCast } = await import('../relay.js');
+    const relay = new RelayCast({ apiKey: 'rk_live_test123' });
 
     mockFetch.mockImplementation(() => mockResponse([]));
     await relay.activity(5);
@@ -56,8 +56,8 @@ describe('Relay dashboard methods', () => {
   });
 
   it('allDmConversations() calls GET /v1/dm/conversations/all', async () => {
-    const { Relay } = await import('../relay.js');
-    const relay = new Relay({ apiKey: 'rk_live_test123' });
+    const { RelayCast } = await import('../relay.js');
+    const relay = new RelayCast({ apiKey: 'rk_live_test123' });
 
     mockFetch.mockImplementation(() => mockResponse([]));
     await relay.allDmConversations();
@@ -68,8 +68,8 @@ describe('Relay dashboard methods', () => {
   });
 
   it('agents.rotateToken() calls POST /v1/agents/:name/rotate-token', async () => {
-    const { Relay } = await import('../relay.js');
-    const relay = new Relay({ apiKey: 'rk_live_test123' });
+    const { RelayCast } = await import('../relay.js');
+    const relay = new RelayCast({ apiKey: 'rk_live_test123' });
 
     mockFetch.mockImplementation(() =>
       mockResponse({ token: 'at_live_newtoken' }),
@@ -83,8 +83,8 @@ describe('Relay dashboard methods', () => {
   });
 
   it('agents.rotateToken() URL-encodes the agent name', async () => {
-    const { Relay } = await import('../relay.js');
-    const relay = new Relay({ apiKey: 'rk_live_test123' });
+    const { RelayCast } = await import('../relay.js');
+    const relay = new RelayCast({ apiKey: 'rk_live_test123' });
 
     mockFetch.mockImplementation(() =>
       mockResponse({ token: 'at_live_tok' }),

--- a/packages/sdk/src/__tests__/index.test.ts
+++ b/packages/sdk/src/__tests__/index.test.ts
@@ -3,7 +3,7 @@ import { SDK_VERSION } from '../index.js';
 
 describe('@relaycast/sdk', () => {
   it('exports SDK_VERSION', () => {
-    expect(SDK_VERSION).toBe('0.1.0');
+    expect(SDK_VERSION).toBe('0.2.3');
   });
 });
 

--- a/packages/sdk/src/__tests__/index.test.ts
+++ b/packages/sdk/src/__tests__/index.test.ts
@@ -3,7 +3,7 @@ import { SDK_VERSION } from '../index.js';
 
 describe('@relaycast/sdk', () => {
   it('exports SDK_VERSION', () => {
-    expect(SDK_VERSION).toBe('0.2.3');
+    expect(SDK_VERSION).toMatch(/^\d+\.\d+\.\d+/);
   });
 });
 

--- a/packages/sdk/src/__tests__/programmability.test.ts
+++ b/packages/sdk/src/__tests__/programmability.test.ts
@@ -33,8 +33,8 @@ describe('Programmability SDK', () => {
 
   describe('webhooks', () => {
     it('create() posts to /v1/webhooks', async () => {
-      const { Relay } = await import('../relay.js');
-      const relay = new Relay({ apiKey: 'rk_live_test123' });
+      const { RelayCast } = await import('../relay.js');
+      const relay = new RelayCast({ apiKey: 'rk_live_test123' });
 
       mockFetch.mockImplementation(() =>
         mockResponse({ webhook_id: 'wh_1', name: 'GitHub', channel: 'dev', url: 'https://...', created_at: '2025-01-01' }),
@@ -48,8 +48,8 @@ describe('Programmability SDK', () => {
     });
 
     it('list() gets /v1/webhooks', async () => {
-      const { Relay } = await import('../relay.js');
-      const relay = new Relay({ apiKey: 'rk_live_test123' });
+      const { RelayCast } = await import('../relay.js');
+      const relay = new RelayCast({ apiKey: 'rk_live_test123' });
 
       mockFetch.mockImplementation(() => mockResponse([]));
       await relay.webhooks.list();
@@ -60,8 +60,8 @@ describe('Programmability SDK', () => {
     });
 
     it('delete() deletes /v1/webhooks/:id (handles 204)', async () => {
-      const { Relay } = await import('../relay.js');
-      const relay = new Relay({ apiKey: 'rk_live_test123' });
+      const { RelayCast } = await import('../relay.js');
+      const relay = new RelayCast({ apiKey: 'rk_live_test123' });
 
       mockFetch.mockImplementation(() => mock204());
       await relay.webhooks.delete('wh_1');
@@ -72,8 +72,8 @@ describe('Programmability SDK', () => {
     });
 
     it('trigger() posts to /v1/hooks/:webhookId', async () => {
-      const { Relay } = await import('../relay.js');
-      const relay = new Relay({ apiKey: 'rk_live_test123' });
+      const { RelayCast } = await import('../relay.js');
+      const relay = new RelayCast({ apiKey: 'rk_live_test123' });
 
       mockFetch.mockImplementation(() =>
         mockResponse({ message_id: 'm_1', channel: 'dev', text: 'alert', created_at: '2025-01-01' }),
@@ -91,8 +91,8 @@ describe('Programmability SDK', () => {
 
   describe('subscriptions', () => {
     it('create() posts to /v1/subscriptions', async () => {
-      const { Relay } = await import('../relay.js');
-      const relay = new Relay({ apiKey: 'rk_live_test123' });
+      const { RelayCast } = await import('../relay.js');
+      const relay = new RelayCast({ apiKey: 'rk_live_test123' });
 
       mockFetch.mockImplementation(() =>
         mockResponse({ id: 'sub_1', events: ['message.created'], url: 'https://hook.example.com' }),
@@ -112,8 +112,8 @@ describe('Programmability SDK', () => {
     });
 
     it('list() gets /v1/subscriptions', async () => {
-      const { Relay } = await import('../relay.js');
-      const relay = new Relay({ apiKey: 'rk_live_test123' });
+      const { RelayCast } = await import('../relay.js');
+      const relay = new RelayCast({ apiKey: 'rk_live_test123' });
 
       mockFetch.mockImplementation(() => mockResponse([]));
       await relay.subscriptions.list();
@@ -124,8 +124,8 @@ describe('Programmability SDK', () => {
     });
 
     it('get() gets /v1/subscriptions/:id', async () => {
-      const { Relay } = await import('../relay.js');
-      const relay = new Relay({ apiKey: 'rk_live_test123' });
+      const { RelayCast } = await import('../relay.js');
+      const relay = new RelayCast({ apiKey: 'rk_live_test123' });
 
       mockFetch.mockImplementation(() =>
         mockResponse({ id: 'sub_1', events: ['message.created'], url: 'https://hook.example.com' }),
@@ -138,8 +138,8 @@ describe('Programmability SDK', () => {
     });
 
     it('delete() deletes /v1/subscriptions/:id (handles 204)', async () => {
-      const { Relay } = await import('../relay.js');
-      const relay = new Relay({ apiKey: 'rk_live_test123' });
+      const { RelayCast } = await import('../relay.js');
+      const relay = new RelayCast({ apiKey: 'rk_live_test123' });
 
       mockFetch.mockImplementation(() => mock204());
       await relay.subscriptions.delete('sub_1');
@@ -154,8 +154,8 @@ describe('Programmability SDK', () => {
 
   describe('commands', () => {
     it('register() posts to /v1/commands', async () => {
-      const { Relay } = await import('../relay.js');
-      const relay = new Relay({ apiKey: 'rk_live_test123' });
+      const { RelayCast } = await import('../relay.js');
+      const relay = new RelayCast({ apiKey: 'rk_live_test123' });
 
       mockFetch.mockImplementation(() =>
         mockResponse({ id: 'cmd_1', command: 'deploy', description: 'Deploy app' }),
@@ -177,8 +177,8 @@ describe('Programmability SDK', () => {
     });
 
     it('list() gets /v1/commands', async () => {
-      const { Relay } = await import('../relay.js');
-      const relay = new Relay({ apiKey: 'rk_live_test123' });
+      const { RelayCast } = await import('../relay.js');
+      const relay = new RelayCast({ apiKey: 'rk_live_test123' });
 
       mockFetch.mockImplementation(() => mockResponse([]));
       await relay.commands.list();
@@ -189,8 +189,8 @@ describe('Programmability SDK', () => {
     });
 
     it('delete() deletes /v1/commands/:command (handles 204)', async () => {
-      const { Relay } = await import('../relay.js');
-      const relay = new Relay({ apiKey: 'rk_live_test123' });
+      const { RelayCast } = await import('../relay.js');
+      const relay = new RelayCast({ apiKey: 'rk_live_test123' });
 
       mockFetch.mockImplementation(() => mock204());
       await relay.commands.delete('deploy');

--- a/packages/sdk/src/__tests__/relay.test.ts
+++ b/packages/sdk/src/__tests__/relay.test.ts
@@ -139,6 +139,215 @@ describe('Relay', () => {
     });
   });
 
+  describe('workspace.delete', () => {
+    it('delete() calls DELETE /v1/workspace', async () => {
+      const { Relay } = await import('../relay.js');
+      const relay = new Relay({ apiKey: 'rk_live_test123' });
+
+      mockFetch.mockImplementation(() =>
+        Promise.resolve({ ok: true, status: 204, json: () => Promise.resolve(undefined) }),
+      );
+      await relay.workspace.delete();
+
+      const [url, init] = mockFetch.mock.calls[0]!;
+      expect(url).toBe('https://api.agentrelay.dev/v1/workspace');
+      expect(init.method).toBe('DELETE');
+    });
+  });
+
+  describe('systemPrompt', () => {
+    it('get() calls GET /v1/workspace/system-prompt', async () => {
+      const { Relay } = await import('../relay.js');
+      const relay = new Relay({ apiKey: 'rk_live_test123' });
+
+      mockFetch.mockImplementation(() =>
+        mockResponse({ prompt: 'Be helpful', is_default: false }),
+      );
+      const result = await relay.systemPrompt.get();
+
+      const [url, init] = mockFetch.mock.calls[0]!;
+      expect(url).toBe('https://api.agentrelay.dev/v1/workspace/system-prompt');
+      expect(init.method).toBe('GET');
+      expect(result).toEqual({ prompt: 'Be helpful', is_default: false });
+    });
+
+    it('set() calls PUT /v1/workspace/system-prompt', async () => {
+      const { Relay } = await import('../relay.js');
+      const relay = new Relay({ apiKey: 'rk_live_test123' });
+
+      mockFetch.mockImplementation(() =>
+        mockResponse({ prompt: 'New prompt', is_default: false }),
+      );
+      await relay.systemPrompt.set({ prompt: 'New prompt' });
+
+      const [url, init] = mockFetch.mock.calls[0]!;
+      expect(url).toBe('https://api.agentrelay.dev/v1/workspace/system-prompt');
+      expect(init.method).toBe('PUT');
+      expect(init.body).toBe(JSON.stringify({ prompt: 'New prompt' }));
+    });
+  });
+
+  describe('agents.update', () => {
+    it('update() calls PATCH /v1/agents/:name', async () => {
+      const { Relay } = await import('../relay.js');
+      const relay = new Relay({ apiKey: 'rk_live_test123' });
+
+      mockFetch.mockImplementation(() => mockResponse({ name: 'Bot', status: 'online' }));
+      await relay.agents.update('Bot', { status: 'online' });
+
+      const [url, init] = mockFetch.mock.calls[0]!;
+      expect(url).toBe('https://api.agentrelay.dev/v1/agents/Bot');
+      expect(init.method).toBe('PATCH');
+      expect(init.body).toBe(JSON.stringify({ status: 'online' }));
+    });
+  });
+
+  describe('agents.delete', () => {
+    it('delete() calls DELETE /v1/agents/:name', async () => {
+      const { Relay } = await import('../relay.js');
+      const relay = new Relay({ apiKey: 'rk_live_test123' });
+
+      mockFetch.mockImplementation(() =>
+        Promise.resolve({ ok: true, status: 204, json: () => Promise.resolve(undefined) }),
+      );
+      await relay.agents.delete('Bot');
+
+      const [url, init] = mockFetch.mock.calls[0]!;
+      expect(url).toBe('https://api.agentrelay.dev/v1/agents/Bot');
+      expect(init.method).toBe('DELETE');
+    });
+  });
+
+  describe('agents.presence', () => {
+    it('presence() calls GET /v1/agents/presence', async () => {
+      const { Relay } = await import('../relay.js');
+      const relay = new Relay({ apiKey: 'rk_live_test123' });
+
+      const data = [{ agent_id: 'a_1', agent_name: 'Bot', status: 'online' }];
+      mockFetch.mockImplementation(() => mockResponse(data));
+      const result = await relay.agents.presence();
+
+      const [url, init] = mockFetch.mock.calls[0]!;
+      expect(url).toBe('https://api.agentrelay.dev/v1/agents/presence');
+      expect(init.method).toBe('GET');
+      expect(result).toEqual(data);
+    });
+  });
+
+  describe('Relay.createWorkspace', () => {
+    it('calls POST /v1/workspaces without auth', async () => {
+      const { Relay } = await import('../relay.js');
+
+      mockFetch.mockImplementation(() =>
+        Promise.resolve({
+          ok: true,
+          status: 200,
+          json: () =>
+            Promise.resolve({
+              ok: true,
+              data: { workspace_id: 'ws_1', api_key: 'rk_live_new', created_at: '2024-01-01' },
+            }),
+        }),
+      );
+
+      const result = await Relay.createWorkspace('My Workspace');
+
+      const [url, init] = mockFetch.mock.calls[0]!;
+      expect(url).toBe('https://api.agentrelay.dev/v1/workspaces');
+      expect(init.method).toBe('POST');
+      expect(init.body).toBe(JSON.stringify({ name: 'My Workspace' }));
+      expect(init.headers.Authorization).toBeUndefined();
+      expect(result.workspace_id).toBe('ws_1');
+    });
+
+    it('uses custom baseUrl', async () => {
+      const { Relay } = await import('../relay.js');
+
+      mockFetch.mockImplementation(() =>
+        Promise.resolve({
+          ok: true,
+          status: 200,
+          json: () =>
+            Promise.resolve({
+              ok: true,
+              data: { workspace_id: 'ws_1', api_key: 'rk_live_new', created_at: '2024-01-01' },
+            }),
+        }),
+      );
+
+      await Relay.createWorkspace('Test', 'http://localhost:3000');
+
+      const [url] = mockFetch.mock.calls[0]!;
+      expect(url).toBe('http://localhost:3000/v1/workspaces');
+    });
+
+    it('throws RelayError on failure', async () => {
+      const { Relay } = await import('../relay.js');
+      const { RelayError } = await import('../client.js');
+
+      mockFetch.mockImplementation(() =>
+        Promise.resolve({
+          ok: false,
+          status: 409,
+          json: () =>
+            Promise.resolve({
+              ok: false,
+              error: { code: 'workspace_exists', message: 'Already exists' },
+            }),
+        }),
+      );
+
+      await expect(Relay.createWorkspace('Dup')).rejects.toBeInstanceOf(RelayError);
+    });
+  });
+
+  describe('agents.registerOrGet', () => {
+    it('returns register result when agent does not exist', async () => {
+      const { Relay } = await import('../relay.js');
+      const relay = new Relay({ apiKey: 'rk_live_test123' });
+
+      const created = { id: 'a_1', name: 'Bot', token: 'at_live_new', status: 'online', created_at: '2024-01-01' };
+      mockFetch.mockImplementation(() => mockResponse(created));
+
+      const result = await relay.agents.registerOrGet({ name: 'Bot' });
+      expect(result).toEqual(created);
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+    });
+
+    it('falls back to get + rotateToken on agent_already_exists', async () => {
+      const { Relay } = await import('../relay.js');
+      const relay = new Relay({ apiKey: 'rk_live_test123' });
+
+      mockFetch
+        .mockImplementationOnce(() =>
+          mockResponse({ code: 'agent_already_exists', message: 'exists' }, false, 409),
+        )
+        .mockImplementationOnce(() =>
+          mockResponse({ id: 'a_1', name: 'Bot', status: 'online', created_at: '2024-01-01' }),
+        )
+        .mockImplementationOnce(() =>
+          mockResponse({ token: 'at_live_rotated' }),
+        );
+
+      const result = await relay.agents.registerOrGet({ name: 'Bot' });
+      expect(result.token).toBe('at_live_rotated');
+      expect(result.name).toBe('Bot');
+      expect(mockFetch).toHaveBeenCalledTimes(3);
+    });
+
+    it('rethrows non-conflict errors', async () => {
+      const { Relay } = await import('../relay.js');
+      const { RelayError } = await import('../client.js');
+      const relay = new Relay({ apiKey: 'rk_live_test123' });
+
+      mockFetch.mockImplementation(() =>
+        mockResponse({ code: 'internal_error', message: 'boom' }, false, 500),
+      );
+
+      await expect(relay.agents.registerOrGet({ name: 'Bot' })).rejects.toBeInstanceOf(RelayError);
+    });
+  });
+
   describe('as()', () => {
     it('returns an AgentClient that uses the agent token for Authorization', async () => {
       const { Relay } = await import('../relay.js');

--- a/packages/sdk/src/__tests__/relay.test.ts
+++ b/packages/sdk/src/__tests__/relay.test.ts
@@ -12,7 +12,7 @@ function mockResponse(data: unknown, apiOk = true, status = 200) {
   });
 }
 
-describe('Relay', () => {
+describe('RelayCast', () => {
   beforeEach(() => {
     mockFetch.mockReset();
     vi.useRealTimers();
@@ -20,8 +20,8 @@ describe('Relay', () => {
 
   describe('workspace', () => {
     it('info() calls GET /v1/workspace', async () => {
-      const { Relay } = await import('../relay.js');
-      const relay = new Relay({ apiKey: 'rk_live_test123' });
+      const { RelayCast } = await import('../relay.js');
+      const relay = new RelayCast({ apiKey: 'rk_live_test123' });
 
       mockFetch.mockImplementation(() => mockResponse({ id: 'ws_1' }));
       await relay.workspace.info();
@@ -35,8 +35,8 @@ describe('Relay', () => {
     });
 
     it('update() calls PATCH /v1/workspace with JSON body', async () => {
-      const { Relay } = await import('../relay.js');
-      const relay = new Relay({ apiKey: 'rk_live_test123' });
+      const { RelayCast } = await import('../relay.js');
+      const relay = new RelayCast({ apiKey: 'rk_live_test123' });
 
       mockFetch.mockImplementation(() => mockResponse({ id: 'ws_1', name: 'new' }));
       await relay.workspace.update({ name: 'new' } as any);
@@ -52,8 +52,8 @@ describe('Relay', () => {
 
   describe('agents', () => {
     it('register() calls POST /v1/agents', async () => {
-      const { Relay } = await import('../relay.js');
-      const relay = new Relay({ apiKey: 'rk_live_test123' });
+      const { RelayCast } = await import('../relay.js');
+      const relay = new RelayCast({ apiKey: 'rk_live_test123' });
 
       mockFetch.mockImplementation(() => mockResponse({ ok: true }));
       await relay.agents.register({ name: 'Worker' } as any);
@@ -65,8 +65,8 @@ describe('Relay', () => {
     });
 
     it('list() calls GET /v1/agents', async () => {
-      const { Relay } = await import('../relay.js');
-      const relay = new Relay({ apiKey: 'rk_live_test123' });
+      const { RelayCast } = await import('../relay.js');
+      const relay = new RelayCast({ apiKey: 'rk_live_test123' });
 
       mockFetch.mockImplementation(() => mockResponse([]));
       await relay.agents.list();
@@ -77,8 +77,8 @@ describe('Relay', () => {
     });
 
     it('list() with status filter adds query params', async () => {
-      const { Relay } = await import('../relay.js');
-      const relay = new Relay({ apiKey: 'rk_live_test123' });
+      const { RelayCast } = await import('../relay.js');
+      const relay = new RelayCast({ apiKey: 'rk_live_test123' });
 
       mockFetch.mockImplementation(() => mockResponse([]));
       await relay.agents.list({ status: 'active' } as any);
@@ -88,8 +88,8 @@ describe('Relay', () => {
     });
 
     it('get() calls GET /v1/agents/:name with URL encoding', async () => {
-      const { Relay } = await import('../relay.js');
-      const relay = new Relay({ apiKey: 'rk_live_test123' });
+      const { RelayCast } = await import('../relay.js');
+      const relay = new RelayCast({ apiKey: 'rk_live_test123' });
 
       mockFetch.mockImplementation(() => mockResponse({ name: 'a/b' }));
       await relay.agents.get('a/b');
@@ -101,9 +101,9 @@ describe('Relay', () => {
 
   describe('error handling', () => {
     it('throws RelayError on API error', async () => {
-      const { Relay } = await import('../relay.js');
+      const { RelayCast } = await import('../relay.js');
       const { RelayError } = await import('../client.js');
-      const relay = new Relay({ apiKey: 'rk_live_test123' });
+      const relay = new RelayCast({ apiKey: 'rk_live_test123' });
 
       mockFetch.mockImplementation(() =>
         mockResponse({ code: 'bad_request', message: 'Nope' }, false, 400),
@@ -118,8 +118,8 @@ describe('Relay', () => {
 
     it('retries on 5xx with exponential backoff (200ms, 400ms, 800ms)', async () => {
       vi.useFakeTimers();
-      const { Relay } = await import('../relay.js');
-      const relay = new Relay({ apiKey: 'rk_live_test123' });
+      const { RelayCast } = await import('../relay.js');
+      const relay = new RelayCast({ apiKey: 'rk_live_test123' });
 
       mockFetch
         .mockImplementationOnce(() => mockResponse({ code: 'e', message: 'x' }, false, 500))
@@ -141,8 +141,8 @@ describe('Relay', () => {
 
   describe('workspace.delete', () => {
     it('delete() calls DELETE /v1/workspace', async () => {
-      const { Relay } = await import('../relay.js');
-      const relay = new Relay({ apiKey: 'rk_live_test123' });
+      const { RelayCast } = await import('../relay.js');
+      const relay = new RelayCast({ apiKey: 'rk_live_test123' });
 
       mockFetch.mockImplementation(() =>
         Promise.resolve({ ok: true, status: 204, json: () => Promise.resolve(undefined) }),
@@ -157,8 +157,8 @@ describe('Relay', () => {
 
   describe('systemPrompt', () => {
     it('get() calls GET /v1/workspace/system-prompt', async () => {
-      const { Relay } = await import('../relay.js');
-      const relay = new Relay({ apiKey: 'rk_live_test123' });
+      const { RelayCast } = await import('../relay.js');
+      const relay = new RelayCast({ apiKey: 'rk_live_test123' });
 
       mockFetch.mockImplementation(() =>
         mockResponse({ prompt: 'Be helpful', is_default: false }),
@@ -172,8 +172,8 @@ describe('Relay', () => {
     });
 
     it('set() calls PUT /v1/workspace/system-prompt', async () => {
-      const { Relay } = await import('../relay.js');
-      const relay = new Relay({ apiKey: 'rk_live_test123' });
+      const { RelayCast } = await import('../relay.js');
+      const relay = new RelayCast({ apiKey: 'rk_live_test123' });
 
       mockFetch.mockImplementation(() =>
         mockResponse({ prompt: 'New prompt', is_default: false }),
@@ -189,8 +189,8 @@ describe('Relay', () => {
 
   describe('agents.update', () => {
     it('update() calls PATCH /v1/agents/:name', async () => {
-      const { Relay } = await import('../relay.js');
-      const relay = new Relay({ apiKey: 'rk_live_test123' });
+      const { RelayCast } = await import('../relay.js');
+      const relay = new RelayCast({ apiKey: 'rk_live_test123' });
 
       mockFetch.mockImplementation(() => mockResponse({ name: 'Bot', status: 'online' }));
       await relay.agents.update('Bot', { status: 'online' });
@@ -204,8 +204,8 @@ describe('Relay', () => {
 
   describe('agents.delete', () => {
     it('delete() calls DELETE /v1/agents/:name', async () => {
-      const { Relay } = await import('../relay.js');
-      const relay = new Relay({ apiKey: 'rk_live_test123' });
+      const { RelayCast } = await import('../relay.js');
+      const relay = new RelayCast({ apiKey: 'rk_live_test123' });
 
       mockFetch.mockImplementation(() =>
         Promise.resolve({ ok: true, status: 204, json: () => Promise.resolve(undefined) }),
@@ -220,8 +220,8 @@ describe('Relay', () => {
 
   describe('agents.presence', () => {
     it('presence() calls GET /v1/agents/presence', async () => {
-      const { Relay } = await import('../relay.js');
-      const relay = new Relay({ apiKey: 'rk_live_test123' });
+      const { RelayCast } = await import('../relay.js');
+      const relay = new RelayCast({ apiKey: 'rk_live_test123' });
 
       const data = [{ agent_id: 'a_1', agent_name: 'Bot', status: 'online' }];
       mockFetch.mockImplementation(() => mockResponse(data));
@@ -234,9 +234,9 @@ describe('Relay', () => {
     });
   });
 
-  describe('Relay.createWorkspace', () => {
+  describe('RelayCast.createWorkspace', () => {
     it('calls POST /v1/workspaces without auth', async () => {
-      const { Relay } = await import('../relay.js');
+      const { RelayCast } = await import('../relay.js');
 
       mockFetch.mockImplementation(() =>
         Promise.resolve({
@@ -250,7 +250,7 @@ describe('Relay', () => {
         }),
       );
 
-      const result = await Relay.createWorkspace('My Workspace');
+      const result = await RelayCast.createWorkspace('My Workspace');
 
       const [url, init] = mockFetch.mock.calls[0]!;
       expect(url).toBe('https://api.agentrelay.dev/v1/workspaces');
@@ -261,7 +261,7 @@ describe('Relay', () => {
     });
 
     it('uses custom baseUrl', async () => {
-      const { Relay } = await import('../relay.js');
+      const { RelayCast } = await import('../relay.js');
 
       mockFetch.mockImplementation(() =>
         Promise.resolve({
@@ -275,14 +275,14 @@ describe('Relay', () => {
         }),
       );
 
-      await Relay.createWorkspace('Test', 'http://localhost:3000');
+      await RelayCast.createWorkspace('Test', 'http://localhost:3000');
 
       const [url] = mockFetch.mock.calls[0]!;
       expect(url).toBe('http://localhost:3000/v1/workspaces');
     });
 
     it('throws RelayError on failure', async () => {
-      const { Relay } = await import('../relay.js');
+      const { RelayCast } = await import('../relay.js');
       const { RelayError } = await import('../client.js');
 
       mockFetch.mockImplementation(() =>
@@ -297,14 +297,14 @@ describe('Relay', () => {
         }),
       );
 
-      await expect(Relay.createWorkspace('Dup')).rejects.toBeInstanceOf(RelayError);
+      await expect(RelayCast.createWorkspace('Dup')).rejects.toBeInstanceOf(RelayError);
     });
   });
 
   describe('agents.registerOrGet', () => {
     it('returns register result when agent does not exist', async () => {
-      const { Relay } = await import('../relay.js');
-      const relay = new Relay({ apiKey: 'rk_live_test123' });
+      const { RelayCast } = await import('../relay.js');
+      const relay = new RelayCast({ apiKey: 'rk_live_test123' });
 
       const created = { id: 'a_1', name: 'Bot', token: 'at_live_new', status: 'online', created_at: '2024-01-01' };
       mockFetch.mockImplementation(() => mockResponse(created));
@@ -315,8 +315,8 @@ describe('Relay', () => {
     });
 
     it('falls back to get + rotateToken on agent_already_exists', async () => {
-      const { Relay } = await import('../relay.js');
-      const relay = new Relay({ apiKey: 'rk_live_test123' });
+      const { RelayCast } = await import('../relay.js');
+      const relay = new RelayCast({ apiKey: 'rk_live_test123' });
 
       mockFetch
         .mockImplementationOnce(() =>
@@ -336,9 +336,9 @@ describe('Relay', () => {
     });
 
     it('rethrows non-conflict errors', async () => {
-      const { Relay } = await import('../relay.js');
+      const { RelayCast } = await import('../relay.js');
       const { RelayError } = await import('../client.js');
-      const relay = new Relay({ apiKey: 'rk_live_test123' });
+      const relay = new RelayCast({ apiKey: 'rk_live_test123' });
 
       mockFetch.mockImplementation(() =>
         mockResponse({ code: 'internal_error', message: 'boom' }, false, 500),
@@ -350,9 +350,9 @@ describe('Relay', () => {
 
   describe('as()', () => {
     it('returns an AgentClient that uses the agent token for Authorization', async () => {
-      const { Relay } = await import('../relay.js');
+      const { RelayCast } = await import('../relay.js');
       const { AgentClient } = await import('../agent.js');
-      const relay = new Relay({ apiKey: 'rk_live_test123' });
+      const relay = new RelayCast({ apiKey: 'rk_live_test123' });
 
       mockFetch.mockImplementation(() => mockResponse({ ok: true }));
       const agentClient = relay.as('at_live_agent123');

--- a/packages/sdk/src/__tests__/ws.test.ts
+++ b/packages/sdk/src/__tests__/ws.test.ts
@@ -231,6 +231,47 @@ describe('WsClient', () => {
     expect(handler).not.toHaveBeenCalled();
   });
 
+  it('emits error event on WebSocket error', () => {
+    const client = new WsClient({ token: 'at_live_test' });
+    const handler = vi.fn();
+    client.on('error', handler);
+
+    client.connect();
+    const ws = MockWebSocket.instances[0]!;
+    ws.simulateOpen();
+
+    ws.onerror?.();
+
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(handler).toHaveBeenCalledWith(expect.objectContaining({ type: 'error' }));
+  });
+
+  it('emits reconnecting event with attempt count', () => {
+    const client = new WsClient({ token: 'at_live_test' });
+    const handler = vi.fn();
+    client.on('reconnecting', handler);
+
+    client.connect();
+    const ws = MockWebSocket.instances[0]!;
+    ws.simulateOpen();
+    ws.simulateClose();
+
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(handler).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'reconnecting', attempt: 1 }),
+    );
+
+    // Advance timer to trigger reconnect, then close again
+    vi.advanceTimersByTime(1000);
+    const ws2 = MockWebSocket.instances[1]!;
+    ws2.simulateClose();
+
+    expect(handler).toHaveBeenCalledTimes(2);
+    expect(handler).toHaveBeenLastCalledWith(
+      expect.objectContaining({ type: 'reconnecting', attempt: 2 }),
+    );
+  });
+
   it('does not send if WebSocket is not open', () => {
     const client = new WsClient({ token: 'at_live_test' });
     // Don't connect, just try to subscribe

--- a/packages/sdk/src/__tests__/ws.test.ts
+++ b/packages/sdk/src/__tests__/ws.test.ts
@@ -83,7 +83,7 @@ describe('WsClient', () => {
     ws.simulateMessage({
       type: 'message.created',
       channel: 'general',
-      message: { id: 'm_1', agent_name: 'Bot', text: 'hi' },
+      message: { id: 'm_1', agent_name: 'Bot', text: 'hi', attachments: [] },
     });
 
     expect(handler).toHaveBeenCalledTimes(1);
@@ -175,11 +175,11 @@ describe('WsClient', () => {
     const ws = MockWebSocket.instances[0]!;
     ws.simulateOpen();
 
-    ws.simulateMessage({ type: 'message.created', channel: 'general', message: {} });
+    ws.simulateMessage({ type: 'message.created', channel: 'general', message: { id: 'm_1', agent_name: 'Bot', text: 'hi', attachments: [] } });
     expect(handler).toHaveBeenCalledTimes(1);
 
     unsub();
-    ws.simulateMessage({ type: 'message.created', channel: 'general', message: {} });
+    ws.simulateMessage({ type: 'message.created', channel: 'general', message: { id: 'm_1', agent_name: 'Bot', text: 'hi', attachments: [] } });
     expect(handler).toHaveBeenCalledTimes(1);
   });
 
@@ -210,7 +210,7 @@ describe('WsClient', () => {
     ws.simulateOpen();
     // 'open' synthetic event is also emitted to wildcard
 
-    ws.simulateMessage({ type: 'message.created', channel: 'general', message: {} });
+    ws.simulateMessage({ type: 'message.created', channel: 'general', message: { id: 'm_1', agent_name: 'Bot', text: 'hi', attachments: [] } });
     ws.simulateMessage({ type: 'pong' });
 
     // open + message.created + pong = 3

--- a/packages/sdk/src/__tests__/ws.test.ts
+++ b/packages/sdk/src/__tests__/ws.test.ts
@@ -231,6 +231,86 @@ describe('WsClient', () => {
     expect(handler).not.toHaveBeenCalled();
   });
 
+  it('forwards unrecognized event types to wildcard and typed listeners', () => {
+    const client = new WsClient({ token: 'at_live_test' });
+    const wildcardHandler = vi.fn();
+    const typedHandler = vi.fn();
+    client.on('*', wildcardHandler);
+    client.on('typing.started', typedHandler);
+
+    client.connect();
+    const ws = MockWebSocket.instances[0]!;
+    ws.simulateOpen();
+
+    ws.simulateMessage({ type: 'typing.started', agent_name: 'Alice', channel: 'general' });
+
+    expect(wildcardHandler).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'typing.started', agent_name: 'Alice' }),
+    );
+    expect(typedHandler).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'typing.started', agent_name: 'Alice' }),
+    );
+  });
+
+  it('ignores objects without a type field', () => {
+    const client = new WsClient({ token: 'at_live_test' });
+    const handler = vi.fn();
+    client.on('*', handler);
+
+    client.connect();
+    const ws = MockWebSocket.instances[0]!;
+    ws.simulateOpen();
+    // Reset after open event
+    handler.mockClear();
+
+    ws.simulateMessage({ data: 'no type field' });
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it('logs dropped messages with missing type when debug is enabled', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const client = new WsClient({ token: 'at_live_test', debug: true });
+    client.connect();
+    const ws = MockWebSocket.instances[0]!;
+    ws.simulateOpen();
+
+    ws.simulateMessage({ data: 'no type field' });
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('missing or invalid "type"'),
+      expect.anything(),
+    );
+    warnSpy.mockRestore();
+  });
+
+  it('logs malformed JSON when debug is enabled', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const client = new WsClient({ token: 'at_live_test', debug: true });
+    client.connect();
+    const ws = MockWebSocket.instances[0]!;
+    ws.simulateOpen();
+
+    ws.onmessage?.({ data: 'not json' });
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('malformed'),
+      expect.stringContaining('not json'),
+      expect.anything(),
+    );
+    warnSpy.mockRestore();
+  });
+
+  it('does not log when debug is disabled', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const client = new WsClient({ token: 'at_live_test' });
+    client.connect();
+    const ws = MockWebSocket.instances[0]!;
+    ws.simulateOpen();
+
+    ws.simulateMessage({ data: 'no type field' });
+    ws.onmessage?.({ data: 'not json' });
+    expect(warnSpy).not.toHaveBeenCalled();
+    warnSpy.mockRestore();
+  });
+
   it('emits error event on WebSocket error', () => {
     const client = new WsClient({ token: 'at_live_test' });
     const handler = vi.fn();

--- a/packages/sdk/src/agent.ts
+++ b/packages/sdk/src/agent.ts
@@ -120,6 +120,7 @@ export class AgentClient {
     // Lifecycle
     connected:    (handler: () => void): (() => void) => this.onEvent('open', handler as (e: never) => void),
     disconnected: (handler: () => void): (() => void) => this.onEvent('close', handler as (e: never) => void),
+    error:        (handler: () => void): (() => void) => this.onEvent('error', handler as (e: never) => void),
     reconnecting: (handler: (attempt: number) => void): (() => void) => {
       if (!this.ws) {
         throw new Error('WebSocket not connected. Call connect() first.');

--- a/packages/sdk/src/agent.ts
+++ b/packages/sdk/src/agent.ts
@@ -187,8 +187,9 @@ export class AgentClient {
     join: (name: string): Promise<unknown> =>
       this.client.post(`/v1/channels/${encodeURIComponent(name)}/join`),
 
-    leave: (name: string): Promise<void> =>
-      this.client.post(`/v1/channels/${encodeURIComponent(name)}/leave`) as Promise<void>,
+    leave: async (name: string): Promise<void> => {
+      await this.client.post(`/v1/channels/${encodeURIComponent(name)}/leave`);
+    },
 
     setTopic: (name: string, topic: string): Promise<Channel> =>
       this.client.patch(`/v1/channels/${encodeURIComponent(name)}/topic`, { topic }),

--- a/packages/sdk/src/agent.ts
+++ b/packages/sdk/src/agent.ts
@@ -8,6 +8,7 @@ import type {
   CreateGroupDmRequest,
   DmConversationSummary,
   CreateChannelRequest,
+  UpdateChannelRequest,
   Channel,
   ChannelMemberInfo,
   ReactionGroup,
@@ -203,6 +204,9 @@ export class AgentClient {
 
     members: (name: string): Promise<ChannelMemberInfo[]> =>
       this.client.get(`/v1/channels/${encodeURIComponent(name)}/members`),
+
+    update: (name: string, data: UpdateChannelRequest): Promise<Channel> =>
+      this.client.patch(`/v1/channels/${encodeURIComponent(name)}`, data),
   };
 
   // === Reactions ===

--- a/packages/sdk/src/agent.ts
+++ b/packages/sdk/src/agent.ts
@@ -20,8 +20,29 @@ import type {
   FileInfo,
   InvokeCommandRequest,
   CommandInvocation,
+  WsClientEvent,
+  MessageCreatedEvent,
+  MessageUpdatedEvent,
+  ThreadReplyEvent,
+  MessageReadEvent,
+  ReactionAddedEvent,
+  ReactionRemovedEvent,
+  DmReceivedEvent,
+  GroupDmReceivedEvent,
+  AgentOnlineEvent,
+  AgentOfflineEvent,
+  ChannelCreatedEvent,
+  ChannelUpdatedEvent,
+  ChannelArchivedEvent,
+  MemberJoinedEvent,
+  MemberLeftEvent,
+  FileUploadedEvent,
+  WebhookReceivedEvent,
+  CommandInvokedEvent,
+  WsReconnectingEvent,
 } from '@relaycast/types';
 import { HttpClient, type RequestOptions } from './client.js';
+import { WsClient } from './ws.js';
 
 function stripHash(channel: string): string {
   return channel.startsWith('#') ? channel.slice(1) : channel;
@@ -38,10 +59,81 @@ function idempotencyHeaders(opts?: IdempotencyOption): RequestOptions | undefine
 
 export class AgentClient {
   public readonly client: HttpClient;
+  private ws: WsClient | null = null;
 
   constructor(client: HttpClient) {
     this.client = client;
   }
+
+  // === WebSocket ===
+
+  connect(): void {
+    if (this.ws) return;
+    this.ws = new WsClient({
+      token: this.client.apiKey,
+      baseUrl: this.client.baseUrl,
+    });
+    this.ws.connect();
+  }
+
+  disconnect(): void {
+    if (this.ws) {
+      this.ws.disconnect();
+      this.ws = null;
+    }
+  }
+
+  subscribe(channels: string[]): void {
+    this.ws?.subscribe(channels);
+  }
+
+  unsubscribe(channels: string[]): void {
+    this.ws?.unsubscribe(channels);
+  }
+
+  private onEvent<T extends WsClientEvent>(eventType: string, handler: (e: T) => void): () => void {
+    if (!this.ws) {
+      throw new Error('WebSocket not connected. Call connect() first.');
+    }
+    return this.ws.on(eventType, handler as (e: WsClientEvent) => void);
+  }
+
+  on = {
+    messageCreated:  (handler: (e: MessageCreatedEvent) => void): (() => void)  => this.onEvent('message.created', handler),
+    messageUpdated:  (handler: (e: MessageUpdatedEvent) => void): (() => void)  => this.onEvent('message.updated', handler),
+    threadReply:     (handler: (e: ThreadReplyEvent) => void): (() => void)     => this.onEvent('thread.reply', handler),
+    messageRead:     (handler: (e: MessageReadEvent) => void): (() => void)     => this.onEvent('message.read', handler),
+    reactionAdded:   (handler: (e: ReactionAddedEvent) => void): (() => void)   => this.onEvent('reaction.added', handler),
+    reactionRemoved: (handler: (e: ReactionRemovedEvent) => void): (() => void) => this.onEvent('reaction.removed', handler),
+    dmReceived:      (handler: (e: DmReceivedEvent) => void): (() => void)      => this.onEvent('dm.received', handler),
+    groupDmReceived: (handler: (e: GroupDmReceivedEvent) => void): (() => void) => this.onEvent('group_dm.received', handler),
+    agentOnline:     (handler: (e: AgentOnlineEvent) => void): (() => void)     => this.onEvent('agent.online', handler),
+    agentOffline:    (handler: (e: AgentOfflineEvent) => void): (() => void)    => this.onEvent('agent.offline', handler),
+    channelCreated:  (handler: (e: ChannelCreatedEvent) => void): (() => void)  => this.onEvent('channel.created', handler),
+    channelUpdated:  (handler: (e: ChannelUpdatedEvent) => void): (() => void)  => this.onEvent('channel.updated', handler),
+    channelArchived: (handler: (e: ChannelArchivedEvent) => void): (() => void) => this.onEvent('channel.archived', handler),
+    memberJoined:    (handler: (e: MemberJoinedEvent) => void): (() => void)    => this.onEvent('member.joined', handler),
+    memberLeft:      (handler: (e: MemberLeftEvent) => void): (() => void)      => this.onEvent('member.left', handler),
+    fileUploaded:    (handler: (e: FileUploadedEvent) => void): (() => void)    => this.onEvent('file.uploaded', handler),
+    webhookReceived: (handler: (e: WebhookReceivedEvent) => void): (() => void) => this.onEvent('webhook.received', handler),
+    commandInvoked:  (handler: (e: CommandInvokedEvent) => void): (() => void)  => this.onEvent('command.invoked', handler),
+    // Lifecycle
+    connected:    (handler: () => void): (() => void) => this.onEvent('open', handler as (e: never) => void),
+    disconnected: (handler: () => void): (() => void) => this.onEvent('close', handler as (e: never) => void),
+    reconnecting: (handler: (attempt: number) => void): (() => void) => {
+      if (!this.ws) {
+        throw new Error('WebSocket not connected. Call connect() first.');
+      }
+      return this.ws.on('reconnecting', (e: WsClientEvent) => handler((e as WsReconnectingEvent).attempt));
+    },
+    // Wildcard
+    any: (handler: (e: WsClientEvent) => void): (() => void) => {
+      if (!this.ws) {
+        throw new Error('WebSocket not connected. Call connect() first.');
+      }
+      return this.ws.on('*', handler);
+    },
+  };
 
   // === Messages ===
 

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -1,4 +1,4 @@
-import { SDK_VERSION } from './index.js';
+import { SDK_VERSION } from './version.js';
 
 export interface ClientOptions {
   apiKey: string;

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -42,12 +42,16 @@ const apiEnvelopeSchema = z.object({
 });
 
 export class HttpClient {
-  private apiKey: string;
+  private _apiKey: string;
   private _baseUrl: string;
 
   constructor(options: ClientOptions) {
-    this.apiKey = options.apiKey;
+    this._apiKey = options.apiKey;
     this._baseUrl = options.baseUrl ?? 'https://api.agentrelay.dev';
+  }
+
+  get apiKey(): string {
+    return this._apiKey;
   }
 
   get baseUrl(): string {
@@ -69,7 +73,7 @@ export class HttpClient {
     }
 
     const headers: Record<string, string> = {
-      Authorization: `Bearer ${this.apiKey}`,
+      Authorization: `Bearer ${this._apiKey}`,
       'X-SDK-Version': SDK_VERSION,
       ...(options?.headers || {}),
     };

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -1,3 +1,5 @@
+import { z } from 'zod';
+import { ApiErrorSchema } from '@relaycast/types';
 import { SDK_VERSION } from './version.js';
 
 export interface ClientOptions {
@@ -7,6 +9,7 @@ export interface ClientOptions {
 
 export interface RequestOptions {
   headers?: Record<string, string>;
+  schema?: z.ZodType;
 }
 
 export class RelayError extends Error {
@@ -25,8 +28,18 @@ function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
-type ApiOk<T> = { ok: true; data: T };
-type ApiErr = { ok: false; error: { code: string; message: string } };
+const apiEnvelopeSchema = z.object({
+  ok: z.boolean(),
+  data: z.unknown().optional(),
+  cursor: z.object({
+    next: z.string().nullable(),
+    has_more: z.boolean(),
+  }).optional(),
+  error: z.object({
+    code: z.string(),
+    message: z.string(),
+  }).optional(),
+});
 
 export class HttpClient {
   private apiKey: string;
@@ -87,18 +100,27 @@ export class HttpClient {
         return undefined as T;
       }
 
-      const parsed = (await res.json()) as ApiOk<T> | ApiErr;
-      if (!parsed || typeof parsed !== 'object' || typeof (parsed as any).ok !== 'boolean') {
+      const json: unknown = await res.json();
+      const envelope = apiEnvelopeSchema.safeParse(json);
+
+      if (!envelope.success) {
         throw new RelayError('invalid_response', 'Invalid API response', res.status);
       }
 
-      if (parsed.ok === false) {
-        const code = parsed.error?.code ?? 'unknown_error';
-        const message = parsed.error?.message ?? 'Unknown error';
+      if (!envelope.data.ok) {
+        const errParsed = ApiErrorSchema.safeParse(json);
+        const code = errParsed.success ? errParsed.data.error.code : 'unknown_error';
+        const message = errParsed.success ? errParsed.data.error.message : 'Unknown error';
         throw new RelayError(code, message, res.status);
       }
 
-      return parsed.data;
+      const data = envelope.data.data;
+
+      if (options?.schema) {
+        return options.schema.parse(data) as T;
+      }
+
+      return data as T;
     }
   }
 

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -114,6 +114,10 @@ export class HttpClient {
     return this.request<T>('PATCH', path, body, undefined, options);
   }
 
+  put<T>(path: string, body?: unknown, options?: RequestOptions): Promise<T> {
+    return this.request<T>('PUT', path, body, undefined, options);
+  }
+
   async delete(path: string, options?: RequestOptions): Promise<void> {
     await this.request<unknown>('DELETE', path, undefined, undefined, options);
   }

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -1,4 +1,4 @@
-export const SDK_VERSION = '0.1.0' as const;
+export const SDK_VERSION = '0.2.3' as const;
 
 export { Relay } from './relay.js';
 export type { RelayOptions } from './relay.js';

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -1,5 +1,4 @@
-export const SDK_VERSION = '0.2.3' as const;
-
+export { SDK_VERSION } from './version.js';
 export { Relay } from './relay.js';
 export type { RelayOptions } from './relay.js';
 export { AgentClient } from './agent.js';

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -1,6 +1,6 @@
 export { SDK_VERSION } from './version.js';
-export { Relay } from './relay.js';
-export type { RelayOptions } from './relay.js';
+export { RelayCast } from './relay.js';
+export type { RelayCastOptions } from './relay.js';
 export { AgentClient } from './agent.js';
 export { HttpClient, RelayError } from './client.js';
 export type { ClientOptions } from './client.js';

--- a/packages/sdk/src/relay.ts
+++ b/packages/sdk/src/relay.ts
@@ -29,7 +29,7 @@ import type {
 import { AgentClient } from './agent.js';
 import { BillingClient } from './billing.js';
 import { HttpClient, RelayError } from './client.js';
-import { SDK_VERSION } from './index.js';
+import { SDK_VERSION } from './version.js';
 
 export interface RelayOptions {
   apiKey: string;
@@ -58,15 +58,44 @@ export class Relay {
       },
       body: JSON.stringify({ name }),
     });
-    const parsed = await res.json();
-    if (!parsed.ok) {
+    
+    let parsed: unknown;
+    try {
+      parsed = await res.json();
+    } catch (err) {
       throw new RelayError(
-        parsed.error?.code ?? 'unknown_error',
-        parsed.error?.message ?? 'Unknown error',
+        'invalid_response',
+        `Failed to parse response as JSON: ${err instanceof Error ? err.message : 'unknown error'}`,
         res.status,
       );
     }
-    return parsed.data;
+
+    if (typeof parsed !== 'object' || parsed === null || !('ok' in parsed) || typeof parsed.ok !== 'boolean') {
+      throw new RelayError(
+        'invalid_response',
+        'Response is not a valid Relay API response object',
+        res.status,
+      );
+    }
+
+    if (!parsed.ok) {
+      const error = (parsed as { error?: { code?: string; message?: string } }).error;
+      throw new RelayError(
+        error?.code ?? 'unknown_error',
+        error?.message ?? 'Unknown error',
+        res.status,
+      );
+    }
+    
+    if (!('data' in parsed)) {
+      throw new RelayError(
+        'invalid_response',
+        'Response is missing required "data" field',
+        res.status,
+      );
+    }
+    
+    return (parsed as { data: CreateWorkspaceResponse }).data;
   }
 
   workspace = {

--- a/packages/sdk/src/relay.ts
+++ b/packages/sdk/src/relay.ts
@@ -1,10 +1,15 @@
 import type {
   Agent,
   AgentListQuery,
+  AgentPresenceInfo,
   CreateAgentRequest,
   CreateAgentResponse,
+  UpdateAgentRequest,
   UpdateWorkspaceRequest,
   Workspace,
+  CreateWorkspaceResponse,
+  SystemPrompt,
+  SetSystemPromptRequest,
   CreateWebhookRequest,
   CreateWebhookResponse,
   Webhook,
@@ -23,7 +28,8 @@ import type {
 } from '@relaycast/types';
 import { AgentClient } from './agent.js';
 import { BillingClient } from './billing.js';
-import { HttpClient } from './client.js';
+import { HttpClient, RelayError } from './client.js';
+import { SDK_VERSION } from './index.js';
 
 export interface RelayOptions {
   apiKey: string;
@@ -39,10 +45,41 @@ export class Relay {
     this.billing = new BillingClient(this.client);
   }
 
+  static async createWorkspace(
+    name: string,
+    baseUrl?: string,
+  ): Promise<CreateWorkspaceResponse> {
+    const url = new URL('/v1/workspaces', baseUrl ?? 'https://api.agentrelay.dev');
+    const res = await fetch(url.toString(), {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-SDK-Version': SDK_VERSION,
+      },
+      body: JSON.stringify({ name }),
+    });
+    const parsed = await res.json();
+    if (!parsed.ok) {
+      throw new RelayError(
+        parsed.error?.code ?? 'unknown_error',
+        parsed.error?.message ?? 'Unknown error',
+        res.status,
+      );
+    }
+    return parsed.data;
+  }
+
   workspace = {
     info: (): Promise<Workspace> => this.client.get('/v1/workspace'),
     update: (data: UpdateWorkspaceRequest): Promise<Workspace> =>
       this.client.patch('/v1/workspace', data),
+    delete: (): Promise<void> => this.client.delete('/v1/workspace'),
+  };
+
+  systemPrompt = {
+    get: (): Promise<SystemPrompt> => this.client.get('/v1/workspace/system-prompt'),
+    set: (data: SetSystemPromptRequest): Promise<SystemPrompt> =>
+      this.client.put('/v1/workspace/system-prompt', data),
   };
 
   agents = {
@@ -57,6 +94,30 @@ export class Relay {
       this.client.get(`/v1/agents/${encodeURIComponent(name)}`),
     rotateToken: (name: string): Promise<TokenRotateResponse> =>
       this.client.post(`/v1/agents/${encodeURIComponent(name)}/rotate-token`, {}),
+    update: (name: string, data: UpdateAgentRequest): Promise<Agent> =>
+      this.client.patch(`/v1/agents/${encodeURIComponent(name)}`, data),
+    delete: (name: string): Promise<void> =>
+      this.client.delete(`/v1/agents/${encodeURIComponent(name)}`),
+    presence: (): Promise<AgentPresenceInfo[]> =>
+      this.client.get('/v1/agents/presence'),
+    registerOrGet: async (data: CreateAgentRequest): Promise<CreateAgentResponse> => {
+      try {
+        return await this.agents.register(data);
+      } catch (err) {
+        if (err instanceof RelayError && err.code === 'agent_already_exists') {
+          const agent = await this.agents.get(data.name);
+          const { token } = await this.agents.rotateToken(agent.name);
+          return {
+            id: agent.id,
+            name: agent.name,
+            token,
+            status: agent.status,
+            created_at: agent.created_at,
+          };
+        }
+        throw err;
+      }
+    },
   };
 
   webhooks = {

--- a/packages/sdk/src/relay.ts
+++ b/packages/sdk/src/relay.ts
@@ -32,16 +32,16 @@ import { BillingClient } from './billing.js';
 import { HttpClient, RelayError } from './client.js';
 import { SDK_VERSION } from './version.js';
 
-export interface RelayOptions {
+export interface RelayCastOptions {
   apiKey: string;
   baseUrl?: string;
 }
 
-export class Relay {
+export class RelayCast {
   private client: HttpClient;
   billing: BillingClient;
 
-  constructor(options: RelayOptions) {
+  constructor(options: RelayCastOptions) {
     this.client = new HttpClient(options);
     this.billing = new BillingClient(this.client);
   }

--- a/packages/sdk/src/relay.ts
+++ b/packages/sdk/src/relay.ts
@@ -26,6 +26,7 @@ import type {
   WorkspaceDmConversation,
   TokenRotateResponse,
 } from '@relaycast/types';
+import { ApiErrorSchema, CreateWorkspaceResponseSchema } from '@relaycast/types';
 import { AgentClient } from './agent.js';
 import { BillingClient } from './billing.js';
 import { HttpClient, RelayError } from './client.js';
@@ -58,7 +59,7 @@ export class Relay {
       },
       body: JSON.stringify({ name }),
     });
-    
+
     let parsed: unknown;
     try {
       parsed = await res.json();
@@ -79,14 +80,14 @@ export class Relay {
     }
 
     if (!parsed.ok) {
-      const error = (parsed as { error?: { code?: string; message?: string } }).error;
+      const errResult = ApiErrorSchema.safeParse(parsed);
       throw new RelayError(
-        error?.code ?? 'unknown_error',
-        error?.message ?? 'Unknown error',
+        errResult.success ? errResult.data.error.code : 'unknown_error',
+        errResult.success ? errResult.data.error.message : 'Unknown error',
         res.status,
       );
     }
-    
+
     if (!('data' in parsed)) {
       throw new RelayError(
         'invalid_response',
@@ -94,8 +95,9 @@ export class Relay {
         res.status,
       );
     }
-    
-    return (parsed as { data: CreateWorkspaceResponse }).data;
+
+    const data = (parsed as { data: unknown }).data;
+    return CreateWorkspaceResponseSchema.parse(data);
   }
 
   workspace = {

--- a/packages/sdk/src/version.ts
+++ b/packages/sdk/src/version.ts
@@ -1,0 +1,1 @@
+export const SDK_VERSION = '0.2.3' as const;

--- a/packages/sdk/src/ws.ts
+++ b/packages/sdk/src/ws.ts
@@ -57,7 +57,7 @@ export class WsClient {
     };
 
     this.ws.onerror = () => {
-      // onclose will fire after this
+      this.emit('error', { type: 'error' } as unknown as ServerEvent);
     };
   }
 
@@ -125,6 +125,7 @@ export class WsClient {
     if (this.reconnectAttempt >= this.maxReconnectAttempts) return;
     const delay = Math.min(1000 * Math.pow(2, this.reconnectAttempt), 30_000);
     this.reconnectAttempt++;
+    this.emit('reconnecting', { type: 'reconnecting', attempt: this.reconnectAttempt } as unknown as ServerEvent);
     this.reconnectTimer = setTimeout(() => {
       this.connect();
     }, delay);

--- a/packages/sdk/src/ws.ts
+++ b/packages/sdk/src/ws.ts
@@ -6,6 +6,8 @@ export type EventHandler<T = WsClientEvent> = (event: T) => void;
 export interface WsClientOptions {
   token: string;
   baseUrl?: string;
+  /** Log warnings for dropped/malformed WebSocket messages via console.warn. */
+  debug?: boolean;
 }
 
 export class WsClient {
@@ -18,9 +20,11 @@ export class WsClient {
   private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
   private pingTimer: ReturnType<typeof setInterval> | null = null;
   private closed = false;
+  private debug: boolean;
 
   constructor(options: WsClientOptions) {
     this.token = options.token;
+    this.debug = options.debug ?? false;
     const base = options.baseUrl ?? 'https://api.agentrelay.dev';
     this.baseUrl = base.replace(/^http/, 'ws');
   }
@@ -45,9 +49,20 @@ export class WsClient {
         const result = ServerEventSchema.safeParse(parsed);
         if (result.success) {
           this.emit(result.data.type, result.data);
+        } else if (
+          parsed !== null &&
+          typeof parsed === 'object' &&
+          typeof parsed.type === 'string'
+        ) {
+          // Forward unrecognized event types so wildcard listeners still fire
+          this.emit(parsed.type, parsed as WsClientEvent);
+        } else if (this.debug) {
+          console.warn('[relaycast] Dropped WebSocket message: missing or invalid "type" field', parsed);
         }
-      } catch {
-        // ignore malformed messages
+      } catch (err) {
+        if (this.debug) {
+          console.warn('[relaycast] Dropped malformed WebSocket message:', String(event.data).slice(0, 200), err);
+        }
       }
     };
 

--- a/packages/sdk/src/ws.ts
+++ b/packages/sdk/src/ws.ts
@@ -1,4 +1,5 @@
 import type { WsClientEvent, WsOpenEvent, WsErrorEvent, WsReconnectingEvent, WsCloseEvent } from '@relaycast/types';
+import { ServerEventSchema } from '@relaycast/types';
 
 export type EventHandler<T = WsClientEvent> = (event: T) => void;
 
@@ -40,8 +41,11 @@ export class WsClient {
 
     this.ws.onmessage = (event: MessageEvent) => {
       try {
-        const data = JSON.parse(String(event.data)) as WsClientEvent;
-        this.emit(data.type, data);
+        const parsed = JSON.parse(String(event.data));
+        const result = ServerEventSchema.safeParse(parsed);
+        if (result.success) {
+          this.emit(result.data.type, result.data);
+        }
       } catch {
         // ignore malformed messages
       }
@@ -49,7 +53,6 @@ export class WsClient {
 
     this.ws.onclose = () => {
       this.stopPing();
-      const ws = this.ws;
       this.ws = null;
       if (!this.closed) {
         this.scheduleReconnect();

--- a/packages/sdk/src/ws.ts
+++ b/packages/sdk/src/ws.ts
@@ -1,6 +1,6 @@
-import type { ServerEvent } from '@relaycast/types';
+import type { WsClientEvent, WsOpenEvent, WsErrorEvent, WsReconnectingEvent, WsCloseEvent } from '@relaycast/types';
 
-export type EventHandler<T = ServerEvent> = (event: T) => void;
+export type EventHandler<T = WsClientEvent> = (event: T) => void;
 
 export interface WsClientOptions {
   token: string;
@@ -34,12 +34,13 @@ export class WsClient {
     this.ws.onopen = () => {
       this.reconnectAttempt = 0;
       this.startPing();
-      this.emit('open', { type: 'open' } as unknown as ServerEvent);
+      const openEvent: WsOpenEvent = { type: 'open' };
+      this.emit('open', openEvent);
     };
 
     this.ws.onmessage = (event: MessageEvent) => {
       try {
-        const data = JSON.parse(String(event.data)) as ServerEvent;
+        const data = JSON.parse(String(event.data)) as WsClientEvent;
         this.emit(data.type, data);
       } catch {
         // ignore malformed messages
@@ -53,11 +54,13 @@ export class WsClient {
       if (!this.closed) {
         this.scheduleReconnect();
       }
-      this.emit('close', { type: 'close' } as unknown as ServerEvent);
+      const closeEvent: WsCloseEvent = { type: 'close' };
+      this.emit('close', closeEvent);
     };
 
     this.ws.onerror = () => {
-      this.emit('error', { type: 'error' } as unknown as ServerEvent);
+      const errorEvent: WsErrorEvent = { type: 'error' };
+      this.emit('error', errorEvent);
     };
   }
 
@@ -96,7 +99,7 @@ export class WsClient {
     this.handlers.get(event)?.delete(handler);
   }
 
-  private emit(event: string, data: ServerEvent): void {
+  private emit(event: string, data: WsClientEvent): void {
     this.handlers.get(event)?.forEach((h) => h(data));
     this.handlers.get('*')?.forEach((h) => h(data));
   }
@@ -125,7 +128,8 @@ export class WsClient {
     if (this.reconnectAttempt >= this.maxReconnectAttempts) return;
     const delay = Math.min(1000 * Math.pow(2, this.reconnectAttempt), 30_000);
     this.reconnectAttempt++;
-    this.emit('reconnecting', { type: 'reconnecting', attempt: this.reconnectAttempt } as unknown as ServerEvent);
+    const reconnectingEvent: WsReconnectingEvent = { type: 'reconnecting', attempt: this.reconnectAttempt };
+    this.emit('reconnecting', reconnectingEvent);
     this.reconnectTimer = setTimeout(() => {
       this.connect();
     }, delay);

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -14,6 +14,9 @@
     "url": "https://github.com/AgentWorkforce/relaycast",
     "directory": "packages/types"
   },
+  "dependencies": {
+    "zod": "^3.24.0"
+  },
   "files": [
     "dist"
   ]

--- a/packages/types/src/agent.ts
+++ b/packages/types/src/agent.ts
@@ -38,3 +38,9 @@ export interface UpdateAgentRequest {
 export interface AgentListQuery {
   status?: AgentStatus | 'all';
 }
+
+export interface AgentPresenceInfo {
+  agent_id: string;
+  agent_name: string;
+  status: 'online' | 'offline';
+}

--- a/packages/types/src/agent.ts
+++ b/packages/types/src/agent.ts
@@ -1,46 +1,57 @@
-export type AgentType = 'agent' | 'human';
-export type AgentStatus = 'online' | 'offline' | 'away';
+import { z } from 'zod';
 
-export interface Agent {
-  id: string;
-  workspace_id: string;
-  name: string;
-  type: AgentType;
-  token_hash: string;
-  status: AgentStatus;
-  persona: string | null;
-  metadata: Record<string, unknown>;
-  created_at: string;
-  last_seen: string;
-}
+export const AgentTypeSchema = z.enum(['agent', 'human']);
+export type AgentType = z.infer<typeof AgentTypeSchema>;
 
-export interface CreateAgentRequest {
-  name: string;
-  type?: AgentType;
-  persona?: string;
-  metadata?: Record<string, unknown>;
-}
+export const AgentStatusSchema = z.enum(['online', 'offline', 'away']);
+export type AgentStatus = z.infer<typeof AgentStatusSchema>;
 
-export interface CreateAgentResponse {
-  id: string;
-  name: string;
-  token: string;
-  status: AgentStatus;
-  created_at: string;
-}
+export const AgentSchema = z.object({
+  id: z.string(),
+  workspace_id: z.string(),
+  name: z.string(),
+  type: AgentTypeSchema,
+  token_hash: z.string(),
+  status: AgentStatusSchema,
+  persona: z.string().nullable(),
+  metadata: z.record(z.unknown()),
+  created_at: z.string(),
+  last_seen: z.string(),
+});
+export type Agent = z.infer<typeof AgentSchema>;
 
-export interface UpdateAgentRequest {
-  status?: AgentStatus;
-  persona?: string;
-  metadata?: Record<string, unknown>;
-}
+export const CreateAgentRequestSchema = z.object({
+  name: z.string(),
+  type: AgentTypeSchema.optional(),
+  persona: z.string().optional(),
+  metadata: z.record(z.unknown()).optional(),
+});
+export type CreateAgentRequest = z.infer<typeof CreateAgentRequestSchema>;
 
-export interface AgentListQuery {
-  status?: AgentStatus | 'all';
-}
+export const CreateAgentResponseSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  token: z.string(),
+  status: AgentStatusSchema,
+  created_at: z.string(),
+});
+export type CreateAgentResponse = z.infer<typeof CreateAgentResponseSchema>;
 
-export interface AgentPresenceInfo {
-  agent_id: string;
-  agent_name: string;
-  status: 'online' | 'offline';
-}
+export const UpdateAgentRequestSchema = z.object({
+  status: AgentStatusSchema.optional(),
+  persona: z.string().optional(),
+  metadata: z.record(z.unknown()).optional(),
+});
+export type UpdateAgentRequest = z.infer<typeof UpdateAgentRequestSchema>;
+
+export const AgentListQuerySchema = z.object({
+  status: z.union([AgentStatusSchema, z.literal('all')]).optional(),
+});
+export type AgentListQuery = z.infer<typeof AgentListQuerySchema>;
+
+export const AgentPresenceInfoSchema = z.object({
+  agent_id: z.string(),
+  agent_name: z.string(),
+  status: z.enum(['online', 'offline']),
+});
+export type AgentPresenceInfo = z.infer<typeof AgentPresenceInfoSchema>;

--- a/packages/types/src/api.ts
+++ b/packages/types/src/api.ts
@@ -1,3 +1,32 @@
+import { z } from 'zod';
+
+export const ApiSuccessSchema = <T extends z.ZodType>(dataSchema: T) =>
+  z.object({
+    ok: z.literal(true),
+    data: dataSchema,
+    cursor: z.object({
+      next: z.string().nullable(),
+      has_more: z.boolean(),
+    }).optional(),
+  });
+
+export const ApiErrorSchema = z.object({
+  ok: z.literal(false),
+  error: z.object({
+    code: z.string(),
+    message: z.string(),
+  }),
+});
+
+export const ApiResponseSchema = <T extends z.ZodType>(dataSchema: T) =>
+  z.discriminatedUnion('ok', [ApiSuccessSchema(dataSchema), ApiErrorSchema]);
+
+export const InboxResponseSchema = z.object({
+  unread_channels: z.array(z.object({ channel_name: z.string(), unread_count: z.number() })),
+  mentions: z.array(z.object({ id: z.string(), channel_name: z.string(), agent_name: z.string(), text: z.string(), created_at: z.string() })),
+  unread_dms: z.array(z.object({ conversation_id: z.string(), from: z.string(), unread_count: z.number(), last_message: z.string().nullable() })),
+});
+
 export interface ApiSuccess<T> {
   ok: true;
   data: T;
@@ -16,9 +45,4 @@ export interface ApiError {
 }
 
 export type ApiResponse<T> = ApiSuccess<T> | ApiError;
-
-export interface InboxResponse {
-  unread_channels: Array<{ channel_name: string; unread_count: number }>;
-  mentions: Array<{ id: string; channel_name: string; agent_name: string; text: string; created_at: string }>;
-  unread_dms: Array<{ conversation_id: string; from: string; unread_count: number; last_message: string | null }>;
-}
+export type InboxResponse = z.infer<typeof InboxResponseSchema>;

--- a/packages/types/src/billing.ts
+++ b/packages/types/src/billing.ts
@@ -1,48 +1,58 @@
-export type PlanType = 'free' | 'pro' | 'enterprise';
-export type SubscriptionStatus = 'active' | 'canceled' | 'past_due' | 'trialing';
+import { z } from 'zod';
 
-export interface BillingSubscription {
-  subscription_id: string;
-  plan: PlanType;
-  status: SubscriptionStatus;
-  current_period_end: string;
-}
+export const PlanTypeSchema = z.enum(['free', 'pro', 'enterprise']);
+export type PlanType = z.infer<typeof PlanTypeSchema>;
 
-export interface UsageRecord {
-  id: string;
-  workspace_id: string;
-  period_start: string;
-  period_end: string;
-  messages_sent: number;
-  api_calls: number;
-  files_uploaded: number;
-  file_bytes: number;
-  ws_minutes: number;
-  created_at: string;
-}
+export const SubscriptionStatusSchema = z.enum(['active', 'canceled', 'past_due', 'trialing']);
+export type SubscriptionStatus = z.infer<typeof SubscriptionStatusSchema>;
 
-export interface UsageInfo {
-  messages_sent: number;
-  messages_stored: number;
-  files_uploaded: number;
-  file_storage_bytes: number;
-  agents_registered: number;
-  api_calls: number;
-  websocket_minutes: number;
-  period_start: string;
-  period_end: string;
-}
+export const BillingSubscriptionSchema = z.object({
+  subscription_id: z.string(),
+  plan: PlanTypeSchema,
+  status: SubscriptionStatusSchema,
+  current_period_end: z.string(),
+});
+export type BillingSubscription = z.infer<typeof BillingSubscriptionSchema>;
 
-export interface SubscribeRequest {
-  plan: PlanType;
-  payment_method: string;
-}
+export const UsageRecordSchema = z.object({
+  id: z.string(),
+  workspace_id: z.string(),
+  period_start: z.string(),
+  period_end: z.string(),
+  messages_sent: z.number(),
+  api_calls: z.number(),
+  files_uploaded: z.number(),
+  file_bytes: z.number(),
+  ws_minutes: z.number(),
+  created_at: z.string(),
+});
+export type UsageRecord = z.infer<typeof UsageRecordSchema>;
 
-export interface PlanLimits {
-  messages_per_month: number;
-  agents: number;
-  file_storage_bytes: number;
-  message_retention_days: number;
-  channels: number;
-  api_rate_per_minute: number;
-}
+export const UsageInfoSchema = z.object({
+  messages_sent: z.number(),
+  messages_stored: z.number(),
+  files_uploaded: z.number(),
+  file_storage_bytes: z.number(),
+  agents_registered: z.number(),
+  api_calls: z.number(),
+  websocket_minutes: z.number(),
+  period_start: z.string(),
+  period_end: z.string(),
+});
+export type UsageInfo = z.infer<typeof UsageInfoSchema>;
+
+export const SubscribeRequestSchema = z.object({
+  plan: PlanTypeSchema,
+  payment_method: z.string(),
+});
+export type SubscribeRequest = z.infer<typeof SubscribeRequestSchema>;
+
+export const PlanLimitsSchema = z.object({
+  messages_per_month: z.number(),
+  agents: z.number(),
+  file_storage_bytes: z.number(),
+  message_retention_days: z.number(),
+  channels: z.number(),
+  api_rate_per_minute: z.number(),
+});
+export type PlanLimits = z.infer<typeof PlanLimitsSchema>;

--- a/packages/types/src/channel.ts
+++ b/packages/types/src/channel.ts
@@ -1,38 +1,46 @@
-export interface Channel {
-  id: string;
-  workspace_id: string;
-  name: string;
-  channel_type: number;
-  topic: string | null;
-  created_by: string | null;
-  created_at: string;
-  is_archived: boolean;
-}
+import { z } from 'zod';
 
-export interface ChannelMember {
-  channel_id: string;
-  agent_id: string;
-  role: 'owner' | 'member';
-  joined_at: string;
-  last_read_id: string | null;
-}
+export const ChannelSchema = z.object({
+  id: z.string(),
+  workspace_id: z.string(),
+  name: z.string(),
+  channel_type: z.number(),
+  topic: z.string().nullable(),
+  created_by: z.string().nullable(),
+  created_at: z.string(),
+  is_archived: z.boolean(),
+});
+export type Channel = z.infer<typeof ChannelSchema>;
 
-export interface CreateChannelRequest {
-  name: string;
-  topic?: string;
-}
+export const ChannelMemberSchema = z.object({
+  channel_id: z.string(),
+  agent_id: z.string(),
+  role: z.enum(['owner', 'member']),
+  joined_at: z.string(),
+  last_read_id: z.string().nullable(),
+});
+export type ChannelMember = z.infer<typeof ChannelMemberSchema>;
 
-export interface UpdateChannelRequest {
-  topic?: string;
-}
+export const CreateChannelRequestSchema = z.object({
+  name: z.string(),
+  topic: z.string().optional(),
+});
+export type CreateChannelRequest = z.infer<typeof CreateChannelRequestSchema>;
 
-export interface ChannelMemberInfo {
-  agent_id: string;
-  agent_name: string;
-  role: 'owner' | 'member';
-  joined_at: string;
-}
+export const UpdateChannelRequestSchema = z.object({
+  topic: z.string().optional(),
+});
+export type UpdateChannelRequest = z.infer<typeof UpdateChannelRequestSchema>;
 
-export interface InviteRequest {
-  agent: string;
-}
+export const ChannelMemberInfoSchema = z.object({
+  agent_id: z.string(),
+  agent_name: z.string(),
+  role: z.enum(['owner', 'member']),
+  joined_at: z.string(),
+});
+export type ChannelMemberInfo = z.infer<typeof ChannelMemberInfoSchema>;
+
+export const InviteRequestSchema = z.object({
+  agent: z.string(),
+});
+export type InviteRequest = z.infer<typeof InviteRequestSchema>;

--- a/packages/types/src/command.ts
+++ b/packages/types/src/command.ts
@@ -1,51 +1,59 @@
-export interface AgentCommand {
-  id: string;
-  workspace_id: string;
-  command: string;
-  description: string;
-  handler_agent_id: string;
-  handler_agent_name: string;
-  parameters: CommandParameter[];
-  created_at: string;
-  is_active: boolean;
-}
+import { z } from 'zod';
 
-export interface CommandParameter {
-  name: string;
-  description?: string;
-  type: 'string' | 'number' | 'boolean';
-  required?: boolean;
-}
+export const CommandParameterSchema = z.object({
+  name: z.string(),
+  description: z.string().optional(),
+  type: z.enum(['string', 'number', 'boolean']),
+  required: z.boolean().optional(),
+});
+export type CommandParameter = z.infer<typeof CommandParameterSchema>;
 
-export interface CreateCommandRequest {
-  command: string;
-  description: string;
-  handler_agent: string;
-  parameters?: CommandParameter[];
-}
+export const AgentCommandSchema = z.object({
+  id: z.string(),
+  workspace_id: z.string(),
+  command: z.string(),
+  description: z.string(),
+  handler_agent_id: z.string(),
+  handler_agent_name: z.string(),
+  parameters: z.array(CommandParameterSchema),
+  created_at: z.string(),
+  is_active: z.boolean(),
+});
+export type AgentCommand = z.infer<typeof AgentCommandSchema>;
 
-export interface CreateCommandResponse {
-  id: string;
-  command: string;
-  description: string;
-  handler_agent: string;
-  parameters: CommandParameter[];
-  created_at: string;
-}
+export const CreateCommandRequestSchema = z.object({
+  command: z.string(),
+  description: z.string(),
+  handler_agent: z.string(),
+  parameters: z.array(CommandParameterSchema).optional(),
+});
+export type CreateCommandRequest = z.infer<typeof CreateCommandRequestSchema>;
 
-export interface InvokeCommandRequest {
-  channel: string;
-  args?: string;
-  parameters?: Record<string, unknown>;
-}
+export const CreateCommandResponseSchema = z.object({
+  id: z.string(),
+  command: z.string(),
+  description: z.string(),
+  handler_agent: z.string(),
+  parameters: z.array(CommandParameterSchema),
+  created_at: z.string(),
+});
+export type CreateCommandResponse = z.infer<typeof CreateCommandResponseSchema>;
 
-export interface CommandInvocation {
-  id: string;
-  command: string;
-  channel: string;
-  invoked_by: string;
-  args: string | null;
-  parameters: Record<string, unknown> | null;
-  response_message_id: string | null;
-  created_at: string;
-}
+export const InvokeCommandRequestSchema = z.object({
+  channel: z.string(),
+  args: z.string().optional(),
+  parameters: z.record(z.unknown()).optional(),
+});
+export type InvokeCommandRequest = z.infer<typeof InvokeCommandRequestSchema>;
+
+export const CommandInvocationSchema = z.object({
+  id: z.string(),
+  command: z.string(),
+  channel: z.string(),
+  invoked_by: z.string(),
+  args: z.string().nullable(),
+  parameters: z.record(z.unknown()).nullable(),
+  response_message_id: z.string().nullable(),
+  created_at: z.string(),
+});
+export type CommandInvocation = z.infer<typeof CommandInvocationSchema>;

--- a/packages/types/src/dashboard.ts
+++ b/packages/types/src/dashboard.ts
@@ -1,34 +1,40 @@
-export interface WorkspaceStats {
-  agents: { total: number; online: number; offline: number };
-  channels: { total: number; archived: number };
-  messages: { total: number; today: number };
-  dms: { total_conversations: number };
-  files: { total: number; storage_bytes: number };
-}
+import { z } from 'zod';
 
-export interface ActivityItem {
-  type: 'message' | 'dm';
-  id: string;
-  channel_name?: string;
-  conversation_id?: string;
-  agent_name: string;
-  text: string;
-  created_at: string;
-}
+export const WorkspaceStatsSchema = z.object({
+  agents: z.object({ total: z.number(), online: z.number(), offline: z.number() }),
+  channels: z.object({ total: z.number(), archived: z.number() }),
+  messages: z.object({ total: z.number(), today: z.number() }),
+  dms: z.object({ total_conversations: z.number() }),
+  files: z.object({ total: z.number(), storage_bytes: z.number() }),
+});
+export type WorkspaceStats = z.infer<typeof WorkspaceStatsSchema>;
 
-export interface WorkspaceDmConversation {
-  id: string;
-  type: string;
-  participants: string[];
-  last_message: {
-    text: string;
-    agent_name: string;
-    created_at: string;
-  } | null;
-  message_count: number;
-}
+export const ActivityItemSchema = z.object({
+  type: z.enum(['message', 'dm']),
+  id: z.string(),
+  channel_name: z.string().optional(),
+  conversation_id: z.string().optional(),
+  agent_name: z.string(),
+  text: z.string(),
+  created_at: z.string(),
+});
+export type ActivityItem = z.infer<typeof ActivityItemSchema>;
 
-export interface TokenRotateResponse {
-  name: string;
-  token: string;
-}
+export const WorkspaceDmConversationSchema = z.object({
+  id: z.string(),
+  type: z.string(),
+  participants: z.array(z.string()),
+  last_message: z.object({
+    text: z.string(),
+    agent_name: z.string(),
+    created_at: z.string(),
+  }).nullable(),
+  message_count: z.number(),
+});
+export type WorkspaceDmConversation = z.infer<typeof WorkspaceDmConversationSchema>;
+
+export const TokenRotateResponseSchema = z.object({
+  name: z.string(),
+  token: z.string(),
+});
+export type TokenRotateResponse = z.infer<typeof TokenRotateResponseSchema>;

--- a/packages/types/src/dm.ts
+++ b/packages/types/src/dm.ts
@@ -1,37 +1,45 @@
-export type DmType = '1:1' | 'group';
+import { z } from 'zod';
 
-export interface DmConversation {
-  id: string;
-  workspace_id: string;
-  channel_id: string;
-  dm_type: DmType;
-  name: string | null;
-  created_at: string;
-}
+export const DmTypeSchema = z.enum(['1:1', 'group']);
+export type DmType = z.infer<typeof DmTypeSchema>;
 
-export interface DmParticipant {
-  conversation_id: string;
-  agent_id: string;
-  joined_at: string;
-  left_at: string | null;
-}
+export const DmConversationSchema = z.object({
+  id: z.string(),
+  workspace_id: z.string(),
+  channel_id: z.string(),
+  dm_type: DmTypeSchema,
+  name: z.string().nullable(),
+  created_at: z.string(),
+});
+export type DmConversation = z.infer<typeof DmConversationSchema>;
 
-export interface SendDmRequest {
-  to: string;
-  text: string;
-}
+export const DmParticipantSchema = z.object({
+  conversation_id: z.string(),
+  agent_id: z.string(),
+  joined_at: z.string(),
+  left_at: z.string().nullable(),
+});
+export type DmParticipant = z.infer<typeof DmParticipantSchema>;
 
-export interface CreateGroupDmRequest {
-  participants: string[];
-  name?: string;
-  text: string;
-}
+export const SendDmRequestSchema = z.object({
+  to: z.string(),
+  text: z.string(),
+});
+export type SendDmRequest = z.infer<typeof SendDmRequestSchema>;
 
-export interface DmConversationSummary {
-  id: string;
-  type: DmType;
-  name: string | null;
-  participants: string[];
-  last_message: string | null;
-  unread_count: number;
-}
+export const CreateGroupDmRequestSchema = z.object({
+  participants: z.array(z.string()),
+  name: z.string().optional(),
+  text: z.string(),
+});
+export type CreateGroupDmRequest = z.infer<typeof CreateGroupDmRequestSchema>;
+
+export const DmConversationSummarySchema = z.object({
+  id: z.string(),
+  type: DmTypeSchema,
+  name: z.string().nullable(),
+  participants: z.array(z.string()),
+  last_message: z.string().nullable(),
+  unread_count: z.number(),
+});
+export type DmConversationSummary = z.infer<typeof DmConversationSummarySchema>;

--- a/packages/types/src/events.ts
+++ b/packages/types/src/events.ts
@@ -139,6 +139,24 @@ export interface CommandInvokedEvent {
   parameters: Record<string, unknown> | null;
 }
 
+// WebSocket client events (emitted by WsClient, not from server)
+export interface WsOpenEvent {
+  type: 'open';
+}
+
+export interface WsErrorEvent {
+  type: 'error';
+}
+
+export interface WsReconnectingEvent {
+  type: 'reconnecting';
+  attempt: number;
+}
+
+export interface WsCloseEvent {
+  type: 'close';
+}
+
 export type ServerEvent =
   | MessageCreatedEvent
   | MessageUpdatedEvent
@@ -162,3 +180,8 @@ export type ServerEvent =
 
 export type ServerEventType = ServerEvent['type'];
 export type ClientEventType = ClientEvent['type'];
+
+// Union of all events that WsClient can emit (includes server events + client-only events)
+export type WsClientEvent = ServerEvent | WsOpenEvent | WsErrorEvent | WsReconnectingEvent | WsCloseEvent;
+export type WsClientEventType = WsClientEvent['type'];
+

--- a/packages/types/src/events.ts
+++ b/packages/types/src/events.ts
@@ -1,187 +1,248 @@
+import { z } from 'zod';
+
 // WebSocket client -> server
-export interface SubscribeEvent {
-  type: 'subscribe';
-  channels: string[];
-}
+export const SubscribeEventSchema = z.object({
+  type: z.literal('subscribe'),
+  channels: z.array(z.string()),
+});
+export type SubscribeEvent = z.infer<typeof SubscribeEventSchema>;
 
-export interface UnsubscribeEvent {
-  type: 'unsubscribe';
-  channels: string[];
-}
+export const UnsubscribeEventSchema = z.object({
+  type: z.literal('unsubscribe'),
+  channels: z.array(z.string()),
+});
+export type UnsubscribeEvent = z.infer<typeof UnsubscribeEventSchema>;
 
-export interface PingEvent {
-  type: 'ping';
-}
+export const PingEventSchema = z.object({
+  type: z.literal('ping'),
+});
+export type PingEvent = z.infer<typeof PingEventSchema>;
 
-export type ClientEvent = SubscribeEvent | UnsubscribeEvent | PingEvent;
+export const ClientEventSchema = z.discriminatedUnion('type', [
+  SubscribeEventSchema,
+  UnsubscribeEventSchema,
+  PingEventSchema,
+]);
+export type ClientEvent = z.infer<typeof ClientEventSchema>;
 
 // WebSocket server -> client
-export interface MessageCreatedEvent {
-  type: 'message.created';
-  channel: string;
-  message: {
-    id: string;
-    agent_name: string;
-    text: string;
-    attachments: Array<{
-      file_id: string;
-      filename: string;
-      url: string;
-      size: number;
-    }>;
-  };
-}
+export const MessageCreatedEventSchema = z.object({
+  type: z.literal('message.created'),
+  channel: z.string(),
+  message: z.object({
+    id: z.string(),
+    agent_name: z.string(),
+    text: z.string(),
+    attachments: z.array(z.object({
+      file_id: z.string(),
+      filename: z.string(),
+      url: z.string(),
+      size: z.number(),
+    })),
+  }),
+});
+export type MessageCreatedEvent = z.infer<typeof MessageCreatedEventSchema>;
 
-export interface MessageUpdatedEvent {
-  type: 'message.updated';
-  channel: string;
-  message: { id: string; agent_name: string; text: string };
-}
+export const MessageUpdatedEventSchema = z.object({
+  type: z.literal('message.updated'),
+  channel: z.string(),
+  message: z.object({ id: z.string(), agent_name: z.string(), text: z.string() }),
+});
+export type MessageUpdatedEvent = z.infer<typeof MessageUpdatedEventSchema>;
 
-export interface ThreadReplyEvent {
-  type: 'thread.reply';
-  parent_id: string;
-  message: { id: string; agent_name: string; text: string };
-}
+export const ThreadReplyEventSchema = z.object({
+  type: z.literal('thread.reply'),
+  parent_id: z.string(),
+  message: z.object({ id: z.string(), agent_name: z.string(), text: z.string() }),
+});
+export type ThreadReplyEvent = z.infer<typeof ThreadReplyEventSchema>;
 
-export interface ReactionAddedEvent {
-  type: 'reaction.added';
-  message_id: string;
-  emoji: string;
-  agent_name: string;
-}
+export const ReactionAddedEventSchema = z.object({
+  type: z.literal('reaction.added'),
+  message_id: z.string(),
+  emoji: z.string(),
+  agent_name: z.string(),
+});
+export type ReactionAddedEvent = z.infer<typeof ReactionAddedEventSchema>;
 
-export interface ReactionRemovedEvent {
-  type: 'reaction.removed';
-  message_id: string;
-  emoji: string;
-  agent_name: string;
-}
+export const ReactionRemovedEventSchema = z.object({
+  type: z.literal('reaction.removed'),
+  message_id: z.string(),
+  emoji: z.string(),
+  agent_name: z.string(),
+});
+export type ReactionRemovedEvent = z.infer<typeof ReactionRemovedEventSchema>;
 
-export interface DmReceivedEvent {
-  type: 'dm.received';
-  conversation_id: string;
-  message: { id: string; agent_name: string; text: string };
-}
+export const DmReceivedEventSchema = z.object({
+  type: z.literal('dm.received'),
+  conversation_id: z.string(),
+  message: z.object({ id: z.string(), agent_name: z.string(), text: z.string() }),
+});
+export type DmReceivedEvent = z.infer<typeof DmReceivedEventSchema>;
 
-export interface GroupDmReceivedEvent {
-  type: 'group_dm.received';
-  conversation_id: string;
-  message: { id: string; agent_name: string; text: string };
-}
+export const GroupDmReceivedEventSchema = z.object({
+  type: z.literal('group_dm.received'),
+  conversation_id: z.string(),
+  message: z.object({ id: z.string(), agent_name: z.string(), text: z.string() }),
+});
+export type GroupDmReceivedEvent = z.infer<typeof GroupDmReceivedEventSchema>;
 
-export interface AgentOnlineEvent {
-  type: 'agent.online';
-  agent: { name: string };
-}
+export const AgentOnlineEventSchema = z.object({
+  type: z.literal('agent.online'),
+  agent: z.object({ name: z.string() }),
+});
+export type AgentOnlineEvent = z.infer<typeof AgentOnlineEventSchema>;
 
-export interface AgentOfflineEvent {
-  type: 'agent.offline';
-  agent: { name: string };
-}
+export const AgentOfflineEventSchema = z.object({
+  type: z.literal('agent.offline'),
+  agent: z.object({ name: z.string() }),
+});
+export type AgentOfflineEvent = z.infer<typeof AgentOfflineEventSchema>;
 
-export interface ChannelCreatedEvent {
-  type: 'channel.created';
-  channel: { name: string; topic: string | null };
-}
+export const ChannelCreatedEventSchema = z.object({
+  type: z.literal('channel.created'),
+  channel: z.object({ name: z.string(), topic: z.string().nullable() }),
+});
+export type ChannelCreatedEvent = z.infer<typeof ChannelCreatedEventSchema>;
 
-export interface ChannelUpdatedEvent {
-  type: 'channel.updated';
-  channel: { name: string; topic: string | null };
-}
+export const ChannelUpdatedEventSchema = z.object({
+  type: z.literal('channel.updated'),
+  channel: z.object({ name: z.string(), topic: z.string().nullable() }),
+});
+export type ChannelUpdatedEvent = z.infer<typeof ChannelUpdatedEventSchema>;
 
-export interface ChannelArchivedEvent {
-  type: 'channel.archived';
-  channel: { name: string };
-}
+export const ChannelArchivedEventSchema = z.object({
+  type: z.literal('channel.archived'),
+  channel: z.object({ name: z.string() }),
+});
+export type ChannelArchivedEvent = z.infer<typeof ChannelArchivedEventSchema>;
 
-export interface MemberJoinedEvent {
-  type: 'member.joined';
-  channel: string;
-  agent_name: string;
-}
+export const MemberJoinedEventSchema = z.object({
+  type: z.literal('member.joined'),
+  channel: z.string(),
+  agent_name: z.string(),
+});
+export type MemberJoinedEvent = z.infer<typeof MemberJoinedEventSchema>;
 
-export interface MemberLeftEvent {
-  type: 'member.left';
-  channel: string;
-  agent_name: string;
-}
+export const MemberLeftEventSchema = z.object({
+  type: z.literal('member.left'),
+  channel: z.string(),
+  agent_name: z.string(),
+});
+export type MemberLeftEvent = z.infer<typeof MemberLeftEventSchema>;
 
-export interface MessageReadEvent {
-  type: 'message.read';
-  message_id: string;
-  agent_name: string;
-  read_at: string;
-}
+export const MessageReadEventSchema = z.object({
+  type: z.literal('message.read'),
+  message_id: z.string(),
+  agent_name: z.string(),
+  read_at: z.string(),
+});
+export type MessageReadEvent = z.infer<typeof MessageReadEventSchema>;
 
-export interface FileUploadedEvent {
-  type: 'file.uploaded';
-  file: { file_id: string; filename: string; uploaded_by: string };
-}
+export const FileUploadedEventSchema = z.object({
+  type: z.literal('file.uploaded'),
+  file: z.object({ file_id: z.string(), filename: z.string(), uploaded_by: z.string() }),
+});
+export type FileUploadedEvent = z.infer<typeof FileUploadedEventSchema>;
 
-export interface PongEvent {
-  type: 'pong';
-}
+export const PongEventSchema = z.object({
+  type: z.literal('pong'),
+});
+export type PongEvent = z.infer<typeof PongEventSchema>;
 
-export interface WebhookReceivedEvent {
-  type: 'webhook.received';
-  webhook_id: string;
-  channel: string;
-  message: { id: string; text: string; source: string | null };
-}
+export const WebhookReceivedEventSchema = z.object({
+  type: z.literal('webhook.received'),
+  webhook_id: z.string(),
+  channel: z.string(),
+  message: z.object({ id: z.string(), text: z.string(), source: z.string().nullable() }),
+});
+export type WebhookReceivedEvent = z.infer<typeof WebhookReceivedEventSchema>;
 
-export interface CommandInvokedEvent {
-  type: 'command.invoked';
-  command: string;
-  channel: string;
-  invoked_by: string;
-  args: string | null;
-  parameters: Record<string, unknown> | null;
-}
+export const CommandInvokedEventSchema = z.object({
+  type: z.literal('command.invoked'),
+  command: z.string(),
+  channel: z.string(),
+  invoked_by: z.string(),
+  args: z.string().nullable(),
+  parameters: z.record(z.unknown()).nullable(),
+});
+export type CommandInvokedEvent = z.infer<typeof CommandInvokedEventSchema>;
 
 // WebSocket client events (emitted by WsClient, not from server)
-export interface WsOpenEvent {
-  type: 'open';
-}
+export const WsOpenEventSchema = z.object({
+  type: z.literal('open'),
+});
+export type WsOpenEvent = z.infer<typeof WsOpenEventSchema>;
 
-export interface WsErrorEvent {
-  type: 'error';
-}
+export const WsErrorEventSchema = z.object({
+  type: z.literal('error'),
+});
+export type WsErrorEvent = z.infer<typeof WsErrorEventSchema>;
 
-export interface WsReconnectingEvent {
-  type: 'reconnecting';
-  attempt: number;
-}
+export const WsReconnectingEventSchema = z.object({
+  type: z.literal('reconnecting'),
+  attempt: z.number(),
+});
+export type WsReconnectingEvent = z.infer<typeof WsReconnectingEventSchema>;
 
-export interface WsCloseEvent {
-  type: 'close';
-}
+export const WsCloseEventSchema = z.object({
+  type: z.literal('close'),
+});
+export type WsCloseEvent = z.infer<typeof WsCloseEventSchema>;
 
-export type ServerEvent =
-  | MessageCreatedEvent
-  | MessageUpdatedEvent
-  | ThreadReplyEvent
-  | ReactionAddedEvent
-  | ReactionRemovedEvent
-  | DmReceivedEvent
-  | GroupDmReceivedEvent
-  | AgentOnlineEvent
-  | AgentOfflineEvent
-  | ChannelCreatedEvent
-  | ChannelUpdatedEvent
-  | ChannelArchivedEvent
-  | MemberJoinedEvent
-  | MemberLeftEvent
-  | MessageReadEvent
-  | FileUploadedEvent
-  | WebhookReceivedEvent
-  | CommandInvokedEvent
-  | PongEvent;
+export const ServerEventSchema = z.discriminatedUnion('type', [
+  MessageCreatedEventSchema,
+  MessageUpdatedEventSchema,
+  ThreadReplyEventSchema,
+  ReactionAddedEventSchema,
+  ReactionRemovedEventSchema,
+  DmReceivedEventSchema,
+  GroupDmReceivedEventSchema,
+  AgentOnlineEventSchema,
+  AgentOfflineEventSchema,
+  ChannelCreatedEventSchema,
+  ChannelUpdatedEventSchema,
+  ChannelArchivedEventSchema,
+  MemberJoinedEventSchema,
+  MemberLeftEventSchema,
+  MessageReadEventSchema,
+  FileUploadedEventSchema,
+  WebhookReceivedEventSchema,
+  CommandInvokedEventSchema,
+  PongEventSchema,
+]);
 
+export type ServerEvent = z.infer<typeof ServerEventSchema>;
 export type ServerEventType = ServerEvent['type'];
 export type ClientEventType = ClientEvent['type'];
 
 // Union of all events that WsClient can emit (includes server events + client-only events)
-export type WsClientEvent = ServerEvent | WsOpenEvent | WsErrorEvent | WsReconnectingEvent | WsCloseEvent;
+export const WsClientEventSchema = z.discriminatedUnion('type', [
+  // Server events
+  MessageCreatedEventSchema,
+  MessageUpdatedEventSchema,
+  ThreadReplyEventSchema,
+  ReactionAddedEventSchema,
+  ReactionRemovedEventSchema,
+  DmReceivedEventSchema,
+  GroupDmReceivedEventSchema,
+  AgentOnlineEventSchema,
+  AgentOfflineEventSchema,
+  ChannelCreatedEventSchema,
+  ChannelUpdatedEventSchema,
+  ChannelArchivedEventSchema,
+  MemberJoinedEventSchema,
+  MemberLeftEventSchema,
+  MessageReadEventSchema,
+  FileUploadedEventSchema,
+  WebhookReceivedEventSchema,
+  CommandInvokedEventSchema,
+  PongEventSchema,
+  // Client-only events
+  WsOpenEventSchema,
+  WsErrorEventSchema,
+  WsReconnectingEventSchema,
+  WsCloseEventSchema,
+]);
+export type WsClientEvent = z.infer<typeof WsClientEventSchema>;
 export type WsClientEventType = WsClientEvent['type'];
-

--- a/packages/types/src/file.ts
+++ b/packages/types/src/file.ts
@@ -1,42 +1,50 @@
-export type FileStatus = 'pending' | 'complete' | 'deleted';
+import { z } from 'zod';
 
-export interface FileRecord {
-  id: string;
-  workspace_id: string;
-  uploaded_by: string;
-  filename: string;
-  content_type: string;
-  size_bytes: number;
-  storage_key: string;
-  status: FileStatus;
-  created_at: string;
-}
+export const FileStatusSchema = z.enum(['pending', 'complete', 'deleted']);
+export type FileStatus = z.infer<typeof FileStatusSchema>;
 
-export interface UploadRequest {
-  filename: string;
-  content_type: string;
-  size_bytes: number;
-}
+export const FileRecordSchema = z.object({
+  id: z.string(),
+  workspace_id: z.string(),
+  uploaded_by: z.string(),
+  filename: z.string(),
+  content_type: z.string(),
+  size_bytes: z.number(),
+  storage_key: z.string(),
+  status: FileStatusSchema,
+  created_at: z.string(),
+});
+export type FileRecord = z.infer<typeof FileRecordSchema>;
 
-export interface UploadResponse {
-  file_id: string;
-  upload_url: string;
-  expires_at: string;
-}
+export const UploadRequestSchema = z.object({
+  filename: z.string(),
+  content_type: z.string(),
+  size_bytes: z.number(),
+});
+export type UploadRequest = z.infer<typeof UploadRequestSchema>;
 
-export interface FileAttachment {
-  file_id: string;
-  filename: string;
-  url: string;
-  size: number;
-}
+export const UploadResponseSchema = z.object({
+  file_id: z.string(),
+  upload_url: z.string(),
+  expires_at: z.string(),
+});
+export type UploadResponse = z.infer<typeof UploadResponseSchema>;
 
-export interface FileInfo {
-  file_id: string;
-  filename: string;
-  content_type: string;
-  size: number;
-  url: string;
-  uploaded_by: string;
-  created_at: string;
-}
+export const FileAttachmentSchema = z.object({
+  file_id: z.string(),
+  filename: z.string(),
+  url: z.string(),
+  size: z.number(),
+});
+export type FileAttachment = z.infer<typeof FileAttachmentSchema>;
+
+export const FileInfoSchema = z.object({
+  file_id: z.string(),
+  filename: z.string(),
+  content_type: z.string(),
+  size: z.number(),
+  url: z.string(),
+  uploaded_by: z.string(),
+  created_at: z.string(),
+});
+export type FileInfo = z.infer<typeof FileInfoSchema>;

--- a/packages/types/src/message.ts
+++ b/packages/types/src/message.ts
@@ -1,86 +1,100 @@
-import type { FileAttachment } from './file.js';
-import type { ReactionGroup } from './reaction.js';
+import { z } from 'zod';
+import { FileAttachmentSchema } from './file.js';
+import { ReactionGroupSchema } from './reaction.js';
 
 // Rich Message Blocks
 
-export interface HeaderBlock {
-  type: 'header';
-  text: string;
-}
+export const HeaderBlockSchema = z.object({
+  type: z.literal('header'),
+  text: z.string(),
+});
+export type HeaderBlock = z.infer<typeof HeaderBlockSchema>;
 
-export interface FieldsBlock {
-  type: 'fields';
-  fields: Array<{ label: string; value: string }>;
-}
+export const FieldsBlockSchema = z.object({
+  type: z.literal('fields'),
+  fields: z.array(z.object({ label: z.string(), value: z.string() })),
+});
+export type FieldsBlock = z.infer<typeof FieldsBlockSchema>;
 
-export interface ActionButton {
-  type: 'button';
-  text: string;
-  action_id: string;
-  value?: string;
-  style?: 'primary' | 'danger';
-}
+export const ActionButtonSchema = z.object({
+  type: z.literal('button'),
+  text: z.string(),
+  action_id: z.string(),
+  value: z.string().optional(),
+  style: z.enum(['primary', 'danger']).optional(),
+});
+export type ActionButton = z.infer<typeof ActionButtonSchema>;
 
-export interface ActionsBlock {
-  type: 'actions';
-  elements: ActionButton[];
-}
+export const ActionsBlockSchema = z.object({
+  type: z.literal('actions'),
+  elements: z.array(ActionButtonSchema),
+});
+export type ActionsBlock = z.infer<typeof ActionsBlockSchema>;
 
-export interface TextBlock {
-  type: 'text';
-  text: string;
-}
+export const TextBlockSchema = z.object({
+  type: z.literal('text'),
+  text: z.string(),
+});
+export type TextBlock = z.infer<typeof TextBlockSchema>;
 
-export interface DividerBlock {
-  type: 'divider';
-}
+export const DividerBlockSchema = z.object({
+  type: z.literal('divider'),
+});
+export type DividerBlock = z.infer<typeof DividerBlockSchema>;
 
-export type MessageBlock =
-  | HeaderBlock
-  | FieldsBlock
-  | ActionsBlock
-  | TextBlock
-  | DividerBlock;
+export const MessageBlockSchema = z.discriminatedUnion('type', [
+  HeaderBlockSchema,
+  FieldsBlockSchema,
+  ActionsBlockSchema,
+  TextBlockSchema,
+  DividerBlockSchema,
+]);
+export type MessageBlock = z.infer<typeof MessageBlockSchema>;
 
-export interface Message {
-  id: string;
-  workspace_id: string;
-  channel_id: string;
-  agent_id: string;
-  thread_id: string | null;
-  body: string;
-  blocks: MessageBlock[] | null;
-  has_attachments: boolean;
-  created_at: string;
-  updated_at: string | null;
-}
+export const MessageSchema = z.object({
+  id: z.string(),
+  workspace_id: z.string(),
+  channel_id: z.string(),
+  agent_id: z.string(),
+  thread_id: z.string().nullable(),
+  body: z.string(),
+  blocks: z.array(MessageBlockSchema).nullable(),
+  has_attachments: z.boolean(),
+  created_at: z.string(),
+  updated_at: z.string().nullable(),
+});
+export type Message = z.infer<typeof MessageSchema>;
 
-export interface MessageWithMeta {
-  id: string;
-  agent_name: string;
-  agent_id: string;
-  text: string;
-  blocks: MessageBlock[] | null;
-  attachments: FileAttachment[];
-  created_at: string;
-  reply_count: number;
-  reactions: ReactionGroup[];
-  read_by_count: number;
-}
+export const MessageWithMetaSchema = z.object({
+  id: z.string(),
+  agent_name: z.string(),
+  agent_id: z.string(),
+  text: z.string(),
+  blocks: z.array(MessageBlockSchema).nullable(),
+  attachments: z.array(FileAttachmentSchema),
+  created_at: z.string(),
+  reply_count: z.number(),
+  reactions: z.array(ReactionGroupSchema),
+  read_by_count: z.number(),
+});
+export type MessageWithMeta = z.infer<typeof MessageWithMetaSchema>;
 
-export interface PostMessageRequest {
-  text: string;
-  blocks?: MessageBlock[];
-  attachments?: string[];
-}
+export const PostMessageRequestSchema = z.object({
+  text: z.string(),
+  blocks: z.array(MessageBlockSchema).optional(),
+  attachments: z.array(z.string()).optional(),
+});
+export type PostMessageRequest = z.infer<typeof PostMessageRequestSchema>;
 
-export interface MessageListQuery {
-  limit?: number;
-  before?: string;
-  after?: string;
-}
+export const MessageListQuerySchema = z.object({
+  limit: z.number().optional(),
+  before: z.string().optional(),
+  after: z.string().optional(),
+});
+export type MessageListQuery = z.infer<typeof MessageListQuerySchema>;
 
-export interface ThreadReplyRequest {
-  text: string;
-  blocks?: MessageBlock[];
-}
+export const ThreadReplyRequestSchema = z.object({
+  text: z.string(),
+  blocks: z.array(MessageBlockSchema).optional(),
+});
+export type ThreadReplyRequest = z.infer<typeof ThreadReplyRequestSchema>;

--- a/packages/types/src/reaction.ts
+++ b/packages/types/src/reaction.ts
@@ -1,17 +1,22 @@
-export interface Reaction {
-  id: string;
-  message_id: string;
-  agent_id: string;
-  emoji: string;
-  created_at: string;
-}
+import { z } from 'zod';
 
-export interface AddReactionRequest {
-  emoji: string;
-}
+export const ReactionSchema = z.object({
+  id: z.string(),
+  message_id: z.string(),
+  agent_id: z.string(),
+  emoji: z.string(),
+  created_at: z.string(),
+});
+export type Reaction = z.infer<typeof ReactionSchema>;
 
-export interface ReactionGroup {
-  emoji: string;
-  count: number;
-  agents: string[];
-}
+export const AddReactionRequestSchema = z.object({
+  emoji: z.string(),
+});
+export type AddReactionRequest = z.infer<typeof AddReactionRequestSchema>;
+
+export const ReactionGroupSchema = z.object({
+  emoji: z.string(),
+  count: z.number(),
+  agents: z.array(z.string()),
+});
+export type ReactionGroup = z.infer<typeof ReactionGroupSchema>;

--- a/packages/types/src/receipt.ts
+++ b/packages/types/src/receipt.ts
@@ -1,17 +1,22 @@
-export interface ReadReceipt {
-  message_id: string;
-  agent_id: string;
-  read_at: string;
-}
+import { z } from 'zod';
 
-export interface ReaderInfo {
-  agent_name: string;
-  agent_id: string;
-  read_at: string;
-}
+export const ReadReceiptSchema = z.object({
+  message_id: z.string(),
+  agent_id: z.string(),
+  read_at: z.string(),
+});
+export type ReadReceipt = z.infer<typeof ReadReceiptSchema>;
 
-export interface ChannelReadStatus {
-  agent_name: string;
-  last_read_id: string | null;
-  last_read_at: string | null;
-}
+export const ReaderInfoSchema = z.object({
+  agent_name: z.string(),
+  agent_id: z.string(),
+  read_at: z.string(),
+});
+export type ReaderInfo = z.infer<typeof ReaderInfoSchema>;
+
+export const ChannelReadStatusSchema = z.object({
+  agent_name: z.string(),
+  last_read_id: z.string().nullable(),
+  last_read_at: z.string().nullable(),
+});
+export type ChannelReadStatus = z.infer<typeof ChannelReadStatusSchema>;

--- a/packages/types/src/subscription.ts
+++ b/packages/types/src/subscription.ts
@@ -1,51 +1,59 @@
-export type SubscribableEventType =
-  | 'message.created'
-  | 'message.updated'
-  | 'thread.reply'
-  | 'reaction.added'
-  | 'reaction.removed'
-  | 'agent.online'
-  | 'agent.offline'
-  | 'channel.created'
-  | 'channel.updated'
-  | 'channel.archived'
-  | 'member.joined'
-  | 'member.left'
-  | 'dm.received'
-  | 'group_dm.received'
-  | 'message.read'
-  | 'file.uploaded'
-  | 'webhook.received'
-  | 'command.invoked';
+import { z } from 'zod';
 
-export interface SubscriptionFilter {
-  channel?: string;
-  mentions?: string;
-}
+export const SubscribableEventTypeSchema = z.enum([
+  'message.created',
+  'message.updated',
+  'thread.reply',
+  'reaction.added',
+  'reaction.removed',
+  'agent.online',
+  'agent.offline',
+  'channel.created',
+  'channel.updated',
+  'channel.archived',
+  'member.joined',
+  'member.left',
+  'dm.received',
+  'group_dm.received',
+  'message.read',
+  'file.uploaded',
+  'webhook.received',
+  'command.invoked',
+]);
+export type SubscribableEventType = z.infer<typeof SubscribableEventTypeSchema>;
 
-export interface EventSubscription {
-  id: string;
-  workspace_id: string;
-  events: SubscribableEventType[];
-  filter: SubscriptionFilter | null;
-  url: string;
-  secret: string | null;
-  is_active: boolean;
-  created_at: string;
-}
+export const SubscriptionFilterSchema = z.object({
+  channel: z.string().optional(),
+  mentions: z.string().optional(),
+});
+export type SubscriptionFilter = z.infer<typeof SubscriptionFilterSchema>;
 
-export interface CreateSubscriptionRequest {
-  events: SubscribableEventType[];
-  filter?: SubscriptionFilter;
-  url: string;
-  secret?: string;
-}
+export const EventSubscriptionSchema = z.object({
+  id: z.string(),
+  workspace_id: z.string(),
+  events: z.array(SubscribableEventTypeSchema),
+  filter: SubscriptionFilterSchema.nullable(),
+  url: z.string(),
+  secret: z.string().nullable(),
+  is_active: z.boolean(),
+  created_at: z.string(),
+});
+export type EventSubscription = z.infer<typeof EventSubscriptionSchema>;
 
-export interface CreateSubscriptionResponse {
-  id: string;
-  events: SubscribableEventType[];
-  filter: SubscriptionFilter | null;
-  url: string;
-  is_active: boolean;
-  created_at: string;
-}
+export const CreateSubscriptionRequestSchema = z.object({
+  events: z.array(SubscribableEventTypeSchema),
+  filter: SubscriptionFilterSchema.optional(),
+  url: z.string(),
+  secret: z.string().optional(),
+});
+export type CreateSubscriptionRequest = z.infer<typeof CreateSubscriptionRequestSchema>;
+
+export const CreateSubscriptionResponseSchema = z.object({
+  id: z.string(),
+  events: z.array(SubscribableEventTypeSchema),
+  filter: SubscriptionFilterSchema.nullable(),
+  url: z.string(),
+  is_active: z.boolean(),
+  created_at: z.string(),
+});
+export type CreateSubscriptionResponse = z.infer<typeof CreateSubscriptionResponseSchema>;

--- a/packages/types/src/webhook.ts
+++ b/packages/types/src/webhook.ts
@@ -1,38 +1,45 @@
-export interface Webhook {
-  id: string;
-  workspace_id: string;
-  name: string;
-  channel_id: string;
-  channel_name: string;
-  url: string;
-  created_by: string | null;
-  created_at: string;
-  is_active: boolean;
-}
+import { z } from 'zod';
 
-export interface CreateWebhookRequest {
-  name: string;
-  channel: string;
-}
+export const WebhookSchema = z.object({
+  id: z.string(),
+  workspace_id: z.string(),
+  name: z.string(),
+  channel_id: z.string(),
+  channel_name: z.string(),
+  url: z.string(),
+  created_by: z.string().nullable(),
+  created_at: z.string(),
+  is_active: z.boolean(),
+});
+export type Webhook = z.infer<typeof WebhookSchema>;
 
-export interface CreateWebhookResponse {
-  webhook_id: string;
-  name: string;
-  channel: string;
-  url: string;
-  created_at: string;
-}
+export const CreateWebhookRequestSchema = z.object({
+  name: z.string(),
+  channel: z.string(),
+});
+export type CreateWebhookRequest = z.infer<typeof CreateWebhookRequestSchema>;
 
-export interface WebhookTriggerRequest {
-  text?: string;
-  blocks?: unknown[];
-  source?: string;
-  payload?: Record<string, unknown>;
-}
+export const CreateWebhookResponseSchema = z.object({
+  webhook_id: z.string(),
+  name: z.string(),
+  channel: z.string(),
+  url: z.string(),
+  created_at: z.string(),
+});
+export type CreateWebhookResponse = z.infer<typeof CreateWebhookResponseSchema>;
 
-export interface WebhookTriggerResponse {
-  message_id: string;
-  channel: string;
-  text: string;
-  created_at: string;
-}
+export const WebhookTriggerRequestSchema = z.object({
+  text: z.string().optional(),
+  blocks: z.array(z.unknown()).optional(),
+  source: z.string().optional(),
+  payload: z.record(z.unknown()).optional(),
+});
+export type WebhookTriggerRequest = z.infer<typeof WebhookTriggerRequestSchema>;
+
+export const WebhookTriggerResponseSchema = z.object({
+  message_id: z.string(),
+  channel: z.string(),
+  text: z.string(),
+  created_at: z.string(),
+});
+export type WebhookTriggerResponse = z.infer<typeof WebhookTriggerResponseSchema>;

--- a/packages/types/src/workspace.ts
+++ b/packages/types/src/workspace.ts
@@ -1,36 +1,44 @@
-export interface Workspace {
-  id: string;
-  name: string;
-  api_key_hash: string;
-  system_prompt: string | null;
-  plan: 'free' | 'pro' | 'enterprise';
-  stripe_customer_id: string | null;
-  stripe_subscription_id: string | null;
-  created_at: string;
-  metadata: Record<string, unknown>;
-}
+import { z } from 'zod';
 
-export interface CreateWorkspaceRequest {
-  name: string;
-}
+export const WorkspaceSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  api_key_hash: z.string(),
+  system_prompt: z.string().nullable(),
+  plan: z.enum(['free', 'pro', 'enterprise']),
+  stripe_customer_id: z.string().nullable(),
+  stripe_subscription_id: z.string().nullable(),
+  created_at: z.string(),
+  metadata: z.record(z.unknown()),
+});
+export type Workspace = z.infer<typeof WorkspaceSchema>;
 
-export interface CreateWorkspaceResponse {
-  workspace_id: string;
-  api_key: string;
-  created_at: string;
-}
+export const CreateWorkspaceRequestSchema = z.object({
+  name: z.string(),
+});
+export type CreateWorkspaceRequest = z.infer<typeof CreateWorkspaceRequestSchema>;
 
-export interface UpdateWorkspaceRequest {
-  name?: string;
-  system_prompt?: string;
-}
+export const CreateWorkspaceResponseSchema = z.object({
+  workspace_id: z.string(),
+  api_key: z.string(),
+  created_at: z.string(),
+});
+export type CreateWorkspaceResponse = z.infer<typeof CreateWorkspaceResponseSchema>;
 
-export interface SystemPrompt {
-  prompt: string;
-  is_default: boolean;
-}
+export const UpdateWorkspaceRequestSchema = z.object({
+  name: z.string().optional(),
+  system_prompt: z.string().optional(),
+});
+export type UpdateWorkspaceRequest = z.infer<typeof UpdateWorkspaceRequestSchema>;
 
-export interface SetSystemPromptRequest {
-  prompt?: string | null;
-  reset?: boolean;
-}
+export const SystemPromptSchema = z.object({
+  prompt: z.string(),
+  is_default: z.boolean(),
+});
+export type SystemPrompt = z.infer<typeof SystemPromptSchema>;
+
+export const SetSystemPromptRequestSchema = z.object({
+  prompt: z.string().nullable().optional(),
+  reset: z.boolean().optional(),
+});
+export type SetSystemPromptRequest = z.infer<typeof SetSystemPromptRequestSchema>;

--- a/packages/types/src/workspace.ts
+++ b/packages/types/src/workspace.ts
@@ -24,3 +24,13 @@ export interface UpdateWorkspaceRequest {
   name?: string;
   system_prompt?: string;
 }
+
+export interface SystemPrompt {
+  prompt: string;
+  is_default: boolean;
+}
+
+export interface SetSystemPromptRequest {
+  prompt?: string | null;
+  reset?: boolean;
+}


### PR DESCRIPTION
Introduce new Relay APIs and related client/type updates: add Relay.createWorkspace, workspace.delete, systemPrompt.get/set, agents.update/delete/presence, and agents.registerOrGet (with conflict handling). Add AgentClient.channels.update and HttpClient.put. Improve WsClient to emit 'error' and 'reconnecting' events. Add new types (AgentPresenceInfo, SystemPrompt, SetSystemPromptRequest) and bump SDK_VERSION to 0.2.3. Tests updated/added to cover the new behaviors.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/agentworkforce/relaycast/pull/20" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
