### PR TITLE
Add preview env audit workflow and improve cleanup

### DIFF
--- a/.github/workflows/preview-env-audit.yml
+++ b/.github/workflows/preview-env-audit.yml
@@ -1,0 +1,160 @@
+name: Preview Environment Audit
+
+on:
+  workflow_dispatch:
+    inputs:
+      remove_stale:
+        description: Delete stale preview workers after audit
+        required: true
+        type: boolean
+        default: false
+  workflow_call:
+    inputs:
+      remove_stale:
+        required: false
+        type: boolean
+        default: false
+    secrets:
+      CLOUDFLARE_API_TOKEN:
+        required: true
+      CLOUDFLARE_ACCOUNT_ID:
+        required: true
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  audit-preview-environments:
+    name: Audit Preview Environments
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Audit and optionally remove stale preview workers
+        shell: bash
+        env:
+          GH_REPO: ${{ github.repository }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CF_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CF_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          REMOVE_STALE: ${{ inputs.remove_stale }}
+        run: |
+          set -euo pipefail
+
+          if [ -z "${CF_API_TOKEN}" ] || [ -z "${CF_ACCOUNT_ID}" ]; then
+            echo "Missing CLOUDFLARE_API_TOKEN or CLOUDFLARE_ACCOUNT_ID secret."
+            exit 1
+          fi
+
+          if [ -z "${REMOVE_STALE}" ]; then
+            REMOVE_STALE="false"
+          fi
+
+          echo "Loading open PRs for ${GH_REPO}..."
+          OPEN_PRS=()
+          page=1
+          while :; do
+            resp="$(curl -fsS \
+              -H "Authorization: Bearer ${GH_TOKEN}" \
+              -H "Accept: application/vnd.github+json" \
+              "https://api.github.com/repos/${GH_REPO}/pulls?state=open&per_page=100&page=${page}")"
+
+            count="$(echo "${resp}" | jq 'length')"
+            if [ "${count}" -eq 0 ]; then
+              break
+            fi
+
+            while IFS= read -r pr; do
+              OPEN_PRS+=("${pr}")
+            done < <(echo "${resp}" | jq -r --arg repo "${GH_REPO}" '.[] | select(.head.repo.full_name == $repo) | .number')
+
+            page="$((page + 1))"
+          done
+
+          declare -A KEEP=()
+          for pr in "${OPEN_PRS[@]}"; do
+            KEEP["relaycast-pr-${pr}"]=1
+            KEEP["relaycast-observer-pr-${pr}"]=1
+          done
+
+          echo "Loading worker scripts from Cloudflare account..."
+          workers_resp="$(curl -fsS \
+            -H "Authorization: Bearer ${CF_API_TOKEN}" \
+            "https://api.cloudflare.com/client/v4/accounts/${CF_ACCOUNT_ID}/workers/scripts")"
+
+          mapfile -t PREVIEW_WORKERS < <(
+            echo "${workers_resp}" \
+              | jq -r '.result[] | (.id // .name // empty)' \
+              | grep -E '^relaycast(-observer)?-pr-[0-9]+$' \
+              | sort -u || true
+          )
+
+          ACTIVE=()
+          STALE=()
+          for worker in "${PREVIEW_WORKERS[@]}"; do
+            if [ -n "${KEEP[$worker]:-}" ]; then
+              ACTIVE+=("${worker}")
+            else
+              STALE+=("${worker}")
+            fi
+          done
+
+          echo "Open PR count: ${#OPEN_PRS[@]}"
+          echo "Preview workers found: ${#PREVIEW_WORKERS[@]}"
+          echo "Stale workers: ${#STALE[@]}"
+
+          {
+            echo "## Preview Environment Audit"
+            echo ""
+            echo "- Repository: \`${GH_REPO}\`"
+            echo "- Mode: \`$([ "${REMOVE_STALE}" = "true" ] && echo "remove" || echo "audit")\`"
+            echo "- Open PRs: ${#OPEN_PRS[@]}"
+            echo "- Preview workers found: ${#PREVIEW_WORKERS[@]}"
+            echo "- Stale workers: ${#STALE[@]}"
+            echo ""
+
+            echo "### Stale Preview Workers"
+            if [ "${#STALE[@]}" -eq 0 ]; then
+              echo "_None_"
+            else
+              for worker in "${STALE[@]}"; do
+                echo "- \`${worker}\`"
+              done
+            fi
+          } >> "${GITHUB_STEP_SUMMARY}"
+
+          if [ "${REMOVE_STALE}" != "true" ]; then
+            exit 0
+          fi
+
+          if [ "${#STALE[@]}" -eq 0 ]; then
+            echo "No stale workers to remove."
+            exit 0
+          fi
+
+          deleted=0
+          failed=0
+          for worker in "${STALE[@]}"; do
+            echo "Deleting stale worker: ${worker}"
+            delete_resp="$(curl -sS -X DELETE \
+              -H "Authorization: Bearer ${CF_API_TOKEN}" \
+              "https://api.cloudflare.com/client/v4/accounts/${CF_ACCOUNT_ID}/workers/scripts/${worker}")"
+            if [ "$(echo "${delete_resp}" | jq -r '.success')" = "true" ]; then
+              deleted="$((deleted + 1))"
+            else
+              failed="$((failed + 1))"
+              echo "Failed deleting ${worker}:"
+              echo "${delete_resp}" | jq -r '.errors[]?.message // "Unknown API error"'
+            fi
+          done
+
+          {
+            echo ""
+            echo "### Remove Results"
+            echo "- Deleted: ${deleted}"
+            echo "- Failed: ${failed}"
+          } >> "${GITHUB_STEP_SUMMARY}"
+
+          if [ "${failed}" -gt 0 ]; then
+            exit 1
+          fi

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -175,7 +175,7 @@ jobs:
               `| API | ${url} |\n` +
               `| Health | ${url}/health |\n` +
               `| Observer | ${observerUrl} |\n\n` +
-              `This preview shares the staging database and will be cleaned up when the PR is closed.\n\n` +
+              `This preview shares the staging database and will be cleaned up when the PR is merged or closed.\n\n` +
               `### Run E2E tests\n` +
               `\`\`\`bash\n` +
               `npm run e2e -- ${url} --ci\n` +
@@ -201,7 +201,7 @@ jobs:
 
   cleanup-preview:
     name: Cleanup Preview
-    if: github.event.action == 'closed' && github.event.pull_request.head.repo.full_name == github.repository
+    if: github.event.action == 'closed' && (github.event.pull_request.merged == true || github.event.pull_request.state == 'closed') && github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     env:
       CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
@@ -210,5 +210,14 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 22
-      - run: npx wrangler delete --name "relaycast-pr-${{ github.event.pull_request.number }}" --force
-      - run: npx wrangler delete --name "relaycast-observer-pr-${{ github.event.pull_request.number }}" --force || true
+      - name: Delete preview workers
+        shell: bash
+        run: |
+          set -euo pipefail
+          PR_NUM="${{ github.event.pull_request.number }}"
+          for worker in "relaycast-pr-${PR_NUM}" "relaycast-observer-pr-${PR_NUM}"; do
+            echo "Deleting ${worker}"
+            if ! npx wrangler delete --name "${worker}" --force; then
+              echo "Unable to delete ${worker} (already removed or not found)."
+            fi
+          done

--- a/.trajectories/completed/2026-02/traj_lb1h61b1acre.json
+++ b/.trajectories/completed/2026-02/traj_lb1h61b1acre.json
@@ -1,0 +1,53 @@
+{
+  "id": "traj_lb1h61b1acre",
+  "version": 1,
+  "task": {
+    "title": "Harden preview environment cleanup on PR close/merge"
+  },
+  "status": "completed",
+  "startedAt": "2026-02-19T06:19:51.297Z",
+  "agents": [
+    {
+      "name": "default",
+      "role": "lead",
+      "joinedAt": "2026-02-19T06:20:06.214Z"
+    }
+  ],
+  "chapters": [
+    {
+      "id": "chap_njqe9lvzuajc",
+      "title": "Work",
+      "agentName": "default",
+      "startedAt": "2026-02-19T06:20:06.214Z",
+      "events": [
+        {
+          "ts": 1771482006215,
+          "type": "decision",
+          "content": "Make preview cleanup idempotent for merged/closed PRs: Make preview cleanup idempotent for merged/closed PRs",
+          "raw": {
+            "question": "Make preview cleanup idempotent for merged/closed PRs",
+            "chosen": "Make preview cleanup idempotent for merged/closed PRs",
+            "alternatives": [],
+            "reasoning": "Current cleanup can stop after first failed delete, leaving observer preview worker undeleted; a single guarded cleanup script should attempt both resources on every PR close (merged or not)."
+          },
+          "significance": "high"
+        }
+      ],
+      "endedAt": "2026-02-19T06:20:30.737Z"
+    }
+  ],
+  "commits": [],
+  "filesChanged": [],
+  "projectId": "/Users/will/Projects/relaycast",
+  "tags": [],
+  "_trace": {
+    "startRef": "10d3df0a1118f4bae7147bc257c4cdbe07f7a04a",
+    "endRef": "10d3df0a1118f4bae7147bc257c4cdbe07f7a04a"
+  },
+  "completedAt": "2026-02-19T06:20:30.737Z",
+  "retrospective": {
+    "summary": "Updated preview cleanup to run on PR close (merged or not) and delete both preview workers in a single idempotent step so cleanup continues even if a worker is already missing",
+    "approach": "Standard approach",
+    "confidence": 0.9
+  }
+}

--- a/.trajectories/completed/2026-02/traj_lb1h61b1acre.md
+++ b/.trajectories/completed/2026-02/traj_lb1h61b1acre.md
@@ -1,0 +1,31 @@
+# Trajectory: Harden preview environment cleanup on PR close/merge
+
+> **Status:** ✅ Completed
+> **Confidence:** 90%
+> **Started:** February 19, 2026 at 01:19 AM
+> **Completed:** February 19, 2026 at 01:20 AM
+
+---
+
+## Summary
+
+Updated preview cleanup to run on PR close (merged or not) and delete both preview workers in a single idempotent step so cleanup continues even if a worker is already missing
+
+**Approach:** Standard approach
+
+---
+
+## Key Decisions
+
+### Make preview cleanup idempotent for merged/closed PRs
+- **Chose:** Make preview cleanup idempotent for merged/closed PRs
+- **Reasoning:** Current cleanup can stop after first failed delete, leaving observer preview worker undeleted; a single guarded cleanup script should attempt both resources on every PR close (merged or not).
+
+---
+
+## Chapters
+
+### 1. Work
+*Agent: default*
+
+- Make preview cleanup idempotent for merged/closed PRs: Make preview cleanup idempotent for merged/closed PRs

--- a/.trajectories/completed/2026-02/traj_qja7zvywp7xq.json
+++ b/.trajectories/completed/2026-02/traj_qja7zvywp7xq.json
@@ -1,0 +1,53 @@
+{
+  "id": "traj_qja7zvywp7xq",
+  "version": 1,
+  "task": {
+    "title": "Fix failure in GitHub Actions job 64106388975"
+  },
+  "status": "completed",
+  "startedAt": "2026-02-19T06:16:20.221Z",
+  "agents": [
+    {
+      "name": "default",
+      "role": "lead",
+      "joinedAt": "2026-02-19T06:18:06.064Z"
+    }
+  ],
+  "chapters": [
+    {
+      "id": "chap_u8et7e5hc83g",
+      "title": "Work",
+      "agentName": "default",
+      "startedAt": "2026-02-19T06:18:06.064Z",
+      "events": [
+        {
+          "ts": 1771481886065,
+          "type": "decision",
+          "content": "Gate production deploy on presence of production resource variables: Gate production deploy on presence of production resource variables",
+          "raw": {
+            "question": "Gate production deploy on presence of production resource variables",
+            "chosen": "Gate production deploy on presence of production resource variables",
+            "alternatives": [],
+            "reasoning": "Repository only has staging vars; production D1/KV IDs are unset, so deploy-production cannot run successfully. Conditional execution avoids false-red deploy runs while keeping production deploy active once vars are configured"
+          },
+          "significance": "high"
+        }
+      ],
+      "endedAt": "2026-02-19T06:18:17.449Z"
+    }
+  ],
+  "commits": [],
+  "filesChanged": [],
+  "projectId": "/Users/will/Projects/relaycast",
+  "tags": [],
+  "_trace": {
+    "startRef": "10d3df0a1118f4bae7147bc257c4cdbe07f7a04a",
+    "endRef": "10d3df0a1118f4bae7147bc257c4cdbe07f7a04a"
+  },
+  "completedAt": "2026-02-19T06:18:17.449Z",
+  "retrospective": {
+    "summary": "Confirmed linked staging E2E failure was fixed in main; identified new production failure due missing PRODUCTION_D1_DATABASE_ID/PRODUCTION_KV_ID vars and gated deploy-production job on those vars to avoid hard-fail runs until configured",
+    "approach": "Standard approach",
+    "confidence": 0.88
+  }
+}

--- a/.trajectories/completed/2026-02/traj_qja7zvywp7xq.md
+++ b/.trajectories/completed/2026-02/traj_qja7zvywp7xq.md
@@ -1,0 +1,31 @@
+# Trajectory: Fix failure in GitHub Actions job 64106388975
+
+> **Status:** ✅ Completed
+> **Confidence:** 88%
+> **Started:** February 19, 2026 at 01:16 AM
+> **Completed:** February 19, 2026 at 01:18 AM
+
+---
+
+## Summary
+
+Confirmed linked staging E2E failure was fixed in main; identified new production failure due missing PRODUCTION_D1_DATABASE_ID/PRODUCTION_KV_ID vars and gated deploy-production job on those vars to avoid hard-fail runs until configured
+
+**Approach:** Standard approach
+
+---
+
+## Key Decisions
+
+### Gate production deploy on presence of production resource variables
+- **Chose:** Gate production deploy on presence of production resource variables
+- **Reasoning:** Repository only has staging vars; production D1/KV IDs are unset, so deploy-production cannot run successfully. Conditional execution avoids false-red deploy runs while keeping production deploy active once vars are configured
+
+---
+
+## Chapters
+
+### 1. Work
+*Agent: default*
+
+- Gate production deploy on presence of production resource variables: Gate production deploy on presence of production resource variables

--- a/.trajectories/completed/2026-02/traj_ytd41ii48d1k.json
+++ b/.trajectories/completed/2026-02/traj_ytd41ii48d1k.json
@@ -1,0 +1,53 @@
+{
+  "id": "traj_ytd41ii48d1k",
+  "version": 1,
+  "task": {
+    "title": "Add callable preview environment audit/remove workflow"
+  },
+  "status": "completed",
+  "startedAt": "2026-02-19T06:25:18.213Z",
+  "agents": [
+    {
+      "name": "default",
+      "role": "lead",
+      "joinedAt": "2026-02-19T06:25:25.167Z"
+    }
+  ],
+  "chapters": [
+    {
+      "id": "chap_4440kg6sri82",
+      "title": "Work",
+      "agentName": "default",
+      "startedAt": "2026-02-19T06:25:25.167Z",
+      "events": [
+        {
+          "ts": 1771482325167,
+          "type": "decision",
+          "content": "Use workflow_dispatch + workflow_call for preview cleanup automation: Use workflow_dispatch + workflow_call for preview cleanup automation",
+          "raw": {
+            "question": "Use workflow_dispatch + workflow_call for preview cleanup automation",
+            "chosen": "Use workflow_dispatch + workflow_call for preview cleanup automation",
+            "alternatives": [],
+            "reasoning": "This makes preview environment cleanup callable manually and from other workflows, with safe audit mode as default and explicit remove mode."
+          },
+          "significance": "high"
+        }
+      ],
+      "endedAt": "2026-02-19T06:25:28.292Z"
+    }
+  ],
+  "commits": [],
+  "filesChanged": [],
+  "projectId": "/Users/will/Projects/relaycast",
+  "tags": [],
+  "_trace": {
+    "startRef": "10d3df0a1118f4bae7147bc257c4cdbe07f7a04a",
+    "endRef": "10d3df0a1118f4bae7147bc257c4cdbe07f7a04a"
+  },
+  "completedAt": "2026-02-19T06:25:28.292Z",
+  "retrospective": {
+    "summary": "Added .github/workflows/preview-env-audit.yml as a callable/manual workflow to audit Cloudflare preview workers against open PRs and optionally delete stale workers",
+    "approach": "Standard approach",
+    "confidence": 0.88
+  }
+}

--- a/.trajectories/completed/2026-02/traj_ytd41ii48d1k.md
+++ b/.trajectories/completed/2026-02/traj_ytd41ii48d1k.md
@@ -1,0 +1,31 @@
+# Trajectory: Add callable preview environment audit/remove workflow
+
+> **Status:** ✅ Completed
+> **Confidence:** 88%
+> **Started:** February 19, 2026 at 01:25 AM
+> **Completed:** February 19, 2026 at 01:25 AM
+
+---
+
+## Summary
+
+Added .github/workflows/preview-env-audit.yml as a callable/manual workflow to audit Cloudflare preview workers against open PRs and optionally delete stale workers
+
+**Approach:** Standard approach
+
+---
+
+## Key Decisions
+
+### Use workflow_dispatch + workflow_call for preview cleanup automation
+- **Chose:** Use workflow_dispatch + workflow_call for preview cleanup automation
+- **Reasoning:** This makes preview environment cleanup callable manually and from other workflows, with safe audit mode as default and explicit remove mode.
+
+---
+
+## Chapters
+
+### 1. Work
+*Agent: default*
+
+- Use workflow_dispatch + workflow_call for preview cleanup automation: Use workflow_dispatch + workflow_call for preview cleanup automation

--- a/.trajectories/index.json
+++ b/.trajectories/index.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "lastUpdated": "2026-02-19T05:47:25.180Z",
+  "lastUpdated": "2026-02-19T06:25:28.364Z",
   "trajectories": {
     "traj_o8g8ahqth5fx": {
       "title": "Wave 0: add repo infrastructure files (docker, turbo, tsconfig, env)",
@@ -505,6 +505,27 @@
       "startedAt": "2026-02-19T05:46:55.050Z",
       "completedAt": "2026-02-19T05:47:25.089Z",
       "path": "/Users/will/Projects/relaycast/.trajectories/completed/2026-02/traj_6814hh1aleva.json"
+    },
+    "traj_qja7zvywp7xq": {
+      "title": "Fix failure in GitHub Actions job 64106388975",
+      "status": "completed",
+      "startedAt": "2026-02-19T06:16:20.221Z",
+      "completedAt": "2026-02-19T06:18:17.449Z",
+      "path": "/Users/will/Projects/relaycast/.trajectories/completed/2026-02/traj_qja7zvywp7xq.json"
+    },
+    "traj_lb1h61b1acre": {
+      "title": "Harden preview environment cleanup on PR close/merge",
+      "status": "completed",
+      "startedAt": "2026-02-19T06:19:51.297Z",
+      "completedAt": "2026-02-19T06:20:30.737Z",
+      "path": "/Users/will/Projects/relaycast/.trajectories/completed/2026-02/traj_lb1h61b1acre.json"
+    },
+    "traj_ytd41ii48d1k": {
+      "title": "Add callable preview environment audit/remove workflow",
+      "status": "completed",
+      "startedAt": "2026-02-19T06:25:18.213Z",
+      "completedAt": "2026-02-19T06:25:28.292Z",
+      "path": "/Users/will/Projects/relaycast/.trajectories/completed/2026-02/traj_ytd41ii48d1k.json"
     }
   }
 }


### PR DESCRIPTION
Add a callable/manual .github/workflows/preview-env-audit.yml to audit Cloudflare preview workers against open PRs and optionally delete stale workers. Harden preview cleanup in .github/workflows/preview.yml to run for merged or closed PRs and make deletion idempotent by attempting removal of both relaycast-pr- and relaycast-observer- workers with robust error handling. Also add trajectory records (.trajectories/completed/*) and update .trajectories/index.json metadata.