### PR TITLE
Fix agent spawn CLI metadata propagation

### DIFF
--- a/packages/dashboard/src/components/AgentPanel.tsx
+++ b/packages/dashboard/src/components/AgentPanel.tsx
@@ -44,7 +44,7 @@ interface AgentPanelProps {
 
 export function AgentPanel({ agent, onClose }: AgentPanelProps) {
   const status = statusLabel(agent.status);
-  const cli = (agent.metadata?.cli as string) || 'unknown';
+  const cli = (agent.metadata?.cli as string) || (agent.metadata?.spawn as Record<string, unknown>)?.cli as string || 'unknown';
   const currentTask = (agent.metadata?.current_task as string) || '';
 
   // Collect metadata entries to display (excluding known fields)

--- a/packages/dashboard/src/components/AgentSidebar.tsx
+++ b/packages/dashboard/src/components/AgentSidebar.tsx
@@ -185,7 +185,7 @@ export function AgentSidebar({
               <span className="truncate flex-1 text-left">{agent.name}</span>
               <span className={cn('h-2 w-2 rounded-full shrink-0', statusColor(agent.status))} />
               <span className="text-[10px] text-[var(--color-text-dim)] shrink-0">
-                {(agent.metadata?.cli as string) || agent.type}
+                {(agent.metadata?.cli as string) || (agent.metadata?.spawn as Record<string, unknown>)?.cli as string || agent.type}
               </span>
             </button>
           ))}

--- a/packages/server/src/engine/agent.ts
+++ b/packages/server/src/engine/agent.ts
@@ -259,6 +259,7 @@ export async function spawnAgent(
     const spawnMetadata = {
       ...(existing.metadata as Record<string, unknown> || {}),
       ...(data.metadata || {}),
+      cli: data.cli,
       spawn: {
         cli: data.cli,
         task: data.task,
@@ -286,6 +287,7 @@ export async function spawnAgent(
 
     const spawnMetadata = {
       ...(data.metadata || {}),
+      cli: data.cli,
       spawn: {
         cli: data.cli,
         task: data.task,

--- a/packages/server/src/engine/agent.ts
+++ b/packages/server/src/engine/agent.ts
@@ -402,7 +402,7 @@ export async function releaseAgent(
 
   // Mark as offline and clear spawn metadata
   const existingMetadata = (agent.metadata as Record<string, unknown>) || {};
-  const { spawn: _spawn, ...restMetadata } = existingMetadata;
+  const { spawn: _spawn, cli: _cli, ...restMetadata } = existingMetadata;
 
   await db
     .update(agents)


### PR DESCRIPTION
## Summary
- Promote `cli` to a top-level metadata key during `spawnAgent` so the dashboard displays it without reaching into the nested `spawn` object
- Update `AgentPanel` and `AgentSidebar` to fall back to `metadata.spawn.cli` for agents spawned before this change

## Test plan
- [ ] Spawn an agent via the API and verify `metadata.cli` is set at the top level
- [ ] Confirm the dashboard sidebar and agent panel show the correct CLI label
- [ ] Verify agents spawned before this change still display their CLI via the fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/agentworkforce/relaycast/pull/33" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
