### PR TITLE
Add REST heartbeat endpoint and fix CLI type display

### DIFF
--- a/packages/dashboard/src/components/AgentPanel.tsx
+++ b/packages/dashboard/src/components/AgentPanel.tsx
@@ -44,7 +44,7 @@ interface AgentPanelProps {
 
 export function AgentPanel({ agent, onClose }: AgentPanelProps) {
   const status = statusLabel(agent.status);
-  const cli = (agent.metadata?.cli as string) || 'unknown';
+  const cli = (agent.metadata?.cli as string) || (agent.metadata?.spawn as Record<string, unknown>)?.cli as string || 'unknown';
   const currentTask = (agent.metadata?.current_task as string) || '';
 
   // Collect metadata entries to display (excluding known fields)

--- a/packages/dashboard/src/components/AgentSidebar.tsx
+++ b/packages/dashboard/src/components/AgentSidebar.tsx
@@ -185,7 +185,7 @@ export function AgentSidebar({
               <span className="truncate flex-1 text-left">{agent.name}</span>
               <span className={cn('h-2 w-2 rounded-full shrink-0', statusColor(agent.status))} />
               <span className="text-[10px] text-[var(--color-text-dim)] shrink-0">
-                {(agent.metadata?.cli as string) || agent.type}
+                {(agent.metadata?.cli as string) || (agent.metadata?.spawn as Record<string, unknown>)?.cli as string || agent.type}
               </span>
             </button>
           ))}

--- a/packages/sdk/src/agent.ts
+++ b/packages/sdk/src/agent.ts
@@ -76,6 +76,11 @@ export class AgentClient {
     this.ws.connect();
   }
 
+  /** Send a REST heartbeat to keep this agent online in PresenceDO without a WebSocket. */
+  async heartbeat(): Promise<void> {
+    await this.client.post('/v1/agents/heartbeat', {});
+  }
+
   async disconnect(): Promise<void> {
     if (this.ws) {
       // Notify the server before closing the WebSocket so presence

--- a/packages/server/src/engine/agent.ts
+++ b/packages/server/src/engine/agent.ts
@@ -259,6 +259,7 @@ export async function spawnAgent(
     const spawnMetadata = {
       ...(existing.metadata as Record<string, unknown> || {}),
       ...(data.metadata || {}),
+      cli: data.cli,
       spawn: {
         cli: data.cli,
         task: data.task,
@@ -286,6 +287,7 @@ export async function spawnAgent(
 
     const spawnMetadata = {
       ...(data.metadata || {}),
+      cli: data.cli,
       spawn: {
         cli: data.cli,
         task: data.task,

--- a/packages/server/src/routes/presence.ts
+++ b/packages/server/src/routes/presence.ts
@@ -21,6 +21,28 @@ presenceRoutes.get('/agents/presence', requireAuth, rateLimit, async (c) => {
   }
 });
 
+// POST /agents/heartbeat — refresh presence for an agent (REST alternative to WebSocket ping)
+presenceRoutes.post('/agents/heartbeat', requireAgentToken, rateLimit, async (c) => {
+  try {
+    const agent = c.get('agent')!;
+    const workspace = c.get('workspace');
+    const doId = c.env.PRESENCE_DO.idFromName(workspace.id);
+    const stub = c.env.PRESENCE_DO.get(doId);
+    await stub.fetch(new Request('http://do/heartbeat', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ agentId: agent.id, workspaceId: workspace.id, agentName: agent.name }),
+    }));
+    return c.json({ ok: true });
+  } catch (err: unknown) {
+    const error = err as Error & { code?: string; status?: number };
+    return c.json({
+      ok: false,
+      error: { code: error.code || 'internal_error', message: error.message },
+    }, (error.status || 500) as any);
+  }
+});
+
 // POST /agents/disconnect — explicitly mark agent offline
 presenceRoutes.post('/agents/disconnect', requireAgentToken, rateLimit, async (c) => {
   try {


### PR DESCRIPTION
## Summary
- Adds `POST /v1/agents/heartbeat` REST endpoint so agents can maintain presence without a WebSocket connection
- Fixes CLI type not showing in dashboard by setting `metadata.cli` at top level during spawn
- Dashboard components now fall back to `metadata.spawn.cli` for backward compatibility

## Changes
- **Server**: New `POST /agents/heartbeat` route in `presence.ts`
- **SDK**: `heartbeat()` method on `AgentClient`
- **Engine**: `spawnAgent()` sets `cli` at top level of metadata (both new + existing agent paths)
- **Dashboard**: `AgentSidebar.tsx` and `AgentPanel.tsx` read `metadata.spawn.cli` as fallback

## Test plan
- [ ] Verify `POST /v1/agents/heartbeat` keeps agent online in PresenceDO
- [ ] Verify CLI type displays correctly for newly spawned agents
- [ ] Verify CLI type displays for agents spawned before this change (via fallback)
- [ ] Verify existing disconnect flow still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/agentworkforce/relaycast/pull/34" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
