### PR TITLE
feat: add PostHog logging to server

### DIFF
--- a/packages/server/src/env.ts
+++ b/packages/server/src/env.ts
@@ -1,4 +1,5 @@
 import type { workspaces, agents } from './db/schema.js';
+import type { Logger } from './logger.js';
 
 /** Cloudflare Worker bindings */
 export interface CloudflareBindings {
@@ -21,6 +22,9 @@ export interface CloudflareBindings {
   ENVIRONMENT: string;
   APP_SEMVER?: string;
   APP_VERSION?: string;
+  // PostHog logging (optional)
+  POSTHOG_API_KEY?: string;
+  POSTHOG_HOST?: string;
 }
 
 /** Hono context variables set by middleware */
@@ -28,6 +32,7 @@ export interface AppVariables {
   workspace: typeof workspaces.$inferSelect;
   agent: typeof agents.$inferSelect | undefined;
   db: ReturnType<typeof import('./db/index.js').getDb>;
+  logger: Logger;
 }
 
 /** The Hono Env type used throughout the app */

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -1,5 +1,7 @@
-export const SERVER_VERSION = '0.1.0' as const;
+export const SERVER_VERSION = '0.3.1' as const;
 
 export { generateId, getSnowflakeGenerator, SnowflakeGenerator } from './engine/snowflake.js';
 export { getDb, healthCheck as dbHealthCheck } from './db/index.js';
 export { hashToken } from './middleware/auth.js';
+export { createLogger } from './logger.js';
+export type { Logger, LogLevel, LogContext } from './logger.js';

--- a/packages/server/src/logger.ts
+++ b/packages/server/src/logger.ts
@@ -1,0 +1,182 @@
+/**
+ * Logger for Relaycast server
+ *
+ * - Emits console logs in development (ENVIRONMENT !== 'production')
+ * - Sends to PostHog in production only
+ * - Tracks app_version and sdk_version in each log
+ */
+
+import type { CloudflareBindings } from './env.js';
+
+// SDK version from @relaycast/sdk package (keep in sync with packages/sdk/package.json)
+const SDK_VERSION = '0.3.1';
+
+export type LogLevel = 'info' | 'warn' | 'error' | 'debug';
+
+export interface LogContext {
+  workspaceId?: string;
+  agentId?: string;
+  requestId?: string;
+  route?: string;
+  method?: string;
+  statusCode?: number;
+  durationMs?: number;
+  [key: string]: unknown;
+}
+
+interface PostHogEvent {
+  event: string;
+  distinct_id: string;
+  properties: Record<string, unknown>;
+  timestamp?: string;
+}
+
+/**
+ * Send events to PostHog via HTTP API (works in Cloudflare Workers)
+ */
+async function sendToPostHog(
+  apiKey: string,
+  host: string,
+  events: PostHogEvent[],
+): Promise<void> {
+  try {
+    await fetch(`${host}/batch`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        api_key: apiKey,
+        batch: events,
+      }),
+    });
+  } catch {
+    // Silently ignore PostHog errors - logging should never break the app
+  }
+}
+
+/**
+ * Create a logger instance bound to Cloudflare bindings
+ */
+export function createLogger(env: CloudflareBindings) {
+  const isProduction = env.ENVIRONMENT === 'production';
+  const appVersion = env.APP_SEMVER || env.APP_VERSION || 'unknown';
+  const posthogKey = (env as CloudflareBindings & { POSTHOG_API_KEY?: string }).POSTHOG_API_KEY;
+  const posthogHost = (env as CloudflareBindings & { POSTHOG_HOST?: string }).POSTHOG_HOST || 'https://us.i.posthog.com';
+
+  // Buffer for batching events
+  const eventBuffer: PostHogEvent[] = [];
+
+  function getCommonProperties(): Record<string, unknown> {
+    return {
+      app_version: appVersion,
+      sdk_version: SDK_VERSION,
+      environment: env.ENVIRONMENT || 'development',
+    };
+  }
+
+  function log(level: LogLevel, message: string, context: LogContext = {}): void {
+    const timestamp = new Date().toISOString();
+    const commonProps = getCommonProperties();
+
+    // Console output in development (or always for errors)
+    if (!isProduction || level === 'error') {
+      const logData = {
+        timestamp,
+        level,
+        message,
+        ...commonProps,
+        ...context,
+      };
+
+      if (level === 'error') {
+        console.error(JSON.stringify(logData));
+      } else if (level === 'warn') {
+        console.warn(JSON.stringify(logData));
+      } else {
+        console.log(JSON.stringify(logData));
+      }
+    }
+
+    // PostHog in production only
+    if (isProduction && posthogKey) {
+      const distinctId = context.workspaceId || 'server';
+
+      eventBuffer.push({
+        event: `server_log_${level}`,
+        distinct_id: distinctId,
+        timestamp,
+        properties: {
+          $lib: 'relaycast-server',
+          $lib_version: appVersion,
+          message,
+          ...commonProps,
+          ...context,
+        },
+      });
+    }
+  }
+
+  return {
+    /**
+     * Log an informational message
+     */
+    info(message: string, context: LogContext = {}): void {
+      log('info', message, context);
+    },
+
+    /**
+     * Log a warning message
+     */
+    warn(message: string, context: LogContext = {}): void {
+      log('warn', message, context);
+    },
+
+    /**
+     * Log an error message
+     */
+    error(message: string, error?: Error | unknown, context: LogContext = {}): void {
+      const errorContext: LogContext = { ...context };
+
+      if (error instanceof Error) {
+        errorContext.error_name = error.name;
+        errorContext.error_message = error.message;
+        errorContext.error_stack = error.stack;
+      } else if (error !== undefined) {
+        errorContext.error_raw = String(error);
+      }
+
+      log('error', message, errorContext);
+    },
+
+    /**
+     * Log a debug message (only in development)
+     */
+    debug(message: string, context: LogContext = {}): void {
+      if (!isProduction) {
+        log('debug', message, context);
+      }
+    },
+
+    /**
+     * Flush buffered events to PostHog
+     * Call this at the end of request handling via waitUntil()
+     */
+    async flush(): Promise<void> {
+      if (eventBuffer.length > 0 && posthogKey) {
+        const events = [...eventBuffer];
+        eventBuffer.length = 0;
+        await sendToPostHog(posthogKey, posthogHost, events);
+      }
+    },
+
+    /**
+     * Get the number of buffered events
+     */
+    get bufferedCount(): number {
+      return eventBuffer.length;
+    },
+  };
+}
+
+export type Logger = ReturnType<typeof createLogger>;

--- a/packages/server/src/middleware/logger.ts
+++ b/packages/server/src/middleware/logger.ts
@@ -1,0 +1,42 @@
+import type { MiddlewareHandler } from 'hono';
+import type { AppEnv } from '../env.js';
+import { createLogger } from '../logger.js';
+
+/**
+ * Middleware that creates a logger instance and adds it to the context.
+ * Also logs request completion with timing information.
+ */
+export const loggerMiddleware: MiddlewareHandler<AppEnv> = async (c, next) => {
+  const logger = createLogger(c.env);
+  c.set('logger', logger);
+
+  const start = Date.now();
+  const requestId = crypto.randomUUID();
+
+  await next();
+
+  const durationMs = Date.now() - start;
+  const statusCode = c.res.status;
+
+  // Log request completion
+  if (statusCode >= 500) {
+    logger.error('Request failed', undefined, {
+      requestId,
+      route: c.req.path,
+      method: c.req.method,
+      statusCode,
+      durationMs,
+    });
+  } else if (statusCode >= 400) {
+    logger.warn('Request client error', {
+      requestId,
+      route: c.req.path,
+      method: c.req.method,
+      statusCode,
+      durationMs,
+    });
+  }
+
+  // Flush logs to PostHog asynchronously (don't block response)
+  c.executionCtx.waitUntil(logger.flush());
+};

--- a/packages/server/src/worker.ts
+++ b/packages/server/src/worker.ts
@@ -3,6 +3,8 @@ import { cors } from 'hono/cors';
 import { secureHeaders } from 'hono/secure-headers';
 import type { AppEnv } from './env.js';
 import { dbMiddleware } from './middleware/db.js';
+import { loggerMiddleware } from './middleware/logger.js';
+import { createLogger } from './logger.js';
 import { MCP_VERSION } from '@relaycast/mcp';
 
 // Route imports
@@ -40,6 +42,7 @@ const app = new Hono<AppEnv>();
 
 // Global middleware
 app.use('*', cors());
+app.use('*', loggerMiddleware);
 app.use('*', dbMiddleware);
 
 // MCP server card — before secureHeaders to avoid cross-origin policy issues
@@ -241,10 +244,37 @@ app.notFound((c) => {
 // Global error handler
 app.onError((err, c) => {
   const error = err as Error & { code?: string; status?: number };
+  const logger = c.get('logger') || createLogger(c.env);
+
   if (error.message?.includes('JSON')) {
+    logger.warn('Invalid JSON in request body', {
+      route: c.req.path,
+      method: c.req.method,
+    });
+    c.executionCtx.waitUntil(logger.flush());
     return c.json({ ok: false, error: { code: 'invalid_json', message: 'Malformed JSON in request body' } }, 400);
   }
+
   const status = error.status || 500;
+
+  // Log all errors (warnings for 4xx, errors for 5xx)
+  if (status >= 500) {
+    logger.error('Unhandled server error', error, {
+      route: c.req.path,
+      method: c.req.method,
+      statusCode: status,
+    });
+  } else {
+    logger.warn('Request error', {
+      route: c.req.path,
+      method: c.req.method,
+      statusCode: status,
+      error_message: error.message,
+    });
+  }
+
+  c.executionCtx.waitUntil(logger.flush());
+
   return c.json({
     ok: false,
     error: {
@@ -259,35 +289,52 @@ async function handleQueue(batch: MessageBatch, env: AppEnv['Bindings']) {
   const { getDb } = await import('./db/index.js');
   const { deliverEvent } = await import('./engine/eventDelivery.js');
   const db = getDb(env.DB);
+  const logger = createLogger(env);
 
   for (const msg of batch.messages) {
     try {
       const event = msg.body as { type: string; workspaceId: string; data: Record<string, unknown> };
       const result = await deliverEvent(db, event.workspaceId, event.type, event.data);
       if (result.failed > 0) {
-        console.warn(
-          `[queue] Non-retryable webhook delivery failures for event ${event.type}: ${result.failed}/${result.attempted}`,
-        );
+        logger.warn('Webhook delivery failures', {
+          workspaceId: event.workspaceId,
+          eventType: event.type,
+          failed: result.failed,
+          attempted: result.attempted,
+        });
       }
       msg.ack();
-    } catch {
+    } catch (err) {
+      logger.error('Queue message processing failed', err, {
+        messageId: msg.id,
+      });
       msg.retry();
     }
   }
+
+  await logger.flush();
 }
 
 // Scheduled handler for cleanup tasks
 async function handleScheduled(event: ScheduledEvent, env: AppEnv['Bindings']) {
   const { getDb } = await import('./db/index.js');
   const db = getDb(env.DB);
+  const logger = createLogger(env);
 
   // Clean up expired idempotency keys
   try {
     const { sql } = await import('drizzle-orm');
     await db.run(sql`DELETE FROM idempotency_keys WHERE expires_at < unixepoch()`);
-  } catch {
-    // Table may not exist yet
+    logger.info('Scheduled cleanup completed', {
+      cronTrigger: event.cron,
+    });
+  } catch (err) {
+    logger.error('Scheduled cleanup failed', err, {
+      cronTrigger: event.cron,
+    });
   }
+
+  await logger.flush();
 }
 
 export default {

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -5,6 +5,7 @@ compatibility_flags = ["nodejs_compat"]
 
 [vars]
 ENVIRONMENT = "production"
+POSTHOG_HOST = "https://us.i.posthog.com"
 
 # D1 Database
 [[d1_databases]]
@@ -177,3 +178,4 @@ crons = []
 # R2_ACCESS_KEY_ID
 # R2_SECRET_ACCESS_KEY
 # CF_ACCOUNT_ID
+# POSTHOG_API_KEY


### PR DESCRIPTION
## Summary

Adds PostHog logging to the Relaycast server for error monitoring and observability.

**Features:**
- Console logs in development, PostHog in production
- Tracks `app_version` and `sdk_version` in every log event
- Logs errors, warnings, and request failures automatically

**New files:**
- `packages/server/src/logger.ts` - Core logger module using PostHog HTTP API
- `packages/server/src/middleware/logger.ts` - Hono middleware for request logging

**Configuration:**
Set via Cloudflare Worker secrets:
- `POSTHOG_API_KEY` - Your PostHog project API key
- `POSTHOG_HOST` - PostHog API host (default: `https://us.i.posthog.com`)

**Log events sent to PostHog:**
- `server_log_error` - Server errors (5xx), unhandled exceptions
- `server_log_warn` - Client errors (4xx), webhook delivery failures
- `server_log_info` - Scheduled task completions
- `server_log_debug` - Debug info (development only)

**Each log includes:**
- `app_version`, `sdk_version`, `environment`
- `workspaceId`, `route`, `method`, `statusCode`, `durationMs`
- Error details (name, message, stack) when applicable

## Test plan

- [ ] Deploy to staging with POSTHOG_API_KEY secret set
- [ ] Trigger a 500 error and verify it appears in PostHog
- [ ] Trigger a 400 error and verify warning appears
- [ ] Verify console logs appear in wrangler dev (development mode)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/agentworkforce/relaycast/pull/36" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
