### PR TITLE
Add centralized logging and PostHog support

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -101,6 +101,19 @@ jobs:
         shell: bash
         run: |
           echo "semver=$(node -p 'require("./packages/server/package.json").version')" >> "$GITHUB_OUTPUT"
+      - name: Sync PostHog API key secret (production)
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ -z "${POSTHOG_API_KEY:-}" ]; then
+            echo "POSTHOG_API_KEY GitHub secret is not set."
+            exit 1
+          fi
+          echo "$POSTHOG_API_KEY" | npx wrangler secret put POSTHOG_API_KEY --name relaycast-api
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          POSTHOG_API_KEY: ${{ secrets.POSTHOG_API_KEY }}
       - uses: ./.github/actions/deploy-worker
         with:
           worker-name: relaycast-api

--- a/.trajectories/completed/2026-02/traj_6oqalk31dh5h.json
+++ b/.trajectories/completed/2026-02/traj_6oqalk31dh5h.json
@@ -1,0 +1,53 @@
+{
+  "id": "traj_6oqalk31dh5h",
+  "version": 1,
+  "task": {
+    "title": "Wire POSTHOG_API_KEY GitHub Secret into deploy workflow and sync to Cloudflare Worker secret"
+  },
+  "status": "completed",
+  "startedAt": "2026-02-19T16:01:05.777Z",
+  "agents": [
+    {
+      "name": "default",
+      "role": "lead",
+      "joinedAt": "2026-02-19T16:01:51.016Z"
+    }
+  ],
+  "chapters": [
+    {
+      "id": "chap_2pmfbri2jfrv",
+      "title": "Work",
+      "agentName": "default",
+      "startedAt": "2026-02-19T16:01:51.016Z",
+      "events": [
+        {
+          "ts": 1771516911017,
+          "type": "decision",
+          "content": "Synced POSTHOG_API_KEY from GitHub Secrets to Cloudflare Worker secret during production deploy: Synced POSTHOG_API_KEY from GitHub Secrets to Cloudflare Worker secret during production deploy",
+          "raw": {
+            "question": "Synced POSTHOG_API_KEY from GitHub Secrets to Cloudflare Worker secret during production deploy",
+            "chosen": "Synced POSTHOG_API_KEY from GitHub Secrets to Cloudflare Worker secret during production deploy",
+            "alternatives": [],
+            "reasoning": "Keeps key out of wrangler vars/repo while ensuring the worker always has the current secret value at deploy time."
+          },
+          "significance": "high"
+        }
+      ],
+      "endedAt": "2026-02-19T16:01:54.075Z"
+    }
+  ],
+  "commits": [],
+  "filesChanged": [],
+  "projectId": "/Users/will/Projects/relaycast",
+  "tags": [],
+  "_trace": {
+    "startRef": "02e619b2d726b069915a41d57ce246dbad22a552",
+    "endRef": "02e619b2d726b069915a41d57ce246dbad22a552"
+  },
+  "completedAt": "2026-02-19T16:01:54.075Z",
+  "retrospective": {
+    "summary": "Updated deploy workflow to set Cloudflare Worker secret POSTHOG_API_KEY from GitHub secret during production deploys.",
+    "approach": "Standard approach",
+    "confidence": 0.93
+  }
+}

--- a/.trajectories/completed/2026-02/traj_6oqalk31dh5h.md
+++ b/.trajectories/completed/2026-02/traj_6oqalk31dh5h.md
@@ -1,0 +1,31 @@
+# Trajectory: Wire POSTHOG_API_KEY GitHub Secret into deploy workflow and sync to Cloudflare Worker secret
+
+> **Status:** ✅ Completed
+> **Confidence:** 93%
+> **Started:** February 19, 2026 at 11:01 AM
+> **Completed:** February 19, 2026 at 11:01 AM
+
+---
+
+## Summary
+
+Updated deploy workflow to set Cloudflare Worker secret POSTHOG_API_KEY from GitHub secret during production deploys.
+
+**Approach:** Standard approach
+
+---
+
+## Key Decisions
+
+### Synced POSTHOG_API_KEY from GitHub Secrets to Cloudflare Worker secret during production deploy
+- **Chose:** Synced POSTHOG_API_KEY from GitHub Secrets to Cloudflare Worker secret during production deploy
+- **Reasoning:** Keeps key out of wrangler vars/repo while ensuring the worker always has the current secret value at deploy time.
+
+---
+
+## Chapters
+
+### 1. Work
+*Agent: default*
+
+- Synced POSTHOG_API_KEY from GitHub Secrets to Cloudflare Worker secret during production deploy: Synced POSTHOG_API_KEY from GitHub Secrets to Cloudflare Worker secret during production deploy

--- a/.trajectories/completed/2026-02/traj_azdtac0r4bdj.json
+++ b/.trajectories/completed/2026-02/traj_azdtac0r4bdj.json
@@ -1,0 +1,65 @@
+{
+  "id": "traj_azdtac0r4bdj",
+  "version": 1,
+  "task": {
+    "title": "Address useful Copilot feedback: add toErrorDetails tests and improve logger flush reliability in background/DO paths"
+  },
+  "status": "completed",
+  "startedAt": "2026-02-19T16:28:53.985Z",
+  "agents": [
+    {
+      "name": "default",
+      "role": "lead",
+      "joinedAt": "2026-02-19T16:29:42.190Z"
+    }
+  ],
+  "chapters": [
+    {
+      "id": "chap_9lqcfq7glhtj",
+      "title": "Work",
+      "agentName": "default",
+      "startedAt": "2026-02-19T16:29:42.190Z",
+      "events": [
+        {
+          "ts": 1771518582191,
+          "type": "decision",
+          "content": "Added explicit tests for toErrorDetails helper edge cases: Added explicit tests for toErrorDetails helper edge cases",
+          "raw": {
+            "question": "Added explicit tests for toErrorDetails helper edge cases",
+            "chosen": "Added explicit tests for toErrorDetails helper edge cases",
+            "alternatives": [],
+            "reasoning": "Covers Error with stack, Error without stack, and non-Error values to prevent regressions in structured error metadata."
+          },
+          "significance": "high"
+        },
+        {
+          "ts": 1771518585495,
+          "type": "decision",
+          "content": "Added flush calls in background error handler and ChannelDO fetch finally block: Added flush calls in background error handler and ChannelDO fetch finally block",
+          "raw": {
+            "question": "Added flush calls in background error handler and ChannelDO fetch finally block",
+            "chosen": "Added flush calls in background error handler and ChannelDO fetch finally block",
+            "alternatives": [],
+            "reasoning": "Improves delivery reliability for async log exports in contexts without request middleware lifecycle hooks."
+          },
+          "significance": "high"
+        }
+      ],
+      "endedAt": "2026-02-19T16:29:49.101Z"
+    }
+  ],
+  "commits": [],
+  "filesChanged": [],
+  "projectId": "/Users/will/Projects/relaycast",
+  "tags": [],
+  "_trace": {
+    "startRef": "89e861ca7936ae60b433a6e179620e2f305c555a",
+    "endRef": "89e861ca7936ae60b433a6e179620e2f305c555a"
+  },
+  "completedAt": "2026-02-19T16:29:49.101Z",
+  "retrospective": {
+    "summary": "Implemented useful Copilot follow-ups: direct toErrorDetails test coverage and improved flush reliability for background-task and ChannelDO logging paths.",
+    "approach": "Standard approach",
+    "confidence": 0.95
+  }
+}

--- a/.trajectories/completed/2026-02/traj_azdtac0r4bdj.md
+++ b/.trajectories/completed/2026-02/traj_azdtac0r4bdj.md
@@ -1,0 +1,36 @@
+# Trajectory: Address useful Copilot feedback: add toErrorDetails tests and improve logger flush reliability in background/DO paths
+
+> **Status:** ✅ Completed
+> **Confidence:** 95%
+> **Started:** February 19, 2026 at 11:28 AM
+> **Completed:** February 19, 2026 at 11:29 AM
+
+---
+
+## Summary
+
+Implemented useful Copilot follow-ups: direct toErrorDetails test coverage and improved flush reliability for background-task and ChannelDO logging paths.
+
+**Approach:** Standard approach
+
+---
+
+## Key Decisions
+
+### Added explicit tests for toErrorDetails helper edge cases
+- **Chose:** Added explicit tests for toErrorDetails helper edge cases
+- **Reasoning:** Covers Error with stack, Error without stack, and non-Error values to prevent regressions in structured error metadata.
+
+### Added flush calls in background error handler and ChannelDO fetch finally block
+- **Chose:** Added flush calls in background error handler and ChannelDO fetch finally block
+- **Reasoning:** Improves delivery reliability for async log exports in contexts without request middleware lifecycle hooks.
+
+---
+
+## Chapters
+
+### 1. Work
+*Agent: default*
+
+- Added explicit tests for toErrorDetails helper edge cases: Added explicit tests for toErrorDetails helper edge cases
+- Added flush calls in background error handler and ChannelDO fetch finally block: Added flush calls in background error handler and ChannelDO fetch finally block

--- a/.trajectories/completed/2026-02/traj_iguwex834jkq.json
+++ b/.trajectories/completed/2026-02/traj_iguwex834jkq.json
@@ -1,0 +1,65 @@
+{
+  "id": "traj_iguwex834jkq",
+  "version": 1,
+  "task": {
+    "title": "Add PostHog production logging in server with local console logger and version metadata"
+  },
+  "status": "completed",
+  "startedAt": "2026-02-19T14:33:18.296Z",
+  "agents": [
+    {
+      "name": "default",
+      "role": "lead",
+      "joinedAt": "2026-02-19T14:39:05.171Z"
+    }
+  ],
+  "chapters": [
+    {
+      "id": "chap_oamky3cqk9b9",
+      "title": "Work",
+      "agentName": "default",
+      "startedAt": "2026-02-19T14:39:05.171Z",
+      "events": [
+        {
+          "ts": 1771511945172,
+          "type": "decision",
+          "content": "Implemented a centralized server logger with environment-based sinks: Implemented a centralized server logger with environment-based sinks",
+          "raw": {
+            "question": "Implemented a centralized server logger with environment-based sinks",
+            "chosen": "Implemented a centralized server logger with environment-based sinks",
+            "alternatives": [],
+            "reasoning": "Keeps log formatting/version metadata consistent and enforces console output outside production while routing production logs to PostHog."
+          },
+          "significance": "high"
+        },
+        {
+          "ts": 1771511949926,
+          "type": "decision",
+          "content": "Used PostHog Logs OTLP HTTP endpoint directly from the worker: Used PostHog Logs OTLP HTTP endpoint directly from the worker",
+          "raw": {
+            "question": "Used PostHog Logs OTLP HTTP endpoint directly from the worker",
+            "chosen": "Used PostHog Logs OTLP HTTP endpoint directly from the worker",
+            "alternatives": [],
+            "reasoning": "Cloudflare worker runtime can emit small JSON payloads via fetch without adding heavyweight OpenTelemetry runtime dependencies."
+          },
+          "significance": "high"
+        }
+      ],
+      "endedAt": "2026-02-19T14:39:13.254Z"
+    }
+  ],
+  "commits": [],
+  "filesChanged": [],
+  "projectId": "/Users/will/Projects/relaycast",
+  "tags": [],
+  "_trace": {
+    "startRef": "02e619b2d726b069915a41d57ce246dbad22a552",
+    "endRef": "02e619b2d726b069915a41d57ce246dbad22a552"
+  },
+  "completedAt": "2026-02-19T14:39:13.254Z",
+  "retrospective": {
+    "summary": "Added centralized server logging with console output in non-production, PostHog OTLP log export in production, automatic app/sdk version metadata on each log, and integrated logger into worker/fanout/background/workspace-stream/ChannelDO error paths with tests.",
+    "approach": "Standard approach",
+    "confidence": 0.9
+  }
+}

--- a/.trajectories/completed/2026-02/traj_iguwex834jkq.md
+++ b/.trajectories/completed/2026-02/traj_iguwex834jkq.md
@@ -1,0 +1,36 @@
+# Trajectory: Add PostHog production logging in server with local console logger and version metadata
+
+> **Status:** ✅ Completed
+> **Confidence:** 90%
+> **Started:** February 19, 2026 at 09:33 AM
+> **Completed:** February 19, 2026 at 09:39 AM
+
+---
+
+## Summary
+
+Added centralized server logging with console output in non-production, PostHog OTLP log export in production, automatic app/sdk version metadata on each log, and integrated logger into worker/fanout/background/workspace-stream/ChannelDO error paths with tests.
+
+**Approach:** Standard approach
+
+---
+
+## Key Decisions
+
+### Implemented a centralized server logger with environment-based sinks
+- **Chose:** Implemented a centralized server logger with environment-based sinks
+- **Reasoning:** Keeps log formatting/version metadata consistent and enforces console output outside production while routing production logs to PostHog.
+
+### Used PostHog Logs OTLP HTTP endpoint directly from the worker
+- **Chose:** Used PostHog Logs OTLP HTTP endpoint directly from the worker
+- **Reasoning:** Cloudflare worker runtime can emit small JSON payloads via fetch without adding heavyweight OpenTelemetry runtime dependencies.
+
+---
+
+## Chapters
+
+### 1. Work
+*Agent: default*
+
+- Implemented a centralized server logger with environment-based sinks: Implemented a centralized server logger with environment-based sinks
+- Used PostHog Logs OTLP HTTP endpoint directly from the worker: Used PostHog Logs OTLP HTTP endpoint directly from the worker

--- a/.trajectories/completed/2026-02/traj_y9blwypztwkw.json
+++ b/.trajectories/completed/2026-02/traj_y9blwypztwkw.json
@@ -1,0 +1,65 @@
+{
+  "id": "traj_y9blwypztwkw",
+  "version": 1,
+  "task": {
+    "title": "Enhance server PostHog logging with request middleware and flush reliability"
+  },
+  "status": "completed",
+  "startedAt": "2026-02-19T16:14:09.336Z",
+  "agents": [
+    {
+      "name": "default",
+      "role": "lead",
+      "joinedAt": "2026-02-19T16:14:12.820Z"
+    }
+  ],
+  "chapters": [
+    {
+      "id": "chap_jshqxkikxg60",
+      "title": "Work",
+      "agentName": "default",
+      "startedAt": "2026-02-19T16:14:12.820Z",
+      "events": [
+        {
+          "ts": 1771517652821,
+          "type": "decision",
+          "content": "Introduced a context-aware getRequestLogger helper and child loggers: Introduced a context-aware getRequestLogger helper and child loggers",
+          "raw": {
+            "question": "Introduced a context-aware getRequestLogger helper and child loggers",
+            "chosen": "Introduced a context-aware getRequestLogger helper and child loggers",
+            "alternatives": [],
+            "reasoning": "Allows all request codepaths to share one logger instance (and pending sends) while preserving per-module source tags."
+          },
+          "significance": "high"
+        },
+        {
+          "ts": 1771517658489,
+          "type": "decision",
+          "content": "Added logger middleware that sets request_id and flushes with waitUntil: Added logger middleware that sets request_id and flushes with waitUntil",
+          "raw": {
+            "question": "Added logger middleware that sets request_id and flushes with waitUntil",
+            "chosen": "Added logger middleware that sets request_id and flushes with waitUntil",
+            "alternatives": [],
+            "reasoning": "Attaches request metadata to logs and improves reliability of asynchronous PostHog exports without delaying response delivery."
+          },
+          "significance": "high"
+        }
+      ],
+      "endedAt": "2026-02-19T16:14:21.942Z"
+    }
+  ],
+  "commits": [],
+  "filesChanged": [],
+  "projectId": "/Users/will/Projects/relaycast",
+  "tags": [],
+  "_trace": {
+    "startRef": "7b6f34fcb9012fa9c492b79b4554c9b96f8e9164",
+    "endRef": "7b6f34fcb9012fa9c492b79b4554c9b96f8e9164"
+  },
+  "completedAt": "2026-02-19T16:14:21.942Z",
+  "retrospective": {
+    "summary": "Added request logger middleware, shared logger state with child loggers, context-aware logger retrieval, and explicit flush handling for queue/scheduled paths. Logs now consistently include request metadata plus app/sdk versions and are flushed more reliably.",
+    "approach": "Standard approach",
+    "confidence": 0.93
+  }
+}

--- a/.trajectories/completed/2026-02/traj_y9blwypztwkw.md
+++ b/.trajectories/completed/2026-02/traj_y9blwypztwkw.md
@@ -1,0 +1,36 @@
+# Trajectory: Enhance server PostHog logging with request middleware and flush reliability
+
+> **Status:** ✅ Completed
+> **Confidence:** 93%
+> **Started:** February 19, 2026 at 11:14 AM
+> **Completed:** February 19, 2026 at 11:14 AM
+
+---
+
+## Summary
+
+Added request logger middleware, shared logger state with child loggers, context-aware logger retrieval, and explicit flush handling for queue/scheduled paths. Logs now consistently include request metadata plus app/sdk versions and are flushed more reliably.
+
+**Approach:** Standard approach
+
+---
+
+## Key Decisions
+
+### Introduced a context-aware getRequestLogger helper and child loggers
+- **Chose:** Introduced a context-aware getRequestLogger helper and child loggers
+- **Reasoning:** Allows all request codepaths to share one logger instance (and pending sends) while preserving per-module source tags.
+
+### Added logger middleware that sets request_id and flushes with waitUntil
+- **Chose:** Added logger middleware that sets request_id and flushes with waitUntil
+- **Reasoning:** Attaches request metadata to logs and improves reliability of asynchronous PostHog exports without delaying response delivery.
+
+---
+
+## Chapters
+
+### 1. Work
+*Agent: default*
+
+- Introduced a context-aware getRequestLogger helper and child loggers: Introduced a context-aware getRequestLogger helper and child loggers
+- Added logger middleware that sets request_id and flushes with waitUntil: Added logger middleware that sets request_id and flushes with waitUntil

--- a/.trajectories/index.json
+++ b/.trajectories/index.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "lastUpdated": "2026-02-19T16:01:54.153Z",
+  "lastUpdated": "2026-02-19T16:14:22.012Z",
   "trajectories": {
     "traj_o8g8ahqth5fx": {
       "title": "Wave 0: add repo infrastructure files (docker, turbo, tsconfig, env)",
@@ -560,6 +560,13 @@
       "startedAt": "2026-02-19T16:01:05.777Z",
       "completedAt": "2026-02-19T16:01:54.075Z",
       "path": "/Users/will/Projects/relaycast/.trajectories/completed/2026-02/traj_6oqalk31dh5h.json"
+    },
+    "traj_y9blwypztwkw": {
+      "title": "Enhance server PostHog logging with request middleware and flush reliability",
+      "status": "completed",
+      "startedAt": "2026-02-19T16:14:09.336Z",
+      "completedAt": "2026-02-19T16:14:21.942Z",
+      "path": "/Users/will/Projects/relaycast/.trajectories/completed/2026-02/traj_y9blwypztwkw.json"
     }
   }
 }

--- a/.trajectories/index.json
+++ b/.trajectories/index.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "lastUpdated": "2026-02-19T16:14:22.012Z",
+  "lastUpdated": "2026-02-19T16:29:49.179Z",
   "trajectories": {
     "traj_o8g8ahqth5fx": {
       "title": "Wave 0: add repo infrastructure files (docker, turbo, tsconfig, env)",
@@ -567,6 +567,13 @@
       "startedAt": "2026-02-19T16:14:09.336Z",
       "completedAt": "2026-02-19T16:14:21.942Z",
       "path": "/Users/will/Projects/relaycast/.trajectories/completed/2026-02/traj_y9blwypztwkw.json"
+    },
+    "traj_azdtac0r4bdj": {
+      "title": "Address useful Copilot feedback: add toErrorDetails tests and improve logger flush reliability in background/DO paths",
+      "status": "completed",
+      "startedAt": "2026-02-19T16:28:53.985Z",
+      "completedAt": "2026-02-19T16:29:49.101Z",
+      "path": "/Users/will/Projects/relaycast/.trajectories/completed/2026-02/traj_azdtac0r4bdj.json"
     }
   }
 }

--- a/.trajectories/index.json
+++ b/.trajectories/index.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "lastUpdated": "2026-02-19T07:04:27.853Z",
+  "lastUpdated": "2026-02-19T16:01:54.153Z",
   "trajectories": {
     "traj_o8g8ahqth5fx": {
       "title": "Wave 0: add repo infrastructure files (docker, turbo, tsconfig, env)",
@@ -546,6 +546,20 @@
       "startedAt": "2026-02-19T06:58:04.923Z",
       "completedAt": "2026-02-19T07:04:27.776Z",
       "path": "/Users/will/Projects/relaycast/.trajectories/completed/2026-02/traj_z6z8dggfaksc.json"
+    },
+    "traj_iguwex834jkq": {
+      "title": "Add PostHog production logging in server with local console logger and version metadata",
+      "status": "completed",
+      "startedAt": "2026-02-19T14:33:18.296Z",
+      "completedAt": "2026-02-19T14:39:13.254Z",
+      "path": "/Users/will/Projects/relaycast/.trajectories/completed/2026-02/traj_iguwex834jkq.json"
+    },
+    "traj_6oqalk31dh5h": {
+      "title": "Wire POSTHOG_API_KEY GitHub Secret into deploy workflow and sync to Cloudflare Worker secret",
+      "status": "completed",
+      "startedAt": "2026-02-19T16:01:05.777Z",
+      "completedAt": "2026-02-19T16:01:54.075Z",
+      "path": "/Users/will/Projects/relaycast/.trajectories/completed/2026-02/traj_6oqalk31dh5h.json"
     }
   }
 }

--- a/packages/server/src/durable-objects/channel.ts
+++ b/packages/server/src/durable-objects/channel.ts
@@ -1,4 +1,5 @@
 import type { CloudflareBindings } from '../env.js';
+import { createLogger, toErrorDetails } from '../lib/logger.js';
 
 /**
  * ChannelDO — internal-only actor for sequencing and fanout.
@@ -10,6 +11,7 @@ import type { CloudflareBindings } from '../env.js';
 export class ChannelDO implements DurableObject {
   private state: DurableObjectState;
   private env: CloudflareBindings;
+  private logger: ReturnType<typeof createLogger>;
 
   /** Monotonic sequence counter for message ordering within this channel. */
   private channelSeq: number | null = null;
@@ -19,6 +21,7 @@ export class ChannelDO implements DurableObject {
   constructor(state: DurableObjectState, env: CloudflareBindings) {
     this.state = state;
     this.env = env;
+    this.logger = createLogger(env, { source: 'channel_do' });
   }
 
   /* ------------------------------------------------------------------ */
@@ -72,14 +75,17 @@ export class ChannelDO implements DurableObject {
     for (let i = 0; i < results.length; i++) {
       const result = results[i];
       if (result.status === 'rejected') {
-        console.error(
-          `[ChannelDO] fanout failed for agent ${members[i]} in workspace ${workspaceId}:`,
-          result.reason,
-        );
+        this.logger.error(`fanout failed for agent ${members[i]} in workspace ${workspaceId}`, {
+          workspace_id: workspaceId,
+          agent_id: members[i],
+          ...toErrorDetails(result.reason),
+        });
       } else if (!result.value.ok) {
-        console.error(
-          `[ChannelDO] fanout returned ${result.value.status} for agent ${members[i]} in workspace ${workspaceId}`,
-        );
+        this.logger.error(`fanout returned ${result.value.status} for agent ${members[i]} in workspace ${workspaceId}`, {
+          workspace_id: workspaceId,
+          agent_id: members[i],
+          status: result.value.status,
+        });
       }
     }
   }
@@ -120,7 +126,11 @@ export class ChannelDO implements DurableObject {
     if (body.members && body.members.length > 0 && currentMembers.length === 0) {
       this.members = body.members;
       await this.state.storage.put('members', body.members);
-      console.log(`[ChannelDO] Initialized members cache with ${body.members.length} members`);
+      this.logger.info(`Initialized members cache with ${body.members.length} members`, {
+        workspace_id: body.workspaceId,
+        channel_id: body.channelId ?? 'unknown',
+        member_count: body.members.length,
+      });
     }
 
     // If still no members, try loading from D1 as fallback
@@ -130,10 +140,18 @@ export class ChannelDO implements DurableObject {
         if (members.length > 0) {
           this.members = members;
           await this.state.storage.put('members', members);
-          console.log(`[ChannelDO] Loaded ${members.length} members from D1 for channel ${body.channelId}`);
+          this.logger.info(`Loaded ${members.length} members from D1 for channel ${body.channelId}`, {
+            workspace_id: body.workspaceId,
+            channel_id: body.channelId,
+            member_count: members.length,
+          });
         }
       } catch (err) {
-        console.error(`[ChannelDO] Failed to load members from D1:`, err);
+        this.logger.error('Failed to load members from D1', {
+          workspace_id: body.workspaceId,
+          channel_id: body.channelId,
+          ...toErrorDetails(err),
+        });
       }
     }
 

--- a/packages/server/src/durable-objects/channel.ts
+++ b/packages/server/src/durable-objects/channel.ts
@@ -95,17 +95,21 @@ export class ChannelDO implements DurableObject {
   /* ------------------------------------------------------------------ */
 
   async fetch(request: Request): Promise<Response> {
-    const url = new URL(request.url);
+    try {
+      const url = new URL(request.url);
 
-    if (request.method === 'POST' && url.pathname === '/broadcast') {
-      return this.handleBroadcast(request);
+      if (request.method === 'POST' && url.pathname === '/broadcast') {
+        return this.handleBroadcast(request);
+      }
+
+      if (request.method === 'POST' && url.pathname === '/update-members') {
+        return this.handleUpdateMembers(request);
+      }
+
+      return new Response('Not Found', { status: 404 });
+    } finally {
+      await this.logger.flush();
     }
-
-    if (request.method === 'POST' && url.pathname === '/update-members') {
-      return this.handleUpdateMembers(request);
-    }
-
-    return new Response('Not Found', { status: 404 });
   }
 
   /* ------------------------------------------------------------------ */

--- a/packages/server/src/env.ts
+++ b/packages/server/src/env.ts
@@ -1,4 +1,5 @@
 import type { workspaces, agents } from './db/schema.js';
+import type { Logger } from './lib/logger.js';
 
 /** Cloudflare Worker bindings */
 export interface CloudflareBindings {
@@ -31,6 +32,8 @@ export interface AppVariables {
   workspace: typeof workspaces.$inferSelect;
   agent: typeof agents.$inferSelect | undefined;
   db: ReturnType<typeof import('./db/index.js').getDb>;
+  logger: Logger;
+  requestId: string;
 }
 
 /** The Hono Env type used throughout the app */

--- a/packages/server/src/env.ts
+++ b/packages/server/src/env.ts
@@ -21,6 +21,9 @@ export interface CloudflareBindings {
   ENVIRONMENT: string;
   APP_SEMVER?: string;
   APP_VERSION?: string;
+  SDK_SEMVER?: string;
+  POSTHOG_API_KEY?: string;
+  POSTHOG_HOST?: string;
 }
 
 /** Hono context variables set by middleware */

--- a/packages/server/src/lib/__tests__/logger.test.ts
+++ b/packages/server/src/lib/__tests__/logger.test.ts
@@ -1,0 +1,107 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createLogger } from '../logger.js';
+
+function getAttribute(
+  attrs: Array<{ key: string; value: Record<string, unknown> }>,
+  key: string,
+): Record<string, unknown> | undefined {
+  return attrs.find((attr) => attr.key === key)?.value;
+}
+
+describe('logger', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('writes structured console logs outside production', () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+
+    const logger = createLogger({
+      ENVIRONMENT: 'development',
+      APP_SEMVER: '1.2.3',
+      SDK_SEMVER: '9.9.9',
+    } as any, {
+      source: 'test.logger',
+    });
+
+    logger.error('boom', { workspace_id: 'ws_123' });
+
+    expect(consoleError).toHaveBeenCalledWith(
+      '[test.logger] boom',
+      expect.objectContaining({
+        app_version: '1.2.3',
+        sdk_version: '9.9.9',
+        workspace_id: 'ws_123',
+      }),
+    );
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('sends logs to PostHog in production with version metadata', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const fetchMock = vi.fn().mockResolvedValue(new Response(null, { status: 200 }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const logger = createLogger({
+      ENVIRONMENT: 'production',
+      APP_SEMVER: '2.0.0',
+      POSTHOG_API_KEY: 'phc_test_project_key',
+      POSTHOG_HOST: 'https://us.i.posthog.com/',
+    } as any, {
+      source: 'worker.on_error',
+      sdkVersion: '0.3.1',
+    });
+
+    logger.error('Unhandled request error', { workspace_id: 'ws_123', status: 500 });
+    await Promise.resolve();
+
+    expect(consoleError).not.toHaveBeenCalled();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe('https://us.i.posthog.com/i/v1/logs');
+    expect(init.method).toBe('POST');
+    expect((init.headers as Record<string, string>).Authorization).toBe('Bearer phc_test_project_key');
+
+    const payload = JSON.parse(String(init.body));
+    const logRecord = payload.resourceLogs[0].scopeLogs[0].logRecords[0];
+    const attrs = logRecord.attributes as Array<{ key: string; value: Record<string, unknown> }>;
+
+    expect(getAttribute(attrs, 'app_version')?.stringValue).toBe('2.0.0');
+    expect(getAttribute(attrs, 'sdk_version')?.stringValue).toBe('0.3.1');
+    expect(getAttribute(attrs, 'workspace_id')?.stringValue).toBe('ws_123');
+    expect(getAttribute(attrs, 'status')?.intValue).toBe('500');
+  });
+
+  it('prefers x-sdk-version request header over env sdk version', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response(null, { status: 200 }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const logger = createLogger({
+      ENVIRONMENT: 'production',
+      APP_SEMVER: '2.0.0',
+      SDK_SEMVER: 'env-sdk-version',
+      POSTHOG_API_KEY: 'phc_test_project_key',
+    } as any, {
+      source: 'request.test',
+      request: new Request('https://api.relaycast.dev/v1/workspace', {
+        headers: { 'x-sdk-version': 'header-sdk-version' },
+      }),
+    });
+
+    logger.warn('Request warning');
+    await Promise.resolve();
+
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    const payload = JSON.parse(String(init.body));
+    const attrs = payload.resourceLogs[0].scopeLogs[0].logRecords[0]
+      .attributes as Array<{ key: string; value: Record<string, unknown> }>;
+
+    expect(getAttribute(attrs, 'sdk_version')?.stringValue).toBe('header-sdk-version');
+  });
+});

--- a/packages/server/src/lib/__tests__/logger.test.ts
+++ b/packages/server/src/lib/__tests__/logger.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { createLogger } from '../logger.js';
+import { createLogger, toErrorDetails } from '../logger.js';
 
 function getAttribute(
   attrs: Array<{ key: string; value: Record<string, unknown> }>,
@@ -134,5 +134,48 @@ describe('logger', () => {
     resolveFetch?.(new Response(null, { status: 200 }));
     await flushPromise;
     expect(flushSettled).toBe(true);
+  });
+
+  it('toErrorDetails returns name, message, and stack for Error instances', () => {
+    const err = new Error('boom');
+    err.name = 'BoomError';
+
+    const details = toErrorDetails(err);
+    expect(details.error_name).toBe('BoomError');
+    expect(details.error_message).toBe('boom');
+    expect(details.error_stack).toContain('Error');
+  });
+
+  it('toErrorDetails omits stack when not present on Error', () => {
+    const err = new Error('no stack');
+    Object.defineProperty(err, 'stack', { value: undefined, configurable: true });
+
+    const details = toErrorDetails(err);
+    expect(details).toEqual({
+      error_name: 'Error',
+      error_message: 'no stack',
+    });
+  });
+
+  it('toErrorDetails handles non-Error values', () => {
+    expect(toErrorDetails('string failure')).toEqual({
+      error_name: 'NonError',
+      error_message: 'string failure',
+    });
+
+    expect(toErrorDetails({ code: 42 })).toEqual({
+      error_name: 'NonError',
+      error_message: '[object Object]',
+    });
+
+    expect(toErrorDetails(null)).toEqual({
+      error_name: 'NonError',
+      error_message: 'null',
+    });
+
+    expect(toErrorDetails(undefined)).toEqual({
+      error_name: 'NonError',
+      error_message: 'undefined',
+    });
   });
 });

--- a/packages/server/src/lib/__tests__/logger.test.ts
+++ b/packages/server/src/lib/__tests__/logger.test.ts
@@ -104,4 +104,35 @@ describe('logger', () => {
 
     expect(getAttribute(attrs, 'sdk_version')?.stringValue).toBe('header-sdk-version');
   });
+
+  it('shares pending sends across child loggers and flush waits for completion', async () => {
+    let resolveFetch: ((value: Response) => void) | null = null;
+    const fetchMock = vi.fn().mockImplementation(
+      () => new Promise<Response>((resolve) => { resolveFetch = resolve; }),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const logger = createLogger({
+      ENVIRONMENT: 'production',
+      APP_SEMVER: '2.0.0',
+      POSTHOG_API_KEY: 'phc_test_project_key',
+    } as any, {
+      source: 'request',
+      fields: { request_id: 'req_123' },
+    });
+    const child = logger.child('fanout.channel', { workspace_id: 'ws_123' });
+
+    child.error('child failure');
+    const flushPromise = logger.flush();
+    let flushSettled = false;
+    void flushPromise.then(() => { flushSettled = true; });
+    await Promise.resolve();
+
+    expect(flushSettled).toBe(false);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    resolveFetch?.(new Response(null, { status: 200 }));
+    await flushPromise;
+    expect(flushSettled).toBe(true);
+  });
 });

--- a/packages/server/src/lib/logger.ts
+++ b/packages/server/src/lib/logger.ts
@@ -1,0 +1,204 @@
+import type { Context } from 'hono';
+import type { AppEnv, CloudflareBindings } from '../env.js';
+
+type LogLevel = 'debug' | 'info' | 'warn' | 'error';
+type LogFields = Record<string, unknown>;
+
+const DEFAULT_POSTHOG_HOST = 'https://us.i.posthog.com';
+const DEFAULT_APP_VERSION = '0.1.0';
+const DEFAULT_SDK_VERSION = 'unknown';
+const SERVICE_NAME = 'relaycast-server';
+const LOGGER_SCOPE = 'relaycast.server.logger';
+
+const SEVERITY_BY_LEVEL: Record<LogLevel, number> = {
+  debug: 5,
+  info: 9,
+  warn: 13,
+  error: 17,
+};
+
+export interface Logger {
+  debug: (message: string, fields?: LogFields) => void;
+  info: (message: string, fields?: LogFields) => void;
+  warn: (message: string, fields?: LogFields) => void;
+  error: (message: string, fields?: LogFields) => void;
+}
+
+interface CreateLoggerOptions {
+  source: string;
+  request?: Request;
+  sdkVersion?: string;
+  fields?: LogFields;
+}
+
+function isProduction(env: CloudflareBindings): boolean {
+  return env.ENVIRONMENT.toLowerCase() === 'production';
+}
+
+function getPostHogHost(env: CloudflareBindings): string {
+  const configured = env.POSTHOG_HOST ?? DEFAULT_POSTHOG_HOST;
+  return configured.endsWith('/') ? configured.slice(0, -1) : configured;
+}
+
+function getAppVersion(env: CloudflareBindings): string {
+  return env.APP_SEMVER ?? env.APP_VERSION ?? DEFAULT_APP_VERSION;
+}
+
+function getSdkVersion(env: CloudflareBindings, request?: Request, explicit?: string): string {
+  if (explicit) return explicit;
+  const fromHeader = request?.headers.get('x-sdk-version');
+  if (fromHeader) return fromHeader;
+  return env.SDK_SEMVER ?? DEFAULT_SDK_VERSION;
+}
+
+function toAttributeValue(value: unknown): { stringValue?: string; boolValue?: boolean; intValue?: string; doubleValue?: number } {
+  if (typeof value === 'string') return { stringValue: value };
+  if (typeof value === 'boolean') return { boolValue: value };
+  if (typeof value === 'number') {
+    if (Number.isFinite(value) && Number.isInteger(value)) return { intValue: String(value) };
+    if (Number.isFinite(value)) return { doubleValue: value };
+    return { stringValue: String(value) };
+  }
+  if (value === null) return { stringValue: 'null' };
+  if (value === undefined) return { stringValue: 'undefined' };
+  try {
+    return { stringValue: JSON.stringify(value) };
+  } catch {
+    return { stringValue: String(value) };
+  }
+}
+
+function metadataToAttributes(metadata: LogFields): Array<{ key: string; value: ReturnType<typeof toAttributeValue> }> {
+  return Object.entries(metadata).map(([key, value]) => ({
+    key,
+    value: toAttributeValue(value),
+  }));
+}
+
+async function sendToPostHog(
+  env: CloudflareBindings,
+  level: LogLevel,
+  message: string,
+  metadata: LogFields,
+  appVersion: string,
+): Promise<void> {
+  const apiKey = env.POSTHOG_API_KEY;
+  if (!apiKey) return;
+
+  const timestampNanos = `${Date.now()}000000`;
+  const payload = {
+    resourceLogs: [{
+      resource: {
+        attributes: [
+          { key: 'service.name', value: { stringValue: SERVICE_NAME } },
+          { key: 'service.version', value: { stringValue: appVersion } },
+          { key: 'deployment.environment', value: { stringValue: env.ENVIRONMENT } },
+        ],
+      },
+      scopeLogs: [{
+        scope: { name: LOGGER_SCOPE, version: appVersion },
+        logRecords: [{
+          timeUnixNano: timestampNanos,
+          observedTimeUnixNano: timestampNanos,
+          severityNumber: SEVERITY_BY_LEVEL[level],
+          severityText: level.toUpperCase(),
+          body: { stringValue: message },
+          attributes: metadataToAttributes(metadata),
+        }],
+      }],
+    }],
+  };
+
+  try {
+    await fetch(`${getPostHogHost(env)}/i/v1/logs`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(payload),
+    });
+  } catch {
+    // Best effort: do not fail request handling if log export fails.
+  }
+}
+
+function writeConsole(level: LogLevel, source: string, message: string, metadata: LogFields): void {
+  const line = `[${source}] ${message}`;
+  if (level === 'debug') {
+    console.debug(line, metadata);
+    return;
+  }
+  if (level === 'info') {
+    console.info(line, metadata);
+    return;
+  }
+  if (level === 'warn') {
+    console.warn(line, metadata);
+    return;
+  }
+  console.error(line, metadata);
+}
+
+export function createLogger(env: CloudflareBindings, options: CreateLoggerOptions): Logger {
+  const appVersion = getAppVersion(env);
+  const sdkVersion = getSdkVersion(env, options.request, options.sdkVersion);
+  const production = isProduction(env);
+  const baseFields = options.fields ?? {};
+
+  const log = (level: LogLevel, message: string, fields: LogFields = {}) => {
+    const metadata: LogFields = {
+      app_version: appVersion,
+      sdk_version: sdkVersion,
+      environment: env.ENVIRONMENT,
+      source: options.source,
+      ...baseFields,
+      ...fields,
+    };
+
+    if (!production) {
+      writeConsole(level, options.source, message, metadata);
+      return;
+    }
+
+    void sendToPostHog(env, level, message, metadata, appVersion);
+  };
+
+  return {
+    debug: (message, fields) => log('debug', message, fields),
+    info: (message, fields) => log('info', message, fields),
+    warn: (message, fields) => log('warn', message, fields),
+    error: (message, fields) => log('error', message, fields),
+  };
+}
+
+export function createRequestLogger(
+  c: Context<AppEnv>,
+  source: string,
+  fields?: LogFields,
+): Logger {
+  const request = (() => {
+    const maybeReq = (c as unknown as { req?: { raw?: unknown } }).req?.raw;
+    return maybeReq instanceof Request ? maybeReq : undefined;
+  })();
+
+  return createLogger(c.env, {
+    source,
+    request,
+    fields,
+  });
+}
+
+export function toErrorDetails(error: unknown): { error_name: string; error_message: string; error_stack?: string } {
+  if (error instanceof Error) {
+    return {
+      error_name: error.name,
+      error_message: error.message,
+      ...(error.stack ? { error_stack: error.stack } : {}),
+    };
+  }
+  return {
+    error_name: 'NonError',
+    error_message: String(error),
+  };
+}

--- a/packages/server/src/lib/logger.ts
+++ b/packages/server/src/lib/logger.ts
@@ -22,6 +22,8 @@ export interface Logger {
   info: (message: string, fields?: LogFields) => void;
   warn: (message: string, fields?: LogFields) => void;
   error: (message: string, fields?: LogFields) => void;
+  flush: () => Promise<void>;
+  child: (source: string, fields?: LogFields) => Logger;
 }
 
 interface CreateLoggerOptions {
@@ -29,6 +31,11 @@ interface CreateLoggerOptions {
   request?: Request;
   sdkVersion?: string;
   fields?: LogFields;
+  state?: LoggerState;
+}
+
+interface LoggerState {
+  pending: Set<Promise<void>>;
 }
 
 function isProduction(env: CloudflareBindings): boolean {
@@ -110,7 +117,7 @@ async function sendToPostHog(
   };
 
   try {
-    await fetch(`${getPostHogHost(env)}/i/v1/logs`, {
+    const response = await fetch(`${getPostHogHost(env)}/i/v1/logs`, {
       method: 'POST',
       headers: {
         Authorization: `Bearer ${apiKey}`,
@@ -118,6 +125,9 @@ async function sendToPostHog(
       },
       body: JSON.stringify(payload),
     });
+    if (!response.ok) {
+      // Best effort: ignore non-2xx response from logging backend.
+    }
   } catch {
     // Best effort: do not fail request handling if log export fails.
   }
@@ -145,6 +155,7 @@ export function createLogger(env: CloudflareBindings, options: CreateLoggerOptio
   const sdkVersion = getSdkVersion(env, options.request, options.sdkVersion);
   const production = isProduction(env);
   const baseFields = options.fields ?? {};
+  const state = options.state ?? { pending: new Set<Promise<void>>() };
 
   const log = (level: LogLevel, message: string, fields: LogFields = {}) => {
     const metadata: LogFields = {
@@ -161,7 +172,9 @@ export function createLogger(env: CloudflareBindings, options: CreateLoggerOptio
       return;
     }
 
-    void sendToPostHog(env, level, message, metadata, appVersion);
+    const promise = sendToPostHog(env, level, message, metadata, appVersion);
+    state.pending.add(promise);
+    void promise.finally(() => state.pending.delete(promise));
   };
 
   return {
@@ -169,6 +182,17 @@ export function createLogger(env: CloudflareBindings, options: CreateLoggerOptio
     info: (message, fields) => log('info', message, fields),
     warn: (message, fields) => log('warn', message, fields),
     error: (message, fields) => log('error', message, fields),
+    flush: async () => {
+      if (state.pending.size === 0) return;
+      await Promise.allSettled(Array.from(state.pending));
+    },
+    child: (source, fields = {}) => createLogger(env, {
+      source,
+      request: options.request,
+      sdkVersion: options.sdkVersion,
+      fields: { ...baseFields, ...fields },
+      state,
+    }),
   };
 }
 
@@ -182,11 +206,36 @@ export function createRequestLogger(
     return maybeReq instanceof Request ? maybeReq : undefined;
   })();
 
+  const contextReq = (c as unknown as { req?: { path?: string; method?: string } }).req;
+  const maybeRequestId = (c as unknown as { get?: (key: string) => unknown }).get?.('requestId');
+  const requestId = typeof maybeRequestId === 'string' ? maybeRequestId : undefined;
+
   return createLogger(c.env, {
     source,
     request,
-    fields,
+    fields: {
+      ...(requestId ? { request_id: requestId } : {}),
+      ...(contextReq?.path ? { route: contextReq.path } : {}),
+      ...(contextReq?.method ? { method: contextReq.method } : {}),
+      ...(fields ?? {}),
+    },
   });
+}
+
+export function getRequestLogger(
+  c: Context<AppEnv>,
+  source: string,
+  fields?: LogFields,
+): Logger {
+  const maybeLogger = (c as unknown as { get?: (key: string) => unknown }).get?.('logger');
+  if (
+    maybeLogger &&
+    typeof maybeLogger === 'object' &&
+    typeof (maybeLogger as Logger).child === 'function'
+  ) {
+    return (maybeLogger as Logger).child(source, fields);
+  }
+  return createRequestLogger(c, source, fields);
 }
 
 export function toErrorDetails(error: unknown): { error_name: string; error_message: string; error_stack?: string } {

--- a/packages/server/src/middleware/logger.ts
+++ b/packages/server/src/middleware/logger.ts
@@ -1,0 +1,43 @@
+import type { MiddlewareHandler } from 'hono';
+import type { AppEnv } from '../env.js';
+import { createRequestLogger } from '../lib/logger.js';
+
+type WaitUntilContext = {
+  executionCtx?: {
+    waitUntil: (promise: Promise<unknown>) => void;
+  };
+};
+
+export const loggerMiddleware: MiddlewareHandler<AppEnv> = async (c, next) => {
+  const requestId = crypto.randomUUID();
+  c.set('requestId', requestId);
+
+  const logger = createRequestLogger(c, 'request', { request_id: requestId });
+  c.set('logger', logger);
+
+  const startedAt = Date.now();
+  await next();
+
+  const durationMs = Date.now() - startedAt;
+  const statusCode = c.res.status;
+
+  if (statusCode >= 500) {
+    logger.error('Request failed', {
+      status_code: statusCode,
+      duration_ms: durationMs,
+    });
+  } else if (statusCode >= 400) {
+    logger.warn('Request client error', {
+      status_code: statusCode,
+      duration_ms: durationMs,
+    });
+  }
+
+  const flushPromise = logger.flush();
+  const executionCtx = (c as unknown as WaitUntilContext).executionCtx;
+  if (executionCtx && typeof executionCtx.waitUntil === 'function') {
+    executionCtx.waitUntil(flushPromise);
+    return;
+  }
+  void flushPromise;
+};

--- a/packages/server/src/routes/__tests__/fanout.test.ts
+++ b/packages/server/src/routes/__tests__/fanout.test.ts
@@ -146,7 +146,11 @@ describe('fanout helpers', () => {
     await fanoutToChannel(c, 'ch_1', 'message.created', { text: 'hi' });
 
     expect(consoleError).toHaveBeenCalledWith(
-      expect.stringContaining('[fanout] ChannelDO broadcast failed: 500 for channel ch_1'),
+      expect.stringContaining('ChannelDO broadcast failed: 500 for channel ch_1'),
+      expect.objectContaining({
+        app_version: expect.any(String),
+        sdk_version: expect.any(String),
+      }),
     );
     consoleError.mockRestore();
   });
@@ -165,8 +169,10 @@ describe('fanout helpers', () => {
       .resolves.toBeUndefined();
 
     expect(consoleError).toHaveBeenCalledWith(
-      expect.stringContaining('[fanout] ChannelDO broadcast error for channel ch_1'),
-      expect.any(Error),
+      expect.stringContaining('ChannelDO broadcast error for channel ch_1'),
+      expect.objectContaining({
+        error_message: 'Network failure',
+      }),
     );
     consoleError.mockRestore();
   });
@@ -184,7 +190,10 @@ describe('fanout helpers', () => {
     await fanoutToWorkspace(c, 'agent.online', { agent_name: 'Bot' });
 
     expect(consoleError).toHaveBeenCalledWith(
-      expect.stringContaining('[fanout] PresenceDO status failed: 500 for workspace ws_123'),
+      expect.stringContaining('PresenceDO status failed: 500 for workspace ws_123'),
+      expect.objectContaining({
+        event_type: 'agent.online',
+      }),
     );
     consoleError.mockRestore();
   });
@@ -202,7 +211,10 @@ describe('fanout helpers', () => {
     await updateChannelMembers(c, 'ch_2', ['a1']);
 
     expect(consoleError).toHaveBeenCalledWith(
-      expect.stringContaining('[fanout] ChannelDO update-members failed: 500 for channel ch_2'),
+      expect.stringContaining('ChannelDO update-members failed: 500 for channel ch_2'),
+      expect.objectContaining({
+        channel_id: 'ch_2',
+      }),
     );
     consoleError.mockRestore();
   });

--- a/packages/server/src/routes/background.ts
+++ b/packages/server/src/routes/background.ts
@@ -1,6 +1,6 @@
 import type { Context } from 'hono';
 import type { AppEnv } from '../env.js';
-import { createRequestLogger, toErrorDetails } from '../lib/logger.js';
+import { getRequestLogger, toErrorDetails } from '../lib/logger.js';
 
 type WaitUntilContext = {
   executionCtx?: {
@@ -22,7 +22,7 @@ export function runInBackground(
   task: Promise<unknown> | unknown,
   label: string,
 ): void {
-  const logger = createRequestLogger(c, 'background.task');
+  const logger = getRequestLogger(c, 'background.task');
   const wrapped = Promise.resolve(task).catch((error) => {
     logger.error(`${label} failed`, {
       ...toErrorDetails(error),

--- a/packages/server/src/routes/background.ts
+++ b/packages/server/src/routes/background.ts
@@ -1,5 +1,6 @@
 import type { Context } from 'hono';
 import type { AppEnv } from '../env.js';
+import { createRequestLogger, toErrorDetails } from '../lib/logger.js';
 
 type WaitUntilContext = {
   executionCtx?: {
@@ -21,8 +22,11 @@ export function runInBackground(
   task: Promise<unknown> | unknown,
   label: string,
 ): void {
+  const logger = createRequestLogger(c, 'background.task');
   const wrapped = Promise.resolve(task).catch((error) => {
-    console.error(`[background] ${label} failed:`, error);
+    logger.error(`${label} failed`, {
+      ...toErrorDetails(error),
+    });
   });
 
   let executionCtx: WaitUntilContext['executionCtx'];

--- a/packages/server/src/routes/background.ts
+++ b/packages/server/src/routes/background.ts
@@ -23,10 +23,11 @@ export function runInBackground(
   label: string,
 ): void {
   const logger = getRequestLogger(c, 'background.task');
-  const wrapped = Promise.resolve(task).catch((error) => {
+  const wrapped = Promise.resolve(task).catch(async (error) => {
     logger.error(`${label} failed`, {
       ...toErrorDetails(error),
     });
+    await logger.flush();
   });
 
   let executionCtx: WaitUntilContext['executionCtx'];

--- a/packages/server/src/routes/fanout.ts
+++ b/packages/server/src/routes/fanout.ts
@@ -2,7 +2,7 @@ import type { Context } from 'hono';
 import type { AppEnv } from '../env.js';
 import { transformForClient, type WsEvent } from '../engine/wsTransform.js';
 import { isWorkspaceStreamEnabled } from '../lib/workspaceStream.js';
-import { createRequestLogger, toErrorDetails } from '../lib/logger.js';
+import { getRequestLogger, toErrorDetails } from '../lib/logger.js';
 
 type HonoContext = Context<AppEnv>;
 
@@ -26,7 +26,7 @@ async function deliverToAgent(
   agentId: string,
   payload: Record<string, unknown>,
 ): Promise<void> {
-  const logger = createRequestLogger(c, 'fanout.deliver_to_agent');
+  const logger = getRequestLogger(c, 'fanout.deliver_to_agent');
   const workspaceId = c.get('workspace').id;
   try {
     const doId = c.env.AGENT_DO.idFromName(`${workspaceId}:${agentId}`);
@@ -57,7 +57,7 @@ async function publishToWorkspaceStream(
   c: HonoContext,
   payload: Record<string, unknown>,
 ): Promise<void> {
-  const logger = createRequestLogger(c, 'fanout.workspace_stream');
+  const logger = getRequestLogger(c, 'fanout.workspace_stream');
   const workspaceId = c.get('workspace').id;
   if (!(await isWorkspaceStreamEnabled(c.env, workspaceId))) return;
   try {
@@ -89,7 +89,7 @@ export async function fanoutToChannel(
   data: Record<string, unknown>,
   members?: string[], // Optional: provide members for DO cache initialization
 ): Promise<void> {
-  const logger = createRequestLogger(c, 'fanout.channel');
+  const logger = getRequestLogger(c, 'fanout.channel');
   const workspaceId = c.get('workspace').id;
   const event = buildEvent(type, workspaceId, data, channelId);
   const payload = transformForClient(event);
@@ -148,7 +148,7 @@ export async function fanoutToWorkspace(
   type: string,
   data: Record<string, unknown>,
 ): Promise<void> {
-  const logger = createRequestLogger(c, 'fanout.workspace');
+  const logger = getRequestLogger(c, 'fanout.workspace');
   const workspaceId = c.get('workspace').id;
   try {
     const doId = c.env.PRESENCE_DO.idFromName(workspaceId);
@@ -180,7 +180,7 @@ export async function updateChannelMembers(
   channelId: string,
   memberIds: string[],
 ): Promise<void> {
-  const logger = createRequestLogger(c, 'fanout.update_channel_members');
+  const logger = getRequestLogger(c, 'fanout.update_channel_members');
   const workspaceId = c.get('workspace').id;
   try {
     const doId = c.env.CHANNEL_DO.idFromName(`${workspaceId}:${channelId}`);

--- a/packages/server/src/routes/fanout.ts
+++ b/packages/server/src/routes/fanout.ts
@@ -2,6 +2,7 @@ import type { Context } from 'hono';
 import type { AppEnv } from '../env.js';
 import { transformForClient, type WsEvent } from '../engine/wsTransform.js';
 import { isWorkspaceStreamEnabled } from '../lib/workspaceStream.js';
+import { createRequestLogger, toErrorDetails } from '../lib/logger.js';
 
 type HonoContext = Context<AppEnv>;
 
@@ -25,6 +26,7 @@ async function deliverToAgent(
   agentId: string,
   payload: Record<string, unknown>,
 ): Promise<void> {
+  const logger = createRequestLogger(c, 'fanout.deliver_to_agent');
   const workspaceId = c.get('workspace').id;
   try {
     const doId = c.env.AGENT_DO.idFromName(`${workspaceId}:${agentId}`);
@@ -35,10 +37,18 @@ async function deliverToAgent(
       body: JSON.stringify({ ...payload, workspaceId, agentId }),
     }));
     if (!res.ok) {
-      console.error(`[fanout] AgentDO deliver failed: ${res.status} for agent ${agentId}`);
+      logger.error(`AgentDO deliver failed: ${res.status} for agent ${agentId}`, {
+        workspace_id: workspaceId,
+        agent_id: agentId,
+        status: res.status,
+      });
     }
   } catch (err) {
-    console.error(`[fanout] AgentDO deliver error for agent ${agentId}:`, err);
+    logger.error(`AgentDO deliver error for agent ${agentId}`, {
+      workspace_id: workspaceId,
+      agent_id: agentId,
+      ...toErrorDetails(err),
+    });
     throw err;
   }
 }
@@ -47,6 +57,7 @@ async function publishToWorkspaceStream(
   c: HonoContext,
   payload: Record<string, unknown>,
 ): Promise<void> {
+  const logger = createRequestLogger(c, 'fanout.workspace_stream');
   const workspaceId = c.get('workspace').id;
   if (!(await isWorkspaceStreamEnabled(c.env, workspaceId))) return;
   try {
@@ -58,10 +69,16 @@ async function publishToWorkspaceStream(
       body: JSON.stringify(payload),
     }));
     if (!res.ok) {
-      console.error(`[fanout] WorkspaceStreamDO deliver failed: ${res.status} for workspace ${workspaceId}`);
+      logger.error(`WorkspaceStreamDO deliver failed: ${res.status} for workspace ${workspaceId}`, {
+        workspace_id: workspaceId,
+        status: res.status,
+      });
     }
   } catch (err) {
-    console.error(`[fanout] WorkspaceStreamDO deliver error for workspace ${workspaceId}:`, err);
+    logger.error(`WorkspaceStreamDO deliver error for workspace ${workspaceId}`, {
+      workspace_id: workspaceId,
+      ...toErrorDetails(err),
+    });
   }
 }
 
@@ -72,6 +89,7 @@ export async function fanoutToChannel(
   data: Record<string, unknown>,
   members?: string[], // Optional: provide members for DO cache initialization
 ): Promise<void> {
+  const logger = createRequestLogger(c, 'fanout.channel');
   const workspaceId = c.get('workspace').id;
   const event = buildEvent(type, workspaceId, data, channelId);
   const payload = transformForClient(event);
@@ -87,10 +105,20 @@ export async function fanoutToChannel(
         body: JSON.stringify({ workspaceId, channelId, event: payload, members }),
       }));
       if (!res.ok) {
-        console.error(`[fanout] ChannelDO broadcast failed: ${res.status} for channel ${channelId}, event ${type}`);
+        logger.error(`ChannelDO broadcast failed: ${res.status} for channel ${channelId}, event ${type}`, {
+          workspace_id: workspaceId,
+          channel_id: channelId,
+          event_type: type,
+          status: res.status,
+        });
       }
     } catch (err) {
-      console.error(`[fanout] ChannelDO broadcast error for channel ${channelId}, event ${type}:`, err);
+      logger.error(`ChannelDO broadcast error for channel ${channelId}, event ${type}`, {
+        workspace_id: workspaceId,
+        channel_id: channelId,
+        event_type: type,
+        ...toErrorDetails(err),
+      });
     }
   })());
   tasks.push(publishToWorkspaceStream(c, payload));
@@ -120,20 +148,29 @@ export async function fanoutToWorkspace(
   type: string,
   data: Record<string, unknown>,
 ): Promise<void> {
+  const logger = createRequestLogger(c, 'fanout.workspace');
   const workspaceId = c.get('workspace').id;
   try {
     const doId = c.env.PRESENCE_DO.idFromName(workspaceId);
     const stub = c.env.PRESENCE_DO.get(doId);
     const res = await stub.fetch(new Request('http://do/status'));
     if (!res.ok) {
-      console.error(`[fanout] PresenceDO status failed: ${res.status} for workspace ${workspaceId}`);
+      logger.error(`PresenceDO status failed: ${res.status} for workspace ${workspaceId}`, {
+        workspace_id: workspaceId,
+        event_type: type,
+        status: res.status,
+      });
       return;
     }
     const body = await res.json() as { agents?: string[] };
     const agentIds = body.agents ?? [];
     await fanoutToAgents(c, agentIds, type, data);
   } catch (err) {
-    console.error(`[fanout] fanoutToWorkspace error for workspace ${workspaceId}, event ${type}:`, err);
+    logger.error(`fanoutToWorkspace error for workspace ${workspaceId}, event ${type}`, {
+      workspace_id: workspaceId,
+      event_type: type,
+      ...toErrorDetails(err),
+    });
     throw err;
   }
 }
@@ -143,6 +180,7 @@ export async function updateChannelMembers(
   channelId: string,
   memberIds: string[],
 ): Promise<void> {
+  const logger = createRequestLogger(c, 'fanout.update_channel_members');
   const workspaceId = c.get('workspace').id;
   try {
     const doId = c.env.CHANNEL_DO.idFromName(`${workspaceId}:${channelId}`);
@@ -153,10 +191,18 @@ export async function updateChannelMembers(
       body: JSON.stringify({ members: memberIds }),
     }));
     if (!res.ok) {
-      console.error(`[fanout] ChannelDO update-members failed: ${res.status} for channel ${channelId}`);
+      logger.error(`ChannelDO update-members failed: ${res.status} for channel ${channelId}`, {
+        workspace_id: workspaceId,
+        channel_id: channelId,
+        status: res.status,
+      });
     }
   } catch (err) {
-    console.error(`[fanout] ChannelDO update-members error for channel ${channelId}:`, err);
+    logger.error(`ChannelDO update-members error for channel ${channelId}`, {
+      workspace_id: workspaceId,
+      channel_id: channelId,
+      ...toErrorDetails(err),
+    });
     throw err;
   }
 }

--- a/packages/server/src/routes/workspace.ts
+++ b/packages/server/src/routes/workspace.ts
@@ -10,7 +10,7 @@ import {
   getWorkspaceStreamConfig,
   setWorkspaceStreamOverride,
 } from '../lib/workspaceStream.js';
-import { createRequestLogger, toErrorDetails } from '../lib/logger.js';
+import { getRequestLogger, toErrorDetails } from '../lib/logger.js';
 
 export const workspaceRoutes = new Hono<AppEnv>();
 
@@ -154,7 +154,7 @@ workspaceRoutes.post('/agents/:name/rotate-token', requireWorkspaceKey, rateLimi
 
 // GET /workspace/stream - get workspace stream effective config
 workspaceRoutes.get('/workspace/stream', requireWorkspaceKey, rateLimit, async (c) => {
-  const logger = createRequestLogger(c, 'workspace.stream.get');
+  const logger = getRequestLogger(c, 'workspace.stream.get');
   const workspaceId = c.get('workspace').id;
   try {
     const config = await getWorkspaceStreamConfig(c.env, workspaceId);
@@ -183,7 +183,7 @@ workspaceRoutes.get('/workspace/stream', requireWorkspaceKey, rateLimit, async (
 
 // PUT /workspace/stream - set workspace stream override
 workspaceRoutes.put('/workspace/stream', requireWorkspaceKey, rateLimit, async (c) => {
-  const logger = createRequestLogger(c, 'workspace.stream.put');
+  const logger = getRequestLogger(c, 'workspace.stream.put');
   const workspaceId = c.get('workspace').id;
   try {
     const body = await c.req.json() as { enabled?: unknown; mode?: unknown };

--- a/packages/server/src/routes/workspace.ts
+++ b/packages/server/src/routes/workspace.ts
@@ -10,6 +10,7 @@ import {
   getWorkspaceStreamConfig,
   setWorkspaceStreamOverride,
 } from '../lib/workspaceStream.js';
+import { createRequestLogger, toErrorDetails } from '../lib/logger.js';
 
 export const workspaceRoutes = new Hono<AppEnv>();
 
@@ -153,6 +154,7 @@ workspaceRoutes.post('/agents/:name/rotate-token', requireWorkspaceKey, rateLimi
 
 // GET /workspace/stream - get workspace stream effective config
 workspaceRoutes.get('/workspace/stream', requireWorkspaceKey, rateLimit, async (c) => {
+  const logger = createRequestLogger(c, 'workspace.stream.get');
   const workspaceId = c.get('workspace').id;
   try {
     const config = await getWorkspaceStreamConfig(c.env, workspaceId);
@@ -166,11 +168,11 @@ workspaceRoutes.get('/workspace/stream', requireWorkspaceKey, rateLimit, async (
     });
   } catch (err: unknown) {
     const error = err as Error & { code?: string; status?: number };
-    console.error('[workspace/stream] Failed to get stream config', {
+    logger.error('Failed to get stream config', {
       workspaceId,
       code: error.code,
       status: error.status,
-      message: error.message,
+      ...toErrorDetails(error),
     });
     return c.json({
       ok: false,
@@ -181,6 +183,7 @@ workspaceRoutes.get('/workspace/stream', requireWorkspaceKey, rateLimit, async (
 
 // PUT /workspace/stream - set workspace stream override
 workspaceRoutes.put('/workspace/stream', requireWorkspaceKey, rateLimit, async (c) => {
+  const logger = createRequestLogger(c, 'workspace.stream.put');
   const workspaceId = c.get('workspace').id;
   try {
     const body = await c.req.json() as { enabled?: unknown; mode?: unknown };
@@ -210,11 +213,11 @@ workspaceRoutes.put('/workspace/stream', requireWorkspaceKey, rateLimit, async (
     });
   } catch (err: unknown) {
     const error = err as Error & { code?: string; status?: number };
-    console.error('[workspace/stream] Failed to update stream config', {
+    logger.error('Failed to update stream config', {
       workspaceId,
       code: error.code,
       status: error.status,
-      message: error.message,
+      ...toErrorDetails(error),
     });
     return c.json({
       ok: false,

--- a/packages/server/src/worker.ts
+++ b/packages/server/src/worker.ts
@@ -3,6 +3,7 @@ import { cors } from 'hono/cors';
 import { secureHeaders } from 'hono/secure-headers';
 import type { AppEnv } from './env.js';
 import { dbMiddleware } from './middleware/db.js';
+import { loggerMiddleware } from './middleware/logger.js';
 import { MCP_VERSION } from '@relaycast/mcp';
 
 // Route imports
@@ -27,7 +28,7 @@ import { inboundWebhookRoutes } from './routes/inboundWebhook.js';
 import { eventSubscriptionRoutes } from './routes/eventSubscription.js';
 import { commandRoutes } from './routes/command.js';
 import { isWorkspaceStreamEnabled } from './lib/workspaceStream.js';
-import { createLogger, createRequestLogger, toErrorDetails } from './lib/logger.js';
+import { createLogger, getRequestLogger, toErrorDetails } from './lib/logger.js';
 
 // Durable Object exports
 export { ChannelDO } from './durable-objects/channel.js';
@@ -41,6 +42,7 @@ const app = new Hono<AppEnv>();
 
 // Global middleware
 app.use('*', cors());
+app.use('*', loggerMiddleware);
 app.use('*', dbMiddleware);
 
 // MCP server card — before secureHeaders to avoid cross-origin policy issues
@@ -242,7 +244,7 @@ app.notFound((c) => {
 // Global error handler
 app.onError((err, c) => {
   const error = err as Error & { code?: string; status?: number };
-  const logger = createRequestLogger(c, 'worker.on_error');
+  const logger = getRequestLogger(c, 'worker.on_error');
   logger.error('Unhandled request error', {
     error_code: error.code ?? 'internal_error',
     error_status: error.status ?? 500,
@@ -291,6 +293,7 @@ async function handleQueue(batch: MessageBatch, env: AppEnv['Bindings']) {
       msg.retry();
     }
   }
+  await logger.flush();
 }
 
 // Scheduled handler for cleanup tasks
@@ -309,6 +312,7 @@ async function handleScheduled(event: ScheduledEvent, env: AppEnv['Bindings']) {
       schedule: event.cron ?? 'unknown',
     });
   }
+  await logger.flush();
 }
 
 export default {

--- a/packages/server/src/worker.ts
+++ b/packages/server/src/worker.ts
@@ -27,6 +27,7 @@ import { inboundWebhookRoutes } from './routes/inboundWebhook.js';
 import { eventSubscriptionRoutes } from './routes/eventSubscription.js';
 import { commandRoutes } from './routes/command.js';
 import { isWorkspaceStreamEnabled } from './lib/workspaceStream.js';
+import { createLogger, createRequestLogger, toErrorDetails } from './lib/logger.js';
 
 // Durable Object exports
 export { ChannelDO } from './durable-objects/channel.js';
@@ -241,6 +242,15 @@ app.notFound((c) => {
 // Global error handler
 app.onError((err, c) => {
   const error = err as Error & { code?: string; status?: number };
+  const logger = createRequestLogger(c, 'worker.on_error');
+  logger.error('Unhandled request error', {
+    error_code: error.code ?? 'internal_error',
+    error_status: error.status ?? 500,
+    path: c.req.path,
+    method: c.req.method,
+    ...toErrorDetails(error),
+  });
+
   if (error.message?.includes('JSON')) {
     return c.json({ ok: false, error: { code: 'invalid_json', message: 'Malformed JSON in request body' } }, 400);
   }
@@ -259,18 +269,25 @@ async function handleQueue(batch: MessageBatch, env: AppEnv['Bindings']) {
   const { getDb } = await import('./db/index.js');
   const { deliverEvent } = await import('./engine/eventDelivery.js');
   const db = getDb(env.DB);
+  const logger = createLogger(env, { source: 'worker.queue' });
 
   for (const msg of batch.messages) {
     try {
       const event = msg.body as { type: string; workspaceId: string; data: Record<string, unknown> };
       const result = await deliverEvent(db, event.workspaceId, event.type, event.data);
       if (result.failed > 0) {
-        console.warn(
-          `[queue] Non-retryable webhook delivery failures for event ${event.type}: ${result.failed}/${result.attempted}`,
-        );
+        logger.warn('Non-retryable webhook delivery failures', {
+          event_type: event.type,
+          workspace_id: event.workspaceId,
+          failed: result.failed,
+          attempted: result.attempted,
+        });
       }
       msg.ack();
-    } catch {
+    } catch (error) {
+      logger.error('Webhook queue message processing failed; retrying', {
+        ...toErrorDetails(error),
+      });
       msg.retry();
     }
   }
@@ -280,13 +297,17 @@ async function handleQueue(batch: MessageBatch, env: AppEnv['Bindings']) {
 async function handleScheduled(event: ScheduledEvent, env: AppEnv['Bindings']) {
   const { getDb } = await import('./db/index.js');
   const db = getDb(env.DB);
+  const logger = createLogger(env, { source: 'worker.scheduled' });
 
   // Clean up expired idempotency keys
   try {
     const { sql } = await import('drizzle-orm');
     await db.run(sql`DELETE FROM idempotency_keys WHERE expires_at < unixepoch()`);
-  } catch {
-    // Table may not exist yet
+  } catch (error) {
+    logger.warn('Failed to clean expired idempotency keys', {
+      ...toErrorDetails(error),
+      schedule: event.cron ?? 'unknown',
+    });
   }
 }
 

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -5,6 +5,8 @@ compatibility_flags = ["nodejs_compat"]
 
 [vars]
 ENVIRONMENT = "production"
+# APP_SEMVER / APP_VERSION / SDK_SEMVER can be injected at deploy time for observability metadata.
+# POSTHOG_HOST is optional and defaults to https://us.i.posthog.com in the server logger.
 
 # D1 Database
 [[d1_databases]]
@@ -177,3 +179,4 @@ crons = []
 # R2_ACCESS_KEY_ID
 # R2_SECRET_ACCESS_KEY
 # CF_ACCOUNT_ID
+# POSTHOG_API_KEY


### PR DESCRIPTION
Introduce a centralized server logger that writes structured console output outside production and sends OTLP-style logs to PostHog in production. Adds packages/server/src/lib/logger.ts with helpers (createLogger, createRequestLogger, toErrorDetails) and tests; replace ad-hoc console.* calls across ChannelDO, fanout, background, workspace, and worker codepaths to use the logger and include app/sdk/version metadata. Expose SDK_SEMVER, POSTHOG_API_KEY and POSTHOG_HOST in env typings and document POSTHOG_API_KEY in wrangler.toml. Update GitHub Actions deploy workflow to sync the POSTHOG_API_KEY secret into the Cloudflare Worker at deploy time (requires POSTHOG_API_KEY and Cloudflare secrets). Also add trajectory metadata files for these changes.