### PR TITLE
Include handler_agent_id in command websocket events

### DIFF
--- a/packages/sdk-rust/CHANGELOG.md
+++ b/packages/sdk-rust/CHANGELOG.md
@@ -9,6 +9,13 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
 ### Changed
 - No unreleased changes yet.
 
+## [0.2.4] - 2026-02-21
+
+### Changed
+- Added optional `agent_id` parsing for websocket message payloads.
+- Added `handler_agent_id` parsing for `command.invoked` websocket events.
+- Added websocket parity tests covering `agent_id` and `handler_agent_id` fields.
+
 ## [0.2.3] - 2026-02-21
 
 ### Added

--- a/packages/sdk-rust/Cargo.toml
+++ b/packages/sdk-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "relaycast"
-version = "0.2.3"
+version = "0.2.4"
 edition = "2021"
 authors = ["Agent Workforce <team@agentrelay.dev>"]
 description = "Rust SDK for RelayCast - multi-agent coordination platform"

--- a/packages/sdk-rust/src/types.rs
+++ b/packages/sdk-rust/src/types.rs
@@ -637,6 +637,8 @@ pub struct CommandInvocation {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct MessageEventPayload {
     pub id: String,
+    #[serde(default)]
+    pub agent_id: Option<String>,
     pub agent_name: String,
     pub text: String,
     pub attachments: Vec<FileAttachment>,
@@ -645,6 +647,8 @@ pub struct MessageEventPayload {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct MessageUpdatedPayload {
     pub id: String,
+    #[serde(default)]
+    pub agent_id: Option<String>,
     pub agent_name: String,
     pub text: String,
 }
@@ -652,6 +656,8 @@ pub struct MessageUpdatedPayload {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ThreadReplyPayload {
     pub id: String,
+    #[serde(default)]
+    pub agent_id: Option<String>,
     pub agent_name: String,
     pub text: String,
 }
@@ -659,6 +665,8 @@ pub struct ThreadReplyPayload {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct DmEventPayload {
     pub id: String,
+    #[serde(default)]
+    pub agent_id: Option<String>,
     pub agent_name: String,
     pub text: String,
 }
@@ -868,6 +876,7 @@ pub struct CommandInvokedEvent {
     pub command: String,
     pub channel: String,
     pub invoked_by: String,
+    pub handler_agent_id: String,
     pub args: Option<String>,
     pub parameters: Option<serde_json::Map<String, serde_json::Value>>,
 }

--- a/packages/sdk-rust/tests/parity.rs
+++ b/packages/sdk-rust/tests/parity.rs
@@ -1,6 +1,6 @@
 use relaycast::{
     AgentClient, MessageListQuery, RelayCast, RelayCastOptions, ReleaseAgentRequest,
-    SpawnAgentRequest,
+    SpawnAgentRequest, WsEvent,
 };
 use serde_json::json;
 use wiremock::matchers::{body_json, header, method, path, query_param};
@@ -216,4 +216,68 @@ async fn agent_heartbeat_uses_presence_endpoint() {
     let agent = AgentClient::new("at_live_test", Some(server.uri()))
         .expect("failed to create agent client");
     agent.heartbeat().await.expect("heartbeat failed");
+}
+
+#[test]
+fn ws_message_created_deserializes_optional_agent_id() {
+    let event = serde_json::from_value::<WsEvent>(json!({
+        "type": "message.created",
+        "channel": "general",
+        "message": {
+            "id": "m_1",
+            "agent_id": "a_123",
+            "agent_name": "alice",
+            "text": "hello",
+            "attachments": []
+        }
+    }))
+    .expect("failed to parse ws message.created");
+
+    match event {
+        WsEvent::MessageCreated(msg) => {
+            assert_eq!(msg.message.agent_id.as_deref(), Some("a_123"));
+            assert_eq!(msg.message.agent_name, "alice");
+        }
+        other => panic!("unexpected event variant: {other:?}"),
+    }
+}
+
+#[test]
+fn ws_command_invoked_deserializes_handler_agent_id() {
+    let event = serde_json::from_value::<WsEvent>(json!({
+        "type": "command.invoked",
+        "command": "/spawn",
+        "channel": "general",
+        "invoked_by": "lead",
+        "handler_agent_id": "a_handler_1",
+        "parameters": {
+            "name": "worker-1",
+            "cli": "codex"
+        }
+    }))
+    .expect("failed to parse ws command.invoked");
+
+    match event {
+        WsEvent::CommandInvoked(cmd) => {
+            assert_eq!(cmd.handler_agent_id, "a_handler_1");
+            assert_eq!(cmd.command, "/spawn");
+        }
+        other => panic!("unexpected event variant: {other:?}"),
+    }
+}
+
+#[test]
+fn ws_command_invoked_requires_handler_agent_id() {
+    let err = serde_json::from_value::<WsEvent>(json!({
+        "type": "command.invoked",
+        "command": "/spawn",
+        "channel": "general",
+        "invoked_by": "lead",
+        "parameters": {
+            "name": "worker-1"
+        }
+    }))
+    .expect_err("expected missing handler_agent_id to fail");
+
+    assert!(err.to_string().contains("handler_agent_id"));
 }

--- a/packages/server/src/engine/__tests__/wsTransform.test.ts
+++ b/packages/server/src/engine/__tests__/wsTransform.test.ts
@@ -241,12 +241,20 @@ describe('transformForClient', () => {
   });
 
   it('transforms command.invoked', () => {
-    const event = makeEvent('command.invoked', { command: '/hello', channel: 'general', invoked_by: 'agent_1', args: 'x', parameters: { a: 1 } });
+    const event = makeEvent('command.invoked', {
+      command: '/hello',
+      channel: 'general',
+      invoked_by: 'agent_1',
+      handler_agent_id: 'agent_2',
+      args: 'x',
+      parameters: { a: 1 },
+    });
     expect(transformForClient(event)).toEqual({
       type: 'command.invoked',
       command: '/hello',
       channel: 'general',
       invoked_by: 'agent_1',
+      handler_agent_id: 'agent_2',
       args: 'x',
       parameters: { a: 1 },
     });

--- a/packages/server/src/engine/wsTransform.ts
+++ b/packages/server/src/engine/wsTransform.ts
@@ -192,6 +192,7 @@ export function transformForClient(event: WsEvent): Record<string, unknown> {
         command: d.command as string,
         channel: d.channel as string,
         invoked_by: d.invoked_by as string,
+        handler_agent_id: d.handler_agent_id as string,
         args: (d.args as string | null) ?? null,
         parameters: (d.parameters as Record<string, unknown> | null) ?? null,
       };

--- a/packages/types/src/events.ts
+++ b/packages/types/src/events.ts
@@ -183,6 +183,7 @@ export const CommandInvokedEventSchema = z.object({
   command: z.string(),
   channel: z.string(),
   invoked_by: z.string(),
+  handler_agent_id: z.string(),
   args: z.string().nullable(),
   parameters: z.record(z.string(), z.unknown()).nullable(),
 });


### PR DESCRIPTION
### Changed
- Added optional `agent_id` parsing for websocket message payloads.
- Added `handler_agent_id` parsing for `command.invoked` websocket events.
- Added websocket parity tests covering `agent_id` and `handler_agent_id` fields.