### PR TITLE
sdk-rust: add reconnect lifecycle and DM parity APIs

### DIFF
--- a/packages/sdk-rust/CHANGELOG.md
+++ b/packages/sdk-rust/CHANGELOG.md
@@ -9,6 +9,30 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
 ### Changed
 - No unreleased changes yet.
 
+## [0.2.5] - 2026-02-22
+
+### Added
+- Added WebSocket lifecycle events with `subscribe_lifecycle()` and `WsLifecycleEvent` (`Open`, `Close`, `Error`, `Reconnecting`).
+- Added configurable WebSocket reconnect settings in `WsClientOptions` (`max_reconnect_attempts`, `max_reconnect_delay_ms`).
+- Added runtime token update APIs for long-lived clients: `WsClient::set_token(...)` and `AgentClient::set_token(...)`.
+- Added typed DM helper methods on `AgentClient`:
+  - `dm_typed(...)`
+  - `create_group_dm_typed(...)`
+  - `send_dm_message_typed(...)`
+  - `add_dm_participant_typed(...)`
+- Added typed DM response structs:
+  - `DmSendResponse`
+  - `GroupDmConversationResponse`
+  - `GroupDmMessageResponse`
+  - `GroupDmParticipantResponse`
+  - `GroupDmParticipantRef`
+
+### Changed
+- WebSocket client now reconnects automatically with exponential backoff and re-subscribes previously subscribed channels after reconnect.
+- `DmConversationSummary` parsing now supports both string and object forms for `participants`, and string/object forms for `last_message`.
+- Group DM participant add endpoint payload now uses `agent_name` for wire compatibility.
+- Expanded Rust SDK parity tests for DM payload compatibility and participant add request shape.
+
 ## [0.2.4] - 2026-02-21
 
 ### Changed

--- a/packages/sdk-rust/src/agent.rs
+++ b/packages/sdk-rust/src/agent.rs
@@ -3,7 +3,7 @@
 use crate::client::{ClientOptions, HttpClient, RequestOptions};
 use crate::error::Result;
 use crate::types::*;
-use crate::ws::{EventReceiver, WsClient, WsClientOptions};
+use crate::ws::{EventReceiver, LifecycleReceiver, WsClient, WsClientOptions};
 
 /// Strip leading '#' from channel names.
 fn strip_hash(channel: &str) -> &str {
@@ -35,6 +35,16 @@ impl AgentClient {
     /// Get a reference to the underlying HTTP client.
     pub fn http_client(&self) -> &HttpClient {
         &self.client
+    }
+
+    /// Replace the agent token for HTTP and WebSocket operations.
+    pub async fn set_token(&mut self, token: impl Into<String>) -> Result<()> {
+        let token = token.into();
+        self.client = self.client.with_api_key(token.clone())?;
+        if let Some(ws) = self.ws.as_ref() {
+            ws.set_token(token).await;
+        }
+        Ok(())
     }
 
     // === WebSocket ===
@@ -91,6 +101,14 @@ impl AgentClient {
         self.ws
             .as_ref()
             .map(|ws| ws.subscribe_events())
+            .ok_or(crate::error::RelayError::NotConnected)
+    }
+
+    /// Subscribe to lifecycle events such as connect/reconnect/close.
+    pub fn subscribe_lifecycle(&self) -> Result<LifecycleReceiver> {
+        self.ws
+            .as_ref()
+            .map(|ws| ws.subscribe_lifecycle())
             .ok_or(crate::error::RelayError::NotConnected)
     }
 
@@ -268,6 +286,21 @@ impl AgentClient {
         self.client.post("/v1/dm", Some(body), options).await
     }
 
+    /// Send a direct message to another agent (typed response).
+    pub async fn dm_typed(
+        &self,
+        agent: &str,
+        text: &str,
+        idempotency_key: Option<String>,
+    ) -> Result<DmSendResponse> {
+        let body = SendDmRequest {
+            to: agent.to_string(),
+            text: text.to_string(),
+        };
+        let options = idempotency_key.map(RequestOptions::with_idempotency_key);
+        self.client.post("/v1/dm", Some(body), options).await
+    }
+
     /// Get DM conversations.
     pub async fn dm_conversations(&self) -> Result<Vec<DmConversationSummary>> {
         self.client.get("/v1/dm/conversations", None, None).await
@@ -320,6 +353,14 @@ impl AgentClient {
         self.client.post("/v1/dm/group", Some(request), None).await
     }
 
+    /// Create a group DM (typed response).
+    pub async fn create_group_dm_typed(
+        &self,
+        request: CreateGroupDmRequest,
+    ) -> Result<GroupDmConversationResponse> {
+        self.client.post("/v1/dm/group", Some(request), None).await
+    }
+
     /// Send a message to a DM conversation.
     pub async fn send_dm_message(
         &self,
@@ -338,13 +379,50 @@ impl AgentClient {
             .await
     }
 
+    /// Send a message to a DM conversation (typed response).
+    pub async fn send_dm_message_typed(
+        &self,
+        conversation_id: &str,
+        text: &str,
+        idempotency_key: Option<String>,
+    ) -> Result<GroupDmMessageResponse> {
+        let body = serde_json::json!({ "text": text });
+        let options = idempotency_key.map(RequestOptions::with_idempotency_key);
+        self.client
+            .post(
+                &format!("/v1/dm/{}/messages", urlencoding::encode(conversation_id)),
+                Some(body),
+                options,
+            )
+            .await
+    }
+
     /// Add a participant to a group DM.
     pub async fn add_dm_participant(
         &self,
         conversation_id: &str,
         agent: &str,
     ) -> Result<serde_json::Value> {
-        let body = serde_json::json!({ "agent": agent });
+        let body = serde_json::json!({ "agent_name": agent });
+        self.client
+            .post(
+                &format!(
+                    "/v1/dm/{}/participants",
+                    urlencoding::encode(conversation_id)
+                ),
+                Some(body),
+                None,
+            )
+            .await
+    }
+
+    /// Add a participant to a group DM (typed response).
+    pub async fn add_dm_participant_typed(
+        &self,
+        conversation_id: &str,
+        agent: &str,
+    ) -> Result<GroupDmParticipantResponse> {
+        let body = serde_json::json!({ "agent_name": agent });
         self.client
             .post(
                 &format!(

--- a/packages/sdk-rust/src/lib.rs
+++ b/packages/sdk-rust/src/lib.rs
@@ -77,7 +77,7 @@ pub use agent::AgentClient;
 pub use client::{ClientOptions, HttpClient, RequestOptions};
 pub use error::{RelayError, Result};
 pub use relay::{RelayCast, RelayCastOptions};
-pub use ws::{EventReceiver, WsClient, WsClientOptions};
+pub use ws::{EventReceiver, LifecycleReceiver, WsClient, WsClientOptions, WsLifecycleEvent};
 
 // Re-export commonly used types
 pub use types::{
@@ -116,6 +116,7 @@ pub use types::{
     // Workspace
     CreateWorkspaceResponse,
     DmConversationSummary,
+    DmSendResponse,
     DmReceivedEvent,
     EventSubscription,
     // Files
@@ -123,6 +124,10 @@ pub use types::{
     FileListOptions,
     FileUploadedEvent,
     GroupDmReceivedEvent,
+    GroupDmConversationResponse,
+    GroupDmMessageResponse,
+    GroupDmParticipantRef,
+    GroupDmParticipantResponse,
     // Inbox
     InboxResponse,
     InvokeCommandRequest,

--- a/packages/sdk-rust/src/types.rs
+++ b/packages/sdk-rust/src/types.rs
@@ -381,9 +381,112 @@ pub struct DmConversationSummary {
     #[serde(rename = "type")]
     pub dm_type: String,
     pub name: Option<String>,
+    #[serde(default, deserialize_with = "deserialize_dm_participants")]
     pub participants: Vec<String>,
+    #[serde(default, deserialize_with = "deserialize_dm_last_message")]
     pub last_message: Option<String>,
     pub unread_count: i64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DmSendResponse {
+    pub id: String,
+    pub conversation_id: String,
+    pub from_agent_id: String,
+    pub to: String,
+    pub text: String,
+    pub created_at: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GroupDmParticipantRef {
+    pub agent_id: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GroupDmConversationResponse {
+    pub id: String,
+    pub channel_id: String,
+    pub dm_type: String,
+    pub name: Option<String>,
+    pub participants: Vec<GroupDmParticipantRef>,
+    pub created_at: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GroupDmMessageResponse {
+    pub id: String,
+    pub conversation_id: String,
+    pub agent_id: String,
+    pub text: String,
+    pub created_at: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GroupDmParticipantResponse {
+    pub conversation_id: String,
+    pub agent: String,
+    pub already_member: bool,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(untagged)]
+enum DmParticipantValue {
+    Name(String),
+    Object {
+        agent_name: Option<String>,
+        agent_id: Option<String>,
+    },
+}
+
+fn deserialize_dm_participants<'de, D>(deserializer: D) -> std::result::Result<Vec<String>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let raw = Vec::<DmParticipantValue>::deserialize(deserializer)?;
+    Ok(raw
+        .into_iter()
+        .filter_map(|item| match item {
+            DmParticipantValue::Name(name) if !name.is_empty() => Some(name),
+            DmParticipantValue::Object {
+                agent_name: Some(name),
+                ..
+            } if !name.is_empty() => Some(name),
+            DmParticipantValue::Object {
+                agent_id: Some(id), ..
+            } if !id.is_empty() => Some(id),
+            _ => None,
+        })
+        .collect())
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(untagged)]
+enum DmLastMessageValue {
+    Text(String),
+    Object {
+        text: Option<String>,
+        body: Option<String>,
+    },
+}
+
+fn deserialize_dm_last_message<'de, D>(
+    deserializer: D,
+) -> std::result::Result<Option<String>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let raw = Option::<DmLastMessageValue>::deserialize(deserializer)?;
+    Ok(match raw {
+        Some(DmLastMessageValue::Text(text)) if !text.is_empty() => Some(text),
+        Some(DmLastMessageValue::Object { text: Some(text), .. }) if !text.is_empty() => {
+            Some(text)
+        }
+        Some(DmLastMessageValue::Object { body: Some(body), .. }) if !body.is_empty() => {
+            Some(body)
+        }
+        _ => None,
+    })
 }
 
 // === Search ===

--- a/packages/sdk-rust/src/ws.rs
+++ b/packages/sdk-rust/src/ws.rs
@@ -1,8 +1,10 @@
 //! WebSocket client for real-time events.
 
 use futures_util::{SinkExt, StreamExt};
+use std::collections::HashSet;
 use std::sync::Arc;
 use tokio::sync::{broadcast, mpsc, Mutex};
+use tokio::time::{Duration, MissedTickBehavior};
 use tokio_tungstenite::{connect_async, tungstenite::Message};
 use tracing::{debug, warn};
 use url::Url;
@@ -15,6 +17,8 @@ const SDK_VERSION: &str = env!("CARGO_PKG_VERSION");
 const DEFAULT_ORIGIN_SURFACE: &str = "sdk";
 const DEFAULT_ORIGIN_CLIENT: &str = "@relaycast/sdk-rust";
 const PING_INTERVAL_SECS: u64 = 30;
+const DEFAULT_MAX_RECONNECT_ATTEMPTS: u32 = 10;
+const DEFAULT_MAX_RECONNECT_DELAY_MS: u64 = 30_000;
 
 /// Options for creating a WebSocket client.
 #[derive(Debug, Clone)]
@@ -31,6 +35,10 @@ pub struct WsClientOptions {
     pub origin_client: Option<String>,
     /// SDK origin version metadata.
     pub origin_version: Option<String>,
+    /// Maximum reconnect attempts before giving up (default: 10).
+    pub max_reconnect_attempts: Option<u32>,
+    /// Maximum reconnect delay in milliseconds (default: 30000).
+    pub max_reconnect_delay_ms: Option<u64>,
 }
 
 impl WsClientOptions {
@@ -43,6 +51,8 @@ impl WsClientOptions {
             origin_surface: None,
             origin_client: None,
             origin_version: None,
+            max_reconnect_attempts: None,
+            max_reconnect_delay_ms: None,
         }
     }
 
@@ -70,20 +80,46 @@ impl WsClientOptions {
         self.origin_version = Some(origin_version.into());
         self
     }
+
+    /// Set max reconnect attempts.
+    pub fn with_max_reconnect_attempts(mut self, attempts: u32) -> Self {
+        self.max_reconnect_attempts = Some(attempts);
+        self
+    }
+
+    /// Set max reconnect delay in milliseconds.
+    pub fn with_max_reconnect_delay_ms(mut self, delay_ms: u64) -> Self {
+        self.max_reconnect_delay_ms = Some(delay_ms);
+        self
+    }
 }
 
 /// A handle for subscribing to WebSocket events.
 pub type EventReceiver = broadcast::Receiver<WsEvent>;
+/// A handle for subscribing to WebSocket lifecycle events.
+pub type LifecycleReceiver = broadcast::Receiver<WsLifecycleEvent>;
+
+/// Lifecycle events emitted by the WebSocket client.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum WsLifecycleEvent {
+    Open,
+    Close,
+    Error(String),
+    Reconnecting { attempt: u32 },
+}
 
 /// WebSocket client for receiving real-time events.
 pub struct WsClient {
-    token: String,
+    token: Arc<Mutex<String>>,
     base_url: String,
     debug: bool,
     origin_surface: String,
     origin_client: String,
     origin_version: String,
+    max_reconnect_attempts: u32,
+    max_reconnect_delay_ms: u64,
     event_tx: broadcast::Sender<WsEvent>,
+    lifecycle_tx: broadcast::Sender<WsLifecycleEvent>,
     command_tx: Option<mpsc::Sender<WsCommand>>,
     is_connected: Arc<Mutex<bool>>,
 }
@@ -104,9 +140,10 @@ impl WsClient {
             .replace("http://", "ws://");
 
         let (event_tx, _) = broadcast::channel(1024);
+        let (lifecycle_tx, _) = broadcast::channel(128);
 
         Self {
-            token: options.token,
+            token: Arc::new(Mutex::new(options.token)),
             base_url: base_url.trim_end_matches('/').to_string(),
             debug: options.debug,
             origin_surface: options
@@ -118,7 +155,14 @@ impl WsClient {
             origin_version: options
                 .origin_version
                 .unwrap_or_else(|| SDK_VERSION.to_string()),
+            max_reconnect_attempts: options
+                .max_reconnect_attempts
+                .unwrap_or(DEFAULT_MAX_RECONNECT_ATTEMPTS),
+            max_reconnect_delay_ms: options
+                .max_reconnect_delay_ms
+                .unwrap_or(DEFAULT_MAX_RECONNECT_DELAY_MS),
             event_tx,
+            lifecycle_tx,
             command_tx: None,
             is_connected: Arc::new(Mutex::new(false)),
         }
@@ -134,6 +178,16 @@ impl WsClient {
         self.event_tx.subscribe()
     }
 
+    /// Subscribe to lifecycle events.
+    pub fn subscribe_lifecycle(&self) -> LifecycleReceiver {
+        self.lifecycle_tx.subscribe()
+    }
+
+    /// Update the token used for subsequent reconnect attempts.
+    pub async fn set_token(&self, token: impl Into<String>) {
+        *self.token.lock().await = token.into();
+    }
+
     /// Connect to the WebSocket server.
     pub async fn connect(&mut self) -> Result<()> {
         if *self.is_connected.lock().await {
@@ -142,93 +196,236 @@ impl WsClient {
 
         let mut url = Url::parse(&format!("{}/v1/ws", self.base_url))?;
         {
+            let token = self.token.lock().await.clone();
             let mut query = url.query_pairs_mut();
-            query.append_pair("token", &self.token);
+            query.append_pair("token", &token);
             query.append_pair("origin_surface", &self.origin_surface);
             query.append_pair("origin_client", &self.origin_client);
             query.append_pair("origin_version", &self.origin_version);
         }
 
         let (ws_stream, _) = connect_async(url.as_str()).await?;
-        let (mut write, mut read) = ws_stream.split();
 
         let (command_tx, mut command_rx) = mpsc::channel::<WsCommand>(32);
         self.command_tx = Some(command_tx);
 
+        let token = self.token.clone();
         let event_tx = self.event_tx.clone();
+        let lifecycle_tx = self.lifecycle_tx.clone();
         let is_connected = self.is_connected.clone();
         let debug = self.debug;
+        let base_url = self.base_url.clone();
+        let origin_surface = self.origin_surface.clone();
+        let origin_client = self.origin_client.clone();
+        let origin_version = self.origin_version.clone();
+        let max_reconnect_attempts = self.max_reconnect_attempts;
+        let max_reconnect_delay_ms = self.max_reconnect_delay_ms;
 
         *is_connected.lock().await = true;
 
         // Spawn the WebSocket handler task
         tokio::spawn(async move {
-            let mut ping_interval =
-                tokio::time::interval(tokio::time::Duration::from_secs(PING_INTERVAL_SECS));
+            let mut subscribed_channels: HashSet<String> = HashSet::new();
+            let mut current_stream = Some(ws_stream);
+            let mut reconnect_attempt = 0u32;
+            let mut should_stop = false;
 
-            loop {
-                tokio::select! {
-                    // Handle incoming messages
-                    msg = read.next() => {
-                        match msg {
-                            Some(Ok(Message::Text(text))) => {
-                                match serde_json::from_str::<WsEvent>(&text) {
-                                    Ok(event) => {
-                                        let _ = event_tx.send(event);
-                                    }
-                                    Err(e) => {
-                                        if debug {
-                                            warn!("[relaycast] Dropped WebSocket message: {}: {}", e, &text[..text.len().min(200)]);
+            'outer: while !should_stop {
+                let stream = if let Some(stream) = current_stream.take() {
+                    stream
+                } else {
+                    let mut reconnect_url = match Url::parse(&format!("{}/v1/ws", base_url)) {
+                        Ok(url) => url,
+                        Err(err) => {
+                            let _ = lifecycle_tx.send(WsLifecycleEvent::Error(err.to_string()));
+                            break 'outer;
+                        }
+                    };
+
+                    let current_token = token.lock().await.clone();
+                    {
+                        let mut query = reconnect_url.query_pairs_mut();
+                        query.append_pair("token", &current_token);
+                        query.append_pair("origin_surface", &origin_surface);
+                        query.append_pair("origin_client", &origin_client);
+                        query.append_pair("origin_version", &origin_version);
+                    }
+
+                    match connect_async(reconnect_url.as_str()).await {
+                        Ok((stream, _)) => stream,
+                        Err(err) => {
+                            let _ = lifecycle_tx.send(WsLifecycleEvent::Error(err.to_string()));
+
+                            if reconnect_attempt >= max_reconnect_attempts {
+                                break 'outer;
+                            }
+                            reconnect_attempt += 1;
+                            let _ = lifecycle_tx.send(WsLifecycleEvent::Reconnecting {
+                                attempt: reconnect_attempt,
+                            });
+                            let delay_ms = reconnect_delay_ms(reconnect_attempt, max_reconnect_delay_ms);
+                            let reconnect_sleep = tokio::time::sleep(Duration::from_millis(delay_ms));
+                            tokio::pin!(reconnect_sleep);
+
+                            loop {
+                                tokio::select! {
+                                    _ = &mut reconnect_sleep => break,
+                                    cmd = command_rx.recv() => {
+                                        match cmd {
+                                            Some(WsCommand::Subscribe(channels)) => {
+                                                for ch in channels {
+                                                    subscribed_channels.insert(ch);
+                                                }
+                                            }
+                                            Some(WsCommand::Unsubscribe(channels)) => {
+                                                for ch in channels {
+                                                    subscribed_channels.remove(&ch);
+                                                }
+                                            }
+                                            Some(WsCommand::Disconnect) | None => {
+                                                should_stop = true;
+                                                break;
+                                            }
                                         }
                                     }
                                 }
                             }
-                            Some(Ok(Message::Close(_))) | None => {
-                                debug!("WebSocket connection closed");
-                                break;
-                            }
-                            Some(Err(e)) => {
-                                warn!("WebSocket error: {}", e);
-                                break;
-                            }
-                            _ => {}
+                            continue;
                         }
                     }
+                };
 
-                    // Handle commands
-                    cmd = command_rx.recv() => {
-                        match cmd {
-                            Some(WsCommand::Subscribe(channels)) => {
-                                let msg = serde_json::json!({
-                                    "type": "subscribe",
-                                    "channels": channels
-                                });
-                                if let Err(e) = write.send(Message::Text(msg.to_string().into())).await {
-                                    warn!("Failed to send subscribe: {}", e);
+                let (mut write, mut read) = stream.split();
+                reconnect_attempt = 0;
+                *is_connected.lock().await = true;
+                let _ = lifecycle_tx.send(WsLifecycleEvent::Open);
+
+                // Re-subscribe all known channels on every new socket.
+                if !subscribed_channels.is_empty() {
+                    let msg = serde_json::json!({
+                        "type": "subscribe",
+                        "channels": subscribed_channels.iter().cloned().collect::<Vec<_>>()
+                    });
+                    if let Err(err) = write.send(Message::Text(msg.to_string().into())).await {
+                        let _ = lifecycle_tx.send(WsLifecycleEvent::Error(err.to_string()));
+                        *is_connected.lock().await = false;
+                        continue;
+                    }
+                }
+
+                let mut ping_interval = tokio::time::interval(Duration::from_secs(PING_INTERVAL_SECS));
+                ping_interval.set_missed_tick_behavior(MissedTickBehavior::Skip);
+
+                loop {
+                    tokio::select! {
+                        msg = read.next() => {
+                            match msg {
+                                Some(Ok(Message::Text(text))) => {
+                                    match serde_json::from_str::<WsEvent>(&text) {
+                                        Ok(event) => {
+                                            let _ = event_tx.send(event);
+                                        }
+                                        Err(err) => {
+                                            if debug {
+                                                warn!("[relaycast] Dropped WebSocket message: {}: {}", err, &text[..text.len().min(200)]);
+                                            }
+                                        }
+                                    }
+                                }
+                                Some(Ok(Message::Close(_))) | None => {
+                                    debug!("WebSocket connection closed");
+                                    break;
+                                }
+                                Some(Err(err)) => {
+                                    let _ = lifecycle_tx.send(WsLifecycleEvent::Error(err.to_string()));
+                                    break;
+                                }
+                                _ => {}
+                            }
+                        }
+                        cmd = command_rx.recv() => {
+                            match cmd {
+                                Some(WsCommand::Subscribe(channels)) => {
+                                    for ch in &channels {
+                                        subscribed_channels.insert(ch.clone());
+                                    }
+                                    let msg = serde_json::json!({
+                                        "type": "subscribe",
+                                        "channels": channels
+                                    });
+                                    if let Err(err) = write.send(Message::Text(msg.to_string().into())).await {
+                                        let _ = lifecycle_tx.send(WsLifecycleEvent::Error(err.to_string()));
+                                        break;
+                                    }
+                                }
+                                Some(WsCommand::Unsubscribe(channels)) => {
+                                    for ch in &channels {
+                                        subscribed_channels.remove(ch);
+                                    }
+                                    let msg = serde_json::json!({
+                                        "type": "unsubscribe",
+                                        "channels": channels
+                                    });
+                                    if let Err(err) = write.send(Message::Text(msg.to_string().into())).await {
+                                        let _ = lifecycle_tx.send(WsLifecycleEvent::Error(err.to_string()));
+                                        break;
+                                    }
+                                }
+                                Some(WsCommand::Disconnect) | None => {
+                                    should_stop = true;
+                                    let _ = write.send(Message::Close(None)).await;
+                                    break;
                                 }
                             }
-                            Some(WsCommand::Unsubscribe(channels)) => {
-                                let msg = serde_json::json!({
-                                    "type": "unsubscribe",
-                                    "channels": channels
-                                });
-                                if let Err(e) = write.send(Message::Text(msg.to_string().into())).await {
-                                    warn!("Failed to send unsubscribe: {}", e);
-                                }
-                            }
-                            Some(WsCommand::Disconnect) | None => {
-                                let _ = write.send(Message::Close(None)).await;
+                        }
+                        _ = ping_interval.tick() => {
+                            let ping = serde_json::json!({"type": "ping"});
+                            if let Err(err) = write.send(Message::Text(ping.to_string().into())).await {
+                                let _ = lifecycle_tx.send(WsLifecycleEvent::Error(err.to_string()));
                                 break;
                             }
                         }
                     }
+                }
 
-                    // Send pings
-                    _ = ping_interval.tick() => {
-                        let ping = serde_json::json!({"type": "ping"});
-                        if let Err(e) = write.send(Message::Text(ping.to_string().into())).await {
-                            warn!("Failed to send ping: {}", e);
-                            break;
+                *is_connected.lock().await = false;
+                let _ = lifecycle_tx.send(WsLifecycleEvent::Close);
+
+                if should_stop {
+                    break 'outer;
+                }
+
+                if reconnect_attempt >= max_reconnect_attempts {
+                    break 'outer;
+                }
+                reconnect_attempt += 1;
+                let _ = lifecycle_tx.send(WsLifecycleEvent::Reconnecting {
+                    attempt: reconnect_attempt,
+                });
+                let delay_ms = reconnect_delay_ms(reconnect_attempt, max_reconnect_delay_ms);
+                let reconnect_sleep = tokio::time::sleep(Duration::from_millis(delay_ms));
+                tokio::pin!(reconnect_sleep);
+
+                loop {
+                    tokio::select! {
+                        _ = &mut reconnect_sleep => break,
+                        cmd = command_rx.recv() => {
+                            match cmd {
+                                Some(WsCommand::Subscribe(channels)) => {
+                                    for ch in channels {
+                                        subscribed_channels.insert(ch);
+                                    }
+                                }
+                                Some(WsCommand::Unsubscribe(channels)) => {
+                                    for ch in channels {
+                                        subscribed_channels.remove(&ch);
+                                    }
+                                }
+                                Some(WsCommand::Disconnect) | None => {
+                                    should_stop = true;
+                                    break;
+                                }
+                            }
                         }
                     }
                 }
@@ -278,4 +475,10 @@ impl Drop for WsClient {
         // Note: We can't call async disconnect here, but the task will
         // eventually clean up when the channels are dropped
     }
+}
+
+fn reconnect_delay_ms(attempt: u32, max_delay_ms: u64) -> u64 {
+    let exp = attempt.saturating_sub(1);
+    let delay = 1_000u64.saturating_mul(2u64.saturating_pow(exp));
+    delay.min(max_delay_ms.max(1_000))
 }

--- a/packages/sdk-rust/tests/parity.rs
+++ b/packages/sdk-rust/tests/parity.rs
@@ -1,6 +1,6 @@
 use relaycast::{
-    AgentClient, MessageListQuery, RelayCast, RelayCastOptions, ReleaseAgentRequest,
-    SpawnAgentRequest, WsEvent,
+    AgentClient, DmConversationSummary, MessageListQuery, RelayCast, RelayCastOptions,
+    ReleaseAgentRequest, SpawnAgentRequest, WsEvent,
 };
 use serde_json::json;
 use wiremock::matchers::{body_json, header, method, path, query_param};
@@ -280,4 +280,57 @@ fn ws_command_invoked_requires_handler_agent_id() {
     .expect_err("expected missing handler_agent_id to fail");
 
     assert!(err.to_string().contains("handler_agent_id"));
+}
+
+#[test]
+fn dm_conversation_summary_supports_object_shapes() {
+    let summary = serde_json::from_value::<DmConversationSummary>(json!({
+        "id": "dm_1",
+        "channel_id": "c_1",
+        "type": "group",
+        "name": "ops-room",
+        "participants": [
+            { "agent_name": "alice", "agent_id": "a_1" },
+            { "agent_id": "a_2" },
+            "carol"
+        ],
+        "last_message": { "text": "latest update" },
+        "unread_count": 3
+    }))
+    .expect("failed to parse dm conversation summary");
+
+    assert_eq!(summary.participants, vec!["alice", "a_2", "carol"]);
+    assert_eq!(summary.last_message.as_deref(), Some("latest update"));
+}
+
+#[tokio::test]
+async fn add_dm_participant_uses_agent_name_payload_and_typed_response() {
+    let server = MockServer::start().await;
+    let agent = AgentClient::new("at_live_test", Some(server.uri()))
+        .expect("failed to create agent client");
+
+    Mock::given(method("POST"))
+        .and(path("/v1/dm/dm_123/participants"))
+        .and(body_json(json!({ "agent_name": "worker-1" })))
+        .respond_with(ok(json!({
+            "conversation_id": "dm_123",
+            "agent": "worker-1",
+            "already_member": false
+        })))
+        .expect(2)
+        .mount(&server)
+        .await;
+
+    let untyped = agent
+        .add_dm_participant("dm_123", "worker-1")
+        .await
+        .expect("add_dm_participant failed");
+    assert_eq!(untyped["agent"], "worker-1");
+
+    let typed = agent
+        .add_dm_participant_typed("dm_123", "worker-1")
+        .await
+        .expect("add_dm_participant_typed failed");
+    assert_eq!(typed.agent, "worker-1");
+    assert!(!typed.already_member);
 }


### PR DESCRIPTION
## Summary
- add reconnect/lifecycle support to the Rust WebSocket client, including automatic re-subscribe of channels
- add runtime token update support across AgentClient and WsClient
- add typed DM helper APIs and DM response structs in the Rust SDK
- align DM parsing/payload parity (participants/last_message compatibility and agent_name participant payload)
- update the Rust SDK changelog with 0.2.5 release notes

## Testing
- cargo test (in packages/sdk-rust)
