### PR TITLE
feat: add metadata columns to channels and messages (migration only)

### DIFF
--- a/packages/server/src/db/migrations/0002_add_metadata_columns.sql
+++ b/packages/server/src/db/migrations/0002_add_metadata_columns.sql
@@ -1,0 +1,16 @@
+-- Migration: 0002_add_metadata_columns
+-- Purpose: Add metadata JSON columns to channels and messages tables
+-- for storing integration-specific data (e.g., Slack channel IDs, message timestamps)
+--
+-- SQLite ALTER TABLE ADD COLUMN constraints:
+-- - Cannot add NOT NULL column without DEFAULT to table with existing rows
+-- - DEFAULT must be a constant expression
+-- - Column will have DEFAULT value for new rows; existing rows get the default retroactively
+
+-- Add metadata column to channels table
+-- Stores JSON object for integration-specific data (e.g., slack_channel_id)
+ALTER TABLE channels ADD COLUMN metadata TEXT DEFAULT '{}';
+
+-- Add metadata column to messages table
+-- Stores JSON object for integration-specific data (e.g., slack_ts, slack_thread_ts)
+ALTER TABLE messages ADD COLUMN metadata TEXT DEFAULT '{}';


### PR DESCRIPTION
## Summary
- Adds `metadata` TEXT column with default `'{}'` to `channels` table
- Adds `metadata` TEXT column with default `'{}'` to `messages` table
- Migration-only PR - no code changes to reference the columns yet

## Purpose
Store integration-specific data (e.g., Slack channel IDs, message timestamps) for the Slack-Relaycast bridge integration.

## Test plan
- [ ] Migration applies successfully to staging
- [ ] E2E tests pass after migration
- [ ] Existing data remains intact

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/agentworkforce/relaycast/pull/58" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
