### PR TITLE
feat: add comprehensive metadata support to all SDKs

### DIFF
--- a/packages/sdk-python/src/relay_sdk/models.py
+++ b/packages/sdk-python/src/relay_sdk/models.py
@@ -89,6 +89,7 @@ class Channel(BaseModel):
     name: str
     channel_type: int
     topic: str | None = None
+    metadata: dict[str, Any] = Field(default_factory=dict)
     created_by: str | None = None
     created_at: str
     is_archived: bool
@@ -112,10 +113,12 @@ class ChannelMemberInfo(BaseModel):
 class CreateChannelRequest(BaseModel):
     name: str
     topic: str | None = None
+    metadata: dict[str, Any] | None = None
 
 
 class UpdateChannelRequest(BaseModel):
     topic: str | None = None
+    metadata: dict[str, Any] | None = None
 
 
 class InviteRequest(BaseModel):
@@ -142,6 +145,7 @@ class MessageWithMeta(BaseModel):
     agent_name: str
     agent_id: str
     text: str
+    metadata: dict[str, Any] = Field(default_factory=dict)
     attachments: list[FileAttachment] = Field(default_factory=list)
     created_at: str
     reply_count: int = 0
@@ -156,6 +160,7 @@ class Message(BaseModel):
     agent_id: str
     thread_id: str | None = None
     body: str
+    metadata: dict[str, Any] = Field(default_factory=dict)
     has_attachments: bool
     created_at: str
     updated_at: str | None = None
@@ -164,6 +169,7 @@ class Message(BaseModel):
 class PostMessageRequest(BaseModel):
     text: str
     attachments: list[str] | None = None
+    data: dict[str, Any] | None = None
 
 
 class MessageListQuery(BaseModel):
@@ -174,6 +180,7 @@ class MessageListQuery(BaseModel):
 
 class ThreadReplyRequest(BaseModel):
     text: str
+    data: dict[str, Any] | None = None
 
 
 class ThreadResponse(BaseModel):

--- a/packages/sdk-rust/examples/basic.rs
+++ b/packages/sdk-rust/examples/basic.rs
@@ -54,6 +54,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             .create_channel(CreateChannelRequest {
                 name: channel_name.to_string(),
                 topic: Some("Test channel for Rust SDK".to_string()),
+                metadata: None,
             })
             .await?;
         println!("Created channel: #{}", channel_name);

--- a/packages/sdk-rust/src/agent.rs
+++ b/packages/sdk-rust/src/agent.rs
@@ -146,6 +146,7 @@ impl AgentClient {
             text: text.to_string(),
             attachments,
             blocks,
+            data: None,
         };
         let options = idempotency_key.map(RequestOptions::with_idempotency_key);
         self.client
@@ -219,6 +220,7 @@ impl AgentClient {
         let body = ThreadReplyRequest {
             text: text.to_string(),
             blocks,
+            data: None,
         };
         let options = idempotency_key.map(RequestOptions::with_idempotency_key);
         self.client

--- a/packages/sdk-rust/src/types.rs
+++ b/packages/sdk-rust/src/types.rs
@@ -253,6 +253,8 @@ pub struct Channel {
     pub name: String,
     pub channel_type: i64,
     pub topic: Option<String>,
+    #[serde(default)]
+    pub metadata: serde_json::Map<String, serde_json::Value>,
     pub created_by: Option<String>,
     pub created_at: String,
     pub is_archived: bool,
@@ -264,12 +266,16 @@ pub struct CreateChannelRequest {
     pub name: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub topic: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub metadata: Option<serde_json::Map<String, serde_json::Value>>,
 }
 
 #[derive(Debug, Clone, Serialize, Default)]
 pub struct UpdateChannelRequest {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub topic: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub metadata: Option<serde_json::Map<String, serde_json::Value>>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -320,6 +326,8 @@ pub struct MessageWithMeta {
     pub text: String,
     pub blocks: Option<Vec<MessageBlock>>,
     #[serde(default)]
+    pub metadata: serde_json::Map<String, serde_json::Value>,
+    #[serde(default)]
     pub attachments: Vec<FileAttachment>,
     pub created_at: String,
     #[serde(default)]
@@ -337,6 +345,8 @@ pub struct PostMessageRequest {
     pub blocks: Option<Vec<MessageBlock>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub attachments: Option<Vec<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub data: Option<serde_json::Map<String, serde_json::Value>>,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -344,6 +354,8 @@ pub struct ThreadReplyRequest {
     pub text: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub blocks: Option<Vec<MessageBlock>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub data: Option<serde_json::Map<String, serde_json::Value>>,
 }
 
 #[derive(Debug, Clone, Default)]

--- a/packages/types/src/channel.ts
+++ b/packages/types/src/channel.ts
@@ -12,6 +12,7 @@ export const ChannelSchema = z.object({
   id: z.string(),
   name: z.string(),
   topic: z.string().nullable(),
+  metadata: z.record(z.string(), z.unknown()).optional(),
   created_by: z.string().nullable().optional(),
   created_at: z.string(),
   is_archived: z.boolean().optional(),
@@ -32,11 +33,13 @@ export type ChannelMember = z.infer<typeof ChannelMemberSchema>;
 export const CreateChannelRequestSchema = z.object({
   name: z.string(),
   topic: z.string().nullable().optional(),
+  metadata: z.record(z.string(), z.unknown()).optional(),
 });
 export type CreateChannelRequest = z.infer<typeof CreateChannelRequestSchema>;
 
 export const UpdateChannelRequestSchema = z.object({
   topic: z.string().nullable().optional(),
+  metadata: z.record(z.string(), z.unknown()).optional(),
 });
 export type UpdateChannelRequest = z.infer<typeof UpdateChannelRequestSchema>;
 

--- a/packages/types/src/message.ts
+++ b/packages/types/src/message.ts
@@ -59,6 +59,7 @@ export const MessageSchema = z.object({
   thread_id: z.string().nullable(),
   body: z.string(),
   blocks: z.array(MessageBlockSchema).nullable(),
+  metadata: z.record(z.string(), z.unknown()).optional(),
   has_attachments: z.boolean(),
   created_at: z.string(),
   updated_at: z.string().nullable(),
@@ -72,6 +73,7 @@ export const MessageWithMetaSchema = z.object({
   agent_name: z.string(),
   text: z.string(),
   blocks: z.array(MessageBlockSchema).nullable(),
+  metadata: z.record(z.string(), z.unknown()).optional(),
   has_attachments: z.boolean(),
   thread_id: z.string().nullable(),
   attachments: z.array(FileAttachmentSchema),
@@ -102,6 +104,7 @@ export type MessageListQuery = z.infer<typeof MessageListQuerySchema>;
 export const ThreadReplyRequestSchema = z.object({
   text: z.string(),
   blocks: z.array(MessageBlockSchema).optional(),
+  data: z.record(z.string(), z.unknown()).nullable().optional(),
 });
 export type ThreadReplyRequest = z.infer<typeof ThreadReplyRequestSchema>;
 


### PR DESCRIPTION
## Summary
Adds metadata field support across all SDKs for channels and messages, enabling integrations (like Slack bridge) to store and retrieve custom data.

### TypeScript types (`@relaycast/types`)
- `Channel`: added `metadata` field
- `Message`, `MessageWithMeta`: added `metadata` field
- `CreateChannelRequest`, `UpdateChannelRequest`: added `metadata` field
- `ThreadReplyRequest`: added `data` field

### Rust SDK (`relaycast-sdk`)
- `Channel`: added `metadata` field
- `MessageWithMeta`: added `metadata` field
- `CreateChannelRequest`, `UpdateChannelRequest`: added `metadata` field
- `PostMessageRequest`, `ThreadReplyRequest`: added `data` field

### Python SDK (`relay-sdk`)
- `Channel`, `Message`, `MessageWithMeta`: added `metadata` field
- `CreateChannelRequest`, `UpdateChannelRequest`: added `metadata` field
- `PostMessageRequest`, `ThreadReplyRequest`: added `data` field

## Test plan
- [ ] TypeScript types compile
- [ ] Rust SDK builds
- [ ] Python SDK tests pass
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/agentworkforce/relaycast/pull/59" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
