### PR TITLE
fix publish

### DIFF
--- a/.github/workflows/publish-rust.yml
+++ b/.github/workflows/publish-rust.yml
@@ -169,7 +169,7 @@ jobs:
         run: cargo test --manifest-path packages/sdk-rust/Cargo.toml
 
       - name: Cargo publish dry-run
-        run: cargo publish --manifest-path packages/sdk-rust/Cargo.toml --dry-run
+        run: cargo publish --manifest-path packages/sdk-rust/Cargo.toml --dry-run --allow-dirty
 
       - name: Authenticate with crates.io
         if: github.event.inputs.dry_run != 'true'
@@ -178,7 +178,7 @@ jobs:
 
       - name: Publish to crates.io
         if: github.event.inputs.dry_run != 'true'
-        run: cargo publish --manifest-path packages/sdk-rust/Cargo.toml
+        run: cargo publish --manifest-path packages/sdk-rust/Cargo.toml --allow-dirty
         env:
           CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
 


### PR DESCRIPTION
- Also updated npm provenance publishing to use the new named npm publish workflow file `publish-npm.yml`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/agentworkforce/relaycast/pull/60" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
