### PR TITLE
mcp: remove explicit any usage in ws bridge and piggyback

### DIFF
--- a/packages/mcp/src/piggyback.ts
+++ b/packages/mcp/src/piggyback.ts
@@ -18,18 +18,35 @@ const MESSAGE_TOOLS = new Set([
   'invoke_command',
 ]);
 
+type ToolHandler = (...args: unknown[]) => unknown;
+type RegisterToolFn = (
+  name: string,
+  config: unknown,
+  handler: ToolHandler | undefined,
+) => unknown;
+type ContentCarrier = { content: Array<Record<string, unknown>> };
+
+function hasContentArray(value: unknown): value is ContentCarrier {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    Array.isArray((value as { content?: unknown }).content)
+  );
+}
+
 export function enablePiggyback(
   mcpServer: McpServer,
   getSession: () => SessionState,
   getAgentClient: () => AgentClient,
   telemetry?: McpTelemetry,
 ): void {
-  const original = mcpServer.registerTool.bind(mcpServer);
+  const original = mcpServer.registerTool.bind(mcpServer) as RegisterToolFn;
+  const mutableServer = mcpServer as unknown as { registerTool: RegisterToolFn };
 
-  (mcpServer as any).registerTool = (
+  mutableServer.registerTool = (
     name: string,
-    config: any,
-    handler: any,
+    config: unknown,
+    handler: ToolHandler | undefined,
   ) => {
     if (!handler) {
       return original(name, config, handler);
@@ -37,14 +54,14 @@ export function enablePiggyback(
 
     const shouldPiggybackInbox = !SKIP_PIGGYBACK.has(name);
 
-    const wrapped = async (...args: any[]) => {
+    const wrapped = async (...args: unknown[]) => {
       const startedAt = Date.now();
       telemetry?.capture('relaycast_mcp_tool_invoked', {
         source_surface: 'mcp',
         tool_name: name,
       });
 
-      let result: any;
+      let result: unknown;
       try {
         result = await handler(...args);
       } catch (error) {
@@ -100,7 +117,7 @@ export function enablePiggyback(
           inbox.recentReactions?.length ?? 0,
         );
 
-        if (hasUnread && Array.isArray(result?.content)) {
+        if (hasUnread && hasContentArray(result)) {
           const selfName = getSession().agentName;
           const inboxText = formatInbox(inbox, selfName);
           if (inboxText) {

--- a/packages/mcp/src/resources/ws-bridge.ts
+++ b/packages/mcp/src/resources/ws-bridge.ts
@@ -1,33 +1,39 @@
 import type { WsClient, WsClientEvent } from '@relaycast/sdk';
 import type { SubscriptionManager } from './subscriptions.js';
 
+function getStringEventField(event: WsClientEvent, field: string): string | null {
+  const candidate = (event as Record<string, unknown>)[field];
+  return typeof candidate === 'string' ? candidate : null;
+}
+
 /**
  * Maps a WebSocket ServerEvent to the relay:// resource URIs it affects.
  */
 export function eventToResourceUris(event: WsClientEvent): string[] {
   switch (event.type) {
-    case 'message.created':
-      return [
-        'relay://inbox',
-        `relay://channels/${(event as any).channel}/messages`,
-      ];
-    case 'message.updated':
-      return [`relay://channels/${(event as any).channel}/messages`];
-    case 'thread.reply':
-      return [
-        'relay://inbox',
-        `relay://messages/${(event as any).parentId}/thread`,
-      ];
+    case 'message.created': {
+      const channel = getStringEventField(event, 'channel');
+      return channel
+        ? ['relay://inbox', `relay://channels/${channel}/messages`]
+        : ['relay://inbox'];
+    }
+    case 'message.updated': {
+      const channel = getStringEventField(event, 'channel');
+      return channel ? [`relay://channels/${channel}/messages`] : [];
+    }
+    case 'thread.reply': {
+      const parentId = getStringEventField(event, 'parentId');
+      return parentId
+        ? ['relay://inbox', `relay://messages/${parentId}/thread`]
+        : ['relay://inbox'];
+    }
     case 'dm.received':
-      return [
-        'relay://inbox',
-        `relay://dm/${(event as any).conversationId}`,
-      ];
-    case 'group_dm.received':
-      return [
-        'relay://inbox',
-        `relay://dm/${(event as any).conversationId}`,
-      ];
+    case 'group_dm.received': {
+      const conversationId = getStringEventField(event, 'conversationId');
+      return conversationId
+        ? ['relay://inbox', `relay://dm/${conversationId}`]
+        : ['relay://inbox'];
+    }
     case 'agent.online':
     case 'agent.offline':
       return ['relay://agents'];
@@ -38,13 +44,10 @@ export function eventToResourceUris(event: WsClientEvent): string[] {
     case 'member.left':
       return ['relay://channels'];
     case 'webhook.received':
-      return [
-        `relay://channels/${(event as any).channel}/messages`,
-      ];
-    case 'command.invoked':
-      return [
-        `relay://channels/${(event as any).channel}/messages`,
-      ];
+    case 'command.invoked': {
+      const channel = getStringEventField(event, 'channel');
+      return channel ? [`relay://channels/${channel}/messages`] : [];
+    }
     case 'message.read':
       return [];
     case 'file.uploaded':


### PR DESCRIPTION
## Summary
- replace explicit `any` casts in `eventToResourceUris` with safe string field extraction helpers
- replace explicit `any` in MCP `registerTool` monkey-patch with `unknown`-based handler/config typing and a content-array type guard
- preserve existing piggyback and resource URI behavior while clearing lint annotations

## Validation
- npm --prefix packages/mcp run lint
- npx eslint packages/mcp/src/resources/ws-bridge.ts packages/mcp/src/piggyback.ts
- npm --prefix packages/mcp run test -- src/__tests__/piggyback.test.ts src/__tests__/ws-bridge.test.ts