### PR TITLE
sdk-rust: add registration cache + conflict strategies for relay integration

### DIFF
--- a/packages/mcp/src/piggyback.ts
+++ b/packages/mcp/src/piggyback.ts
@@ -18,18 +18,35 @@ const MESSAGE_TOOLS = new Set([
   'invoke_command',
 ]);
 
+type ToolHandler = (...args: unknown[]) => unknown;
+type RegisterToolFn = (
+  name: string,
+  config: unknown,
+  handler: ToolHandler | undefined,
+) => unknown;
+type ContentCarrier = { content: Array<Record<string, unknown>> };
+
+function hasContentArray(value: unknown): value is ContentCarrier {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    Array.isArray((value as { content?: unknown }).content)
+  );
+}
+
 export function enablePiggyback(
   mcpServer: McpServer,
   getSession: () => SessionState,
   getAgentClient: () => AgentClient,
   telemetry?: McpTelemetry,
 ): void {
-  const original = mcpServer.registerTool.bind(mcpServer);
+  const original = mcpServer.registerTool.bind(mcpServer) as RegisterToolFn;
+  const mutableServer = mcpServer as unknown as { registerTool: RegisterToolFn };
 
-  (mcpServer as any).registerTool = (
+  mutableServer.registerTool = (
     name: string,
-    config: any,
-    handler: any,
+    config: unknown,
+    handler: ToolHandler | undefined,
   ) => {
     if (!handler) {
       return original(name, config, handler);
@@ -37,14 +54,14 @@ export function enablePiggyback(
 
     const shouldPiggybackInbox = !SKIP_PIGGYBACK.has(name);
 
-    const wrapped = async (...args: any[]) => {
+    const wrapped = async (...args: unknown[]) => {
       const startedAt = Date.now();
       telemetry?.capture('relaycast_mcp_tool_invoked', {
         source_surface: 'mcp',
         tool_name: name,
       });
 
-      let result: any;
+      let result: unknown;
       try {
         result = await handler(...args);
       } catch (error) {
@@ -100,7 +117,7 @@ export function enablePiggyback(
           inbox.recentReactions?.length ?? 0,
         );
 
-        if (hasUnread && Array.isArray(result?.content)) {
+        if (hasUnread && hasContentArray(result)) {
           const selfName = getSession().agentName;
           const inboxText = formatInbox(inbox, selfName);
           if (inboxText) {

--- a/packages/mcp/src/resources/ws-bridge.ts
+++ b/packages/mcp/src/resources/ws-bridge.ts
@@ -1,33 +1,39 @@
 import type { WsClient, WsClientEvent } from '@relaycast/sdk';
 import type { SubscriptionManager } from './subscriptions.js';
 
+function getStringEventField(event: WsClientEvent, field: string): string | null {
+  const candidate = (event as Record<string, unknown>)[field];
+  return typeof candidate === 'string' ? candidate : null;
+}
+
 /**
  * Maps a WebSocket ServerEvent to the relay:// resource URIs it affects.
  */
 export function eventToResourceUris(event: WsClientEvent): string[] {
   switch (event.type) {
-    case 'message.created':
-      return [
-        'relay://inbox',
-        `relay://channels/${(event as any).channel}/messages`,
-      ];
-    case 'message.updated':
-      return [`relay://channels/${(event as any).channel}/messages`];
-    case 'thread.reply':
-      return [
-        'relay://inbox',
-        `relay://messages/${(event as any).parentId}/thread`,
-      ];
+    case 'message.created': {
+      const channel = getStringEventField(event, 'channel');
+      return channel
+        ? ['relay://inbox', `relay://channels/${channel}/messages`]
+        : ['relay://inbox'];
+    }
+    case 'message.updated': {
+      const channel = getStringEventField(event, 'channel');
+      return channel ? [`relay://channels/${channel}/messages`] : [];
+    }
+    case 'thread.reply': {
+      const parentId = getStringEventField(event, 'parentId');
+      return parentId
+        ? ['relay://inbox', `relay://messages/${parentId}/thread`]
+        : ['relay://inbox'];
+    }
     case 'dm.received':
-      return [
-        'relay://inbox',
-        `relay://dm/${(event as any).conversationId}`,
-      ];
-    case 'group_dm.received':
-      return [
-        'relay://inbox',
-        `relay://dm/${(event as any).conversationId}`,
-      ];
+    case 'group_dm.received': {
+      const conversationId = getStringEventField(event, 'conversationId');
+      return conversationId
+        ? ['relay://inbox', `relay://dm/${conversationId}`]
+        : ['relay://inbox'];
+    }
     case 'agent.online':
     case 'agent.offline':
       return ['relay://agents'];
@@ -38,13 +44,10 @@ export function eventToResourceUris(event: WsClientEvent): string[] {
     case 'member.left':
       return ['relay://channels'];
     case 'webhook.received':
-      return [
-        `relay://channels/${(event as any).channel}/messages`,
-      ];
-    case 'command.invoked':
-      return [
-        `relay://channels/${(event as any).channel}/messages`,
-      ];
+    case 'command.invoked': {
+      const channel = getStringEventField(event, 'channel');
+      return channel ? [`relay://channels/${channel}/messages`] : [];
+    }
     case 'message.read':
       return [];
     case 'file.uploaded':

--- a/packages/sdk-rust/src/agent.rs
+++ b/packages/sdk-rust/src/agent.rs
@@ -347,6 +347,32 @@ impl AgentClient {
             .await
     }
 
+    /// Get DM history for a conversation with a specific agent participant.
+    ///
+    /// Returns an empty vector when no matching conversation exists.
+    pub async fn dm_messages_with_agent(
+        &self,
+        agent: &str,
+        opts: Option<MessageListQuery>,
+    ) -> Result<Vec<MessageWithMeta>> {
+        let target = agent.trim();
+        if target.is_empty() {
+            return Ok(vec![]);
+        }
+
+        let conversations = self.dm_conversations().await?;
+        let Some(conversation) = conversations.into_iter().find(|conversation| {
+            conversation
+                .participants
+                .iter()
+                .any(|participant| participant.eq_ignore_ascii_case(target))
+        }) else {
+            return Ok(vec![]);
+        };
+
+        self.dm_messages(&conversation.id, opts).await
+    }
+
     /// Create a group DM.
     pub async fn create_group_dm(
         &self,

--- a/packages/sdk-rust/src/credentials.rs
+++ b/packages/sdk-rust/src/credentials.rs
@@ -61,6 +61,18 @@ pub struct AgentSession {
     pub token: String,
 }
 
+/// Behavior when the preferred agent name already exists.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum NameConflictStrategy {
+    /// Rotate the existing agent token and keep the same name.
+    #[default]
+    RotateExisting,
+    /// Retry registration once with a random name suffix.
+    RetryWithSuffixOnce,
+    /// Return a conflict error without rotating or retrying.
+    Fail,
+}
+
 /// Configuration for session bootstrapping.
 #[derive(Debug, Clone, Default)]
 pub struct BootstrapConfig {
@@ -73,6 +85,8 @@ pub struct BootstrapConfig {
     /// Workspace API key from environment or config.
     /// If not set, a new workspace is created.
     pub api_key: Option<String>,
+    /// How to resolve name conflicts when preferred_name is already taken.
+    pub conflict_strategy: NameConflictStrategy,
 }
 
 /// File-based credential store with atomic writes and Unix permissions.
@@ -259,11 +273,12 @@ pub async fn bootstrap_session(
         .unwrap_or_else(|| format!("agent-{}", &uuid_v4_short()));
 
     let agent_type = config.agent_type.unwrap_or_else(|| "agent".into());
+    let conflict_strategy = config.conflict_strategy;
 
     match relay
         .register_agent(CreateAgentRequest {
             name: name.clone(),
-            agent_type: Some(agent_type),
+            agent_type: Some(agent_type.clone()),
             persona: None,
             metadata: None,
         })
@@ -280,19 +295,56 @@ pub async fn bootstrap_session(
                 result.token,
             )
         }
-        Err(e) if e.is_conflict() => {
-            // Agent name taken — try rotating the existing one
-            let rotate_result = relay.rotate_agent_token(&name).await?;
-            let ws_id = workspace_id.unwrap_or_default();
-            finish_session(
-                store,
-                ws_id,
-                cached_agent_id,
-                api_key,
-                Some(name),
-                rotate_result.token,
-            )
-        }
+        Err(e) if e.is_conflict() => match conflict_strategy {
+            NameConflictStrategy::RotateExisting => {
+                let rotate_result = relay.rotate_agent_token(&name).await?;
+                let ws_id = workspace_id.unwrap_or_default();
+                finish_session(
+                    store,
+                    ws_id,
+                    cached_agent_id,
+                    api_key,
+                    Some(name),
+                    rotate_result.token,
+                )
+            }
+            NameConflictStrategy::RetryWithSuffixOnce => {
+                let suffix_name = format!("{}-{}", name, uuid_v4_short());
+                let retried = relay
+                    .register_agent(CreateAgentRequest {
+                        name: suffix_name.clone(),
+                        agent_type: Some(agent_type),
+                        persona: None,
+                        metadata: None,
+                    })
+                    .await;
+
+                match retried {
+                    Ok(result) => {
+                        let ws_id = workspace_id.unwrap_or_default();
+                        finish_session(
+                            store,
+                            ws_id,
+                            result.id,
+                            api_key,
+                            Some(result.name),
+                            result.token,
+                        )
+                    }
+                    Err(err) if err.is_conflict() => Err(RelayError::api(
+                        "agent_already_exists",
+                        format!("agent name '{}' already exists after retry", suffix_name),
+                        409,
+                    )),
+                    Err(err) => Err(err),
+                }
+            }
+            NameConflictStrategy::Fail => Err(RelayError::api(
+                "agent_already_exists",
+                format!("agent name '{}' already exists", name),
+                409,
+            )),
+        },
         Err(e) if e.is_auth_rejection() => {
             // Cached key is stale — create fresh workspace
             let (fresh_key, fresh_ws_id) = create_fresh_workspace(base_url).await?;
@@ -373,6 +425,23 @@ fn uuid_v4_short() -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serde_json::json;
+    use wiremock::matchers::{body_string_contains, method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    fn ok(data: serde_json::Value) -> ResponseTemplate {
+        ResponseTemplate::new(200).set_body_json(json!({ "ok": true, "data": data }))
+    }
+
+    fn api_error(status: u16, code: &str, message: &str) -> ResponseTemplate {
+        ResponseTemplate::new(status).set_body_json(json!({
+            "ok": false,
+            "error": {
+                "code": code,
+                "message": message
+            }
+        }))
+    }
 
     #[test]
     fn credential_store_round_trip() {
@@ -442,5 +511,82 @@ mod tests {
 
         let perms = fs::metadata(store.path()).unwrap().permissions();
         assert_eq!(perms.mode() & 0o777, 0o600);
+    }
+
+    #[tokio::test]
+    async fn conflict_strategy_fail_returns_conflict_error() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/v1/agents"))
+            .and(body_string_contains("\"name\":\"lead\""))
+            .respond_with(api_error(409, "agent_already_exists", "name taken"))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let dir = tempfile::tempdir().unwrap();
+        let store = CredentialStore::new(dir.path().join("creds.json"));
+        let result = bootstrap_session(
+            &store,
+            BootstrapConfig {
+                preferred_name: Some("lead".to_string()),
+                api_key: Some("rk_live_test".to_string()),
+                base_url: Some(server.uri()),
+                conflict_strategy: NameConflictStrategy::Fail,
+                ..Default::default()
+            },
+        )
+        .await;
+
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(err.is_conflict());
+    }
+
+    #[tokio::test]
+    async fn conflict_strategy_retry_with_suffix_registers_new_name() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/v1/agents"))
+            .and(body_string_contains("\"name\":\"lead\""))
+            .respond_with(api_error(409, "agent_already_exists", "name taken"))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        Mock::given(method("POST"))
+            .and(path("/v1/agents"))
+            .and(body_string_contains("\"name\":\"lead-"))
+            .respond_with(ok(json!({
+                "id": "a_retry",
+                "name": "lead-suffixed",
+                "token": "at_live_retry",
+                "status": "online",
+                "created_at": "2026-01-01T00:00:00.000Z"
+            })))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let dir = tempfile::tempdir().unwrap();
+        let store = CredentialStore::new(dir.path().join("creds.json"));
+        let session = bootstrap_session(
+            &store,
+            BootstrapConfig {
+                preferred_name: Some("lead".to_string()),
+                api_key: Some("rk_live_test".to_string()),
+                base_url: Some(server.uri()),
+                conflict_strategy: NameConflictStrategy::RetryWithSuffixOnce,
+                ..Default::default()
+            },
+        )
+        .await
+        .expect("bootstrap with suffix retry should succeed");
+
+        assert_eq!(session.token, "at_live_retry");
+        assert_eq!(
+            session.credentials.agent_name.as_deref(),
+            Some("lead-suffixed")
+        );
     }
 }

--- a/packages/sdk-rust/src/lib.rs
+++ b/packages/sdk-rust/src/lib.rs
@@ -69,6 +69,7 @@ pub mod agent;
 pub mod client;
 pub mod credentials;
 pub mod error;
+pub mod registration;
 pub mod relay;
 pub mod types;
 pub mod ws;
@@ -77,6 +78,11 @@ pub mod ws;
 pub use agent::AgentClient;
 pub use client::{ClientOptions, HttpClient, RequestOptions};
 pub use error::{RelayError, Result};
+pub use registration::{
+    format_registration_error, registration_is_retryable, registration_retry_after_secs,
+    retry_agent_registration, AgentRegistrationClient, AgentRegistrationError,
+    AgentRegistrationRetryOutcome,
+};
 pub use relay::{RelayCast, RelayCastOptions};
 pub use ws::{EventReceiver, LifecycleReceiver, WsClient, WsClientOptions, WsLifecycleEvent};
 

--- a/packages/sdk-rust/src/registration.rs
+++ b/packages/sdk-rust/src/registration.rs
@@ -1,0 +1,429 @@
+//! Agent registration helpers with token caching, cooldown handling, and retries.
+
+use std::collections::HashMap;
+use std::path::Path;
+use std::sync::{Arc, Mutex, MutexGuard};
+use std::time::{Duration, Instant};
+
+use thiserror::Error;
+
+use crate::error::RelayError;
+use crate::{RelayCast, SpawnAgentRequest};
+
+const DEFAULT_REGISTRATION_COOLDOWN_SECS: u64 = 60;
+
+fn lock_unpoisoned<T>(mutex: &Mutex<T>) -> MutexGuard<'_, T> {
+    match mutex.lock() {
+        Ok(guard) => guard,
+        Err(poisoned) => poisoned.into_inner(),
+    }
+}
+
+fn normalize_cli(raw: &str) -> Option<String> {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+
+    let candidate = trimmed
+        .split_whitespace()
+        .next()
+        .unwrap_or(trimmed)
+        .to_string();
+
+    let executable = Path::new(&candidate)
+        .file_name()
+        .and_then(|part| part.to_str())
+        .unwrap_or(candidate.as_str());
+
+    let cli = executable
+        .split(':')
+        .next()
+        .unwrap_or(executable)
+        .trim()
+        .to_ascii_lowercase();
+
+    let normalized = match cli.as_str() {
+        "claude" | "claudecode" | "claude-code" | "claude_code" => "claude",
+        "codex" => "codex",
+        "gemini" => "gemini",
+        "aider" => "aider",
+        "goose" => "goose",
+        _ => return None,
+    };
+
+    Some(normalized.to_string())
+}
+
+fn registration_cli_from_hint(cli_hint: Option<&str>, default_cli: &str) -> String {
+    cli_hint
+        .and_then(normalize_cli)
+        .or_else(|| normalize_cli(default_cli))
+        .unwrap_or_else(|| "claude".to_string())
+}
+
+/// Errors emitted by [`AgentRegistrationClient`].
+#[derive(Debug, Clone, Error, PartialEq, Eq)]
+pub enum AgentRegistrationError {
+    #[error("invalid agent name for registration")]
+    InvalidAgentName,
+    #[error(
+        "registration for '{agent_name}' is blocked for {retry_after_secs}s due to previous rate limiting"
+    )]
+    Blocked {
+        agent_name: String,
+        retry_after_secs: u64,
+    },
+    #[error(
+        "registration for '{agent_name}' was rate-limited; retry after {retry_after_secs}s: {detail}"
+    )]
+    RateLimited {
+        agent_name: String,
+        retry_after_secs: u64,
+        detail: String,
+    },
+    #[error("registration failed for '{agent_name}' ({status}): {detail}")]
+    Api {
+        agent_name: String,
+        status: u16,
+        detail: String,
+    },
+    #[error("registration transport error for '{agent_name}': {detail}")]
+    Transport { agent_name: String, detail: String },
+    #[error("registration response missing token for '{agent_name}'")]
+    MissingToken { agent_name: String },
+}
+
+/// Retries exhausted or fatal outcome for [`retry_agent_registration`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum AgentRegistrationRetryOutcome {
+    /// All retries exhausted for a retryable error.
+    RetryableExhausted(AgentRegistrationError),
+    /// Non-retryable error.
+    Fatal(AgentRegistrationError),
+}
+
+/// Registers agents via RelayCast spawn endpoint and caches bearer tokens.
+#[derive(Clone)]
+pub struct AgentRegistrationClient {
+    relay: RelayCast,
+    default_cli: String,
+    agent_tokens: Arc<Mutex<HashMap<String, String>>>,
+    registration_cooldowns: Arc<Mutex<HashMap<String, Instant>>>,
+}
+
+impl AgentRegistrationClient {
+    /// Create a new registration client.
+    pub fn new(relay: RelayCast, default_cli: impl Into<String>) -> Self {
+        Self {
+            relay,
+            default_cli: default_cli.into(),
+            agent_tokens: Arc::new(Mutex::new(HashMap::new())),
+            registration_cooldowns: Arc::new(Mutex::new(HashMap::new())),
+        }
+    }
+
+    /// Pre-populate the token cache for an agent.
+    pub fn seed_agent_token(&self, agent_name: &str, token: &str) {
+        lock_unpoisoned(&self.agent_tokens).insert(agent_name.to_string(), token.to_string());
+    }
+
+    /// Read an agent token from cache, if present.
+    pub fn cached_agent_token(&self, agent_name: &str) -> Option<String> {
+        lock_unpoisoned(&self.agent_tokens).get(agent_name).cloned()
+    }
+
+    /// Return remaining block duration for a rate-limited agent registration.
+    pub fn registration_block_remaining(&self, agent_name: &str) -> Option<Duration> {
+        let trimmed = agent_name.trim();
+        if trimmed.is_empty() {
+            return None;
+        }
+
+        let mut guard = lock_unpoisoned(&self.registration_cooldowns);
+        let blocked_until = guard.get(trimmed).copied()?;
+        let now = Instant::now();
+        if blocked_until <= now {
+            guard.remove(trimmed);
+            return None;
+        }
+        Some(blocked_until - now)
+    }
+
+    /// Remove cached token and cooldown state for an agent.
+    pub fn invalidate_cached_registration(&self, agent_name: &str) {
+        let trimmed = agent_name.trim();
+        if trimmed.is_empty() {
+            return;
+        }
+        lock_unpoisoned(&self.agent_tokens).remove(trimmed);
+        lock_unpoisoned(&self.registration_cooldowns).remove(trimmed);
+    }
+
+    /// Register (or rotate) an agent token via `/v1/agents/spawn`.
+    pub async fn register_agent_token(
+        &self,
+        agent_name: &str,
+        cli_hint: Option<&str>,
+    ) -> std::result::Result<String, AgentRegistrationError> {
+        let trimmed_name = agent_name.trim();
+        if trimmed_name.is_empty() {
+            return Err(AgentRegistrationError::InvalidAgentName);
+        }
+
+        if let Some(token) = self.cached_agent_token(trimmed_name) {
+            return Ok(token);
+        }
+
+        if let Some(remaining) = self.registration_block_remaining(trimmed_name) {
+            return Err(AgentRegistrationError::Blocked {
+                agent_name: trimmed_name.to_string(),
+                retry_after_secs: remaining.as_secs().max(1),
+            });
+        }
+
+        let request = SpawnAgentRequest {
+            name: trimmed_name.to_string(),
+            cli: registration_cli_from_hint(cli_hint, &self.default_cli),
+            task: format!("relay worker session for {}", trimmed_name),
+            channel: None,
+            persona: None,
+            metadata: None,
+        };
+
+        match self.relay.spawn_agent(request).await {
+            Ok(result) => {
+                if result.token.trim().is_empty() {
+                    return Err(AgentRegistrationError::MissingToken {
+                        agent_name: trimmed_name.to_string(),
+                    });
+                }
+                lock_unpoisoned(&self.agent_tokens)
+                    .insert(trimmed_name.to_string(), result.token.clone());
+                lock_unpoisoned(&self.registration_cooldowns).remove(trimmed_name);
+                Ok(result.token)
+            }
+            Err(RelayError::Api {
+                status: 429,
+                message,
+                code,
+            }) => {
+                let retry_after_secs = DEFAULT_REGISTRATION_COOLDOWN_SECS;
+                let blocked_until = Instant::now() + Duration::from_secs(retry_after_secs);
+                lock_unpoisoned(&self.registration_cooldowns)
+                    .insert(trimmed_name.to_string(), blocked_until);
+                Err(AgentRegistrationError::RateLimited {
+                    agent_name: trimmed_name.to_string(),
+                    retry_after_secs,
+                    detail: format!("{message} (code: {code})"),
+                })
+            }
+            Err(RelayError::Api {
+                status,
+                message,
+                code,
+            }) => Err(AgentRegistrationError::Api {
+                agent_name: trimmed_name.to_string(),
+                status,
+                detail: format!("{message} (code: {code})"),
+            }),
+            Err(error) => Err(AgentRegistrationError::Transport {
+                agent_name: trimmed_name.to_string(),
+                detail: error.to_string(),
+            }),
+        }
+    }
+}
+
+/// Return retry delay seconds for rate-limited registration errors.
+pub fn registration_retry_after_secs(error: &AgentRegistrationError) -> Option<u64> {
+    match error {
+        AgentRegistrationError::Blocked {
+            retry_after_secs, ..
+        } => Some(*retry_after_secs),
+        AgentRegistrationError::RateLimited {
+            retry_after_secs, ..
+        } => Some(*retry_after_secs),
+        _ => None,
+    }
+}
+
+/// Return whether registration errors are transient and safe to retry.
+pub fn registration_is_retryable(error: &AgentRegistrationError) -> bool {
+    matches!(
+        error,
+        AgentRegistrationError::Blocked { .. }
+            | AgentRegistrationError::RateLimited { .. }
+            | AgentRegistrationError::Transport { .. }
+    )
+}
+
+/// Format a human-readable registration error message.
+pub fn format_registration_error(agent_name: &str, error: &AgentRegistrationError) -> String {
+    let mut message = format!("failed to register agent '{}': {}", agent_name, error);
+    if let Some(retry_after_secs) = registration_retry_after_secs(error) {
+        if !message.to_ascii_lowercase().contains("retry after") {
+            message.push_str(&format!(" (retry after {}s)", retry_after_secs));
+        }
+    }
+    message
+}
+
+/// Attempt registration with bounded retries for transient errors.
+pub async fn retry_agent_registration(
+    client: &AgentRegistrationClient,
+    agent_name: &str,
+    cli_hint: Option<&str>,
+) -> std::result::Result<String, AgentRegistrationRetryOutcome> {
+    const MAX_ATTEMPTS: u32 = 3;
+    for attempt in 0..MAX_ATTEMPTS {
+        match client.register_agent_token(agent_name, cli_hint).await {
+            Ok(token) => return Ok(token),
+            Err(error) if registration_is_retryable(&error) && attempt < MAX_ATTEMPTS - 1 => {
+                tokio::time::sleep(Duration::from_secs(2)).await;
+            }
+            Err(error) if registration_is_retryable(&error) => {
+                return Err(AgentRegistrationRetryOutcome::RetryableExhausted(error));
+            }
+            Err(error) => return Err(AgentRegistrationRetryOutcome::Fatal(error)),
+        }
+    }
+    unreachable!()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        format_registration_error, normalize_cli, registration_cli_from_hint,
+        registration_is_retryable, registration_retry_after_secs, AgentRegistrationClient,
+        AgentRegistrationError,
+    };
+    use crate::{RelayCast, RelayCastOptions};
+    use serde_json::json;
+    use wiremock::matchers::{body_string_contains, method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    fn ok(data: serde_json::Value) -> ResponseTemplate {
+        ResponseTemplate::new(200).set_body_json(json!({ "ok": true, "data": data }))
+    }
+
+    #[test]
+    fn normalize_cli_accepts_known_executables() {
+        assert_eq!(normalize_cli("codex"), Some("codex".to_string()));
+        assert_eq!(normalize_cli("node /tmp/claude-code.js"), None);
+        assert_eq!(normalize_cli("python /tmp/unknown.py"), None);
+    }
+
+    #[test]
+    fn registration_cli_falls_back_to_default() {
+        assert_eq!(
+            registration_cli_from_hint(Some("unknown"), "gemini"),
+            "gemini"
+        );
+        assert_eq!(
+            registration_cli_from_hint(None, "totally-unknown"),
+            "claude"
+        );
+    }
+
+    #[tokio::test]
+    async fn register_agent_token_uses_cache_before_network() {
+        let server = MockServer::start().await;
+        let relay =
+            RelayCast::new(RelayCastOptions::new("rk_live_test").with_base_url(server.uri()))
+                .expect("relay init");
+        let client = AgentRegistrationClient::new(relay, "claude");
+        client.seed_agent_token("worker-a", "at_live_cached");
+
+        let token = client
+            .register_agent_token("worker-a", Some("codex"))
+            .await
+            .expect("cache hit should succeed");
+        assert_eq!(token, "at_live_cached");
+    }
+
+    #[tokio::test]
+    async fn register_agent_token_parses_spawn_success() {
+        let server = MockServer::start().await;
+        let relay =
+            RelayCast::new(RelayCastOptions::new("rk_live_test").with_base_url(server.uri()))
+                .expect("relay init");
+        let client = AgentRegistrationClient::new(relay, "claude");
+
+        Mock::given(method("POST"))
+            .and(path("/v1/agents/spawn"))
+            .and(body_string_contains("\"name\":\"worker-b\""))
+            .and(body_string_contains("\"cli\":\"codex\""))
+            .respond_with(ok(json!({
+                "id": "a_worker_b",
+                "name": "worker-b",
+                "token": "at_live_worker_b",
+                "cli": "codex",
+                "task": "relay worker session for worker-b",
+                "channel": null,
+                "status": "online",
+                "created_at": "2026-01-01T00:00:00.000Z",
+                "already_existed": false
+            })))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let token = client
+            .register_agent_token("worker-b", Some("codex"))
+            .await
+            .expect("spawn should succeed");
+        assert_eq!(token, "at_live_worker_b");
+    }
+
+    #[tokio::test]
+    async fn register_agent_token_sets_cooldown_on_rate_limit() {
+        let server = MockServer::start().await;
+        let relay =
+            RelayCast::new(RelayCastOptions::new("rk_live_test").with_base_url(server.uri()))
+                .expect("relay init");
+        let client = AgentRegistrationClient::new(relay, "claude");
+
+        let rate_limited = ResponseTemplate::new(429).set_body_json(json!({
+            "ok": false,
+            "error": {
+                "code": "rate_limited",
+                "message": "too many requests"
+            }
+        }));
+
+        Mock::given(method("POST"))
+            .and(path("/v1/agents/spawn"))
+            .respond_with(rate_limited)
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let error = client
+            .register_agent_token("worker-c", None)
+            .await
+            .expect_err("expected rate-limited error");
+        match error {
+            AgentRegistrationError::RateLimited {
+                retry_after_secs, ..
+            } => assert_eq!(retry_after_secs, 60),
+            other => panic!("unexpected error variant: {other:?}"),
+        }
+
+        assert!(client.registration_block_remaining("worker-c").is_some());
+    }
+
+    #[test]
+    fn registration_retry_helpers_for_rate_limit() {
+        let error = AgentRegistrationError::RateLimited {
+            agent_name: "worker-d".to_string(),
+            retry_after_secs: 25,
+            detail: "429".to_string(),
+        };
+        assert!(registration_is_retryable(&error));
+        assert_eq!(registration_retry_after_secs(&error), Some(25));
+        let message = format_registration_error("worker-d", &error);
+        assert!(message.contains("worker-d"));
+        assert!(message.contains("retry after"));
+    }
+}

--- a/packages/sdk-rust/src/relay.rs
+++ b/packages/sdk-rust/src/relay.rs
@@ -195,6 +195,7 @@ impl RelayCastOptions {
 }
 
 /// Main client for RelayCast workspace operations.
+#[derive(Clone)]
 pub struct RelayCast {
     client: HttpClient,
 }
@@ -699,6 +700,21 @@ impl RelayCast {
         self.client
             .get("/v1/dm/conversations/all", None, None)
             .await
+    }
+
+    /// Resolve participants for a workspace DM conversation.
+    pub async fn dm_conversation_participants(&self, conversation_id: &str) -> Result<Vec<String>> {
+        let target = conversation_id.trim();
+        if target.is_empty() {
+            return Ok(vec![]);
+        }
+
+        let conversations = self.all_dm_conversations().await?;
+        Ok(conversations
+            .into_iter()
+            .find(|conversation| conversation.id == target)
+            .map(|conversation| conversation.participants)
+            .unwrap_or_default())
     }
 
     /// Get DM messages for a workspace conversation.

--- a/packages/sdk-rust/tests/parity.rs
+++ b/packages/sdk-rust/tests/parity.rs
@@ -342,3 +342,98 @@ async fn add_dm_participant_uses_agent_name_payload_and_typed_response() {
     assert_eq!(typed.agent, "worker-1");
     assert!(!typed.already_member);
 }
+
+#[tokio::test]
+async fn dm_messages_with_agent_uses_matching_conversation() {
+    let server = MockServer::start().await;
+    let agent = AgentClient::new("at_live_test", Some(server.uri()))
+        .expect("failed to create agent client");
+
+    Mock::given(method("GET"))
+        .and(path("/v1/dm/conversations"))
+        .respond_with(ok(json!([
+            {
+                "id": "c_1",
+                "type": "dm",
+                "name": null,
+                "participants": ["worker-1", "lead"],
+                "last_message": "hello",
+                "unread_count": 0
+            }
+        ])))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path("/v1/dm/c_1/messages"))
+        .and(query_param("limit", "2"))
+        .respond_with(ok(json!([
+            {
+                "id": "m_1",
+                "agent_name": "worker-1",
+                "agent_id": "a_1",
+                "text": "ping",
+                "created_at": "2026-01-01T00:00:00.000Z",
+                "reply_count": 0,
+                "reactions": [],
+                "read_by_count": 0,
+                "attachments": []
+            }
+        ])))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let messages = agent
+        .dm_messages_with_agent(
+            "worker-1",
+            Some(MessageListQuery {
+                limit: Some(2),
+                before: None,
+                after: None,
+            }),
+        )
+        .await
+        .expect("dm_messages_with_agent failed");
+    assert_eq!(messages.len(), 1);
+    assert_eq!(messages[0].text, "ping");
+}
+
+#[tokio::test]
+async fn dm_conversation_participants_returns_workspace_conversation_members() {
+    let server = MockServer::start().await;
+    let relay = RelayCast::new(RelayCastOptions::new("rk_live_test").with_base_url(server.uri()))
+        .expect("failed to create relay client");
+
+    Mock::given(method("GET"))
+        .and(path("/v1/dm/conversations/all"))
+        .respond_with(ok(json!([
+            {
+                "id": "conv_1",
+                "type": "dm",
+                "participants": ["alice", "bob"],
+                "message_count": 5,
+                "last_message": {
+                    "text": "latest",
+                    "agent_name": "alice",
+                    "created_at": "2026-01-01T00:00:00.000Z"
+                }
+            }
+        ])))
+        .expect(2)
+        .mount(&server)
+        .await;
+
+    let participants = relay
+        .dm_conversation_participants("conv_1")
+        .await
+        .expect("dm_conversation_participants failed");
+    assert_eq!(participants, vec!["alice".to_string(), "bob".to_string()]);
+
+    let missing = relay
+        .dm_conversation_participants("missing")
+        .await
+        .expect("missing conversation should return empty vec");
+    assert!(missing.is_empty());
+}


### PR DESCRIPTION
## Summary
- add a new registration module in sdk-rust with reusable agent registration cache, cooldown, and retry helpers around the agents spawn endpoint
- add NameConflictStrategy to credentials BootstrapConfig so callers can choose RotateExisting (current behavior), RetryWithSuffixOnce, or Fail
- add DM convenience methods for relay integration:
  - AgentClient dm_messages_with_agent(...)
  - RelayCast dm_conversation_participants(...)
- export the new registration helpers from the crate root
- add sdk-rust tests for conflict strategies, registration behavior, and DM helpers

## Why
Relay currently carries custom auth bootstrap, registration cache cooldown, and DM-resolution wrappers. These SDK APIs move that behavior to the SDK layer so relay can delete local wrappers and use typed SDK calls directly.

## Validation
- cargo fmt (packages/sdk-rust)
- cargo test (packages/sdk-rust)
