### PR TITLE
observer: make @mentions clickable and open agent profile

### DIFF
--- a/packages/observer-dashboard/src/components/AgentSidebar.tsx
+++ b/packages/observer-dashboard/src/components/AgentSidebar.tsx
@@ -173,7 +173,6 @@ export function AgentSidebar({
             <button
               key={agent.name}
               onClick={() => {
-                onSelectChannel(null);
                 onSelectAgent(selectedAgent === agent.name ? null : agent.name);
               }}
               className={cn(

--- a/packages/observer-dashboard/src/components/ChatFeed.tsx
+++ b/packages/observer-dashboard/src/components/ChatFeed.tsx
@@ -11,6 +11,8 @@ interface ChatFeedProps {
   selectedChannelMemberCount?: number | null;
   dmLabel?: string;
   onOpenThread?: (messageId: string) => void;
+  mentionNames?: string[];
+  onOpenAgent?: (agentName: string | null) => void;
 }
 
 export function ChatFeed({
@@ -18,6 +20,8 @@ export function ChatFeed({
   selectedChannelMemberCount,
   dmLabel,
   onOpenThread,
+  mentionNames,
+  onOpenAgent,
 }: ChatFeedProps) {
   const isDm = selectedChannel?.startsWith('dm:');
   const channelName = selectedChannel && !isDm ? selectedChannel : null;
@@ -52,9 +56,18 @@ export function ChatFeed({
       {/* Messages */}
       <div className="flex-1 overflow-y-auto">
         {channelName ? (
-          <ChannelMessages channel={channelName} onOpenThread={onOpenThread} />
+          <ChannelMessages
+            channel={channelName}
+            onOpenThread={onOpenThread}
+            mentionNames={mentionNames}
+            onOpenAgent={onOpenAgent}
+          />
         ) : dmId ? (
-          <DmMessages conversationId={dmId} />
+          <DmMessages
+            conversationId={dmId}
+            mentionNames={mentionNames}
+            onOpenAgent={onOpenAgent}
+          />
         ) : (
           <div className="flex flex-col items-center justify-center h-full text-[var(--color-text-dim)]">
             <MessageSquare className="h-8 w-8 mb-2 opacity-40" />
@@ -69,9 +82,13 @@ export function ChatFeed({
 function ChannelMessages({
   channel,
   onOpenThread,
+  mentionNames,
+  onOpenAgent,
 }: {
   channel: string;
   onOpenThread?: (messageId: string) => void;
+  mentionNames?: string[];
+  onOpenAgent?: (agentName: string | null) => void;
 }) {
   const bottomRef = useRef<HTMLDivElement>(null);
   const { messages, loading } = useMessages(channel);
@@ -114,6 +131,8 @@ function ChannelMessages({
             message={msg}
             compact={compact}
             onOpenThread={onOpenThread}
+            mentionNames={mentionNames}
+            onOpenAgent={onOpenAgent}
           />
         );
       })}
@@ -122,7 +141,15 @@ function ChannelMessages({
   );
 }
 
-function DmMessages({ conversationId }: { conversationId: string }) {
+function DmMessages({
+  conversationId,
+  mentionNames,
+  onOpenAgent,
+}: {
+  conversationId: string;
+  mentionNames?: string[];
+  onOpenAgent?: (agentName: string | null) => void;
+}) {
   const bottomRef = useRef<HTMLDivElement>(null);
   const [messages, setMessages] = useState<MessageWithMeta[]>([]);
   const [loading, setLoading] = useState(true);
@@ -187,6 +214,8 @@ function DmMessages({ conversationId }: { conversationId: string }) {
             key={msg.id}
             message={msg}
             compact={compact}
+            mentionNames={mentionNames}
+            onOpenAgent={onOpenAgent}
           />
         );
       })}

--- a/packages/observer-dashboard/src/components/DashboardLayout.tsx
+++ b/packages/observer-dashboard/src/components/DashboardLayout.tsx
@@ -70,10 +70,13 @@ export function DashboardLayout() {
     }));
   });
 
-  // Filter out the dashboard observer agent and stale offline agents (offline > 5 min)
+  // Filter out dashboard observer identities.
+  const mentionableAgents = rawAgents.filter((agent) => !agent.name.startsWith('_dashboard_'));
+  const mentionNames = mentionableAgents.map((agent) => agent.name);
+
+  // Filter out stale offline agents (offline > 5 min) from sidebar listings.
   const STALE_OFFLINE_MS = 5 * 60 * 1000;
-  const agents = rawAgents.filter((a) => {
-    if (a.name.startsWith('_dashboard_')) return false;
+  const agents = mentionableAgents.filter((a) => {
     if (a.status === 'offline' && a.lastSeen) {
       const elapsed = Date.now() - new Date(a.lastSeen).getTime();
       if (elapsed > STALE_OFFLINE_MS) return false;
@@ -156,7 +159,7 @@ export function DashboardLayout() {
 
   // Determine right panel priority: agent panel > thread > activity
   const selectedAgentData: ApiAgent | null = selectedAgent
-    ? agents.find((a) => a.name === selectedAgent) ?? null
+    ? mentionableAgents.find((a) => a.name === selectedAgent) ?? null
     : null;
   const selectedChannelMemberCount =
     selectedChannel && !selectedChannel.startsWith('dm:')
@@ -184,6 +187,8 @@ export function DashboardLayout() {
       <ThreadPanel
         messageId={threadMessageId}
         onClose={() => setThreadMessageId(null)}
+        mentionNames={mentionNames}
+        onOpenAgent={handleSelectAgent}
       />
     );
   } else if (activityOpen) {
@@ -253,6 +258,8 @@ export function DashboardLayout() {
             selectedChannelMemberCount={selectedChannelMemberCount}
             dmLabel={selectedDmLabel}
             onOpenThread={(id) => setThreadMessageId(id)}
+            mentionNames={mentionNames}
+            onOpenAgent={handleSelectAgent}
           />
           {rightPanel}
         </div>

--- a/packages/observer-dashboard/src/components/MessageCard.tsx
+++ b/packages/observer-dashboard/src/components/MessageCard.tsx
@@ -20,9 +20,17 @@ interface MessageCardProps {
   message: MessageWithMeta;
   compact?: boolean;
   onOpenThread?: (messageId: string) => void;
+  mentionNames?: string[];
+  onOpenAgent?: (agentName: string | null) => void;
 }
 
-export function MessageCard({ message, compact = false, onOpenThread }: MessageCardProps) {
+export function MessageCard({
+  message,
+  compact = false,
+  onOpenThread,
+  mentionNames,
+  onOpenAgent,
+}: MessageCardProps) {
   return (
     <div className="flex gap-3 px-4 py-2 hover:bg-[var(--color-bg-hover)] group">
       {compact ? (
@@ -45,6 +53,9 @@ export function MessageCard({ message, compact = false, onOpenThread }: MessageC
           text={message.text}
           className="text-sm text-[var(--color-text-secondary)] break-words"
           showCodeCopyButton
+          mentionNames={mentionNames}
+          onMentionClick={onOpenAgent}
+          mentionClassName="font-semibold text-[var(--color-accent-cyan)] hover:underline cursor-pointer"
         />
         {((message.reactions?.length ?? 0) > 0 || message.replyCount > 0) && (
           <div className="flex items-center gap-2 mt-1">

--- a/packages/observer-dashboard/src/components/ThreadPanel.tsx
+++ b/packages/observer-dashboard/src/components/ThreadPanel.tsx
@@ -17,7 +17,15 @@ function relativeTime(timestamp: string): string {
   return `${days}d ago`;
 }
 
-function ThreadMessageRow({ msg }: { msg: MessageWithMeta }) {
+function ThreadMessageRow({
+  msg,
+  mentionNames,
+  onOpenAgent,
+}: {
+  msg: MessageWithMeta;
+  mentionNames?: string[];
+  onOpenAgent?: (agentName: string | null) => void;
+}) {
   return (
     <div className="flex gap-3 px-4 py-2">
       <AgentAvatar name={msg.agentName} />
@@ -34,6 +42,9 @@ function ThreadMessageRow({ msg }: { msg: MessageWithMeta }) {
           text={msg.text}
           className="text-sm text-[var(--color-text-secondary)] break-words"
           showCodeCopyButton
+          mentionNames={mentionNames}
+          onMentionClick={onOpenAgent}
+          mentionClassName="font-semibold text-[var(--color-accent-cyan)] hover:underline cursor-pointer"
         />
       </div>
     </div>
@@ -43,9 +54,16 @@ function ThreadMessageRow({ msg }: { msg: MessageWithMeta }) {
 interface ThreadPanelProps {
   messageId: string;
   onClose: () => void;
+  mentionNames?: string[];
+  onOpenAgent?: (agentName: string | null) => void;
 }
 
-export function ThreadPanel({ messageId, onClose }: ThreadPanelProps) {
+export function ThreadPanel({
+  messageId,
+  onClose,
+  mentionNames,
+  onOpenAgent,
+}: ThreadPanelProps) {
   const { parent, replies, loading } = useThread(messageId);
 
   return (
@@ -83,7 +101,11 @@ export function ThreadPanel({ messageId, onClose }: ThreadPanelProps) {
           <div>
             {/* Parent message */}
             <div className="border-b border-[var(--color-border-subtle)] pb-2 mb-1">
-              <ThreadMessageRow msg={parent} />
+              <ThreadMessageRow
+                msg={parent}
+                mentionNames={mentionNames}
+                onOpenAgent={onOpenAgent}
+              />
             </div>
 
             {/* Replies */}
@@ -94,7 +116,12 @@ export function ThreadPanel({ messageId, onClose }: ThreadPanelProps) {
             ) : (
               <div className="py-1">
                 {replies.map((reply) => (
-                  <ThreadMessageRow key={reply.id} msg={reply} />
+                  <ThreadMessageRow
+                    key={reply.id}
+                    msg={reply}
+                    mentionNames={mentionNames}
+                    onOpenAgent={onOpenAgent}
+                  />
                 ))}
               </div>
             )}

--- a/packages/react/src/__tests__/messageMarkdown.test.tsx
+++ b/packages/react/src/__tests__/messageMarkdown.test.tsx
@@ -31,6 +31,30 @@ describe('MessageMarkdown', () => {
     expect(links[1]?.getAttribute('rel')).toBeNull();
   });
 
+  it('renders known mentions as clickable links', () => {
+    const onMentionClick = vi.fn();
+    const { container } = render(
+      <MessageMarkdown
+        text={'ping @alice and @unknown and `@alice`'}
+        mentionNames={['alice']}
+        onMentionClick={onMentionClick}
+        mentionClassName="mention-link"
+      />,
+    );
+
+    const links = Array.from(container.querySelectorAll('a'));
+    expect(links).toHaveLength(1);
+    const mention = links[0] as HTMLAnchorElement;
+    expect(mention.textContent).toBe('@alice');
+    expect(mention.tagName).toBe('A');
+    expect(mention.getAttribute('href')).toContain('alice');
+    expect(mention.getAttribute('class')).toContain('mention-link');
+
+    fireEvent.click(mention);
+    expect(onMentionClick).toHaveBeenCalledWith('alice');
+    expect(container.textContent).toContain('@unknown');
+  });
+
   it('renders highlighted fenced code and supports copy button', async () => {
     const writeText = vi.fn().mockResolvedValue(undefined);
     Object.defineProperty(navigator, 'clipboard', {

--- a/packages/react/src/components/MessageMarkdown.tsx
+++ b/packages/react/src/components/MessageMarkdown.tsx
@@ -95,7 +95,6 @@ const COPY_BUTTON_STYLE: CSSProperties = {
 
 const MENTION_LINK_STYLE: CSSProperties = {
   fontWeight: 600,
-  textDecoration: 'none',
 };
 
 const LANGUAGE_ALIASES: Record<string, string> = {

--- a/packages/react/src/components/MessageMarkdown.tsx
+++ b/packages/react/src/components/MessageMarkdown.tsx
@@ -1,6 +1,6 @@
 import { useMemo, type CSSProperties, type MouseEvent, type ReactNode } from 'react';
 import { Highlight, Prism, themes, type Language } from 'prism-react-renderer';
-import ReactMarkdown, { type Components } from 'react-markdown';
+import ReactMarkdown, { defaultUrlTransform, type Components } from 'react-markdown';
 import remarkBreaks from 'remark-breaks';
 import remarkGfm from 'remark-gfm';
 
@@ -68,8 +68,10 @@ const TABLE_CELL_STYLE: CSSProperties = {
   verticalAlign: 'top',
 };
 
-const REMARK_PLUGINS = [remarkGfm, remarkBreaks];
+const BASE_REMARK_PLUGINS = [remarkGfm, remarkBreaks];
 const CODE_THEME = themes.vsDark;
+const MENTION_URL_PREFIX = 'relaycast-agent://';
+const WORD_CHARACTER_PATTERN = /[A-Za-z0-9_]/;
 
 const CODE_BLOCK_CONTAINER_STYLE: CSSProperties = {
   display: 'block',
@@ -91,6 +93,11 @@ const COPY_BUTTON_STYLE: CSSProperties = {
   cursor: 'pointer',
 };
 
+const MENTION_LINK_STYLE: CSSProperties = {
+  fontWeight: 600,
+  textDecoration: 'none',
+};
+
 const LANGUAGE_ALIASES: Record<string, string> = {
   js: 'javascript',
   ts: 'typescript',
@@ -104,9 +111,134 @@ const LANGUAGE_ALIASES: Record<string, string> = {
   plaintext: 'plain',
 };
 
+interface MarkdownNode {
+  type?: string;
+  value?: string;
+  url?: string;
+  children?: MarkdownNode[];
+}
+
 function isExternalHref(href: string | undefined): boolean {
   if (!href) return false;
   return /^(https?:)?\/\//i.test(href);
+}
+
+function escapeRegexLiteral(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function isWordCharacter(value: string | undefined): boolean {
+  return value !== undefined && WORD_CHARACTER_PATTERN.test(value);
+}
+
+function normalizeMentionNames(mentionNames: string[] | undefined): string[] {
+  if (!mentionNames || mentionNames.length === 0) return [];
+
+  const uniqueNames = new Set<string>();
+  for (const rawName of mentionNames) {
+    const normalizedName = rawName.trim();
+    if (normalizedName.length === 0 || /\s/.test(normalizedName)) continue;
+    uniqueNames.add(normalizedName);
+  }
+
+  return Array.from(uniqueNames).sort((a, b) => {
+    if (b.length !== a.length) return b.length - a.length;
+    return a.localeCompare(b);
+  });
+}
+
+function buildMentionMatcher(mentionNames: string[]): RegExp | null {
+  if (mentionNames.length === 0) return null;
+  const escapedNames = mentionNames.map((name) => escapeRegexLiteral(name));
+  return new RegExp(`@(${escapedNames.join('|')})`, 'g');
+}
+
+function splitTextIntoMentionNodes(text: string, mentionMatcher: RegExp): MarkdownNode[] {
+  const nodes: MarkdownNode[] = [];
+  let cursor = 0;
+  let hasMention = false;
+  mentionMatcher.lastIndex = 0;
+
+  for (let match = mentionMatcher.exec(text); match !== null; match = mentionMatcher.exec(text)) {
+    const mention = match[0];
+    const mentionName = match[1];
+    if (!mentionName) continue;
+
+    const start = match.index;
+    const end = start + mention.length;
+    const previousChar = start > 0 ? text[start - 1] : undefined;
+    const nextChar = end < text.length ? text[end] : undefined;
+    if (isWordCharacter(previousChar) || isWordCharacter(nextChar)) {
+      continue;
+    }
+
+    if (start > cursor) {
+      nodes.push({ type: 'text', value: text.slice(cursor, start) });
+    }
+
+    nodes.push({
+      type: 'link',
+      url: `${MENTION_URL_PREFIX}${encodeURIComponent(mentionName)}`,
+      children: [{ type: 'text', value: `@${mentionName}` }],
+    });
+
+    cursor = end;
+    hasMention = true;
+  }
+
+  if (!hasMention) {
+    return [{ type: 'text', value: text }];
+  }
+
+  if (cursor < text.length) {
+    nodes.push({ type: 'text', value: text.slice(cursor) });
+  }
+
+  return nodes;
+}
+
+function rewriteMentionNodes(node: MarkdownNode, mentionMatcher: RegExp): void {
+  if (!Array.isArray(node.children) || node.children.length === 0) return;
+
+  const rewrittenChildren: MarkdownNode[] = [];
+  for (const child of node.children) {
+    if (child.type === 'text' && typeof child.value === 'string') {
+      rewrittenChildren.push(...splitTextIntoMentionNodes(child.value, mentionMatcher));
+      continue;
+    }
+
+    if (child.type !== 'link' && child.type !== 'inlineCode' && child.type !== 'code') {
+      rewriteMentionNodes(child, mentionMatcher);
+    }
+    rewrittenChildren.push(child);
+  }
+
+  node.children = rewrittenChildren;
+}
+
+function createMentionRemarkPlugin(mentionNames: string[]): (() => (tree: unknown) => void) | null {
+  const mentionMatcher = buildMentionMatcher(mentionNames);
+  if (!mentionMatcher) return null;
+
+  return () => (tree: unknown) => {
+    if (!tree || typeof tree !== 'object') return;
+    rewriteMentionNodes(tree as MarkdownNode, mentionMatcher);
+  };
+}
+
+function decodeMentionHref(href: string | undefined): string | null {
+  if (!href || !href.startsWith(MENTION_URL_PREFIX)) return null;
+  const encodedName = href.slice(MENTION_URL_PREFIX.length);
+  try {
+    return decodeURIComponent(encodedName);
+  } catch {
+    return encodedName;
+  }
+}
+
+function transformUrl(url: string): string {
+  if (url.startsWith(MENTION_URL_PREFIX)) return url;
+  return defaultUrlTransform(url);
 }
 
 function toCodeText(children: ReactNode): string {
@@ -240,7 +372,12 @@ function renderCodeBlock(
   );
 }
 
-function buildDefaultComponents(showCodeCopyButton: boolean): Components {
+function buildDefaultComponents(
+  showCodeCopyButton: boolean,
+  onMentionClick?: (mentionName: string) => void,
+  mentionClassName?: string,
+  mentionStyle?: CSSProperties,
+): Components {
   return {
     p({ children }) {
       return <p style={PARAGRAPH_STYLE}>{children}</p>;
@@ -262,7 +399,30 @@ function buildDefaultComponents(showCodeCopyButton: boolean): Components {
     li({ children }) {
       return <li style={{ marginTop: '0.125rem' }}>{children}</li>;
     },
-    a({ href, children, node: _node, ...props }) {
+    a({ href, children, node: _node, style, className, ...props }) {
+      const mentionName = decodeMentionHref(href);
+      if (mentionName) {
+        return (
+          <a
+            {...props}
+            href={href}
+            onClick={(event) => {
+              event.preventDefault();
+              onMentionClick?.(mentionName);
+            }}
+            className={mentionClassName ?? className}
+            style={{
+              ...MENTION_LINK_STYLE,
+              ...(onMentionClick ? { cursor: 'pointer' } : undefined),
+              ...mentionStyle,
+              ...style,
+            }}
+          >
+            {children}
+          </a>
+        );
+      }
+
       const external = isExternalHref(href);
       return (
         <a
@@ -270,7 +430,8 @@ function buildDefaultComponents(showCodeCopyButton: boolean): Components {
           href={href}
           target={external ? '_blank' : undefined}
           rel={external ? 'noopener noreferrer nofollow' : undefined}
-          style={{ textDecoration: 'underline', overflowWrap: 'anywhere' }}
+          className={className}
+          style={{ textDecoration: 'underline', overflowWrap: 'anywhere', ...style }}
         >
           {children}
         </a>
@@ -327,6 +488,10 @@ export interface MessageMarkdownProps {
   className?: string;
   components?: Components;
   showCodeCopyButton?: boolean;
+  mentionNames?: string[];
+  onMentionClick?: (mentionName: string) => void;
+  mentionClassName?: string;
+  mentionStyle?: CSSProperties;
 }
 
 export function MessageMarkdown({
@@ -334,10 +499,28 @@ export function MessageMarkdown({
   className,
   components,
   showCodeCopyButton = false,
+  mentionNames,
+  onMentionClick,
+  mentionClassName,
+  mentionStyle,
 }: MessageMarkdownProps) {
+  const normalizedMentionNames = useMemo(
+    () => normalizeMentionNames(mentionNames),
+    [mentionNames],
+  );
+  const mentionRemarkPlugin = useMemo(
+    () => createMentionRemarkPlugin(normalizedMentionNames),
+    [normalizedMentionNames],
+  );
+  const remarkPlugins = useMemo(
+    () => mentionRemarkPlugin
+      ? [...BASE_REMARK_PLUGINS, mentionRemarkPlugin]
+      : BASE_REMARK_PLUGINS,
+    [mentionRemarkPlugin],
+  );
   const defaultComponents = useMemo(
-    () => buildDefaultComponents(showCodeCopyButton),
-    [showCodeCopyButton],
+    () => buildDefaultComponents(showCodeCopyButton, onMentionClick, mentionClassName, mentionStyle),
+    [showCodeCopyButton, onMentionClick, mentionClassName, mentionStyle],
   );
   const mergedComponents = useMemo(
     () => ({ ...defaultComponents, ...components }),
@@ -348,7 +531,8 @@ export function MessageMarkdown({
     <div className={className}>
       <ReactMarkdown
         components={mergedComponents}
-        remarkPlugins={REMARK_PLUGINS}
+        remarkPlugins={remarkPlugins}
+        urlTransform={transformUrl}
         skipHtml
       >
         {text}


### PR DESCRIPTION
## Summary
- render known @agent mentions in MessageMarkdown as mention links with click callbacks
- style Observer mentions as bold blue links in message cards and thread rows
- wire mention clicks to select the agent and open the right-side Agent Profile pane
- ensure profile pane lookup can resolve offline/stale agents by searching all non-observer identities

## Validation
- npm --prefix packages/react test -- src/__tests__/messageMarkdown.test.tsx
- npm --prefix packages/react run build
- npm --prefix packages/observer-dashboard run build
