### PR TITLE
Add basePath support for observer on agentrelay.dev

### DIFF
--- a/.github/actions/deploy-observer-dashboard/action.yml
+++ b/.github/actions/deploy-observer-dashboard/action.yml
@@ -14,6 +14,9 @@ inputs:
   cloudflare-account-id:
     description: Cloudflare account ID
     required: true
+  base-path:
+    description: Next.js basePath (e.g. /observer for prod)
+    default: ''
 
 runs:
   using: composite
@@ -63,3 +66,4 @@ runs:
       env:
         CLOUDFLARE_API_TOKEN: ${{ inputs.cloudflare-api-token }}
         CLOUDFLARE_ACCOUNT_ID: ${{ inputs.cloudflare-account-id }}
+        NEXT_PUBLIC_BASE_PATH: ${{ inputs.base-path }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -143,6 +143,7 @@ jobs:
       - uses: ./.github/actions/deploy-observer-dashboard
         with:
           branch: main
+          base-path: /observer
           cloudflare-api-token: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           cloudflare-account-id: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
 

--- a/packages/observer-dashboard/next.config.js
+++ b/packages/observer-dashboard/next.config.js
@@ -1,3 +1,5 @@
 /** @type {import('next').NextConfig} */
-const nextConfig = {};
+const nextConfig = {
+  basePath: process.env.NEXT_PUBLIC_BASE_PATH || "",
+};
 module.exports = nextConfig;


### PR DESCRIPTION
## Summary
- Adds `NEXT_PUBLIC_BASE_PATH` env var support to observer dashboard's `next.config.js`
- Prod deploy passes `base-path: /observer` so the dashboard serves at `/observer/*` when proxied through `agentrelay.dev`
- Preview environments are unaffected (default empty base path, served at root)

## Test plan
- [ ] Verify preview deploy still works at `prNN-observer.relaycast.dev/`
- [ ] Verify prod deploy serves observer at `agentrelay.dev/observer`
- [ ] Verify observer assets (`/_next/...`) load correctly under `/observer/_next/...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)