### PR TITLE
Fix DM thread replies & reaction WS fanout

### DIFF
--- a/packages/react/src/components/MessageMarkdown.tsx
+++ b/packages/react/src/components/MessageMarkdown.tsx
@@ -1,6 +1,6 @@
-import { useMemo, type CSSProperties, type MouseEvent, type ReactNode } from 'react';
+import React, { useMemo, type CSSProperties, type MouseEvent, type ReactNode } from 'react';
 import { Highlight, Prism, themes, type Language } from 'prism-react-renderer';
-import ReactMarkdown, { defaultUrlTransform, type Components } from 'react-markdown';
+import ReactMarkdown, { defaultUrlTransform, type Components, type ExtraProps } from 'react-markdown';
 import remarkBreaks from 'remark-breaks';
 import remarkGfm from 'remark-gfm';
 
@@ -459,7 +459,7 @@ function buildDefaultComponents(
     table({ children }) {
       return <table style={TABLE_STYLE}>{children}</table>;
     },
-    th({ children, style, node: _node, ...props }: any) {
+    th({ children, style, node: _node, ...props }: React.ComponentPropsWithoutRef<'th'> & ExtraProps) {
       return (
         <th
           {...props}
@@ -469,7 +469,7 @@ function buildDefaultComponents(
         </th>
       );
     },
-    td({ children, style, node: _node, ...props }: any) {
+    td({ children, style, node: _node, ...props }: React.ComponentPropsWithoutRef<'td'> & ExtraProps) {
       return (
         <td
           {...props}

--- a/packages/react/src/components/MessageMarkdown.tsx
+++ b/packages/react/src/components/MessageMarkdown.tsx
@@ -459,7 +459,7 @@ function buildDefaultComponents(
     table({ children }) {
       return <table style={TABLE_STYLE}>{children}</table>;
     },
-    th({ children, style, node: _node, ...props }) {
+    th({ children, style, node: _node, ...props }: any) {
       return (
         <th
           {...props}
@@ -469,7 +469,7 @@ function buildDefaultComponents(
         </th>
       );
     },
-    td({ children, style, node: _node, ...props }) {
+    td({ children, style, node: _node, ...props }: any) {
       return (
         <td
           {...props}

--- a/packages/server/src/routes/__tests__/fanout.test.ts
+++ b/packages/server/src/routes/__tests__/fanout.test.ts
@@ -6,6 +6,7 @@ import {
   fanoutToAgents,
   fanoutToWorkspace,
   updateChannelMembers,
+  getDmParticipantAgentIds,
 } from '../../routes/fanout.js';
 import { createMockBindings, FAKE_WORKSPACE } from '../../__tests__/test-helpers.js';
 
@@ -240,6 +241,79 @@ describe('fanout helpers', () => {
     const req = channelFetch.mock.calls[0][0] as Request;
     const body = await req.json();
     expect(body.members).toEqual(['agent_1', 'agent_2']);
+  });
+
+  describe('getDmParticipantAgentIds', () => {
+    function createDbContext(conversationRows: any[], participantRows: any[]) {
+      const whereHandler = vi.fn()
+        .mockResolvedValueOnce(conversationRows)
+        .mockResolvedValueOnce(participantRows);
+
+      const db = {
+        select: () => ({
+          from: () => ({
+            where: whereHandler,
+          }),
+        }),
+      };
+
+      return {
+        env: createMockBindings(),
+        get: vi.fn((key: string) => {
+          if (key === 'db') return db;
+          if (key === 'workspace') return FAKE_WORKSPACE;
+          return undefined;
+        }),
+      } as any;
+    }
+
+    it('returns agent IDs for a DM channel', async () => {
+      const c = createDbContext(
+        [{ id: 'conv_1' }],
+        [{ agentId: 'agent_a' }, { agentId: 'agent_b' }],
+      );
+
+      const result = await getDmParticipantAgentIds(c, 'dmch_123');
+      expect(result).toEqual(['agent_a', 'agent_b']);
+    });
+
+    it('returns null for a non-DM channel', async () => {
+      const c = createDbContext([], []);
+      const result = await getDmParticipantAgentIds(c, 'ch_regular');
+      expect(result).toBeNull();
+    });
+
+    it('returns empty array when all DM participants have left', async () => {
+      const c = createDbContext(
+        [{ id: 'conv_2' }],
+        [], // no active participants
+      );
+
+      const result = await getDmParticipantAgentIds(c, 'dmch_456');
+      expect(result).toEqual([]);
+    });
+
+    it('returns null on DB error instead of throwing', async () => {
+      const db = {
+        select: () => ({
+          from: () => ({
+            where: vi.fn().mockRejectedValue(new Error('DB connection failed')),
+          }),
+        }),
+      };
+
+      const c = {
+        env: createMockBindings(),
+        get: vi.fn((key: string) => {
+          if (key === 'db') return db;
+          if (key === 'workspace') return FAKE_WORKSPACE;
+          return undefined;
+        }),
+      } as any;
+
+      const result = await getDmParticipantAgentIds(c, 'dmch_broken');
+      expect(result).toBeNull();
+    });
   });
 
   it('fanoutToChannel supports workspace override when context workspace is missing', async () => {

--- a/packages/server/src/routes/__tests__/reaction.test.ts
+++ b/packages/server/src/routes/__tests__/reaction.test.ts
@@ -18,6 +18,16 @@ vi.mock('../../lib/serverTelemetry.js', () => ({
   emitServerEvent: vi.fn(),
 }));
 
+vi.mock('../fanout.js', async (importOriginal) => {
+  const original = await importOriginal<typeof import('../fanout.js')>();
+  return {
+    ...original,
+    fanoutToChannel: vi.fn().mockResolvedValue(undefined),
+    fanoutToAgents: vi.fn().mockResolvedValue(undefined),
+    getDmParticipantAgentIds: vi.fn().mockResolvedValue(null),
+  };
+});
+
 import { Hono } from 'hono';
 import type { AppEnv } from '../../env.js';
 import { dbMiddleware } from '../../middleware/db.js';
@@ -25,6 +35,7 @@ import { reactionRoutes } from '../../routes/reaction.js';
 import { getDb } from '../../db/index.js';
 import * as reactionEngine from '../../engine/reaction.js';
 import { emitServerEvent } from '../../lib/serverTelemetry.js';
+import { fanoutToChannel, fanoutToAgents, getDmParticipantAgentIds } from '../fanout.js';
 import {
   createMockBindings, mockDbForAgentAuth, mockDbForWorkspaceAuth,
   agentAuthHeaders, wsAuthHeaders,
@@ -135,6 +146,62 @@ describe('POST /v1/messages/:id/reactions', () => {
     expect(res.status).toBe(404);
     const body = await res.json() as any;
     expect(body.error.code).toBe('message_not_found');
+  });
+
+  it('uses fanoutToAgents when reaction is on a DM message', async () => {
+    vi.mocked(getDmParticipantAgentIds).mockResolvedValue(['agent_a', 'agent_b']);
+    vi.mocked(reactionEngine.addReaction).mockResolvedValue({
+      id: 'rxn_dm',
+      message_id: 'msg_dm',
+      agent_name: 'TestBot',
+      emoji: 'heart',
+      created_at: '2025-01-01T00:00:00.000Z',
+      channel_id: 'dmch_100',
+      channel_name: 'dm',
+    });
+
+    const res = await app.request('/v1/messages/msg_dm/reactions', {
+      method: 'POST',
+      headers: agentAuthHeaders(),
+      body: JSON.stringify({ emoji: 'heart' }),
+    }, bindings);
+
+    expect(res.status).toBe(201);
+    expect(fanoutToAgents).toHaveBeenCalledWith(
+      expect.anything(),
+      ['agent_a', 'agent_b'],
+      'reaction.added',
+      expect.objectContaining({ emoji: 'heart' }),
+    );
+    expect(fanoutToChannel).not.toHaveBeenCalled();
+  });
+
+  it('uses fanoutToChannel when reaction is on a regular channel message', async () => {
+    vi.mocked(getDmParticipantAgentIds).mockResolvedValue(null);
+    vi.mocked(reactionEngine.addReaction).mockResolvedValue({
+      id: 'rxn_ch',
+      message_id: 'msg_ch',
+      agent_name: 'TestBot',
+      emoji: 'fire',
+      created_at: '2025-01-01T00:00:00.000Z',
+      channel_id: 'ch_456',
+      channel_name: 'general',
+    });
+
+    const res = await app.request('/v1/messages/msg_ch/reactions', {
+      method: 'POST',
+      headers: agentAuthHeaders(),
+      body: JSON.stringify({ emoji: 'fire' }),
+    }, bindings);
+
+    expect(res.status).toBe(201);
+    expect(fanoutToChannel).toHaveBeenCalledWith(
+      expect.anything(),
+      'ch_456',
+      'reaction.added',
+      expect.objectContaining({ emoji: 'fire' }),
+    );
+    expect(fanoutToAgents).not.toHaveBeenCalled();
   });
 
   it('returns 401 without auth', async () => {

--- a/packages/server/src/routes/__tests__/reaction.test.ts
+++ b/packages/server/src/routes/__tests__/reaction.test.ts
@@ -167,12 +167,14 @@ describe('POST /v1/messages/:id/reactions', () => {
     }, bindings);
 
     expect(res.status).toBe(201);
-    expect(fanoutToAgents).toHaveBeenCalledWith(
-      expect.anything(),
-      ['agent_a', 'agent_b'],
-      'reaction.added',
-      expect.objectContaining({ emoji: 'heart' }),
-    );
+    await vi.waitFor(() => {
+      expect(fanoutToAgents).toHaveBeenCalledWith(
+        expect.anything(),
+        ['agent_a', 'agent_b'],
+        'reaction.added',
+        expect.objectContaining({ emoji: 'heart' }),
+      );
+    });
     expect(fanoutToChannel).not.toHaveBeenCalled();
   });
 
@@ -195,12 +197,14 @@ describe('POST /v1/messages/:id/reactions', () => {
     }, bindings);
 
     expect(res.status).toBe(201);
-    expect(fanoutToChannel).toHaveBeenCalledWith(
-      expect.anything(),
-      'ch_456',
-      'reaction.added',
-      expect.objectContaining({ emoji: 'fire' }),
-    );
+    await vi.waitFor(() => {
+      expect(fanoutToChannel).toHaveBeenCalledWith(
+        expect.anything(),
+        'ch_456',
+        'reaction.added',
+        expect.objectContaining({ emoji: 'fire' }),
+      );
+    });
     expect(fanoutToAgents).not.toHaveBeenCalled();
   });
 

--- a/packages/server/src/routes/__tests__/thread.test.ts
+++ b/packages/server/src/routes/__tests__/thread.test.ts
@@ -13,12 +13,23 @@ vi.mock('../../db/index.js', () => ({
   getDb: vi.fn(),
 }));
 
+vi.mock('../fanout.js', async (importOriginal) => {
+  const original = await importOriginal<typeof import('../fanout.js')>();
+  return {
+    ...original,
+    fanoutToChannel: vi.fn().mockResolvedValue(undefined),
+    fanoutToAgents: vi.fn().mockResolvedValue(undefined),
+    getDmParticipantAgentIds: vi.fn().mockResolvedValue(null),
+  };
+});
+
 import { Hono } from 'hono';
 import type { AppEnv } from '../../env.js';
 import { dbMiddleware } from '../../middleware/db.js';
 import { threadRoutes } from '../../routes/thread.js';
 import { getDb } from '../../db/index.js';
 import * as threadEngine from '../../engine/thread.js';
+import { fanoutToChannel, fanoutToAgents, getDmParticipantAgentIds } from '../fanout.js';
 import {
   createMockBindings, mockDbForAgentAuth, agentAuthHeaders, FAKE_WORKSPACE,
 } from '../../__tests__/test-helpers.js';
@@ -80,6 +91,85 @@ describe('POST /v1/messages/:id/replies', () => {
     expect(res.status).toBe(400);
     const body = await res.json() as any;
     expect(body.error.code).toBe('invalid_request');
+  });
+
+  it('uses fanoutToAgents for DM channel thread replies', async () => {
+    vi.mocked(getDmParticipantAgentIds).mockResolvedValue(['agent_a', 'agent_b']);
+    vi.mocked(threadEngine.postReply).mockResolvedValue({
+      id: 'reply_002',
+      channel_id: 'dmch_100',
+      agent_id: 'agent_456',
+      thread_id: 'msg_002',
+      text: 'DM reply',
+      has_attachments: false,
+      created_at: '2025-01-01T00:00:00.000Z',
+    });
+
+    const res = await app.request('/v1/messages/msg_002/replies', {
+      method: 'POST',
+      headers: agentAuthHeaders(),
+      body: JSON.stringify({ text: 'DM reply' }),
+    }, bindings);
+
+    expect(res.status).toBe(201);
+    expect(fanoutToAgents).toHaveBeenCalledWith(
+      expect.anything(),
+      ['agent_a', 'agent_b'],
+      'thread.reply',
+      expect.objectContaining({ thread_id: 'msg_002' }),
+    );
+    expect(fanoutToChannel).not.toHaveBeenCalled();
+  });
+
+  it('uses fanoutToChannel for regular channel thread replies', async () => {
+    vi.mocked(getDmParticipantAgentIds).mockResolvedValue(null);
+    vi.mocked(threadEngine.postReply).mockResolvedValue({
+      id: 'reply_003',
+      channel_id: 'ch_789',
+      agent_id: 'agent_456',
+      thread_id: 'msg_003',
+      text: 'Channel reply',
+      has_attachments: false,
+      created_at: '2025-01-01T00:00:00.000Z',
+    });
+
+    const res = await app.request('/v1/messages/msg_003/replies', {
+      method: 'POST',
+      headers: agentAuthHeaders(),
+      body: JSON.stringify({ text: 'Channel reply' }),
+    }, bindings);
+
+    expect(res.status).toBe(201);
+    expect(fanoutToChannel).toHaveBeenCalledWith(
+      expect.anything(),
+      'ch_789',
+      'thread.reply',
+      expect.objectContaining({ thread_id: 'msg_003' }),
+    );
+    expect(fanoutToAgents).not.toHaveBeenCalled();
+  });
+
+  it('falls back to fanoutToChannel when getDmParticipantAgentIds errors', async () => {
+    vi.mocked(getDmParticipantAgentIds).mockResolvedValue(null); // error path returns null
+    vi.mocked(threadEngine.postReply).mockResolvedValue({
+      id: 'reply_004',
+      channel_id: 'dmch_broken',
+      agent_id: 'agent_456',
+      thread_id: 'msg_004',
+      text: 'Fallback reply',
+      has_attachments: false,
+      created_at: '2025-01-01T00:00:00.000Z',
+    });
+
+    const res = await app.request('/v1/messages/msg_004/replies', {
+      method: 'POST',
+      headers: agentAuthHeaders(),
+      body: JSON.stringify({ text: 'Fallback reply' }),
+    }, bindings);
+
+    expect(res.status).toBe(201);
+    expect(fanoutToChannel).toHaveBeenCalled();
+    expect(fanoutToAgents).not.toHaveBeenCalled();
   });
 
   it('returns 404 for unknown parent message', async () => {

--- a/packages/server/src/routes/__tests__/thread.test.ts
+++ b/packages/server/src/routes/__tests__/thread.test.ts
@@ -112,12 +112,14 @@ describe('POST /v1/messages/:id/replies', () => {
     }, bindings);
 
     expect(res.status).toBe(201);
-    expect(fanoutToAgents).toHaveBeenCalledWith(
-      expect.anything(),
-      ['agent_a', 'agent_b'],
-      'thread.reply',
-      expect.objectContaining({ thread_id: 'msg_002' }),
-    );
+    await vi.waitFor(() => {
+      expect(fanoutToAgents).toHaveBeenCalledWith(
+        expect.anything(),
+        ['agent_a', 'agent_b'],
+        'thread.reply',
+        expect.objectContaining({ thread_id: 'msg_002' }),
+      );
+    });
     expect(fanoutToChannel).not.toHaveBeenCalled();
   });
 
@@ -140,12 +142,14 @@ describe('POST /v1/messages/:id/replies', () => {
     }, bindings);
 
     expect(res.status).toBe(201);
-    expect(fanoutToChannel).toHaveBeenCalledWith(
-      expect.anything(),
-      'ch_789',
-      'thread.reply',
-      expect.objectContaining({ thread_id: 'msg_003' }),
-    );
+    await vi.waitFor(() => {
+      expect(fanoutToChannel).toHaveBeenCalledWith(
+        expect.anything(),
+        'ch_789',
+        'thread.reply',
+        expect.objectContaining({ thread_id: 'msg_003' }),
+      );
+    });
     expect(fanoutToAgents).not.toHaveBeenCalled();
   });
 
@@ -168,7 +172,9 @@ describe('POST /v1/messages/:id/replies', () => {
     }, bindings);
 
     expect(res.status).toBe(201);
-    expect(fanoutToChannel).toHaveBeenCalled();
+    await vi.waitFor(() => {
+      expect(fanoutToChannel).toHaveBeenCalled();
+    });
     expect(fanoutToAgents).not.toHaveBeenCalled();
   });
 

--- a/packages/server/src/routes/fanout.ts
+++ b/packages/server/src/routes/fanout.ts
@@ -211,7 +211,12 @@ export async function getDmParticipantAgentIds(
       .from(dmParticipants)
       .where(and(eq(dmParticipants.conversationId, conv.id), isNull(dmParticipants.leftAt)));
     return rows.map((r) => r.agentId);
-  } catch {
+  } catch (err) {
+    const logger = getRequestLogger(c, 'fanout.dm_lookup');
+    logger.warn(`getDmParticipantAgentIds failed for channel ${channelId}`, {
+      channel_id: channelId,
+      ...toErrorDetails(err),
+    });
     return null;
   }
 }

--- a/packages/server/src/routes/fanout.ts
+++ b/packages/server/src/routes/fanout.ts
@@ -3,6 +3,8 @@ import type { AppEnv } from '../env.js';
 import { transformForClient, type WsEvent } from '../engine/wsTransform.js';
 import { isWorkspaceStreamEnabled } from '../lib/workspaceStream.js';
 import { getRequestLogger, toErrorDetails } from '../lib/logger.js';
+import { dmConversations, dmParticipants } from '../db/schema.js';
+import { and, eq, isNull } from 'drizzle-orm';
 
 type HonoContext = Context<AppEnv>;
 
@@ -185,6 +187,32 @@ export async function fanoutToWorkspace(
       ...toErrorDetails(err),
     });
     throw err;
+  }
+}
+
+/**
+ * Check if a channel belongs to a DM conversation and return active participant
+ * agent IDs. Returns `null` for regular (non-DM) channels or on any error so
+ * callers can fall back to the standard `fanoutToChannel` path.
+ */
+export async function getDmParticipantAgentIds(
+  c: HonoContext,
+  channelId: string,
+): Promise<string[] | null> {
+  try {
+    const db = c.get('db');
+    const [conv] = await db
+      .select({ id: dmConversations.id })
+      .from(dmConversations)
+      .where(eq(dmConversations.channelId, channelId));
+    if (!conv) return null;
+    const rows = await db
+      .select({ agentId: dmParticipants.agentId })
+      .from(dmParticipants)
+      .where(and(eq(dmParticipants.conversationId, conv.id), isNull(dmParticipants.leftAt)));
+    return rows.map((r) => r.agentId);
+  } catch {
+    return null;
   }
 }
 

--- a/packages/server/src/routes/reaction.ts
+++ b/packages/server/src/routes/reaction.ts
@@ -54,12 +54,18 @@ reactionRoutes.post(
 
       const eventData = { ...reactionData, channel_name, agent_name: agent!.name };
       if (channel_id) {
-        const dmAgentIds = await getDmParticipantAgentIds(c, channel_id);
-        if (dmAgentIds) {
-          runInBackground(c, fanoutToAgents(c, dmAgentIds, 'reaction.added', eventData), 'fanout dm reaction.added');
-        } else {
-          runInBackground(c, fanoutToChannel(c, channel_id, 'reaction.added', eventData), 'fanout reaction.added');
-        }
+        runInBackground(
+          c,
+          (async () => {
+            const dmAgentIds = await getDmParticipantAgentIds(c, channel_id);
+            if (dmAgentIds) {
+              await fanoutToAgents(c, dmAgentIds, 'reaction.added', eventData);
+            } else {
+              await fanoutToChannel(c, channel_id, 'reaction.added', eventData);
+            }
+          })(),
+          'fanout reaction.added',
+        );
       }
       runInBackground(
         c,
@@ -125,12 +131,18 @@ reactionRoutes.delete(
           .where(and(eq(messages.id, c.req.param('id')), eq(channels.workspaceId, workspace.id)));
         if (row?.channelId) {
           const enriched = { ...eventData, channel_name: row.channelName };
-          const dmAgentIds = await getDmParticipantAgentIds(c, row.channelId);
-          if (dmAgentIds) {
-            runInBackground(c, fanoutToAgents(c, dmAgentIds, 'reaction.removed', enriched), 'fanout dm reaction.removed');
-          } else {
-            runInBackground(c, fanoutToChannel(c, row.channelId, 'reaction.removed', enriched), 'fanout reaction.removed');
-          }
+          runInBackground(
+            c,
+            (async () => {
+              const dmAgentIds = await getDmParticipantAgentIds(c, row.channelId);
+              if (dmAgentIds) {
+                await fanoutToAgents(c, dmAgentIds, 'reaction.removed', enriched);
+              } else {
+                await fanoutToChannel(c, row.channelId, 'reaction.removed', enriched);
+              }
+            })(),
+            'fanout reaction.removed',
+          );
         }
       } catch {
         // Ignore fanout failures

--- a/packages/server/src/routes/reaction.ts
+++ b/packages/server/src/routes/reaction.ts
@@ -6,7 +6,7 @@ import { rateLimit } from '../middleware/rateLimit.js';
 import * as reactionEngine from '../engine/reaction.js';
 import { and, eq } from 'drizzle-orm';
 import { channels, messages } from '../db/schema.js';
-import { fanoutToChannel } from './fanout.js';
+import { fanoutToChannel, fanoutToAgents, getDmParticipantAgentIds } from './fanout.js';
 import { runInBackground } from './background.js';
 import { emitServerEvent } from '../lib/serverTelemetry.js';
 
@@ -54,7 +54,12 @@ reactionRoutes.post(
 
       const eventData = { ...reactionData, channel_name, agent_name: agent!.name };
       if (channel_id) {
-        runInBackground(c, fanoutToChannel(c, channel_id, 'reaction.added', eventData), 'fanout reaction.added');
+        const dmAgentIds = await getDmParticipantAgentIds(c, channel_id);
+        if (dmAgentIds) {
+          runInBackground(c, fanoutToAgents(c, dmAgentIds, 'reaction.added', eventData), 'fanout dm reaction.added');
+        } else {
+          runInBackground(c, fanoutToChannel(c, channel_id, 'reaction.added', eventData), 'fanout reaction.added');
+        }
       }
       runInBackground(
         c,
@@ -119,11 +124,13 @@ reactionRoutes.delete(
           .innerJoin(channels, eq(messages.channelId, channels.id))
           .where(and(eq(messages.id, c.req.param('id')), eq(channels.workspaceId, workspace.id)));
         if (row?.channelId) {
-          runInBackground(
-            c,
-            fanoutToChannel(c, row.channelId, 'reaction.removed', { ...eventData, channel_name: row.channelName }),
-            'fanout reaction.removed',
-          );
+          const enriched = { ...eventData, channel_name: row.channelName };
+          const dmAgentIds = await getDmParticipantAgentIds(c, row.channelId);
+          if (dmAgentIds) {
+            runInBackground(c, fanoutToAgents(c, dmAgentIds, 'reaction.removed', enriched), 'fanout dm reaction.removed');
+          } else {
+            runInBackground(c, fanoutToChannel(c, row.channelId, 'reaction.removed', enriched), 'fanout reaction.removed');
+          }
         }
       } catch {
         // Ignore fanout failures

--- a/packages/server/src/routes/thread.ts
+++ b/packages/server/src/routes/thread.ts
@@ -78,12 +78,19 @@ threadRoutes.post(
       if (!idempotent.replayed) {
         const eventData = { ...idempotent.data, from_name: agent?.name };
         if (idempotent.data.channel_id) {
-          const dmAgentIds = await getDmParticipantAgentIds(c, idempotent.data.channel_id);
-          if (dmAgentIds) {
-            runInBackground(c, fanoutToAgents(c, dmAgentIds, 'thread.reply', eventData), 'fanout dm thread.reply');
-          } else {
-            runInBackground(c, fanoutToChannel(c, idempotent.data.channel_id, 'thread.reply', eventData), 'fanout thread.reply');
-          }
+          const channelId = idempotent.data.channel_id;
+          runInBackground(
+            c,
+            (async () => {
+              const dmAgentIds = await getDmParticipantAgentIds(c, channelId);
+              if (dmAgentIds) {
+                await fanoutToAgents(c, dmAgentIds, 'thread.reply', eventData);
+              } else {
+                await fanoutToChannel(c, channelId, 'thread.reply', eventData);
+              }
+            })(),
+            'fanout thread.reply',
+          );
         }
 
         runInBackground(

--- a/packages/server/src/routes/thread.ts
+++ b/packages/server/src/routes/thread.ts
@@ -5,7 +5,7 @@ import { requireAuth } from '../middleware/auth.js';
 import { rateLimit } from '../middleware/rateLimit.js';
 import { parseIdempotencyKey, runIdempotent } from '../middleware/idempotency.js';
 import * as threadEngine from '../engine/thread.js';
-import { fanoutToChannel } from './fanout.js';
+import { fanoutToChannel, fanoutToAgents, getDmParticipantAgentIds } from './fanout.js';
 import { runInBackground } from './background.js';
 import { emitServerEvent } from '../lib/serverTelemetry.js';
 
@@ -78,7 +78,12 @@ threadRoutes.post(
       if (!idempotent.replayed) {
         const eventData = { ...idempotent.data, from_name: agent?.name };
         if (idempotent.data.channel_id) {
-          runInBackground(c, fanoutToChannel(c, idempotent.data.channel_id, 'thread.reply', eventData), 'fanout thread.reply');
+          const dmAgentIds = await getDmParticipantAgentIds(c, idempotent.data.channel_id);
+          if (dmAgentIds) {
+            runInBackground(c, fanoutToAgents(c, dmAgentIds, 'thread.reply', eventData), 'fanout dm thread.reply');
+          } else {
+            runInBackground(c, fanoutToChannel(c, idempotent.data.channel_id, 'thread.reply', eventData), 'fanout thread.reply');
+          }
         }
 
         runInBackground(

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -5,7 +5,7 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {
-    "build": "tsc",
+    "build": "rm -rf dist tsconfig.tsbuildinfo && tsc",
     "test": "vitest run",
     "lint": "eslint src/"
   },

--- a/packages/types/vitest.config.ts
+++ b/packages/types/vitest.config.ts
@@ -3,6 +3,7 @@ import { defineConfig } from 'vitest/config';
 export default defineConfig({
   test: {
     globals: true,
+    exclude: ['dist/**', 'node_modules/**'],
   },
 });
 


### PR DESCRIPTION
## Summary

- **DM thread replies and reactions never reached agents via WebSocket.** `fanoutToChannel()` broadcasts to a ChannelDO, but agents subscribe to named channels — not internal `dmch_*` channels. Added `getDmParticipantAgentIds()` helper that detects DM channels and routes events through `fanoutToAgents()` instead, delivering directly to agent Durable Objects.
- **Hardened `getDmParticipantAgentIds` with try/catch** so DB errors fall back to `fanoutToChannel` instead of crashing the response with 500 (the reply/reaction is already persisted at that point).
- **Fixed pre-existing build issues:** stale types `dist` artifacts breaking tests, missing vitest `exclude` for `dist/`, and implicit `any` types in react `MessageMarkdown.tsx`.

### Files changed
| File | Change |
|------|--------|
| `packages/server/src/routes/fanout.ts` | Added `getDmParticipantAgentIds()` helper |
| `packages/server/src/routes/thread.ts` | DM-aware fanout for `thread.reply` |
| `packages/server/src/routes/reaction.ts` | DM-aware fanout for `reaction.added` and `reaction.removed` |
| `packages/server/src/routes/__tests__/fanout.test.ts` | +4 tests (DM lookup, non-DM, empty participants, DB error) |
| `packages/server/src/routes/__tests__/thread.test.ts` | +3 tests (DM vs channel fanout, error fallback) |
| `packages/server/src/routes/__tests__/reaction.test.ts` | +2 tests (DM vs channel fanout) |
| `packages/types/package.json` | Clean build script |
| `packages/types/vitest.config.ts` | Exclude dist from vitest |
| `packages/react/src/components/MessageMarkdown.tsx` | Fix implicit any types |

## Test plan
- [x] All 360 server tests pass (up from 351)
- [x] Full monorepo build succeeds (7/7 packages)
- [x] Full monorepo test succeeds (13/13 tasks)
- [ ] Manual E2E: open DM between two agents, post thread reply → verify other agent receives `thread.reply` WS event
- [ ] Manual E2E: react to a DM message → verify other agent receives `reaction.added` WS event

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/agentworkforce/relaycast/pull/70" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
