### PR TITLE
mcp: heal stale preconfigured agent tokens on stdio startup

### DIFF
--- a/packages/mcp/src/__tests__/transports.test.ts
+++ b/packages/mcp/src/__tests__/transports.test.ts
@@ -1,0 +1,139 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const mocks = vi.hoisted(() => {
+  const connectMock = vi.fn().mockResolvedValue(undefined);
+  const createRelayMcpServerMock = vi.fn().mockReturnValue({
+    connect: connectMock,
+  });
+  const inboxMock = vi.fn();
+  const registerOrRotateMock = vi.fn();
+  const asMock = vi.fn(() => ({ inbox: inboxMock }));
+  const createInternalRelayCastMock = vi.fn(() => ({
+    as: asMock,
+    agents: {
+      registerOrRotate: registerOrRotateMock,
+    },
+  }));
+  return {
+    connectMock,
+    createRelayMcpServerMock,
+    inboxMock,
+    registerOrRotateMock,
+    asMock,
+    createInternalRelayCastMock,
+  };
+});
+
+vi.mock("@modelcontextprotocol/sdk/server/stdio.js", () => ({
+  StdioServerTransport: class {},
+}));
+
+vi.mock("@modelcontextprotocol/sdk/server/streamableHttp.js", () => ({
+  StreamableHTTPServerTransport: class {},
+}));
+
+vi.mock("./../server.js", () => ({
+  MCP_VERSION: "0.1.2",
+  createRelayMcpServer: mocks.createRelayMcpServerMock,
+}));
+
+vi.mock("@relaycast/sdk/internal", () => ({
+  createInternalRelayCast: mocks.createInternalRelayCastMock,
+}));
+
+vi.mock("./../telemetry.js", () => ({
+  createMcpTelemetry: () => ({ capture: vi.fn() }),
+}));
+
+vi.mock("@relaycast/sdk", () => ({
+  RelayError: class RelayError extends Error {
+    code?: string;
+    statusCode?: number;
+    constructor(
+      code: string,
+      message: string,
+      opts: { statusCode?: number } = {},
+    ) {
+      super(message);
+      this.code = code;
+      this.statusCode = opts.statusCode;
+    }
+  },
+}));
+
+import { startStdio } from "../transports.js";
+
+describe("startStdio bootstrap", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.inboxMock.mockResolvedValue({ unread: 0 });
+    mocks.registerOrRotateMock.mockResolvedValue({
+      name: "worker-1",
+      token: "at_live_fresh",
+    });
+  });
+
+  it("keeps an existing valid agent token", async () => {
+    await startStdio({
+      apiKey: "rk_live_workspace",
+      agentName: "worker-1",
+      agentToken: "at_live_existing",
+    });
+
+    expect(mocks.asMock).toHaveBeenCalledWith("at_live_existing");
+    expect(mocks.registerOrRotateMock).not.toHaveBeenCalled();
+    expect(mocks.createRelayMcpServerMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        agentToken: "at_live_existing",
+        agentName: "worker-1",
+        telemetryTransport: "stdio",
+      }),
+    );
+  });
+
+  it("rotates a stale agent token when validation returns unauthorized", async () => {
+    mocks.inboxMock.mockRejectedValue({
+      code: "unauthorized",
+      statusCode: 401,
+    });
+
+    await startStdio({
+      apiKey: "rk_live_workspace",
+      agentName: "worker-1",
+      agentToken: "at_live_stale",
+      agentType: "agent",
+    });
+
+    expect(mocks.registerOrRotateMock).toHaveBeenCalledWith({
+      name: "worker-1",
+      type: "agent",
+    });
+    expect(mocks.createRelayMcpServerMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        agentToken: "at_live_fresh",
+        agentName: "worker-1",
+        telemetryTransport: "stdio",
+      }),
+    );
+  });
+
+  it("registers or rotates when only workspace key and agent name are provided", async () => {
+    await startStdio({
+      apiKey: "rk_live_workspace",
+      agentName: "worker-1",
+    });
+
+    expect(mocks.asMock).not.toHaveBeenCalled();
+    expect(mocks.registerOrRotateMock).toHaveBeenCalledWith({
+      name: "worker-1",
+      type: undefined,
+    });
+    expect(mocks.createRelayMcpServerMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        agentToken: "at_live_fresh",
+        agentName: "worker-1",
+        telemetryTransport: "stdio",
+      }),
+    );
+  });
+});

--- a/packages/mcp/src/stdio.ts
+++ b/packages/mcp/src/stdio.ts
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-import { startStdio } from './transports.js';
+import { startStdio } from "./transports.js";
 
 /**
  * Resolve the Relaycast API key from RELAY_API_KEY env var.
@@ -12,13 +12,20 @@ function resolveApiKey(): string | undefined {
 function parseStrictAgentName(value: string | undefined): boolean {
   if (!value) return false;
   const normalized = value.trim().toLowerCase();
-  return normalized === '1' || normalized === 'true' || normalized === 'yes' || normalized === 'on';
+  return (
+    normalized === "1" ||
+    normalized === "true" ||
+    normalized === "yes" ||
+    normalized === "on"
+  );
 }
 
-function parseAgentType(value: string | undefined): 'agent' | 'human' | undefined {
+function parseAgentType(
+  value: string | undefined,
+): "agent" | "human" | undefined {
   if (!value) return undefined;
   const normalized = value.trim().toLowerCase();
-  if (normalized === 'agent' || normalized === 'human') {
+  if (normalized === "agent" || normalized === "human") {
     return normalized;
   }
   return undefined;
@@ -28,7 +35,7 @@ startStdio({
   apiKey: resolveApiKey(),
   baseUrl: process.env.RELAY_BASE_URL,
   agentToken: process.env.RELAY_AGENT_TOKEN,
-  agentName: process.env.RELAY_AGENT_NAME,
+  agentName: process.env.RELAY_AGENT_NAME ?? process.env.RELAY_CLAW_NAME,
   agentType: parseAgentType(process.env.RELAY_AGENT_TYPE),
   strictAgentName: parseStrictAgentName(process.env.RELAY_STRICT_AGENT_NAME),
 });

--- a/packages/mcp/src/transports.ts
+++ b/packages/mcp/src/transports.ts
@@ -1,15 +1,72 @@
-import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
-import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
-import { createRelayMcpServer, MCP_VERSION, type McpServerOptions } from './server.js';
-import { randomUUID } from 'node:crypto';
-import { createMcpTelemetry } from './telemetry.js';
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
+import { createInternalRelayCast } from "@relaycast/sdk/internal";
+import { RelayError } from "@relaycast/sdk";
+import {
+  createRelayMcpServer,
+  MCP_VERSION,
+  type McpServerOptions,
+} from "./server.js";
+import { randomUUID } from "node:crypto";
+import { createMcpTelemetry } from "./telemetry.js";
+
+async function resolveStdioBootstrapOptions(
+  options: McpServerOptions,
+): Promise<McpServerOptions> {
+  if (!options.apiKey || !options.agentName) {
+    return options;
+  }
+
+  const relay = createInternalRelayCast(
+    {
+      apiKey: options.apiKey,
+      baseUrl: options.baseUrl,
+    },
+    {
+      surface: "mcp",
+      client: "@relaycast/mcp",
+      version: MCP_VERSION,
+    },
+  );
+
+  if (options.agentToken) {
+    try {
+      await relay.as(options.agentToken).inbox();
+      return options;
+    } catch (err) {
+      const relayErr = err as Partial<RelayError> | undefined;
+      const unauthorized =
+        relayErr?.code === "unauthorized" ||
+        relayErr?.statusCode === 401 ||
+        relayErr?.statusCode === 403;
+      if (!unauthorized) {
+        throw err;
+      }
+    }
+  }
+
+  const registered = await relay.agents.registerOrRotate({
+    name: options.agentName,
+    type: options.agentType,
+  });
+
+  return {
+    ...options,
+    agentToken: registered.token,
+    agentName: registered.name ?? options.agentName,
+  };
+}
 
 /**
  * Start MCP server with stdio transport (single agent).
  * Reads from stdin, writes to stdout.
  */
 export async function startStdio(options: McpServerOptions): Promise<void> {
-  const mcpServer = createRelayMcpServer({ ...options, telemetryTransport: 'stdio' });
+  const bootstrappedOptions = await resolveStdioBootstrapOptions(options);
+  const mcpServer = createRelayMcpServer({
+    ...bootstrappedOptions,
+    telemetryTransport: "stdio",
+  });
   const transport = new StdioServerTransport();
   await mcpServer.connect(transport);
 }
@@ -27,23 +84,29 @@ export interface SessionLifecycle {
  * Session map for HTTP transport (multi-agent).
  * Each session gets its own MCP server + transport + telemetry instance.
  */
-const sessions = new Map<string, { transport: StreamableHTTPServerTransport }>();
+const sessions = new Map<
+  string,
+  { transport: StreamableHTTPServerTransport }
+>();
 
 /**
  * Create Express middleware for HTTP+SSE transport (multi-agent).
  * Each connecting client gets its own session with isolated state and telemetry.
  */
-export function createHttpHandler(baseOptions: McpServerOptions, lifecycle?: SessionLifecycle) {
+export function createHttpHandler(
+  baseOptions: McpServerOptions,
+  lifecycle?: SessionLifecycle,
+) {
   return {
     /** Check whether a session ID is owned by this process. */
     hasSession: (sessionId: string) => sessions.has(sessionId),
 
     handleRequest: async (
-      req: import('node:http').IncomingMessage,
-      res: import('node:http').ServerResponse,
+      req: import("node:http").IncomingMessage,
+      res: import("node:http").ServerResponse,
     ) => {
       // Check for existing session
-      const sessionId = req.headers['mcp-session-id'] as string | undefined;
+      const sessionId = req.headers["mcp-session-id"] as string | undefined;
 
       if (sessionId && sessions.has(sessionId)) {
         const session = sessions.get(sessionId)!;
@@ -53,8 +116,8 @@ export function createHttpHandler(baseOptions: McpServerOptions, lifecycle?: Ses
 
       // New session — create fresh MCP server + transport + telemetry
       const telemetry = createMcpTelemetry(MCP_VERSION, {
-        originSurface: 'mcp',
-        originClient: '@relaycast/mcp',
+        originSurface: "mcp",
+        originClient: "@relaycast/mcp",
         originVersion: MCP_VERSION,
       });
 
@@ -64,7 +127,7 @@ export function createHttpHandler(baseOptions: McpServerOptions, lifecycle?: Ses
 
       const mcpServer = createRelayMcpServer({
         ...baseOptions,
-        telemetryTransport: 'http',
+        telemetryTransport: "http",
         telemetry,
       });
 
@@ -84,9 +147,9 @@ export function createHttpHandler(baseOptions: McpServerOptions, lifecycle?: Ses
       if (transport.sessionId && !sessions.has(transport.sessionId)) {
         sessions.set(transport.sessionId, { transport });
         lifecycle?.onCreated?.(transport.sessionId);
-        telemetry.capture('relaycast_mcp_http_session_started', {
-          source_surface: 'mcp',
-          transport: 'http',
+        telemetry.capture("relaycast_mcp_http_session_started", {
+          source_surface: "mcp",
+          transport: "http",
           mcp_transport_session_id: transport.sessionId,
         });
       }


### PR DESCRIPTION
## Summary
- validate the preconfigured MCP agent token on stdio startup instead of blindly trusting it
- auto-heal stale/unauthorized tokens by calling `registerOrRotate` when the workspace key + agent name are available
- accept `RELAY_CLAW_NAME` as an alias for `RELAY_AGENT_NAME`
- add tests covering valid token reuse, stale token rotation, and name-only bootstrap

## Why
We hit a confusing partial-success state in a real OpenClaw + Relaycast setup:
- workspace key/config was valid
- `list_agents` worked
- inbound messages injected correctly
- but `post_message` / `reply_to_thread` failed because the preconfigured `RELAY_AGENT_TOKEN` was stale/unauthorized

The MCP stdio process was trusting that token forever. This change makes startup defensive:
- if the token still works, keep it
- if it fails auth and we know the intended agent name, self-heal by rotating/refreshing it

## Notes
This is the Relaycast-side half of the fix. The companion OpenClaw-side change should ensure setup passes the agent name through to the MCP environment so this startup healing has the identity it needs.

## Validation
- `npm exec vitest -- run packages/mcp/src/__tests__/transports.test.ts`

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/agentworkforce/relaycast/pull/73" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
