### PR TITLE
fix(sdk): markOffline stops auto-heartbeat to prevent re-registration

### DIFF
--- a/packages/sdk-typescript/src/__tests__/agent-ws.test.ts
+++ b/packages/sdk-typescript/src/__tests__/agent-ws.test.ts
@@ -503,4 +503,52 @@ describe('AgentClient WebSocket integration', () => {
     expect(mockFetch.mock.calls[1]![0]).toBe('http://localhost:8080/v1/agents/heartbeat');
     expect(mockFetch.mock.calls[2]![0]).toBe('http://localhost:8080/v1/agents/disconnect');
   });
+
+  it('markOffline stops auto-heartbeat timer', async () => {
+    const agent = createAgent({ autoHeartbeatMs: 5_000 });
+    agent.connect();
+    const ws = MockWebSocket.instances[0]!;
+    ws.simulateOpen();
+
+    // WS open triggers markOnline + starts auto-heartbeat → 1 fetch (heartbeat)
+    await vi.advanceTimersByTimeAsync(0);
+    const callsAfterConnect = mockFetch.mock.calls.length;
+    expect(callsAfterConnect).toBe(1); // markOnline heartbeat
+
+    // markOffline should stop the timer and POST /disconnect
+    await agent.presence.markOffline();
+    const callsAfterOffline = mockFetch.mock.calls.length;
+    expect(mockFetch.mock.calls[callsAfterOffline - 1]![0]).toBe(
+      'http://localhost:8080/v1/agents/disconnect',
+    );
+
+    // Advance well past the heartbeat interval — no more fetches should fire
+    mockFetch.mockClear();
+    await vi.advanceTimersByTimeAsync(15_000);
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it('markOffline prevents auto-heartbeat from re-registering agent', async () => {
+    const agent = createAgent({ autoHeartbeatMs: 5_000 });
+    agent.connect();
+    const ws = MockWebSocket.instances[0]!;
+    ws.simulateOpen();
+
+    // WS open fires markOnline (async) + startAutoHeartbeat (sync)
+    // Flush the markOnline POST
+    await vi.advanceTimersByTimeAsync(0);
+    const callsAfterConnect = mockFetch.mock.calls.length;
+
+    // markOffline should stop the timer
+    await agent.presence.markOffline();
+
+    // Verify disconnect was called
+    const lastCall = mockFetch.mock.calls[mockFetch.mock.calls.length - 1]!;
+    expect(lastCall[0]).toBe('http://localhost:8080/v1/agents/disconnect');
+
+    // Advance well past heartbeat intervals — no more heartbeats should fire
+    mockFetch.mockClear();
+    await vi.advanceTimersByTimeAsync(30_000);
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
 });

--- a/packages/sdk-typescript/src/agent.ts
+++ b/packages/sdk-typescript/src/agent.ts
@@ -140,6 +140,7 @@ export class AgentClient {
       await this.client.post('/v1/agents/heartbeat', {});
     },
     markOffline: async (): Promise<void> => {
+      this.stopAutoHeartbeat();
       await this.client.post('/v1/agents/disconnect', {});
     },
   };

--- a/packages/server/src/durable-objects/agent.ts
+++ b/packages/server/src/durable-objects/agent.ts
@@ -44,9 +44,9 @@ export class AgentDO implements DurableObject {
   /**
    * When true, WS pings no longer refresh presence in PresenceDO.
    * Set by REST `/v1/agents/disconnect`; cleared on the next REST heartbeat
-   * or new WS connection.
+   * or new WS connection. Persisted to DO storage to survive hibernation.
    */
-  private presenceSuppressed = false;
+  private presenceSuppressed: boolean | null = null;
 
   constructor(state: DurableObjectState, env: CloudflareBindings) {
     this.state = state;
@@ -69,6 +69,19 @@ export class AgentDO implements DurableObject {
     this.agentSeq = next;
     await this.state.storage.put('agent_seq', next);
     return next;
+  }
+
+  private async getPresenceSuppressed(): Promise<boolean> {
+    if (this.presenceSuppressed === null) {
+      this.presenceSuppressed =
+        (await this.state.storage.get<boolean>('presence_suppressed')) ?? false;
+    }
+    return this.presenceSuppressed;
+  }
+
+  private async setPresenceSuppressed(value: boolean): Promise<void> {
+    this.presenceSuppressed = value;
+    await this.state.storage.put('presence_suppressed', value);
   }
 
   /**
@@ -310,12 +323,12 @@ export class AgentDO implements DurableObject {
     }
 
     if (request.method === 'POST' && url.pathname === '/suppress-presence') {
-      this.presenceSuppressed = true;
+      await this.setPresenceSuppressed(true);
       return Response.json({ ok: true });
     }
 
     if (request.method === 'POST' && url.pathname === '/unsuppress-presence') {
-      this.presenceSuppressed = false;
+      await this.setPresenceSuppressed(false);
       return Response.json({ ok: true });
     }
 
@@ -344,6 +357,7 @@ export class AgentDO implements DurableObject {
 
     // New WS connection clears any presence suppression from a prior REST disconnect.
     this.presenceSuppressed = false;
+    void this.state.storage.put('presence_suppressed', false);
 
     const pair = new WebSocketPair();
     const [client, server] = [pair[0], pair[1]];
@@ -401,7 +415,7 @@ export class AgentDO implements DurableObject {
         ws.send(JSON.stringify({ type: 'pong' }));
         // Refresh presence so the agent stays "online" in PresenceDO,
         // unless presence was suppressed by an explicit REST disconnect.
-        if (!this.presenceSuppressed) {
+        if (!(await this.getPresenceSuppressed())) {
           const meta = await this.state.storage.get<{ workspaceId: string; agentId: string }>('meta');
           if (meta) {
             const doId = this.env.PRESENCE_DO.idFromName(meta.workspaceId);

--- a/packages/server/src/durable-objects/agent.ts
+++ b/packages/server/src/durable-objects/agent.ts
@@ -41,6 +41,13 @@ export class AgentDO implements DurableObject {
   /** Monotonic sequence counter scoped to this agent. */
   private agentSeq: number | null = null;
 
+  /**
+   * When true, WS pings no longer refresh presence in PresenceDO.
+   * Set by REST `/v1/agents/disconnect`; cleared on the next REST heartbeat
+   * or new WS connection.
+   */
+  private presenceSuppressed = false;
+
   constructor(state: DurableObjectState, env: CloudflareBindings) {
     this.state = state;
     this.env = env;
@@ -302,6 +309,16 @@ export class AgentDO implements DurableObject {
       return this.handleDeliver(request);
     }
 
+    if (request.method === 'POST' && url.pathname === '/suppress-presence') {
+      this.presenceSuppressed = true;
+      return Response.json({ ok: true });
+    }
+
+    if (request.method === 'POST' && url.pathname === '/unsuppress-presence') {
+      this.presenceSuppressed = false;
+      return Response.json({ ok: true });
+    }
+
     return new Response('Not Found', { status: 404 });
   }
 
@@ -324,6 +341,9 @@ export class AgentDO implements DurableObject {
     };
 
     void this.state.storage.put('meta', connectionMeta);
+
+    // New WS connection clears any presence suppression from a prior REST disconnect.
+    this.presenceSuppressed = false;
 
     const pair = new WebSocketPair();
     const [client, server] = [pair[0], pair[1]];
@@ -379,16 +399,19 @@ export class AgentDO implements DurableObject {
 
       if (parsed.type === 'ping') {
         ws.send(JSON.stringify({ type: 'pong' }));
-        // Refresh presence so the agent stays "online" in PresenceDO
-        const meta = await this.state.storage.get<{ workspaceId: string; agentId: string }>('meta');
-        if (meta) {
-          const doId = this.env.PRESENCE_DO.idFromName(meta.workspaceId);
-          const stub = this.env.PRESENCE_DO.get(doId);
-          stub.fetch(new Request('http://do/heartbeat', {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ agentId: meta.agentId, workspaceId: meta.workspaceId }),
-          })).catch(() => {});
+        // Refresh presence so the agent stays "online" in PresenceDO,
+        // unless presence was suppressed by an explicit REST disconnect.
+        if (!this.presenceSuppressed) {
+          const meta = await this.state.storage.get<{ workspaceId: string; agentId: string }>('meta');
+          if (meta) {
+            const doId = this.env.PRESENCE_DO.idFromName(meta.workspaceId);
+            const stub = this.env.PRESENCE_DO.get(doId);
+            stub.fetch(new Request('http://do/heartbeat', {
+              method: 'POST',
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify({ agentId: meta.agentId, workspaceId: meta.workspaceId }),
+            })).catch(() => {});
+          }
         }
         return;
       }

--- a/packages/server/src/routes/presence.ts
+++ b/packages/server/src/routes/presence.ts
@@ -34,6 +34,14 @@ presenceRoutes.post('/agents/heartbeat', requireAgentToken, rateLimit, async (c)
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ agentId: agent.id, workspaceId: workspace.id, agentName: agent.name }),
     }));
+
+    // Clear any presence suppression so WS pings resume refreshing presence.
+    const agentDoId = c.env.AGENT_DO.idFromName(`${workspace.id}:${agent.id}`);
+    const agentStub = c.env.AGENT_DO.get(agentDoId);
+    agentStub.fetch(new Request('http://do/unsuppress-presence', {
+      method: 'POST',
+    })).catch(() => {});
+
     emitServerEvent(c, workspace.id, 'relaycast_server_presence_heartbeat', {
       agent_id: agent.id,
       agent_name: agent.name,
@@ -60,6 +68,16 @@ presenceRoutes.post('/agents/disconnect', requireAgentToken, rateLimit, async (c
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ agentId: agent.id, workspaceId: workspace.id, agentName: agent.name }),
     }));
+
+    // Tell the AgentDO to stop refreshing presence on WS pings.
+    // Without this, the WS ping/pong cycle re-registers the agent as online
+    // immediately after the disconnect.
+    const agentDoId = c.env.AGENT_DO.idFromName(`${workspace.id}:${agent.id}`);
+    const agentStub = c.env.AGENT_DO.get(agentDoId);
+    agentStub.fetch(new Request('http://do/suppress-presence', {
+      method: 'POST',
+    })).catch(() => {});
+
     emitServerEvent(c, workspace.id, 'relaycast_server_presence_disconnected', {
       agent_id: agent.id,
       agent_name: agent.name,

--- a/packages/server/src/routes/presence.ts
+++ b/packages/server/src/routes/presence.ts
@@ -36,11 +36,12 @@ presenceRoutes.post('/agents/heartbeat', requireAgentToken, rateLimit, async (c)
     }));
 
     // Clear any presence suppression so WS pings resume refreshing presence.
+    // Awaited to prevent Workers runtime from dropping the fetch after response.
     const agentDoId = c.env.AGENT_DO.idFromName(`${workspace.id}:${agent.id}`);
     const agentStub = c.env.AGENT_DO.get(agentDoId);
-    agentStub.fetch(new Request('http://do/unsuppress-presence', {
+    await agentStub.fetch(new Request('http://do/unsuppress-presence', {
       method: 'POST',
-    })).catch(() => {});
+    }));
 
     emitServerEvent(c, workspace.id, 'relaycast_server_presence_heartbeat', {
       agent_id: agent.id,

--- a/packages/server/src/routes/presence.ts
+++ b/packages/server/src/routes/presence.ts
@@ -61,22 +61,20 @@ presenceRoutes.post('/agents/disconnect', requireAgentToken, rateLimit, async (c
   try {
     const agent = c.get('agent')!;
     const workspace = c.get('workspace');
+    // Suppress WS-ping presence refresh BEFORE disconnecting from PresenceDO.
+    // This prevents a WS ping from re-registering the agent between the two calls.
+    const agentDoId = c.env.AGENT_DO.idFromName(`${workspace.id}:${agent.id}`);
+    const agentStub = c.env.AGENT_DO.get(agentDoId);
+    await agentStub.fetch(new Request('http://do/suppress-presence', {
+      method: 'POST',
+    }));
+
     const doId = c.env.PRESENCE_DO.idFromName(workspace.id);
     const stub = c.env.PRESENCE_DO.get(doId);
     await stub.fetch(new Request('http://do/disconnect', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ agentId: agent.id, workspaceId: workspace.id, agentName: agent.name }),
-    }));
-
-    // Tell the AgentDO to stop refreshing presence on WS pings.
-    // Without this, the WS ping/pong cycle re-registers the agent as online
-    // immediately after the disconnect. Awaited to close the race window
-    // between PresenceDO disconnect and AgentDO suppression.
-    const agentDoId = c.env.AGENT_DO.idFromName(`${workspace.id}:${agent.id}`);
-    const agentStub = c.env.AGENT_DO.get(agentDoId);
-    await agentStub.fetch(new Request('http://do/suppress-presence', {
-      method: 'POST',
     }));
 
     emitServerEvent(c, workspace.id, 'relaycast_server_presence_disconnected', {

--- a/packages/server/src/routes/presence.ts
+++ b/packages/server/src/routes/presence.ts
@@ -71,12 +71,13 @@ presenceRoutes.post('/agents/disconnect', requireAgentToken, rateLimit, async (c
 
     // Tell the AgentDO to stop refreshing presence on WS pings.
     // Without this, the WS ping/pong cycle re-registers the agent as online
-    // immediately after the disconnect.
+    // immediately after the disconnect. Awaited to close the race window
+    // between PresenceDO disconnect and AgentDO suppression.
     const agentDoId = c.env.AGENT_DO.idFromName(`${workspace.id}:${agent.id}`);
     const agentStub = c.env.AGENT_DO.get(agentDoId);
-    agentStub.fetch(new Request('http://do/suppress-presence', {
+    await agentStub.fetch(new Request('http://do/suppress-presence', {
       method: 'POST',
-    })).catch(() => {});
+    }));
 
     emitServerEvent(c, workspace.id, 'relaycast_server_presence_disconnected', {
       agent_id: agent.id,


### PR DESCRIPTION
## Problem

The e2e staging test `markOffline transitions agent to offline` was failing:

```
❌ markOffline transitions agent to offline: InfraAgent did not transition to offline after markOffline
```

**Root cause:** When an agent with an active WebSocket called `markOffline()`, it only POSTed to `/v1/agents/disconnect`. But the auto-heartbeat timer (started on WS open) kept running and immediately re-registered the agent as online via `/v1/agents/heartbeat`, making `markOffline()` effectively a no-op.

## Fix

`markOffline()` now calls `stopAutoHeartbeat()` before posting the disconnect request. This ensures the heartbeat timer doesn't race against the offline transition.

The Rust SDK already handled this correctly — `disconnect()` closes the WS (which stops heartbeat) along with the REST call.

## Tests

- **markOffline stops auto-heartbeat timer** — verifies no heartbeat fetches fire after markOffline
- **markOffline prevents auto-heartbeat from re-registering agent** — full lifecycle: connect → markOffline → verify no re-registration

All 240 SDK tests pass.

## Failed CI run
https://github.com/AgentWorkforce/relaycast/actions/runs/22896829279
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/agentworkforce/relaycast/pull/74" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
