### PR TITLE
fix: allow duplicate workspace names

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ Relaycast is the messaging backbone:
 
 ## Core Concepts
 
-- Workspace: isolated environment for one project/team
+- Workspace: isolated environment for one project/team; names are labels and do not need to be globally unique
 - Workspace key (`rk_live_*`): admin token for managing workspace resources
 - Agent token (`at_live_*`): token an individual agent uses to participate
 - Identity types: `agent` (AI worker), `human` (person), `system` (automation/service actor)

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -265,7 +265,7 @@ paths:
   /workspaces:
     post:
       summary: Create workspace
-      description: Create a new workspace and get an API key
+      description: Create a new workspace and get an API key. Workspace names are not globally unique.
       tags:
         - Workspaces
       requestBody:

--- a/packages/sdk-typescript/src/__tests__/agent-ws.test.ts
+++ b/packages/sdk-typescript/src/__tests__/agent-ws.test.ts
@@ -503,4 +503,52 @@ describe('AgentClient WebSocket integration', () => {
     expect(mockFetch.mock.calls[1]![0]).toBe('http://localhost:8080/v1/agents/heartbeat');
     expect(mockFetch.mock.calls[2]![0]).toBe('http://localhost:8080/v1/agents/disconnect');
   });
+
+  it('markOffline stops auto-heartbeat timer', async () => {
+    const agent = createAgent({ autoHeartbeatMs: 5_000 });
+    agent.connect();
+    const ws = MockWebSocket.instances[0]!;
+    ws.simulateOpen();
+
+    // WS open triggers markOnline + starts auto-heartbeat → 1 fetch (heartbeat)
+    await vi.advanceTimersByTimeAsync(0);
+    const callsAfterConnect = mockFetch.mock.calls.length;
+    expect(callsAfterConnect).toBe(1); // markOnline heartbeat
+
+    // markOffline should stop the timer and POST /disconnect
+    await agent.presence.markOffline();
+    const callsAfterOffline = mockFetch.mock.calls.length;
+    expect(mockFetch.mock.calls[callsAfterOffline - 1]![0]).toBe(
+      'http://localhost:8080/v1/agents/disconnect',
+    );
+
+    // Advance well past the heartbeat interval — no more fetches should fire
+    mockFetch.mockClear();
+    await vi.advanceTimersByTimeAsync(15_000);
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it('markOffline prevents auto-heartbeat from re-registering agent', async () => {
+    const agent = createAgent({ autoHeartbeatMs: 5_000 });
+    agent.connect();
+    const ws = MockWebSocket.instances[0]!;
+    ws.simulateOpen();
+
+    // WS open fires markOnline (async) + startAutoHeartbeat (sync)
+    // Flush the markOnline POST
+    await vi.advanceTimersByTimeAsync(0);
+    const callsAfterConnect = mockFetch.mock.calls.length;
+
+    // markOffline should stop the timer
+    await agent.presence.markOffline();
+
+    // Verify disconnect was called
+    const lastCall = mockFetch.mock.calls[mockFetch.mock.calls.length - 1]!;
+    expect(lastCall[0]).toBe('http://localhost:8080/v1/agents/disconnect');
+
+    // Advance well past heartbeat intervals — no more heartbeats should fire
+    mockFetch.mockClear();
+    await vi.advanceTimersByTimeAsync(30_000);
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
 });

--- a/packages/sdk-typescript/src/agent.ts
+++ b/packages/sdk-typescript/src/agent.ts
@@ -140,6 +140,7 @@ export class AgentClient {
       await this.client.post('/v1/agents/heartbeat', {});
     },
     markOffline: async (): Promise<void> => {
+      this.stopAutoHeartbeat();
       await this.client.post('/v1/agents/disconnect', {});
     },
   };

--- a/packages/server/src/db/migrations/0003_workspace_name_not_globally_unique.sql
+++ b/packages/server/src/db/migrations/0003_workspace_name_not_globally_unique.sql
@@ -1,0 +1,4 @@
+-- Workspace names are labels and do not need to be globally unique.
+-- Keep api_key_hash globally unique for authentication.
+
+DROP INDEX IF EXISTS workspaces_name_unique;

--- a/packages/server/src/db/schema.ts
+++ b/packages/server/src/db/schema.ts
@@ -14,7 +14,7 @@ import type { AnySQLiteColumn } from 'drizzle-orm/sqlite-core';
 // ============================================
 export const workspaces = sqliteTable('workspaces', {
   id: text('id').primaryKey(),
-  name: text('name').notNull().unique(),
+  name: text('name').notNull(),
   apiKeyHash: text('api_key_hash').notNull().unique(),
   systemPrompt: text('system_prompt'),
   plan: text('plan').notNull().default('free'),

--- a/packages/server/src/durable-objects/agent.ts
+++ b/packages/server/src/durable-objects/agent.ts
@@ -44,9 +44,9 @@ export class AgentDO implements DurableObject {
   /**
    * When true, WS pings no longer refresh presence in PresenceDO.
    * Set by REST `/v1/agents/disconnect`; cleared on the next REST heartbeat
-   * or new WS connection.
+   * or new WS connection. Persisted to DO storage to survive hibernation.
    */
-  private presenceSuppressed = false;
+  private presenceSuppressed: boolean | null = null;
 
   constructor(state: DurableObjectState, env: CloudflareBindings) {
     this.state = state;
@@ -69,6 +69,19 @@ export class AgentDO implements DurableObject {
     this.agentSeq = next;
     await this.state.storage.put('agent_seq', next);
     return next;
+  }
+
+  private async getPresenceSuppressed(): Promise<boolean> {
+    if (this.presenceSuppressed === null) {
+      this.presenceSuppressed =
+        (await this.state.storage.get<boolean>('presence_suppressed')) ?? false;
+    }
+    return this.presenceSuppressed;
+  }
+
+  private async setPresenceSuppressed(value: boolean): Promise<void> {
+    this.presenceSuppressed = value;
+    await this.state.storage.put('presence_suppressed', value);
   }
 
   /**
@@ -310,12 +323,12 @@ export class AgentDO implements DurableObject {
     }
 
     if (request.method === 'POST' && url.pathname === '/suppress-presence') {
-      this.presenceSuppressed = true;
+      await this.setPresenceSuppressed(true);
       return Response.json({ ok: true });
     }
 
     if (request.method === 'POST' && url.pathname === '/unsuppress-presence') {
-      this.presenceSuppressed = false;
+      await this.setPresenceSuppressed(false);
       return Response.json({ ok: true });
     }
 
@@ -344,6 +357,7 @@ export class AgentDO implements DurableObject {
 
     // New WS connection clears any presence suppression from a prior REST disconnect.
     this.presenceSuppressed = false;
+    void this.state.storage.put('presence_suppressed', false);
 
     const pair = new WebSocketPair();
     const [client, server] = [pair[0], pair[1]];
@@ -401,7 +415,7 @@ export class AgentDO implements DurableObject {
         ws.send(JSON.stringify({ type: 'pong' }));
         // Refresh presence so the agent stays "online" in PresenceDO,
         // unless presence was suppressed by an explicit REST disconnect.
-        if (!this.presenceSuppressed) {
+        if (!(await this.getPresenceSuppressed())) {
           const meta = await this.state.storage.get<{ workspaceId: string; agentId: string }>('meta');
           if (meta) {
             const doId = this.env.PRESENCE_DO.idFromName(meta.workspaceId);

--- a/packages/server/src/durable-objects/agent.ts
+++ b/packages/server/src/durable-objects/agent.ts
@@ -41,6 +41,13 @@ export class AgentDO implements DurableObject {
   /** Monotonic sequence counter scoped to this agent. */
   private agentSeq: number | null = null;
 
+  /**
+   * When true, WS pings no longer refresh presence in PresenceDO.
+   * Set by REST `/v1/agents/disconnect`; cleared on the next REST heartbeat
+   * or new WS connection.
+   */
+  private presenceSuppressed = false;
+
   constructor(state: DurableObjectState, env: CloudflareBindings) {
     this.state = state;
     this.env = env;
@@ -302,6 +309,16 @@ export class AgentDO implements DurableObject {
       return this.handleDeliver(request);
     }
 
+    if (request.method === 'POST' && url.pathname === '/suppress-presence') {
+      this.presenceSuppressed = true;
+      return Response.json({ ok: true });
+    }
+
+    if (request.method === 'POST' && url.pathname === '/unsuppress-presence') {
+      this.presenceSuppressed = false;
+      return Response.json({ ok: true });
+    }
+
     return new Response('Not Found', { status: 404 });
   }
 
@@ -324,6 +341,9 @@ export class AgentDO implements DurableObject {
     };
 
     void this.state.storage.put('meta', connectionMeta);
+
+    // New WS connection clears any presence suppression from a prior REST disconnect.
+    this.presenceSuppressed = false;
 
     const pair = new WebSocketPair();
     const [client, server] = [pair[0], pair[1]];
@@ -379,16 +399,19 @@ export class AgentDO implements DurableObject {
 
       if (parsed.type === 'ping') {
         ws.send(JSON.stringify({ type: 'pong' }));
-        // Refresh presence so the agent stays "online" in PresenceDO
-        const meta = await this.state.storage.get<{ workspaceId: string; agentId: string }>('meta');
-        if (meta) {
-          const doId = this.env.PRESENCE_DO.idFromName(meta.workspaceId);
-          const stub = this.env.PRESENCE_DO.get(doId);
-          stub.fetch(new Request('http://do/heartbeat', {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ agentId: meta.agentId, workspaceId: meta.workspaceId }),
-          })).catch(() => {});
+        // Refresh presence so the agent stays "online" in PresenceDO,
+        // unless presence was suppressed by an explicit REST disconnect.
+        if (!this.presenceSuppressed) {
+          const meta = await this.state.storage.get<{ workspaceId: string; agentId: string }>('meta');
+          if (meta) {
+            const doId = this.env.PRESENCE_DO.idFromName(meta.workspaceId);
+            const stub = this.env.PRESENCE_DO.get(doId);
+            stub.fetch(new Request('http://do/heartbeat', {
+              method: 'POST',
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify({ agentId: meta.agentId, workspaceId: meta.workspaceId }),
+            })).catch(() => {});
+          }
         }
         return;
       }

--- a/packages/server/src/engine/__tests__/workspace.test.ts
+++ b/packages/server/src/engine/__tests__/workspace.test.ts
@@ -1,0 +1,43 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../snowflake.js', () => ({
+  generateId: vi.fn()
+    .mockReturnValueOnce('ws_new')
+    .mockReturnValueOnce('ch_general'),
+}));
+
+import { createWorkspace } from '../workspace.js';
+
+describe('workspace engine', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('creates duplicate workspace names without preflight lookup', async () => {
+    const returning = vi.fn().mockResolvedValue([
+      {
+        id: 'ws_new',
+        name: 'my-project',
+        apiKeyHash: 'hash',
+        systemPrompt: null,
+        plan: 'free',
+        createdAt: new Date('2026-03-10T00:00:00.000Z'),
+        metadata: {},
+      },
+    ]);
+    const workspaceInsertValues = vi.fn().mockReturnValue({ returning });
+    const channelInsertValues = vi.fn().mockResolvedValue(undefined);
+    const insert = vi.fn()
+      .mockReturnValueOnce({ values: workspaceInsertValues })
+      .mockReturnValueOnce({ values: channelInsertValues });
+    const select = vi.fn();
+
+    const result = await createWorkspace({ insert, select } as any, 'my-project');
+
+    expect(select).not.toHaveBeenCalled();
+    expect(insert).toHaveBeenCalledTimes(2);
+    expect(result.workspace_id).toBe('ws_new');
+    expect(result.api_key).toMatch(/^rk_live_/);
+    expect(result.created_at).toBe('2026-03-10T00:00:00.000Z');
+  });
+});

--- a/packages/server/src/engine/workspace.ts
+++ b/packages/server/src/engine/workspace.ts
@@ -7,17 +7,6 @@ import { generateId } from './snowflake.js';
 type Db = ReturnType<typeof getDb>;
 
 export async function createWorkspace(db: Db, name: string) {
-  // Check for duplicate name
-  const [existing] = await db
-    .select()
-    .from(workspaces)
-    .where(eq(workspaces.name, name));
-  if (existing) {
-    const err = new Error(`Workspace "${name}" already exists`);
-    Object.assign(err, { code: 'workspace_already_exists', status: 409 });
-    throw err;
-  }
-
   const workspaceId = generateId();
   const apiKey = `rk_live_${crypto.randomBytes(16).toString('hex')}`;
   const apiKeyHash = crypto

--- a/packages/server/src/routes/__tests__/workspace.test.ts
+++ b/packages/server/src/routes/__tests__/workspace.test.ts
@@ -28,6 +28,7 @@ import { workspaceRoutes } from '../../routes/workspace.js';
 import * as activityEngine from '../../engine/activity.js';
 import * as dmAllEngine from '../../engine/dmAll.js';
 import * as tokenRotateEngine from '../../engine/tokenRotate.js';
+import * as workspaceEngine from '../../engine/workspace.js';
 import { getDb } from '../../db/index.js';
 import {
   mockDbForWorkspaceAuth,
@@ -51,6 +52,29 @@ app.route('/v1', v1);
 describe('Dashboard routes', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+  });
+
+  describe('POST /v1/workspaces', () => {
+    it('creates a workspace without route-level duplicate name checks', async () => {
+      vi.mocked(getDb).mockReturnValue(mockDbForWorkspaceAuth());
+      vi.spyOn(workspaceEngine, 'createWorkspace').mockResolvedValue({
+        workspace_id: 'ws_new',
+        api_key: 'rk_live_test',
+        created_at: '2026-03-10T00:00:00.000Z',
+      });
+
+      const res = await app.request('/v1/workspaces', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name: 'my-project' }),
+      });
+
+      expect(res.status).toBe(201);
+      expect(workspaceEngine.createWorkspace).toHaveBeenCalledWith(
+        expect.anything(),
+        'my-project',
+      );
+    });
   });
 
   describe('GET /v1/activity', () => {

--- a/packages/server/src/routes/presence.ts
+++ b/packages/server/src/routes/presence.ts
@@ -34,6 +34,14 @@ presenceRoutes.post('/agents/heartbeat', requireAgentToken, rateLimit, async (c)
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ agentId: agent.id, workspaceId: workspace.id, agentName: agent.name }),
     }));
+
+    // Clear any presence suppression so WS pings resume refreshing presence.
+    const agentDoId = c.env.AGENT_DO.idFromName(`${workspace.id}:${agent.id}`);
+    const agentStub = c.env.AGENT_DO.get(agentDoId);
+    agentStub.fetch(new Request('http://do/unsuppress-presence', {
+      method: 'POST',
+    })).catch(() => {});
+
     emitServerEvent(c, workspace.id, 'relaycast_server_presence_heartbeat', {
       agent_id: agent.id,
       agent_name: agent.name,
@@ -60,6 +68,16 @@ presenceRoutes.post('/agents/disconnect', requireAgentToken, rateLimit, async (c
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ agentId: agent.id, workspaceId: workspace.id, agentName: agent.name }),
     }));
+
+    // Tell the AgentDO to stop refreshing presence on WS pings.
+    // Without this, the WS ping/pong cycle re-registers the agent as online
+    // immediately after the disconnect.
+    const agentDoId = c.env.AGENT_DO.idFromName(`${workspace.id}:${agent.id}`);
+    const agentStub = c.env.AGENT_DO.get(agentDoId);
+    agentStub.fetch(new Request('http://do/suppress-presence', {
+      method: 'POST',
+    })).catch(() => {});
+
     emitServerEvent(c, workspace.id, 'relaycast_server_presence_disconnected', {
       agent_id: agent.id,
       agent_name: agent.name,

--- a/packages/server/src/routes/presence.ts
+++ b/packages/server/src/routes/presence.ts
@@ -36,11 +36,12 @@ presenceRoutes.post('/agents/heartbeat', requireAgentToken, rateLimit, async (c)
     }));
 
     // Clear any presence suppression so WS pings resume refreshing presence.
+    // Awaited to prevent Workers runtime from dropping the fetch after response.
     const agentDoId = c.env.AGENT_DO.idFromName(`${workspace.id}:${agent.id}`);
     const agentStub = c.env.AGENT_DO.get(agentDoId);
-    agentStub.fetch(new Request('http://do/unsuppress-presence', {
+    await agentStub.fetch(new Request('http://do/unsuppress-presence', {
       method: 'POST',
-    })).catch(() => {});
+    }));
 
     emitServerEvent(c, workspace.id, 'relaycast_server_presence_heartbeat', {
       agent_id: agent.id,

--- a/packages/server/src/routes/presence.ts
+++ b/packages/server/src/routes/presence.ts
@@ -61,22 +61,20 @@ presenceRoutes.post('/agents/disconnect', requireAgentToken, rateLimit, async (c
   try {
     const agent = c.get('agent')!;
     const workspace = c.get('workspace');
+    // Suppress WS-ping presence refresh BEFORE disconnecting from PresenceDO.
+    // This prevents a WS ping from re-registering the agent between the two calls.
+    const agentDoId = c.env.AGENT_DO.idFromName(`${workspace.id}:${agent.id}`);
+    const agentStub = c.env.AGENT_DO.get(agentDoId);
+    await agentStub.fetch(new Request('http://do/suppress-presence', {
+      method: 'POST',
+    }));
+
     const doId = c.env.PRESENCE_DO.idFromName(workspace.id);
     const stub = c.env.PRESENCE_DO.get(doId);
     await stub.fetch(new Request('http://do/disconnect', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ agentId: agent.id, workspaceId: workspace.id, agentName: agent.name }),
-    }));
-
-    // Tell the AgentDO to stop refreshing presence on WS pings.
-    // Without this, the WS ping/pong cycle re-registers the agent as online
-    // immediately after the disconnect. Awaited to close the race window
-    // between PresenceDO disconnect and AgentDO suppression.
-    const agentDoId = c.env.AGENT_DO.idFromName(`${workspace.id}:${agent.id}`);
-    const agentStub = c.env.AGENT_DO.get(agentDoId);
-    await agentStub.fetch(new Request('http://do/suppress-presence', {
-      method: 'POST',
     }));
 
     emitServerEvent(c, workspace.id, 'relaycast_server_presence_disconnected', {

--- a/packages/server/src/routes/presence.ts
+++ b/packages/server/src/routes/presence.ts
@@ -71,12 +71,13 @@ presenceRoutes.post('/agents/disconnect', requireAgentToken, rateLimit, async (c
 
     // Tell the AgentDO to stop refreshing presence on WS pings.
     // Without this, the WS ping/pong cycle re-registers the agent as online
-    // immediately after the disconnect.
+    // immediately after the disconnect. Awaited to close the race window
+    // between PresenceDO disconnect and AgentDO suppression.
     const agentDoId = c.env.AGENT_DO.idFromName(`${workspace.id}:${agent.id}`);
     const agentStub = c.env.AGENT_DO.get(agentDoId);
-    agentStub.fetch(new Request('http://do/suppress-presence', {
+    await agentStub.fetch(new Request('http://do/suppress-presence', {
       method: 'POST',
-    })).catch(() => {});
+    }));
 
     emitServerEvent(c, workspace.id, 'relaycast_server_presence_disconnected', {
       agent_id: agent.id,


### PR DESCRIPTION
## Summary
- remove global uniqueness from `workspaces.name` in the schema and engine
- add a migration to drop the existing `workspaces_name_unique` index
- add regression coverage and note the behavior in docs

## Validation
- `npx vitest run packages/server/src/engine/__tests__/workspace.test.ts packages/server/src/routes/__tests__/workspace.test.ts packages/server/src/db/__tests__/schema.test.ts`
- `npm test`
- `npm run build`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/agentworkforce/relaycast/pull/75" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
