### PR TITLE
fix: add explicit multi-workspace MCP routing

### DIFF
--- a/packages/mcp/src/__tests__/messaging-tools.test.ts
+++ b/packages/mcp/src/__tests__/messaging-tools.test.ts
@@ -19,11 +19,29 @@ describe('messaging tools', () => {
       sendMessage: vi.fn(),
     },
   };
+  const betaAgentClient = {
+    send: vi.fn(),
+    messages: vi.fn(),
+    reply: vi.fn(),
+    thread: vi.fn(),
+    dm: vi.fn(),
+    dms: {
+      conversations: vi.fn(),
+      createGroup: vi.fn(),
+      sendMessage: vi.fn(),
+    },
+  };
+  const getAgentClient = vi.fn((workspace?: { workspaceId?: string; workspaceAlias?: string }) => {
+    if (workspace?.workspaceId === 'ws_beta' || workspace?.workspaceAlias === 'beta') {
+      return betaAgentClient as any;
+    }
+    return mockAgentClient as any;
+  });
 
   beforeEach(async () => {
     vi.clearAllMocks();
     mcpServer = new McpServer({ name: 'test', version: '0.1.0' });
-    registerMessagingTools(mcpServer, () => mockAgentClient as any);
+    registerMessagingTools(mcpServer, getAgentClient);
     client = new Client({ name: 'test-client', version: '0.1.0' });
     const [ct, st] = InMemoryTransport.createLinkedPair();
     await Promise.all([client.connect(ct), mcpServer.connect(st)]);
@@ -39,10 +57,35 @@ describe('messaging tools', () => {
     expect(result.content).toBeDefined();
   });
 
+  it('post_message routes by workspace_alias', async () => {
+    betaAgentClient.send.mockResolvedValue({ id: 'msg-beta', text: 'hello beta' });
+    await client.callTool({
+      name: 'post_message',
+      arguments: { workspace_alias: 'beta', channel: 'ops', text: 'hello beta' },
+    });
+    expect(getAgentClient).toHaveBeenCalledWith({ workspaceAlias: 'beta' });
+    expect(betaAgentClient.send).toHaveBeenCalledWith('ops', 'hello beta', undefined);
+    expect(mockAgentClient.send).not.toHaveBeenCalled();
+  });
+
   it('get_messages calls messages()', async () => {
     mockAgentClient.messages.mockResolvedValue([]);
     await client.callTool({ name: 'get_messages', arguments: { channel: 'general' } });
     expect(mockAgentClient.messages).toHaveBeenCalledWith('general', {
+      limit: undefined,
+      before: undefined,
+      after: undefined,
+    });
+  });
+
+  it('get_messages routes by workspace_id', async () => {
+    betaAgentClient.messages.mockResolvedValue([]);
+    await client.callTool({
+      name: 'get_messages',
+      arguments: { workspace_id: 'ws_beta', channel: 'ops' },
+    });
+    expect(getAgentClient).toHaveBeenCalledWith({ workspaceId: 'ws_beta' });
+    expect(betaAgentClient.messages).toHaveBeenCalledWith('ops', {
       limit: undefined,
       before: undefined,
       after: undefined,
@@ -58,6 +101,16 @@ describe('messaging tools', () => {
     expect(mockAgentClient.reply).toHaveBeenCalledWith('msg1', 'reply');
   });
 
+  it('reply_to_thread routes by workspace_alias', async () => {
+    betaAgentClient.reply.mockResolvedValue({ id: 'reply_beta' });
+    await client.callTool({
+      name: 'reply_to_thread',
+      arguments: { workspace_alias: 'beta', message_id: 'msg1', text: 'reply' },
+    });
+    expect(getAgentClient).toHaveBeenCalledWith({ workspaceAlias: 'beta' });
+    expect(betaAgentClient.reply).toHaveBeenCalledWith('msg1', 'reply');
+  });
+
   it('get_thread calls thread()', async () => {
     mockAgentClient.thread.mockResolvedValue({ parent: {}, replies: [] });
     await client.callTool({ name: 'get_thread', arguments: { message_id: 'msg1' } });
@@ -68,6 +121,16 @@ describe('messaging tools', () => {
     mockAgentClient.dm.mockResolvedValue({});
     await client.callTool({ name: 'send_dm', arguments: { to: 'bot2', text: 'hi' } });
     expect(mockAgentClient.dm).toHaveBeenCalledWith('bot2', 'hi');
+  });
+
+  it('send_dm routes by workspace_id', async () => {
+    betaAgentClient.dm.mockResolvedValue({});
+    await client.callTool({
+      name: 'send_dm',
+      arguments: { workspace_id: 'ws_beta', to: 'bot2', text: 'hi' },
+    });
+    expect(getAgentClient).toHaveBeenCalledWith({ workspaceId: 'ws_beta' });
+    expect(betaAgentClient.dm).toHaveBeenCalledWith('bot2', 'hi');
   });
 
   it('get_dms calls dms.conversations()', async () => {
@@ -88,5 +151,21 @@ describe('messaging tools', () => {
       name: 'grp',
     });
     expect(mockAgentClient.dms.sendMessage).toHaveBeenCalledWith('conv1', 'hello group');
+  });
+
+  it('returns an error when multiple workspaces exist and no target is specified', async () => {
+    getAgentClient.mockImplementation(() => {
+      throw new Error('Ambiguous workspace selection. Provide workspace_id or workspace_alias.');
+    });
+
+    const result = await client.callTool({
+      name: 'post_message',
+      arguments: { channel: 'general', text: 'hello' },
+    });
+
+    expect(result.isError).toBe(true);
+    expect((result.content?.[0] as { text?: string } | undefined)?.text).toContain(
+      'Ambiguous workspace selection. Provide workspace_id or workspace_alias.',
+    );
   });
 });

--- a/packages/mcp/src/__tests__/server-multi-workspace.test.ts
+++ b/packages/mcp/src/__tests__/server-multi-workspace.test.ts
@@ -1,0 +1,167 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
+
+const mocks = vi.hoisted(() => {
+  const alphaAgentClient = {
+    send: vi.fn().mockResolvedValue({ id: 'msg_alpha' }),
+    messages: vi.fn().mockResolvedValue([]),
+    reply: vi.fn().mockResolvedValue({ id: 'reply_alpha' }),
+    thread: vi.fn().mockResolvedValue({ parent: {}, replies: [] }),
+    dm: vi.fn().mockResolvedValue({}),
+    inbox: vi.fn().mockResolvedValue({ unreadChannels: [], mentions: [], unreadDms: [], recentReactions: [] }),
+    dms: {
+      conversations: vi.fn().mockResolvedValue([]),
+      createGroup: vi.fn().mockResolvedValue({ id: 'dm_alpha' }),
+      sendMessage: vi.fn().mockResolvedValue({ id: 'msg_alpha_dm' }),
+    },
+  };
+  const betaAgentClient = {
+    send: vi.fn().mockResolvedValue({ id: 'msg_beta' }),
+    messages: vi.fn().mockResolvedValue([]),
+    reply: vi.fn().mockResolvedValue({ id: 'reply_beta' }),
+    thread: vi.fn().mockResolvedValue({ parent: {}, replies: [] }),
+    dm: vi.fn().mockResolvedValue({}),
+    inbox: vi.fn().mockResolvedValue({ unreadChannels: [], mentions: [], unreadDms: [], recentReactions: [] }),
+    dms: {
+      conversations: vi.fn().mockResolvedValue([]),
+      createGroup: vi.fn().mockResolvedValue({ id: 'dm_beta' }),
+      sendMessage: vi.fn().mockResolvedValue({ id: 'msg_beta_dm' }),
+    },
+  };
+  const managerAgentFor = vi.fn((workspace?: { workspaceId?: string; workspaceAlias?: string }) => {
+    if (workspace?.workspaceId === 'ws_beta' || workspace?.workspaceAlias === 'beta') {
+      return betaAgentClient;
+    }
+    return alphaAgentClient;
+  });
+  const createInternalWsClient = vi.fn(() => ({
+    on: vi.fn().mockReturnValue(() => {}),
+    connect: vi.fn(),
+    disconnect: vi.fn(),
+  }));
+  const createInternalRelayCast = vi.fn(() => ({
+    as: vi.fn((token: string) => (token === 'at_live_beta' ? betaAgentClient : alphaAgentClient)),
+    agents: {
+      register: vi.fn().mockResolvedValue({ token: 'at_live_alpha' }),
+      list: vi.fn().mockResolvedValue([]),
+      registerOrRotate: vi.fn().mockResolvedValue({ token: 'at_live_alpha' }),
+    },
+    subscriptions: {
+      create: vi.fn().mockResolvedValue({ id: 'sub_1' }),
+      list: vi.fn().mockResolvedValue([]),
+      get: vi.fn().mockResolvedValue({ id: 'sub_1' }),
+      delete: vi.fn().mockResolvedValue(undefined),
+    },
+    webhooks: {
+      create: vi.fn().mockResolvedValue({ id: 'wh_1' }),
+      list: vi.fn().mockResolvedValue([]),
+      delete: vi.fn().mockResolvedValue(undefined),
+      trigger: vi.fn().mockResolvedValue({ id: 'msg_1' }),
+    },
+    commands: {
+      register: vi.fn().mockResolvedValue({ id: 'cmd_1' }),
+      list: vi.fn().mockResolvedValue([]),
+      delete: vi.fn().mockResolvedValue(undefined),
+    },
+  }));
+
+  return {
+    alphaAgentClient,
+    betaAgentClient,
+    managerAgentFor,
+    createInternalWsClient,
+    createInternalRelayCast,
+  };
+});
+
+vi.mock('@relaycast/sdk', () => ({
+  AgentClient: class {},
+  MultiWorkspaceSessionManager: class {
+    agentFor(workspace?: { workspaceId?: string; workspaceAlias?: string }) {
+      return mocks.managerAgentFor(workspace);
+    }
+  },
+}));
+
+vi.mock('@relaycast/sdk/internal', () => ({
+  createInternalRelayCast: mocks.createInternalRelayCast,
+  createInternalWsClient: mocks.createInternalWsClient,
+}));
+
+import { createRelayMcpServer } from '../server.js';
+
+describe('createRelayMcpServer multi-workspace routing', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('routes post_message to the explicit workspace alias', async () => {
+    const server = createRelayMcpServer({
+      workspaces: [
+        {
+          workspaceId: 'ws_alpha',
+          workspaceAlias: 'alpha',
+          workspaceKey: 'rk_live_alpha',
+          agentToken: 'at_live_alpha',
+          agentName: 'Alpha',
+        },
+        {
+          workspaceId: 'ws_beta',
+          workspaceAlias: 'beta',
+          workspaceKey: 'rk_live_beta',
+          agentToken: 'at_live_beta',
+          agentName: 'Beta',
+        },
+      ],
+      defaultWorkspace: 'alpha',
+    });
+    const client = new Client({ name: 'test-client', version: '0.1.0' });
+    const [ct, st] = InMemoryTransport.createLinkedPair();
+    await Promise.all([client.connect(ct), server.connect(st)]);
+
+    const result = await client.callTool({
+      name: 'post_message',
+      arguments: { workspace_alias: 'beta', channel: 'ops', text: 'ship it' },
+    });
+
+    expect(result.isError).toBeFalsy();
+    expect(mocks.managerAgentFor).toHaveBeenCalledWith({ workspaceId: 'ws_beta' });
+    expect(mocks.betaAgentClient.send).toHaveBeenCalledWith('ops', 'ship it', undefined);
+    expect(mocks.alphaAgentClient.send).not.toHaveBeenCalled();
+  });
+
+  it('fails loudly when multiple configured workspaces exist and no target is specified', async () => {
+    const server = createRelayMcpServer({
+      workspaces: [
+        {
+          workspaceId: 'ws_alpha',
+          workspaceAlias: 'alpha',
+          workspaceKey: 'rk_live_alpha',
+          agentToken: 'at_live_alpha',
+          agentName: 'Alpha',
+        },
+        {
+          workspaceId: 'ws_beta',
+          workspaceAlias: 'beta',
+          workspaceKey: 'rk_live_beta',
+          agentToken: 'at_live_beta',
+          agentName: 'Beta',
+        },
+      ],
+    });
+    const client = new Client({ name: 'test-client', version: '0.1.0' });
+    const [ct, st] = InMemoryTransport.createLinkedPair();
+    await Promise.all([client.connect(ct), server.connect(st)]);
+
+    const result = await client.callTool({
+      name: 'post_message',
+      arguments: { channel: 'general', text: 'hello' },
+    });
+
+    expect(result.isError).toBe(true);
+    expect((result.content?.[0] as { text?: string } | undefined)?.text).toContain(
+      'Ambiguous workspace selection. Provide workspace_id or workspace_alias.',
+    );
+  });
+});

--- a/packages/mcp/src/__tests__/server.test.ts
+++ b/packages/mcp/src/__tests__/server.test.ts
@@ -66,6 +66,11 @@ vi.mock('@relaycast/sdk', () => {
 
   return {
     AgentClient: class {},
+    MultiWorkspaceSessionManager: class {
+      agentFor() {
+        return mockAgentClient;
+      }
+    },
     HttpClient: class {},
     Relay: MockRelay,
   };

--- a/packages/mcp/src/__tests__/stdio.test.ts
+++ b/packages/mcp/src/__tests__/stdio.test.ts
@@ -1,0 +1,67 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  startStdio: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('../transports.js', () => ({
+  startStdio: mocks.startStdio,
+}));
+
+describe('stdio entrypoint', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    vi.resetModules();
+    mocks.startStdio.mockClear();
+    process.env = { ...originalEnv };
+    delete process.env.RELAY_WORKSPACES_JSON;
+    delete process.env.RELAY_DEFAULT_WORKSPACE;
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  it('passes RELAY_WORKSPACES_JSON and RELAY_DEFAULT_WORKSPACE to startStdio()', async () => {
+    process.env.RELAY_WORKSPACES_JSON = JSON.stringify([
+      {
+        workspace_id: 'ws_alpha',
+        workspace_alias: 'alpha',
+        api_key: 'rk_live_alpha',
+        agent_token: 'at_live_alpha',
+        agent_name: 'Alpha',
+      },
+      {
+        workspace_id: 'ws_beta',
+        workspace_alias: 'beta',
+        api_key: 'rk_live_beta',
+        agent_token: 'at_live_beta',
+        agent_name: 'Beta',
+      },
+    ]);
+    process.env.RELAY_DEFAULT_WORKSPACE = 'beta';
+
+    await import('../stdio.js');
+
+    expect(mocks.startStdio).toHaveBeenCalledWith(expect.objectContaining({
+      defaultWorkspace: 'beta',
+      workspaces: [
+        {
+          workspaceId: 'ws_alpha',
+          workspaceAlias: 'alpha',
+          workspaceKey: 'rk_live_alpha',
+          agentToken: 'at_live_alpha',
+          agentName: 'Alpha',
+        },
+        {
+          workspaceId: 'ws_beta',
+          workspaceAlias: 'beta',
+          workspaceKey: 'rk_live_beta',
+          agentToken: 'at_live_beta',
+          agentName: 'Beta',
+        },
+      ],
+    }));
+  });
+});

--- a/packages/mcp/src/__tests__/stdio.test.ts
+++ b/packages/mcp/src/__tests__/stdio.test.ts
@@ -23,7 +23,7 @@ describe('stdio entrypoint', () => {
     process.env = originalEnv;
   });
 
-  it('passes RELAY_WORKSPACES_JSON and RELAY_DEFAULT_WORKSPACE to startStdio()', async () => {
+  it('passes legacy array-shaped RELAY_WORKSPACES_JSON and RELAY_DEFAULT_WORKSPACE to startStdio()', async () => {
     process.env.RELAY_WORKSPACES_JSON = JSON.stringify([
       {
         workspace_id: 'ws_alpha',
@@ -46,6 +46,51 @@ describe('stdio entrypoint', () => {
 
     expect(mocks.startStdio).toHaveBeenCalledWith(expect.objectContaining({
       defaultWorkspace: 'beta',
+      workspaces: [
+        {
+          workspaceId: 'ws_alpha',
+          workspaceAlias: 'alpha',
+          workspaceKey: 'rk_live_alpha',
+          agentToken: 'at_live_alpha',
+          agentName: 'Alpha',
+        },
+        {
+          workspaceId: 'ws_beta',
+          workspaceAlias: 'beta',
+          workspaceKey: 'rk_live_beta',
+          agentToken: 'at_live_beta',
+          agentName: 'Beta',
+        },
+      ],
+    }));
+  });
+
+  it('passes object-shaped RELAY_WORKSPACES_JSON with memberships to startStdio()', async () => {
+    process.env.RELAY_WORKSPACES_JSON = JSON.stringify({
+      memberships: [
+        {
+          workspace_id: 'ws_alpha',
+          workspace_alias: 'alpha',
+          api_key: 'rk_live_alpha',
+          agent_token: 'at_live_alpha',
+          agent_name: 'Alpha',
+        },
+        {
+          workspace_id: 'ws_beta',
+          workspace_alias: 'beta',
+          api_key: 'rk_live_beta',
+          agent_token: 'at_live_beta',
+          agent_name: 'Beta',
+        },
+      ],
+      default_workspace_id: 'ws_beta',
+    });
+    process.env.RELAY_DEFAULT_WORKSPACE = 'ws_beta';
+
+    await import('../stdio.js');
+
+    expect(mocks.startStdio).toHaveBeenCalledWith(expect.objectContaining({
+      defaultWorkspace: 'ws_beta',
       workspaces: [
         {
           workspaceId: 'ws_alpha',

--- a/packages/mcp/src/__tests__/transports.test.ts
+++ b/packages/mcp/src/__tests__/transports.test.ts
@@ -136,4 +136,59 @@ describe("startStdio bootstrap", () => {
       }),
     );
   });
+
+  it("bootstraps each configured workspace from workspaces[]", async () => {
+    mocks.registerOrRotateMock
+      .mockResolvedValueOnce({
+        name: "worker-alpha",
+        token: "at_live_alpha",
+      })
+      .mockResolvedValueOnce({
+        name: "worker-beta",
+        token: "at_live_beta",
+      });
+
+    await startStdio({
+      workspaces: [
+        {
+          workspaceId: "ws_alpha",
+          workspaceAlias: "alpha",
+          workspaceKey: "rk_live_alpha",
+          agentName: "worker-alpha",
+        },
+        {
+          workspaceId: "ws_beta",
+          workspaceAlias: "beta",
+          workspaceKey: "rk_live_beta",
+          agentName: "worker-beta",
+          agentToken: "at_live_stale_beta",
+        },
+      ],
+      defaultWorkspace: "alpha",
+    });
+
+    expect(mocks.registerOrRotateMock).toHaveBeenNthCalledWith(1, {
+      name: "worker-alpha",
+      type: undefined,
+    });
+    expect(mocks.asMock).toHaveBeenCalledWith("at_live_stale_beta");
+    expect(mocks.createRelayMcpServerMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        defaultWorkspace: "alpha",
+        telemetryTransport: "stdio",
+        workspaces: [
+          expect.objectContaining({
+            workspaceId: "ws_alpha",
+            agentToken: "at_live_alpha",
+            agentName: "worker-alpha",
+          }),
+          expect.objectContaining({
+            workspaceId: "ws_beta",
+            agentToken: "at_live_stale_beta",
+            agentName: "worker-beta",
+          }),
+        ],
+      }),
+    );
+  });
 });

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -4,3 +4,4 @@ export { startStdio, createHttpHandler } from './transports.js';
 export type { SessionLifecycle } from './transports.js';
 export { DEFAULT_SYSTEM_PROMPT } from './prompts.js';
 export type { SessionState } from './types.js';
+export type { McpWorkspaceConfig } from './workspaces.js';

--- a/packages/mcp/src/piggyback.ts
+++ b/packages/mcp/src/piggyback.ts
@@ -1,7 +1,8 @@
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
-import type { AgentClient } from '@relaycast/sdk';
+import type { AgentClient, WorkspaceRef } from '@relaycast/sdk';
 import type { SessionState } from './types.js';
 import type { McpTelemetry } from './telemetry.js';
+import { workspaceRefFromArgs } from './workspaces.js';
 
 const SKIP_PIGGYBACK = new Set([
   'check_inbox',
@@ -37,7 +38,7 @@ function hasContentArray(value: unknown): value is ContentCarrier {
 export function enablePiggyback(
   mcpServer: McpServer,
   getSession: () => SessionState,
-  getAgentClient: () => AgentClient,
+  getAgentClient: (workspace?: WorkspaceRef) => AgentClient,
   telemetry?: McpTelemetry,
 ): void {
   const original = mcpServer.registerTool.bind(mcpServer) as RegisterToolFn;
@@ -98,10 +99,14 @@ export function enablePiggyback(
         });
       }
 
-      if (!shouldPiggybackInbox || !getSession().agentToken) return result;
+      if (!shouldPiggybackInbox) return result;
 
       try {
-        const client = getAgentClient();
+        const workspaceRef = workspaceRefFromArgs(args[0]);
+        if (!workspaceRef && !getSession().agentToken) {
+          return result;
+        }
+        const client = getAgentClient(workspaceRef);
         const inbox = await client.inbox();
 
         const hasUnread =

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -1,6 +1,6 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { ListToolsRequestSchema } from '@modelcontextprotocol/sdk/types.js';
-import { AgentClient } from '@relaycast/sdk';
+import { AgentClient, type RelayCast, type WorkspaceRef } from '@relaycast/sdk';
 import { createInternalRelayCast, createInternalWsClient } from '@relaycast/sdk/internal';
 import { registerRegistrationTools } from './tools/registration.js';
 import { registerChannelTools } from './tools/channels.js';
@@ -14,8 +14,19 @@ import { registerResourceDefinitions } from './resources/definitions.js';
 import { SubscriptionManager } from './resources/subscriptions.js';
 import { WsBridge } from './resources/ws-bridge.js';
 import { createMcpTelemetry, type McpTelemetry } from './telemetry.js';
+import {
+  buildMultiWorkspaceManager,
+  resolveDefaultWorkspaceId,
+  validateWorkspaceConfigs,
+  type McpWorkspaceConfig,
+} from './workspaces.js';
 
 export const MCP_VERSION = '0.1.2';
+
+type SelectedWorkspace =
+  | { kind: 'configured'; workspaceId: string }
+  | { kind: 'legacy' }
+  | null;
 
 export interface McpServerOptions {
   apiKey?: string;
@@ -28,15 +39,37 @@ export interface McpServerOptions {
   agentType?: 'agent' | 'human';
   /** When true, the `register` tool enforces the pre-registered agentName. */
   strictAgentName?: boolean;
+  /** Multi-workspace bootstrap config for stdio/embedded use. */
+  workspaces?: McpWorkspaceConfig[];
+  /** Default workspace ID or alias used when a tool call omits workspace routing. */
+  defaultWorkspace?: string;
   telemetryTransport?: 'stdio' | 'http';
   telemetry?: McpTelemetry;
 }
 
 export function createRelayMcpServer(options: McpServerOptions): McpServer {
+  const configuredWorkspaces = validateWorkspaceConfigs(options.workspaces ?? []).map((workspace) => ({
+    ...workspace,
+  }));
+  const workspaceById = new Map(configuredWorkspaces.map((workspace) => [workspace.workspaceId, workspace]));
+  const defaultWorkspaceId = resolveDefaultWorkspaceId(configuredWorkspaces, options.defaultWorkspace);
+  let selectedWorkspace: SelectedWorkspace = defaultWorkspaceId
+    ? { kind: 'configured', workspaceId: defaultWorkspaceId }
+    : configuredWorkspaces.length === 0 && (options.apiKey || options.agentToken || options.agentName)
+      ? { kind: 'legacy' }
+      : null;
+  let multiWorkspaceManager = buildMultiWorkspaceManager(
+    configuredWorkspaces,
+    defaultWorkspaceId,
+    options.baseUrl,
+  );
+  const selectedConfiguredWorkspace = selectedWorkspace?.kind === 'configured'
+    ? workspaceById.get(selectedWorkspace.workspaceId) ?? null
+    : null;
   const session: SessionState = createInitialSession({
-    workspaceKey: options.apiKey ?? null,
-    agentToken: options.agentToken ?? null,
-    agentName: options.agentName ?? null,
+    workspaceKey: selectedConfiguredWorkspace?.workspaceKey ?? options.apiKey ?? null,
+    agentToken: selectedConfiguredWorkspace?.agentToken ?? options.agentToken ?? null,
+    agentName: selectedConfiguredWorkspace?.agentName ?? options.agentName ?? null,
   });
   const mcpOrigin = {
     surface: 'mcp' as const,
@@ -66,8 +99,66 @@ export function createRelayMcpServer(options: McpServerOptions): McpServer {
   });
 
   const getSession = () => session;
-  const getRelay = () => {
-    const workspaceKey = session.workspaceKey;
+  const matchConfiguredWorkspaceByKey = (workspaceKey: string | null | undefined): string | null => {
+    if (!workspaceKey) return null;
+    for (const workspace of configuredWorkspaces) {
+      if (workspace.workspaceKey === workspaceKey) {
+        return workspace.workspaceId;
+      }
+    }
+    return null;
+  };
+  const rebuildMultiWorkspaceState = (): void => {
+    multiWorkspaceManager = buildMultiWorkspaceManager(
+      configuredWorkspaces,
+      defaultWorkspaceId,
+      options.baseUrl,
+    );
+  };
+  const resolveConfiguredWorkspaceId = (workspace?: WorkspaceRef): string => {
+    const workspaceId = workspace?.workspaceId?.trim();
+    if (workspaceId) {
+      if (!workspaceById.has(workspaceId)) {
+        throw new Error(`Workspace "${workspaceId}" is not configured.`);
+      }
+      return workspaceId;
+    }
+
+    const workspaceAlias = workspace?.workspaceAlias?.trim();
+    if (workspaceAlias) {
+      const matchedWorkspace = configuredWorkspaces.find(
+        (membership) => membership.workspaceAlias === workspaceAlias,
+      );
+      if (!matchedWorkspace) {
+        throw new Error(`Workspace alias "${workspaceAlias}" is not configured.`);
+      }
+      return matchedWorkspace.workspaceId;
+    }
+
+    if (selectedWorkspace?.kind === 'configured') {
+      return selectedWorkspace.workspaceId;
+    }
+
+    if (defaultWorkspaceId) {
+      return defaultWorkspaceId;
+    }
+
+    if (configuredWorkspaces.length === 1) {
+      return configuredWorkspaces[0]!.workspaceId;
+    }
+
+    throw new Error('Ambiguous workspace selection. Provide workspace_id or workspace_alias.');
+  };
+  const getRelay = (workspace?: WorkspaceRef): RelayCast => {
+    const workspaceKey = selectedWorkspace?.kind === 'legacy' && !workspace
+      ? session.workspaceKey
+      : (() => {
+        if (configuredWorkspaces.length === 0 && !workspace) {
+          return session.workspaceKey;
+        }
+        const configuredWorkspace = workspaceById.get(resolveConfiguredWorkspaceId(workspace));
+        return configuredWorkspace?.workspaceKey ?? null;
+      })();
     if (!workspaceKey) {
       throw new Error(
         'Workspace key not configured. Set RELAY_API_KEY at startup, or call "create_workspace" or "set_workspace_key" first.',
@@ -79,11 +170,41 @@ export function createRelayMcpServer(options: McpServerOptions): McpServer {
     }, mcpOrigin);
   };
   const setSession = (partial: Partial<SessionState>) => {
+    let nextPartial = { ...partial };
+
+    if (partial.workspaceKey !== undefined) {
+      const matchedWorkspaceId = matchConfiguredWorkspaceByKey(partial.workspaceKey);
+      if (matchedWorkspaceId) {
+        selectedWorkspace = { kind: 'configured', workspaceId: matchedWorkspaceId };
+        const configuredWorkspace = workspaceById.get(matchedWorkspaceId)!;
+        nextPartial = {
+          ...nextPartial,
+          workspaceKey: configuredWorkspace.workspaceKey ?? partial.workspaceKey ?? null,
+          agentToken: partial.agentToken === undefined
+            ? configuredWorkspace.agentToken ?? null
+            : partial.agentToken,
+          agentName: partial.agentName === undefined
+            ? configuredWorkspace.agentName ?? null
+            : partial.agentName,
+        };
+      } else if (partial.workspaceKey) {
+        selectedWorkspace = { kind: 'legacy' };
+      } else {
+        selectedWorkspace = defaultWorkspaceId
+          ? { kind: 'configured', workspaceId: defaultWorkspaceId }
+          : configuredWorkspaces.length === 0
+            ? null
+            : configuredWorkspaces.length === 1
+              ? { kind: 'configured', workspaceId: configuredWorkspaces[0]!.workspaceId }
+              : null;
+      }
+    }
+
     const nextAgentToken =
-      partial.agentToken === undefined ? session.agentToken : partial.agentToken;
-    const nextAgentName = partial.agentName ?? session.agentName ?? null;
+      nextPartial.agentToken === undefined ? session.agentToken : nextPartial.agentToken;
+    const nextAgentName = nextPartial.agentName ?? session.agentName ?? null;
     const shouldResetBridge =
-      partial.agentToken !== undefined && partial.agentToken !== session.agentToken;
+      nextPartial.agentToken !== undefined && nextPartial.agentToken !== session.agentToken;
 
     if (shouldResetBridge && session.wsBridge) {
       session.wsBridge.stop();
@@ -113,7 +234,7 @@ export function createRelayMcpServer(options: McpServerOptions): McpServer {
           },
         );
         wsBridge.start();
-        Object.assign(session, partial, {
+        Object.assign(session, nextPartial, {
           wsBridge,
           subscriptions,
           wsInitAttempted: true,
@@ -121,7 +242,7 @@ export function createRelayMcpServer(options: McpServerOptions): McpServer {
       } catch {
         // In non-WS runtimes (e.g. some test environments), keep session usable
         // without real-time resource updates.
-        Object.assign(session, partial, {
+        Object.assign(session, nextPartial, {
           wsBridge: null,
           subscriptions: null,
           wsInitAttempted: true,
@@ -132,11 +253,55 @@ export function createRelayMcpServer(options: McpServerOptions): McpServer {
         agent_name: nextAgentName,
       });
     } else {
-      Object.assign(session, partial);
+      Object.assign(session, nextPartial);
+    }
+
+    if (selectedWorkspace?.kind === 'configured') {
+      const configuredWorkspace = workspaceById.get(selectedWorkspace.workspaceId);
+      if (configuredWorkspace) {
+        configuredWorkspace.workspaceKey = session.workspaceKey ?? undefined;
+        configuredWorkspace.agentToken = session.agentToken ?? undefined;
+        configuredWorkspace.agentName = session.agentName ?? undefined;
+        rebuildMultiWorkspaceState();
+      }
     }
   };
 
-  const getAgentClient = (): AgentClient => {
+  const getAgentClient = (workspace?: WorkspaceRef): AgentClient => {
+    if (workspace) {
+      const workspaceId = resolveConfiguredWorkspaceId(workspace);
+      const configuredWorkspace = workspaceById.get(workspaceId)!;
+      if (!configuredWorkspace.agentToken || !multiWorkspaceManager) {
+        throw new Error(
+          `Agent token not configured for workspace "${workspaceId}". Call "register" for that workspace first.`,
+        );
+      }
+      return multiWorkspaceManager.agentFor({ workspaceId });
+    }
+
+    if (selectedWorkspace?.kind === 'legacy') {
+      if (!session.agentToken) {
+        throw new Error('Not registered. Call the "register" tool first.');
+      }
+      return createInternalRelayCast({
+        apiKey: session.agentToken,
+        baseUrl: options.baseUrl,
+      }, mcpOrigin).as(
+        session.agentToken,
+      );
+    }
+
+    if (configuredWorkspaces.length > 0) {
+      const workspaceId = resolveConfiguredWorkspaceId();
+      const configuredWorkspace = workspaceById.get(workspaceId)!;
+      if (!configuredWorkspace.agentToken || !multiWorkspaceManager) {
+        throw new Error(
+          `Agent token not configured for workspace "${workspaceId}". Call "register" for that workspace first.`,
+        );
+      }
+      return multiWorkspaceManager.agentFor({ workspaceId });
+    }
+
     if (!session.agentToken) {
       throw new Error('Not registered. Call the "register" tool first.');
     }

--- a/packages/mcp/src/stdio.ts
+++ b/packages/mcp/src/stdio.ts
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 import { startStdio } from "./transports.js";
+import { parseWorkspaceEnv } from "./workspaces.js";
 
 /**
  * Resolve the Relaycast API key from RELAY_API_KEY env var.
@@ -7,6 +8,10 @@ import { startStdio } from "./transports.js";
  */
 function resolveApiKey(): string | undefined {
   return process.env.RELAY_API_KEY;
+}
+
+function resolveWorkspaces() {
+  return parseWorkspaceEnv(process.env.RELAY_WORKSPACES_JSON);
 }
 
 function parseStrictAgentName(value: string | undefined): boolean {
@@ -31,11 +36,15 @@ function parseAgentType(
   return undefined;
 }
 
+const workspaces = resolveWorkspaces();
+
 startStdio({
-  apiKey: resolveApiKey(),
+  apiKey: workspaces ? undefined : resolveApiKey(),
   baseUrl: process.env.RELAY_BASE_URL,
-  agentToken: process.env.RELAY_AGENT_TOKEN,
-  agentName: process.env.RELAY_AGENT_NAME ?? process.env.RELAY_CLAW_NAME,
-  agentType: parseAgentType(process.env.RELAY_AGENT_TYPE),
+  agentToken: workspaces ? undefined : process.env.RELAY_AGENT_TOKEN,
+  agentName: workspaces ? undefined : (process.env.RELAY_AGENT_NAME ?? process.env.RELAY_CLAW_NAME),
+  agentType: workspaces ? undefined : parseAgentType(process.env.RELAY_AGENT_TYPE),
   strictAgentName: parseStrictAgentName(process.env.RELAY_STRICT_AGENT_NAME),
+  workspaces,
+  defaultWorkspace: process.env.RELAY_DEFAULT_WORKSPACE,
 });

--- a/packages/mcp/src/tools/messaging.ts
+++ b/packages/mcp/src/tools/messaging.ts
@@ -1,26 +1,29 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
-import type { AgentClient } from '@relaycast/sdk';
+import type { AgentClient, WorkspaceRef } from '@relaycast/sdk';
+import { workspaceRefFromArgs, workspaceRoutingInputShape } from '../workspaces.js';
 
 /** Passthrough object schema for dynamic API responses. */
 const jsonResult = z.object({}).passthrough();
 
 export function registerMessagingTools(
   server: McpServer,
-  getAgentClient: () => AgentClient,
+  getAgentClient: (workspace?: WorkspaceRef) => AgentClient,
 ): void {
   server.registerTool('post_message', {
     title: 'Post Message',
     description: 'Post a new message to a channel. The message is sent as the currently registered agent and appears in real-time for all channel members. Optionally attach files by providing their upload IDs. The agent must be a member of the channel to post.',
     inputSchema: {
+      ...workspaceRoutingInputShape,
       channel: z.string().describe('Name of the channel to post the message to (e.g. "general", "build-alerts")'),
       text: z.string().describe('The message body text, which may include @mentions of other agents'),
       attachments: z.array(z.string()).optional().describe('Array of file attachment IDs obtained from the upload_file tool'),
     },
     outputSchema: jsonResult,
     annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: false, openWorldHint: true },
-  }, async ({ channel, text, attachments }) => {
-    const client = getAgentClient();
+  }, async (args) => {
+    const { channel, text, attachments } = args;
+    const client = getAgentClient(workspaceRefFromArgs(args));
     const msg = await client.send(channel, text, attachments ? { attachments } : undefined);
     return {
       content: [{ type: 'text' as const, text: JSON.stringify(msg, null, 2) }],
@@ -32,6 +35,7 @@ export function registerMessagingTools(
     title: 'Get Messages',
     description: 'Retrieve message history from a channel with optional cursor-based pagination. Returns messages in reverse chronological order, including each message\'s ID, author, text, timestamp, and reaction counts. Use the before/after cursors to page through older or newer messages.',
     inputSchema: {
+      ...workspaceRoutingInputShape,
       channel: z.string().describe('Name of the channel to fetch messages from'),
       limit: z.number().optional().describe('Maximum number of messages to return per page (default varies by server configuration)'),
       before: z.string().optional().describe('Message ID cursor — return only messages older than this ID, used for backward pagination'),
@@ -41,8 +45,9 @@ export function registerMessagingTools(
       messages: z.array(z.object({}).passthrough()).describe('Array of message objects with id, author, text, and timestamp'),
     },
     annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true, openWorldHint: true },
-  }, async ({ channel, limit, before, after }) => {
-    const client = getAgentClient();
+  }, async (args) => {
+    const { channel, limit, before, after } = args;
+    const client = getAgentClient(workspaceRefFromArgs(args));
     const msgs = await client.messages(channel, { limit, before, after });
     return {
       content: [{ type: 'text' as const, text: JSON.stringify(msgs, null, 2) }],
@@ -54,13 +59,15 @@ export function registerMessagingTools(
     title: 'Reply to Thread',
     description: 'Post a reply to an existing message thread. Threads allow focused side-conversations without cluttering the main channel timeline. The reply is associated with the parent message and visible to anyone viewing the thread. If this is the first reply, it starts a new thread on the parent message.',
     inputSchema: {
+      ...workspaceRoutingInputShape,
       message_id: z.string().describe('ID of the parent message to reply to, which becomes the thread root'),
       text: z.string().describe('The reply body text, which may include @mentions of other agents'),
     },
     outputSchema: jsonResult,
     annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: false, openWorldHint: true },
-  }, async ({ message_id, text }) => {
-    const client = getAgentClient();
+  }, async (args) => {
+    const { message_id, text } = args;
+    const client = getAgentClient(workspaceRefFromArgs(args));
     const reply = await client.reply(message_id, text);
     return {
       content: [{ type: 'text' as const, text: JSON.stringify(reply, null, 2) }],
@@ -72,13 +79,15 @@ export function registerMessagingTools(
     title: 'Get Thread',
     description: 'Retrieve a complete thread including the parent message and all its replies. Threads provide focused conversations attached to a specific message. Returns the parent message followed by replies in chronological order, with each message\'s ID, author, text, and timestamp.',
     inputSchema: {
+      ...workspaceRoutingInputShape,
       message_id: z.string().describe('ID of the parent message whose thread should be retrieved'),
       limit: z.number().optional().describe('Maximum number of replies to return (the parent message is always included)'),
     },
     outputSchema: jsonResult,
     annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true, openWorldHint: true },
-  }, async ({ message_id, limit }) => {
-    const client = getAgentClient();
+  }, async (args) => {
+    const { message_id, limit } = args;
+    const client = getAgentClient(workspaceRefFromArgs(args));
     const thread = await client.thread(message_id, limit ? { limit } : undefined);
     return {
       content: [{ type: 'text' as const, text: JSON.stringify(thread, null, 2) }],
@@ -90,13 +99,15 @@ export function registerMessagingTools(
     title: 'Send Direct Message',
     description: 'Send a private direct message to another agent in the workspace. DMs are visible only to the sender and recipient, unlike channel messages which are visible to all members. The recipient agent must be registered in the same workspace.',
     inputSchema: {
+      ...workspaceRoutingInputShape,
       to: z.string().describe('Name of the registered agent to send the direct message to'),
       text: z.string().describe('The direct message body text'),
     },
     outputSchema: jsonResult,
     annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: false, openWorldHint: true },
-  }, async ({ to, text }) => {
-    const client = getAgentClient();
+  }, async (args) => {
+    const { to, text } = args;
+    const client = getAgentClient(workspaceRefFromArgs(args));
     const result = await client.dm(to, text);
     return {
       content: [{ type: 'text' as const, text: JSON.stringify(result, null, 2) }],
@@ -108,14 +119,15 @@ export function registerMessagingTools(
     title: 'List DM Conversations',
     description: 'List all direct message conversations for the current agent. Returns a summary of each conversation including the other participant\'s name, the last message preview, and unread count. Use this to discover ongoing private conversations.',
     inputSchema: {
+      ...workspaceRoutingInputShape,
       limit: z.number().optional().describe('Maximum number of conversations to return'),
     },
     outputSchema: {
       conversations: z.array(z.object({}).passthrough()).describe('Array of DM conversation summaries'),
     },
     annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true, openWorldHint: true },
-  }, async () => {
-    const client = getAgentClient();
+  }, async (args) => {
+    const client = getAgentClient(workspaceRefFromArgs(args));
     const convos = await client.dms.conversations();
     return {
       content: [{ type: 'text' as const, text: JSON.stringify(convos, null, 2) }],
@@ -127,14 +139,16 @@ export function registerMessagingTools(
     title: 'Send Group DM',
     description: 'Create a new group direct message conversation with multiple agents. Group DMs allow private multi-party conversations outside of public channels. Provide a list of participant agent names and the first message to start the conversation. Optionally give the group a descriptive name.',
     inputSchema: {
+      ...workspaceRoutingInputShape,
       participants: z.array(z.string()).describe('Array of agent names to include in the group conversation'),
       name: z.string().optional().describe('Optional display name for the group conversation (e.g. "Backend Team", "Project Alpha")'),
       text: z.string().describe('The first message to send to the group, which initiates the conversation'),
     },
     outputSchema: jsonResult,
     annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: false, openWorldHint: true },
-  }, async ({ participants, name, text }) => {
-    const client = getAgentClient();
+  }, async (args) => {
+    const { participants, name, text } = args;
+    const client = getAgentClient(workspaceRefFromArgs(args));
     const conversation = await client.dms.createGroup({ participants, name });
     const message = await client.dms.sendMessage(conversation.id, text);
     const result = { conversation, message };

--- a/packages/mcp/src/transports.ts
+++ b/packages/mcp/src/transports.ts
@@ -9,10 +9,72 @@ import {
 } from "./server.js";
 import { randomUUID } from "node:crypto";
 import { createMcpTelemetry } from "./telemetry.js";
+import type { McpWorkspaceConfig } from "./workspaces.js";
+
+async function resolveBootstrappedWorkspace(
+  workspace: McpWorkspaceConfig,
+  options: Pick<McpServerOptions, "baseUrl">,
+): Promise<McpWorkspaceConfig> {
+  if (!workspace.workspaceKey || !workspace.agentName) {
+    return workspace;
+  }
+
+  const relay = createInternalRelayCast(
+    {
+      apiKey: workspace.workspaceKey,
+      baseUrl: options.baseUrl,
+    },
+    {
+      surface: "mcp",
+      client: "@relaycast/mcp",
+      version: MCP_VERSION,
+    },
+  );
+
+  if (workspace.agentToken) {
+    try {
+      await relay.as(workspace.agentToken).inbox();
+      return workspace;
+    } catch (err) {
+      const relayErr = err as Partial<RelayError> | undefined;
+      const unauthorized =
+        relayErr?.code === "unauthorized" ||
+        relayErr?.statusCode === 401 ||
+        relayErr?.statusCode === 403;
+      if (!unauthorized) {
+        throw err;
+      }
+    }
+  }
+
+  const registered = await relay.agents.registerOrRotate({
+    name: workspace.agentName,
+    type: workspace.agentType,
+  });
+
+  return {
+    ...workspace,
+    agentToken: registered.token,
+    agentName: registered.name ?? workspace.agentName,
+  };
+}
 
 async function resolveStdioBootstrapOptions(
   options: McpServerOptions,
 ): Promise<McpServerOptions> {
+  if (options.workspaces?.length) {
+    const workspaces = await Promise.all(
+      options.workspaces.map((workspace) =>
+        resolveBootstrappedWorkspace(workspace, options),
+      ),
+    );
+
+    return {
+      ...options,
+      workspaces,
+    };
+  }
+
   if (!options.apiKey || !options.agentName) {
     return options;
   }

--- a/packages/mcp/src/workspaces.ts
+++ b/packages/mcp/src/workspaces.ts
@@ -1,0 +1,174 @@
+import {
+  MultiWorkspaceSessionManager,
+  type WorkspaceMembershipConfig,
+  type WorkspaceRef,
+} from '@relaycast/sdk';
+import { z } from 'zod';
+
+export interface McpWorkspaceConfig {
+  workspaceId: string;
+  workspaceAlias?: string;
+  workspaceKey?: string;
+  agentToken?: string;
+  agentName?: string;
+  agentId?: string;
+  agentType?: 'agent' | 'human';
+}
+
+const configuredWorkspaceSchema = z.object({
+  workspace_id: z.string().trim().min(1),
+  workspace_alias: z.string().trim().min(1).optional(),
+  api_key: z.string().trim().min(1).optional(),
+  agent_token: z.string().trim().min(1).optional(),
+  agent_name: z.string().trim().min(1).optional(),
+  agent_id: z.string().trim().min(1).optional(),
+  agent_type: z.enum(['agent', 'human']).optional(),
+});
+
+export const workspaceRoutingInputShape = {
+  workspace_id: z.string().optional().describe('Optional workspace ID to route this call to explicitly'),
+  workspace_alias: z.string().optional().describe('Optional workspace alias to route this call to explicitly'),
+};
+
+export function parseWorkspaceEnv(value: string | undefined): McpWorkspaceConfig[] | undefined {
+  if (!value) return undefined;
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(value);
+  } catch (error) {
+    throw new Error(
+      `RELAY_WORKSPACES_JSON must be valid JSON: ${error instanceof Error ? error.message : 'unknown error'}`,
+    );
+  }
+
+  if (!Array.isArray(parsed)) {
+    throw new Error('RELAY_WORKSPACES_JSON must decode to an array of workspace objects.');
+  }
+
+  return validateWorkspaceConfigs(parsed.map((item) => {
+    const workspace = configuredWorkspaceSchema.parse(item);
+    return {
+      workspaceId: workspace.workspace_id,
+      ...(workspace.workspace_alias ? { workspaceAlias: workspace.workspace_alias } : {}),
+      ...(workspace.api_key ? { workspaceKey: workspace.api_key } : {}),
+      ...(workspace.agent_token ? { agentToken: workspace.agent_token } : {}),
+      ...(workspace.agent_name ? { agentName: workspace.agent_name } : {}),
+      ...(workspace.agent_id ? { agentId: workspace.agent_id } : {}),
+      ...(workspace.agent_type ? { agentType: workspace.agent_type } : {}),
+    } satisfies McpWorkspaceConfig;
+  }));
+}
+
+export function validateWorkspaceConfigs(workspaces: McpWorkspaceConfig[]): McpWorkspaceConfig[] {
+  const seenWorkspaceIds = new Set<string>();
+  const seenAliases = new Set<string>();
+
+  for (const workspace of workspaces) {
+    const workspaceId = workspace.workspaceId.trim();
+    if (workspaceId.length === 0) {
+      throw new Error('Each configured workspace requires a non-empty workspaceId.');
+    }
+    if (seenWorkspaceIds.has(workspaceId)) {
+      throw new Error(`Duplicate workspaceId "${workspaceId}" is not allowed.`);
+    }
+    seenWorkspaceIds.add(workspaceId);
+
+    const workspaceAlias = workspace.workspaceAlias?.trim();
+    if (!workspaceAlias) continue;
+    if (seenAliases.has(workspaceAlias)) {
+      throw new Error(`Duplicate workspaceAlias "${workspaceAlias}" is not allowed.`);
+    }
+    seenAliases.add(workspaceAlias);
+  }
+
+  return workspaces.map((workspace) => ({
+    workspaceId: workspace.workspaceId.trim(),
+    ...(workspace.workspaceAlias?.trim() ? { workspaceAlias: workspace.workspaceAlias.trim() } : {}),
+    ...(workspace.workspaceKey?.trim() ? { workspaceKey: workspace.workspaceKey.trim() } : {}),
+    ...(workspace.agentToken?.trim() ? { agentToken: workspace.agentToken.trim() } : {}),
+    ...(workspace.agentName?.trim() ? { agentName: workspace.agentName.trim() } : {}),
+    ...(workspace.agentId?.trim() ? { agentId: workspace.agentId.trim() } : {}),
+    ...(workspace.agentType ? { agentType: workspace.agentType } : {}),
+  }));
+}
+
+export function resolveDefaultWorkspaceId(
+  workspaces: McpWorkspaceConfig[],
+  defaultWorkspace: string | undefined,
+): string | undefined {
+  const normalizedDefault = defaultWorkspace?.trim();
+  if (!normalizedDefault) {
+    return workspaces.length === 1 ? workspaces[0]!.workspaceId : undefined;
+  }
+
+  const byId = workspaces.find((workspace) => workspace.workspaceId === normalizedDefault);
+  if (byId) {
+    return byId.workspaceId;
+  }
+
+  const byAlias = workspaces.find((workspace) => workspace.workspaceAlias === normalizedDefault);
+  if (byAlias) {
+    return byAlias.workspaceId;
+  }
+
+  throw new Error(
+    `Default workspace "${normalizedDefault}" does not match any configured workspace_id or workspace_alias.`,
+  );
+}
+
+export function buildMultiWorkspaceManager(
+  workspaces: McpWorkspaceConfig[],
+  defaultWorkspaceId: string | undefined,
+  baseUrl?: string,
+): MultiWorkspaceSessionManager | null {
+  const memberships: WorkspaceMembershipConfig[] = workspaces
+    .filter((workspace) => workspace.agentToken)
+    .map((workspace) => ({
+      workspaceId: workspace.workspaceId,
+      ...(workspace.workspaceAlias ? { workspaceAlias: workspace.workspaceAlias } : {}),
+      ...(workspace.agentId ? { agentId: workspace.agentId } : {}),
+      ...(workspace.agentName ? { agentName: workspace.agentName } : {}),
+      agentToken: workspace.agentToken!,
+      ...(baseUrl ? { baseUrl } : {}),
+    }));
+
+  if (memberships.length === 0) {
+    return null;
+  }
+
+  const managerDefaultWorkspaceId = defaultWorkspaceId && memberships.some(
+    (membership) => membership.workspaceId === defaultWorkspaceId,
+  )
+    ? defaultWorkspaceId
+    : memberships.length === 1 && workspaces.length === 1
+      ? memberships[0]!.workspaceId
+      : undefined;
+
+  return new MultiWorkspaceSessionManager({
+    memberships,
+    ...(managerDefaultWorkspaceId ? { defaultWorkspaceId: managerDefaultWorkspaceId } : {}),
+  });
+}
+
+export function workspaceRefFromArgs(value: unknown): WorkspaceRef | undefined {
+  if (!value || typeof value !== 'object') {
+    return undefined;
+  }
+
+  const workspaceId = typeof (value as { workspace_id?: unknown }).workspace_id === 'string'
+    ? (value as { workspace_id: string }).workspace_id.trim()
+    : '';
+  const workspaceAlias = typeof (value as { workspace_alias?: unknown }).workspace_alias === 'string'
+    ? (value as { workspace_alias: string }).workspace_alias.trim()
+    : '';
+
+  if (!workspaceId && !workspaceAlias) {
+    return undefined;
+  }
+
+  return {
+    ...(workspaceId ? { workspaceId } : {}),
+    ...(workspaceAlias ? { workspaceAlias } : {}),
+  };
+}

--- a/packages/mcp/src/workspaces.ts
+++ b/packages/mcp/src/workspaces.ts
@@ -25,6 +25,11 @@ const configuredWorkspaceSchema = z.object({
   agent_type: z.enum(['agent', 'human']).optional(),
 });
 
+const configuredWorkspacePayloadSchema = z.object({
+  memberships: z.array(configuredWorkspaceSchema),
+  default_workspace_id: z.string().trim().min(1).optional(),
+});
+
 export const workspaceRoutingInputShape = {
   workspace_id: z.string().optional().describe('Optional workspace ID to route this call to explicitly'),
   workspace_alias: z.string().optional().describe('Optional workspace alias to route this call to explicitly'),
@@ -42,11 +47,19 @@ export function parseWorkspaceEnv(value: string | undefined): McpWorkspaceConfig
     );
   }
 
-  if (!Array.isArray(parsed)) {
-    throw new Error('RELAY_WORKSPACES_JSON must decode to an array of workspace objects.');
+  const rawMemberships = Array.isArray(parsed)
+    ? parsed
+    : configuredWorkspacePayloadSchema.safeParse(parsed).success
+      ? configuredWorkspacePayloadSchema.parse(parsed).memberships
+      : null;
+
+  if (!rawMemberships) {
+    throw new Error(
+      'RELAY_WORKSPACES_JSON must decode to either an array of workspace objects or an object containing memberships.',
+    );
   }
 
-  return validateWorkspaceConfigs(parsed.map((item) => {
+  return validateWorkspaceConfigs(rawMemberships.map((item) => {
     const workspace = configuredWorkspaceSchema.parse(item);
     return {
       workspaceId: workspace.workspace_id,

--- a/packages/mcp/vitest.config.ts
+++ b/packages/mcp/vitest.config.ts
@@ -1,8 +1,18 @@
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { defineConfig } from 'vitest/config';
 
+const rootDir = dirname(fileURLToPath(import.meta.url));
+
 export default defineConfig({
+  resolve: {
+    alias: [
+      { find: '@relaycast/sdk/internal', replacement: resolve(rootDir, '../sdk-typescript/src/internal.ts') },
+      { find: '@relaycast/sdk', replacement: resolve(rootDir, '../sdk-typescript/src/index.ts') },
+      { find: '@relaycast/types', replacement: resolve(rootDir, '../types/src/index.ts') },
+    ],
+  },
   test: {
     globals: true,
   },
 });
-


### PR DESCRIPTION
## Summary
- teach `@relaycast/mcp` to consume `RELAY_WORKSPACES_JSON` / `RELAY_DEFAULT_WORKSPACE` and build a `MultiWorkspaceSessionManager`
- add explicit `workspace_id` / `workspace_alias` routing to outbound messaging tools and route piggyback/inbox behavior through the selected workspace
- bootstrap per-workspace agent tokens for stdio startup and fail loudly when workspace selection is ambiguous
- add MCP tests covering stdio parsing, server routing, and outbound multi-workspace tool behavior

## Testing
- npm test
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/agentworkforce/relaycast/pull/79" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
