### PR TITLE
feat(mcp): add env-var workspace bootstrap and per-tool routing

### DIFF
--- a/packages/local/src/main.rs
+++ b/packages/local/src/main.rs
@@ -645,8 +645,8 @@ async fn create_workspace(
         if duplicate {
             return err(
                 StatusCode::CONFLICT,
-                "workspace_name_taken",
-                format!("A workspace named \"{}\" already exists", payload.name.trim()),
+                "workspace_already_exists",
+                format!("Workspace \"{}\" already exists", payload.name.trim()),
             );
         }
     }

--- a/packages/local/src/main.rs
+++ b/packages/local/src/main.rs
@@ -638,6 +638,19 @@ async fn create_workspace(
         );
     }
 
+    // Enforce workspace name uniqueness (matches server behavior)
+    {
+        let store = state.store.read().await;
+        let duplicate = store.workspaces.values().any(|ws| ws.name == payload.name.trim());
+        if duplicate {
+            return err(
+                StatusCode::CONFLICT,
+                "workspace_name_taken",
+                format!("A workspace named \"{}\" already exists", payload.name.trim()),
+            );
+        }
+    }
+
     let workspace_id = new_id("ws");
     let api_key = random_token("rk_live_");
     let created_at = now_iso();

--- a/packages/local/src/main.rs
+++ b/packages/local/src/main.rs
@@ -638,26 +638,14 @@ async fn create_workspace(
         );
     }
 
-    // Enforce workspace name uniqueness (matches server behavior)
-    {
-        let store = state.store.read().await;
-        let duplicate = store.workspaces.values().any(|ws| ws.name == payload.name.trim());
-        if duplicate {
-            return err(
-                StatusCode::CONFLICT,
-                "workspace_already_exists",
-                format!("Workspace \"{}\" already exists", payload.name.trim()),
-            );
-        }
-    }
-
+    let workspace_name = payload.name.trim().to_string();
     let workspace_id = new_id("ws");
     let api_key = random_token("rk_live_");
     let created_at = now_iso();
 
     let workspace = WorkspaceRecord {
         id: workspace_id.clone(),
-        name: payload.name.trim().to_string(),
+        name: workspace_name.clone(),
         api_key: api_key.clone(),
         created_at: created_at.clone(),
         system_prompt: None,
@@ -666,6 +654,14 @@ async fn create_workspace(
     };
 
     let mut store = state.store.write().await;
+    let duplicate = store.workspaces.values().any(|ws| ws.name == workspace_name);
+    if duplicate {
+        return err(
+            StatusCode::CONFLICT,
+            "workspace_already_exists",
+            format!("Workspace \"{}\" already exists", workspace_name),
+        );
+    }
     store
         .workspace_by_key
         .insert(api_key.clone(), workspace_id.clone());

--- a/packages/mcp/src/__tests__/integration.test.ts
+++ b/packages/mcp/src/__tests__/integration.test.ts
@@ -52,6 +52,21 @@ describe('MCP → SDK → HTTP integration', () => {
           api_key: 'rk_live_created123',
           created_at: new Date().toISOString(),
         };
+      } else if (path === '/v1/workspace' && req.method === 'GET') {
+        const authHeader = req.headers.authorization;
+        const name = authHeader === 'Bearer rk_live_ws2'
+          ? 'Workspace Two'
+          : authHeader === 'Bearer rk_live_ws3'
+            ? 'Workspace Three'
+            : 'Integration Workspace';
+        data = {
+          id: 'ws_info',
+          name,
+          system_prompt: null,
+          plan: 'free',
+          created_at: new Date().toISOString(),
+          metadata: {},
+        };
       } else if (path === '/v1/agents' && req.method === 'POST') {
         const authHeader = req.headers.authorization;
         const token = authHeader === 'Bearer rk_live_ws2'
@@ -235,6 +250,21 @@ describe('MCP → SDK → HTTP integration', () => {
       arguments: { workspace_ref: target!.workspace_ref },
     });
     await client.callTool({ name: 'channel.list', arguments: {} });
+    const req = findReq((r) => r.url.endsWith('/v1/channels') && r.method === 'GET');
+    expect(req).toBeDefined();
+    expect(req!.headers.authorization).toBe('Bearer at_test_integration');
+  });
+
+  it('workspace.switch accepts the canonical workspace_name from the API', async () => {
+    await client.callTool({ name: 'workspace.join', arguments: { api_key: 'rk_live_ws2', name: 'Ws2Bot' } });
+
+    captured = [];
+    await client.callTool({
+      name: 'workspace.switch',
+      arguments: { workspace_name: 'Integration Workspace' },
+    });
+    await client.callTool({ name: 'channel.list', arguments: {} });
+
     const req = findReq((r) => r.url.endsWith('/v1/channels') && r.method === 'GET');
     expect(req).toBeDefined();
     expect(req!.headers.authorization).toBe('Bearer at_test_integration');

--- a/packages/mcp/src/__tests__/messaging-tools.test.ts
+++ b/packages/mcp/src/__tests__/messaging-tools.test.ts
@@ -90,3 +90,98 @@ describe('messaging tools', () => {
     expect(mockAgentClient.dms.sendMessage).toHaveBeenCalledWith('conv1', 'hello group');
   });
 });
+
+describe('messaging tools with workspace routing', () => {
+  let mcpServer: McpServer;
+  let client: Client;
+  const defaultClient = {
+    send: vi.fn(),
+    messages: vi.fn(),
+    reply: vi.fn(),
+    thread: vi.fn(),
+    dm: vi.fn(),
+    dms: {
+      conversations: vi.fn(),
+      createGroup: vi.fn(),
+      sendMessage: vi.fn(),
+    },
+  };
+  const routedClient = {
+    send: vi.fn(),
+    messages: vi.fn(),
+    reply: vi.fn(),
+    thread: vi.fn(),
+    dm: vi.fn(),
+    dms: {
+      conversations: vi.fn(),
+      createGroup: vi.fn(),
+      sendMessage: vi.fn(),
+    },
+  };
+
+  const getAgentClient = vi.fn((wsRouting?: { workspace_id?: string; workspace_alias?: string }) => {
+    if (wsRouting?.workspace_id === 'ws_beta' || wsRouting?.workspace_alias === 'beta') {
+      return routedClient as any;
+    }
+    return defaultClient as any;
+  });
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    mcpServer = new McpServer({ name: 'test', version: '0.1.0' });
+    registerMessagingTools(mcpServer, getAgentClient);
+    client = new Client({ name: 'test-client', version: '0.1.0' });
+    const [ct, st] = InMemoryTransport.createLinkedPair();
+    await Promise.all([client.connect(ct), mcpServer.connect(st)]);
+  });
+
+  it('message.post without routing uses default client', async () => {
+    defaultClient.send.mockResolvedValue({ id: 'msg1', text: 'hello' });
+    await client.callTool({
+      name: 'message.post',
+      arguments: { channel: 'general', text: 'hello' },
+    });
+    expect(getAgentClient).toHaveBeenCalledWith(undefined);
+    expect(defaultClient.send).toHaveBeenCalledWith('general', 'hello', undefined);
+  });
+
+  it('message.post with workspace_id routes to correct client', async () => {
+    routedClient.send.mockResolvedValue({ id: 'msg2', text: 'hello beta' });
+    await client.callTool({
+      name: 'message.post',
+      arguments: { channel: 'general', text: 'hello beta', workspace_id: 'ws_beta' },
+    });
+    expect(getAgentClient).toHaveBeenCalledWith({ workspace_id: 'ws_beta', workspace_alias: undefined });
+    expect(routedClient.send).toHaveBeenCalledWith('general', 'hello beta', undefined);
+  });
+
+  it('message.post with workspace_alias routes to correct client', async () => {
+    routedClient.send.mockResolvedValue({ id: 'msg3', text: 'hello beta alias' });
+    await client.callTool({
+      name: 'message.post',
+      arguments: { channel: 'general', text: 'hello beta alias', workspace_alias: 'beta' },
+    });
+    expect(getAgentClient).toHaveBeenCalledWith({ workspace_id: undefined, workspace_alias: 'beta' });
+    expect(routedClient.send).toHaveBeenCalledWith('general', 'hello beta alias', undefined);
+  });
+
+  it('dm.send with workspace_id routes correctly', async () => {
+    routedClient.dm.mockResolvedValue({});
+    await client.callTool({
+      name: 'dm.send',
+      arguments: { to: 'bot2', text: 'hi', workspace_id: 'ws_beta' },
+    });
+    expect(getAgentClient).toHaveBeenCalledWith({ workspace_id: 'ws_beta', workspace_alias: undefined });
+    expect(routedClient.dm).toHaveBeenCalledWith('bot2', 'hi');
+  });
+
+  it('message.list with workspace_alias routes correctly', async () => {
+    routedClient.messages.mockResolvedValue([]);
+    await client.callTool({
+      name: 'message.list',
+      arguments: { channel: 'general', workspace_alias: 'beta' },
+    });
+    expect(getAgentClient).toHaveBeenCalledWith({ workspace_id: undefined, workspace_alias: 'beta' });
+    expect(routedClient.messages).toHaveBeenCalled();
+  });
+});

--- a/packages/mcp/src/__tests__/registration-tools.test.ts
+++ b/packages/mcp/src/__tests__/registration-tools.test.ts
@@ -24,6 +24,40 @@ describe('registration tools', () => {
   beforeEach(async () => {
     vi.clearAllMocks();
     originalFetch = global.fetch;
+    global.fetch = vi.fn(async (url: string | URL, init?: RequestInit) => {
+      const path = new URL(url.toString()).pathname;
+      const headers = new Headers(init?.headers);
+      const authHeader = headers.get('Authorization');
+      const workspaceName = authHeader === 'Bearer rk_live_ws2'
+        ? 'Workspace Two'
+        : authHeader === 'Bearer rk_live_test'
+          ? 'Test Workspace'
+          : authHeader === 'Bearer rk_live_old'
+            ? 'Old Workspace'
+            : 'Primary Workspace';
+
+      if (path === '/v1/workspace') {
+        return new Response(
+          JSON.stringify({
+            ok: true,
+            data: {
+              id: 'ws_info',
+              name: workspaceName,
+              system_prompt: null,
+              plan: 'free',
+              created_at: new Date().toISOString(),
+              metadata: {},
+            },
+          }),
+          { status: 200, headers: { 'content-type': 'application/json' } },
+        );
+      }
+
+      return new Response(
+        JSON.stringify({ ok: true, data: {} }),
+        { status: 200, headers: { 'content-type': 'application/json' } },
+      );
+    }) as unknown as typeof global.fetch;
     session = createInitialSession();
     mcpServer = new McpServer({ name: 'test', version: '0.1.0' });
 
@@ -264,6 +298,24 @@ describe('registration tools', () => {
     expect(session.agentName).toBe('bot2');
   });
 
+  it('join_workspace stores canonical workspace name from the API', async () => {
+    session.workspaceKey = 'rk_live_ws1';
+    session.agentToken = 'at_live_ws1';
+    session.agentName = 'bot1';
+    mockRelay.agents.registerOrRotate.mockResolvedValue({
+      agent: { name: 'bot2' },
+      token: 'at_live_ws2',
+    });
+
+    const result = await client.callTool({
+      name: 'workspace.join',
+      arguments: { api_key: 'rk_live_ws2', name: 'bot2' },
+    });
+
+    expect(result.isError).toBeFalsy();
+    expect(session.workspaces.get('rk_live_ws2')?.workspaceName).toBe('Workspace Two');
+  });
+
   it('switch_workspace restores saved context', async () => {
     session.workspaceKey = 'rk_live_ws1';
     session.agentToken = 'at_live_ws1';
@@ -332,6 +384,40 @@ describe('registration tools', () => {
     expect(session.agentName).toBe('bot2');
   });
 
+  it('switch_workspace accepts canonical workspace_name from the API', async () => {
+    session.workspaceKey = 'rk_live_ws1';
+    session.agentToken = 'at_live_ws1';
+    session.agentName = 'bot1';
+    session.workspaces.set('rk_live_ws1', {
+      workspaceKey: 'rk_live_ws1',
+      agentToken: 'at_live_ws1',
+      agentName: 'bot1',
+      workspaceName: 'Primary Workspace',
+      wsBridge: null,
+      subscriptions: null,
+      wsInitAttempted: false,
+    });
+    session.workspaces.set('rk_live_ws2', {
+      workspaceKey: 'rk_live_ws2',
+      agentToken: 'at_live_ws2',
+      agentName: 'bot2',
+      workspaceName: 'Workspace Two',
+      wsBridge: null,
+      subscriptions: null,
+      wsInitAttempted: false,
+    });
+
+    const result = await client.callTool({
+      name: 'workspace.switch',
+      arguments: { workspace_name: 'Workspace Two' },
+    });
+
+    expect(result.isError).toBeFalsy();
+    expect(session.workspaceKey).toBe('rk_live_ws2');
+    expect(session.agentToken).toBe('at_live_ws2');
+    expect(session.agentName).toBe('bot2');
+  });
+
   it('switch_workspace errors for unknown workspace', async () => {
     session.workspaceKey = 'rk_live_ws1';
 
@@ -359,5 +445,6 @@ describe('registration tools', () => {
     expect(saved).toBeDefined();
     expect(saved!.agentToken).toBe('tok_abc');
     expect(saved!.agentName).toBe('bot1');
+    expect(saved!.workspaceName).toBe('Test Workspace');
   });
 });

--- a/packages/mcp/src/__tests__/server-multi-workspace.test.ts
+++ b/packages/mcp/src/__tests__/server-multi-workspace.test.ts
@@ -1,10 +1,8 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { describe, it, expect, vi } from 'vitest';
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
 import { createRelayMcpServer } from '../server.js';
 import type { McpWorkspaceConfig } from '../workspaces.js';
-import type { SessionState } from '../types.js';
 
 // Mock the SDK internal modules
 vi.mock('@relaycast/sdk/internal', () => {
@@ -105,72 +103,28 @@ describe('multi-workspace server setup', () => {
     expect(server).toBeDefined();
   });
 
-  it('exposes _sessionRef for transport-level workspace population', () => {
+  it('populates workspace contexts during server creation', () => {
+    // createRelayMcpServer now populates session.workspaces internally
+    // from options.workspaces — no _sessionRef needed.
     const server = createRelayMcpServer({
       apiKey: 'rk_live_alpha_key_full',
       agentToken: 'at_alpha',
       agentName: 'AlphaBot',
       workspaces,
     });
-
-    const sessionRef = (server as unknown as { _sessionRef: SessionState })._sessionRef;
-    expect(sessionRef).toBeDefined();
-    expect(sessionRef.workspaces).toBeInstanceOf(Map);
-  });
-
-  it('allows populating workspace contexts via _sessionRef', async () => {
-    const server = createRelayMcpServer({
-      apiKey: 'rk_live_alpha_key_full',
-      agentToken: 'at_alpha',
-      agentName: 'AlphaBot',
-      workspaces,
-    });
-
-    const sessionRef = (server as unknown as { _sessionRef: SessionState })._sessionRef;
-
-    // Simulate what transports.ts bootstrapWorkspaces does
-    for (const ws of workspaces) {
-      if (ws.agent_token && ws.agent_name) {
-        sessionRef.workspaces.set(ws.api_key, {
-          workspaceKey: ws.api_key,
-          agentToken: ws.agent_token,
-          agentName: ws.agent_name,
-          wsBridge: null,
-          subscriptions: null,
-          wsInitAttempted: false,
-        });
-      }
-    }
-
-    expect(sessionRef.workspaces.size).toBe(2);
-    expect(sessionRef.workspaces.get('rk_live_alpha_key_full')?.agentName).toBe('AlphaBot');
-    expect(sessionRef.workspaces.get('rk_live_beta_key_full')?.agentName).toBe('BetaBot');
+    expect(server).toBeDefined();
   });
 
   it('message.post with workspace_id routes to correct workspace', async () => {
     const { createInternalRelayCast, __mockClient } = await import('@relaycast/sdk/internal') as any;
 
+    // Workspace contexts are now populated during server creation
     const server = createRelayMcpServer({
       apiKey: 'rk_live_alpha_key_full',
       agentToken: 'at_alpha',
       agentName: 'AlphaBot',
       workspaces,
     });
-
-    // Populate workspace contexts
-    const sessionRef = (server as unknown as { _sessionRef: SessionState })._sessionRef;
-    for (const ws of workspaces) {
-      if (ws.agent_token && ws.agent_name) {
-        sessionRef.workspaces.set(ws.api_key, {
-          workspaceKey: ws.api_key,
-          agentToken: ws.agent_token,
-          agentName: ws.agent_name,
-          wsBridge: null,
-          subscriptions: null,
-          wsInitAttempted: false,
-        });
-      }
-    }
 
     const client = new Client({ name: 'test-client', version: '0.1.0' });
     const [ct, st] = InMemoryTransport.createLinkedPair();

--- a/packages/mcp/src/__tests__/server-multi-workspace.test.ts
+++ b/packages/mcp/src/__tests__/server-multi-workspace.test.ts
@@ -1,0 +1,195 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
+import { createRelayMcpServer } from '../server.js';
+import type { McpWorkspaceConfig } from '../workspaces.js';
+import type { SessionState } from '../types.js';
+
+// Mock the SDK internal modules
+vi.mock('@relaycast/sdk/internal', () => {
+  const mockClient = {
+    send: vi.fn().mockResolvedValue({ id: 'msg1', text: 'hello' }),
+    messages: vi.fn().mockResolvedValue([]),
+    reply: vi.fn().mockResolvedValue({ id: 'reply1' }),
+    thread: vi.fn().mockResolvedValue({ parent: {}, replies: [] }),
+    dm: vi.fn().mockResolvedValue({}),
+    inbox: vi.fn().mockResolvedValue({}),
+    dms: {
+      conversations: vi.fn().mockResolvedValue([]),
+      createGroup: vi.fn().mockResolvedValue({ id: 'conv1' }),
+      sendMessage: vi.fn().mockResolvedValue({ id: 'msg1' }),
+    },
+    channels: {
+      list: vi.fn().mockResolvedValue([]),
+      create: vi.fn().mockResolvedValue({}),
+      join: vi.fn().mockResolvedValue(undefined),
+      leave: vi.fn().mockResolvedValue(undefined),
+      invite: vi.fn().mockResolvedValue(undefined),
+      setTopic: vi.fn().mockResolvedValue({}),
+      archive: vi.fn().mockResolvedValue(undefined),
+    },
+    react: vi.fn().mockResolvedValue(undefined),
+    unreact: vi.fn().mockResolvedValue(undefined),
+    search: vi.fn().mockResolvedValue([]),
+    markRead: vi.fn().mockResolvedValue(undefined),
+    readers: vi.fn().mockResolvedValue([]),
+    files: { upload: vi.fn().mockResolvedValue({}) },
+    commands: { invoke: vi.fn().mockResolvedValue({}) },
+  };
+
+  const mockRelay = {
+    as: vi.fn().mockReturnValue(mockClient),
+    agents: {
+      registerOrRotate: vi.fn().mockResolvedValue({ token: 'at_test' }),
+      list: vi.fn().mockResolvedValue([]),
+      spawn: vi.fn().mockResolvedValue({}),
+      release: vi.fn().mockResolvedValue({ name: 'test', released: true, deleted: false, reason: null }),
+    },
+    webhooks: {
+      create: vi.fn().mockResolvedValue({}),
+      list: vi.fn().mockResolvedValue([]),
+      delete: vi.fn().mockResolvedValue(undefined),
+      trigger: vi.fn().mockResolvedValue({}),
+    },
+    subscriptions: {
+      create: vi.fn().mockResolvedValue({}),
+      list: vi.fn().mockResolvedValue([]),
+      get: vi.fn().mockResolvedValue({}),
+      delete: vi.fn().mockResolvedValue(undefined),
+    },
+    commands: {
+      register: vi.fn().mockResolvedValue({}),
+      list: vi.fn().mockResolvedValue([]),
+      delete: vi.fn().mockResolvedValue(undefined),
+    },
+  };
+
+  return {
+    createInternalRelayCast: vi.fn().mockReturnValue(mockRelay),
+    createInternalWsClient: vi.fn().mockReturnValue({
+      on: vi.fn(),
+      connect: vi.fn(),
+      close: vi.fn(),
+    }),
+    __mockClient: mockClient,
+    __mockRelay: mockRelay,
+  };
+});
+
+describe('multi-workspace server setup', () => {
+  const workspaces: McpWorkspaceConfig[] = [
+    {
+      workspace_id: 'ws_alpha',
+      workspace_alias: 'alpha',
+      api_key: 'rk_live_alpha_key_full',
+      agent_token: 'at_alpha',
+      agent_name: 'AlphaBot',
+    },
+    {
+      workspace_id: 'ws_beta',
+      workspace_alias: 'beta',
+      api_key: 'rk_live_beta_key_full',
+      agent_token: 'at_beta',
+      agent_name: 'BetaBot',
+    },
+  ];
+
+  it('creates server with workspace configs in options', () => {
+    const server = createRelayMcpServer({
+      apiKey: 'rk_live_alpha_key_full',
+      agentToken: 'at_alpha',
+      agentName: 'AlphaBot',
+      workspaces,
+    });
+    expect(server).toBeDefined();
+  });
+
+  it('exposes _sessionRef for transport-level workspace population', () => {
+    const server = createRelayMcpServer({
+      apiKey: 'rk_live_alpha_key_full',
+      agentToken: 'at_alpha',
+      agentName: 'AlphaBot',
+      workspaces,
+    });
+
+    const sessionRef = (server as unknown as { _sessionRef: SessionState })._sessionRef;
+    expect(sessionRef).toBeDefined();
+    expect(sessionRef.workspaces).toBeInstanceOf(Map);
+  });
+
+  it('allows populating workspace contexts via _sessionRef', async () => {
+    const server = createRelayMcpServer({
+      apiKey: 'rk_live_alpha_key_full',
+      agentToken: 'at_alpha',
+      agentName: 'AlphaBot',
+      workspaces,
+    });
+
+    const sessionRef = (server as unknown as { _sessionRef: SessionState })._sessionRef;
+
+    // Simulate what transports.ts bootstrapWorkspaces does
+    for (const ws of workspaces) {
+      if (ws.agent_token && ws.agent_name) {
+        sessionRef.workspaces.set(ws.api_key, {
+          workspaceKey: ws.api_key,
+          agentToken: ws.agent_token,
+          agentName: ws.agent_name,
+          wsBridge: null,
+          subscriptions: null,
+          wsInitAttempted: false,
+        });
+      }
+    }
+
+    expect(sessionRef.workspaces.size).toBe(2);
+    expect(sessionRef.workspaces.get('rk_live_alpha_key_full')?.agentName).toBe('AlphaBot');
+    expect(sessionRef.workspaces.get('rk_live_beta_key_full')?.agentName).toBe('BetaBot');
+  });
+
+  it('message.post with workspace_id routes to correct workspace', async () => {
+    const { createInternalRelayCast, __mockClient } = await import('@relaycast/sdk/internal') as any;
+
+    const server = createRelayMcpServer({
+      apiKey: 'rk_live_alpha_key_full',
+      agentToken: 'at_alpha',
+      agentName: 'AlphaBot',
+      workspaces,
+    });
+
+    // Populate workspace contexts
+    const sessionRef = (server as unknown as { _sessionRef: SessionState })._sessionRef;
+    for (const ws of workspaces) {
+      if (ws.agent_token && ws.agent_name) {
+        sessionRef.workspaces.set(ws.api_key, {
+          workspaceKey: ws.api_key,
+          agentToken: ws.agent_token,
+          agentName: ws.agent_name,
+          wsBridge: null,
+          subscriptions: null,
+          wsInitAttempted: false,
+        });
+      }
+    }
+
+    const client = new Client({ name: 'test-client', version: '0.1.0' });
+    const [ct, st] = InMemoryTransport.createLinkedPair();
+    await Promise.all([client.connect(ct), server.connect(st)]);
+
+    // Call message.post with workspace_id targeting beta workspace
+    __mockClient.send.mockResolvedValue({ id: 'msg_beta', text: 'hello beta' });
+
+    const result = await client.callTool({
+      name: 'message.post',
+      arguments: {
+        channel: 'general',
+        text: 'hello beta',
+        workspace_id: 'ws_beta',
+      },
+    });
+
+    expect(result.content).toBeDefined();
+    // The createInternalRelayCast should have been called with beta's token
+    expect(createInternalRelayCast).toHaveBeenCalled();
+  });
+});

--- a/packages/mcp/src/__tests__/stdio.test.ts
+++ b/packages/mcp/src/__tests__/stdio.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect } from 'vitest';
+import {
+  parseWorkspaceEnv,
+  validateWorkspaceConfigs,
+  resolveDefaultWorkspaceId,
+} from '../workspaces.js';
+import type { McpWorkspaceConfig } from '../workspaces.js';
+
+describe('RELAY_WORKSPACES_JSON parsing', () => {
+  it('returns empty array for undefined input', () => {
+    expect(parseWorkspaceEnv(undefined)).toEqual([]);
+  });
+
+  it('returns empty array for empty string', () => {
+    expect(parseWorkspaceEnv('')).toEqual([]);
+    expect(parseWorkspaceEnv('  ')).toEqual([]);
+  });
+
+  it('throws on invalid JSON', () => {
+    expect(() => parseWorkspaceEnv('not-json')).toThrow('not valid JSON');
+  });
+
+  it('throws when value is not an array', () => {
+    expect(() => parseWorkspaceEnv('{"foo":"bar"}')).toThrow('must be a JSON array');
+  });
+
+  it('parses valid workspace configs', () => {
+    const json = JSON.stringify([
+      {
+        workspace_id: 'ws_alpha',
+        workspace_alias: 'alpha',
+        api_key: 'rk_live_alpha',
+        agent_token: 'at_live_alpha',
+        agent_name: 'Alpha',
+      },
+      {
+        workspace_id: 'ws_beta',
+        api_key: 'rk_live_beta',
+      },
+    ]);
+
+    const configs = parseWorkspaceEnv(json);
+    expect(configs).toHaveLength(2);
+    expect(configs[0]).toEqual({
+      workspace_id: 'ws_alpha',
+      workspace_alias: 'alpha',
+      api_key: 'rk_live_alpha',
+      agent_token: 'at_live_alpha',
+      agent_name: 'Alpha',
+    });
+    expect(configs[1]).toEqual({
+      workspace_id: 'ws_beta',
+      workspace_alias: undefined,
+      api_key: 'rk_live_beta',
+      agent_token: undefined,
+      agent_name: undefined,
+    });
+  });
+
+  it('throws when workspace_id is missing', () => {
+    const json = JSON.stringify([{ api_key: 'rk_live_x' }]);
+    expect(() => parseWorkspaceEnv(json)).toThrow('workspace_id is required');
+  });
+
+  it('throws when api_key is missing', () => {
+    const json = JSON.stringify([{ workspace_id: 'ws_1' }]);
+    expect(() => parseWorkspaceEnv(json)).toThrow('api_key is required');
+  });
+});
+
+describe('validateWorkspaceConfigs', () => {
+  it('rejects non-object entries', () => {
+    expect(() => validateWorkspaceConfigs(['string'])).toThrow('must be an object');
+  });
+
+  it('accepts valid entries', () => {
+    const result = validateWorkspaceConfigs([
+      { workspace_id: 'ws_1', api_key: 'rk_live_1' },
+    ]);
+    expect(result).toHaveLength(1);
+    expect(result[0].workspace_id).toBe('ws_1');
+  });
+});
+
+describe('resolveDefaultWorkspaceId', () => {
+  const configs: McpWorkspaceConfig[] = [
+    { workspace_id: 'ws_alpha', workspace_alias: 'alpha', api_key: 'rk_live_alpha' },
+    { workspace_id: 'ws_beta', api_key: 'rk_live_beta' },
+  ];
+
+  it('returns undefined for empty configs', () => {
+    expect(resolveDefaultWorkspaceId([])).toBeUndefined();
+  });
+
+  it('returns first workspace_id when no default specified', () => {
+    expect(resolveDefaultWorkspaceId(configs)).toBe('ws_alpha');
+  });
+
+  it('resolves default by workspace_id', () => {
+    expect(resolveDefaultWorkspaceId(configs, 'ws_beta')).toBe('ws_beta');
+  });
+
+  it('resolves default by workspace_alias', () => {
+    expect(resolveDefaultWorkspaceId(configs, 'alpha')).toBe('ws_alpha');
+  });
+
+  it('falls back to first when default does not match', () => {
+    expect(resolveDefaultWorkspaceId(configs, 'nonexistent')).toBe('ws_alpha');
+  });
+});

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -4,3 +4,5 @@ export { startStdio, createHttpHandler } from './transports.js';
 export type { SessionLifecycle } from './transports.js';
 export { DEFAULT_SYSTEM_PROMPT } from './prompts.js';
 export type { SessionState } from './types.js';
+export type { McpWorkspaceConfig } from './workspaces.js';
+export { parseWorkspaceEnv, validateWorkspaceConfigs, resolveDefaultWorkspaceId } from './workspaces.js';

--- a/packages/mcp/src/piggyback.ts
+++ b/packages/mcp/src/piggyback.ts
@@ -40,7 +40,7 @@ function hasContentArray(value: unknown): value is ContentCarrier {
 export function enablePiggyback(
   mcpServer: McpServer,
   getSession: () => SessionState,
-  getAgentClient: () => AgentClient,
+  getAgentClient: (wsRouting?: { workspace_id?: string; workspace_alias?: string }) => AgentClient,
   telemetry?: McpTelemetry,
 ): void {
   const original = mcpServer.registerTool.bind(mcpServer) as RegisterToolFn;

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -264,6 +264,7 @@ export function createRelayMcpServer(options: McpServerOptions): McpServer {
           workspaceKey: ws.api_key,
           agentToken: ws.agent_token,
           agentName: ws.agent_name,
+          workspaceName: ws.workspace_name,
           wsBridge: null,
           subscriptions: null,
           wsInitAttempted: false,

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -26,7 +26,7 @@ import { WsBridge } from './resources/ws-bridge.js';
 import { createMcpTelemetry, type McpTelemetry } from './telemetry.js';
 import { resolveToolName } from './tool-aliases.js';
 import type { McpWorkspaceConfig } from './workspaces.js';
-import { findWorkspaceContext, workspaceRefFromArgs } from './workspaces.js';
+import { findWorkspaceContext } from './workspaces.js';
 
 export const MCP_VERSION = '0.1.2';
 

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -156,12 +156,12 @@ export function createRelayMcpServer(options: McpServerOptions): McpServer {
     wsRouting?: { workspace_id?: string; workspace_alias?: string },
   ): AgentClient => {
     // If workspace routing is specified, resolve the target workspace context
-    if (wsRouting && (wsRouting.workspace_id || wsRouting.workspace_alias) && options.workspaces?.length) {
+    if (wsRouting && (wsRouting.workspace_id || wsRouting.workspace_alias)) {
       const ctx = findWorkspaceContext(session, wsRouting, options.workspaces);
       if (!ctx) {
         throw new Error(
           `Workspace not found: ${wsRouting.workspace_id ?? wsRouting.workspace_alias}. ` +
-          'Check that it was bootstrapped via RELAY_WORKSPACES_JSON.',
+          'Join the workspace first via "workspace.join" or bootstrap via RELAY_WORKSPACES_JSON.',
         );
       }
       return createInternalRelayCast({

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -255,8 +255,22 @@ export function createRelayMcpServer(options: McpServerOptions): McpServer {
     });
   }
 
-  // Expose session reference for transport-level workspace bootstrap.
-  (mcpServer as unknown as { _sessionRef: SessionState })._sessionRef = session;
+  // Populate workspace contexts from options so routing works without
+  // external code reaching into server internals.
+  if (options.workspaces?.length) {
+    for (const ws of options.workspaces) {
+      if (ws.agent_token && ws.agent_name) {
+        session.workspaces.set(ws.api_key, {
+          workspaceKey: ws.api_key,
+          agentToken: ws.agent_token,
+          agentName: ws.agent_name,
+          wsBridge: null,
+          subscriptions: null,
+          wsInitAttempted: false,
+        });
+      }
+    }
+  }
 
   return mcpServer;
 }

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -25,6 +25,8 @@ import { SubscriptionManager } from './resources/subscriptions.js';
 import { WsBridge } from './resources/ws-bridge.js';
 import { createMcpTelemetry, type McpTelemetry } from './telemetry.js';
 import { resolveToolName } from './tool-aliases.js';
+import type { McpWorkspaceConfig } from './workspaces.js';
+import { findWorkspaceContext, workspaceRefFromArgs } from './workspaces.js';
 
 export const MCP_VERSION = '0.1.2';
 
@@ -41,6 +43,10 @@ export interface McpServerOptions {
   strictAgentName?: boolean;
   telemetryTransport?: 'stdio' | 'http';
   telemetry?: McpTelemetry;
+  /** Multi-workspace configs parsed from RELAY_WORKSPACES_JSON. */
+  workspaces?: McpWorkspaceConfig[];
+  /** Default workspace ID or alias to use as the active workspace. */
+  defaultWorkspace?: string;
 }
 
 type ServerRequestHandler<TRequest, TResult extends ServerResult = ServerResult> = (
@@ -146,7 +152,24 @@ export function createRelayMcpServer(options: McpServerOptions): McpServer {
     }
   };
 
-  const getAgentClient = (): AgentClient => {
+  const getAgentClient = (
+    wsRouting?: { workspace_id?: string; workspace_alias?: string },
+  ): AgentClient => {
+    // If workspace routing is specified, resolve the target workspace context
+    if (wsRouting && (wsRouting.workspace_id || wsRouting.workspace_alias) && options.workspaces?.length) {
+      const ctx = findWorkspaceContext(session, wsRouting, options.workspaces);
+      if (!ctx) {
+        throw new Error(
+          `Workspace not found: ${wsRouting.workspace_id ?? wsRouting.workspace_alias}. ` +
+          'Check that it was bootstrapped via RELAY_WORKSPACES_JSON.',
+        );
+      }
+      return createInternalRelayCast({
+        apiKey: ctx.agentToken,
+        baseUrl: options.baseUrl,
+      }, mcpOrigin).as(ctx.agentToken);
+    }
+
     if (!session.agentToken) {
       throw new Error('Not registered. Call the "agent.register" tool first.');
     }
@@ -231,6 +254,9 @@ export function createRelayMcpServer(options: McpServerOptions): McpServer {
       return await origCallToolHandler(request, extra);
     });
   }
+
+  // Expose session reference for transport-level workspace bootstrap.
+  (mcpServer as unknown as { _sessionRef: SessionState })._sessionRef = session;
 
   return mcpServer;
 }

--- a/packages/mcp/src/stdio.ts
+++ b/packages/mcp/src/stdio.ts
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 import { startStdio } from './transports.js';
+import { parseWorkspaceEnv } from './workspaces.js';
 
 /**
  * Resolve the Relaycast API key from RELAY_API_KEY env var.
@@ -24,6 +25,8 @@ function parseAgentType(value: string | undefined): 'agent' | 'human' | undefine
   return undefined;
 }
 
+const workspaces = parseWorkspaceEnv(process.env.RELAY_WORKSPACES_JSON);
+
 startStdio({
   apiKey: resolveApiKey(),
   baseUrl: process.env.RELAY_BASE_URL,
@@ -31,4 +34,6 @@ startStdio({
   agentName: process.env.RELAY_AGENT_NAME,
   agentType: parseAgentType(process.env.RELAY_AGENT_TYPE),
   strictAgentName: parseStrictAgentName(process.env.RELAY_STRICT_AGENT_NAME),
+  workspaces: workspaces.length > 0 ? workspaces : undefined,
+  defaultWorkspace: process.env.RELAY_DEFAULT_WORKSPACE,
 });

--- a/packages/mcp/src/tools/channels.ts
+++ b/packages/mcp/src/tools/channels.ts
@@ -7,7 +7,7 @@ const jsonResult = z.object({}).passthrough();
 
 export function registerChannelTools(
   server: McpServer,
-  getAgentClient: () => AgentClient,
+  getAgentClient: (wsRouting?: { workspace_id?: string; workspace_alias?: string }) => AgentClient,
 ): void {
   server.registerTool(
     'channel.create',

--- a/packages/mcp/src/tools/features.ts
+++ b/packages/mcp/src/tools/features.ts
@@ -8,7 +8,7 @@ const jsonResult = z.object({}).passthrough();
 
 export function registerFeatureTools(
   server: McpServer,
-  getAgentClient: () => AgentClient,
+  getAgentClient: (wsRouting?: { workspace_id?: string; workspace_alias?: string }) => AgentClient,
 ): void {
   server.registerTool('reaction.add', {
     title: 'Add Reaction',

--- a/packages/mcp/src/tools/messaging.ts
+++ b/packages/mcp/src/tools/messaging.ts
@@ -1,13 +1,17 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
 import type { AgentClient } from '@relaycast/sdk';
+import { workspaceRoutingInputShape, workspaceRefFromArgs } from '../workspaces.js';
+
+/** Workspace routing arg type extracted from tool input. */
+type WsRouting = { workspace_id?: string; workspace_alias?: string };
 
 /** Passthrough object schema for dynamic API responses. */
 const jsonResult = z.object({}).passthrough();
 
 export function registerMessagingTools(
   server: McpServer,
-  getAgentClient: () => AgentClient,
+  getAgentClient: (wsRouting?: WsRouting) => AgentClient,
 ): void {
   server.registerTool('message.post', {
     title: 'Post Message',
@@ -16,11 +20,12 @@ export function registerMessagingTools(
       channel: z.string().describe('Name of the channel to post the message to (e.g. "general", "build-alerts")'),
       text: z.string().describe('The message body text, which may include @mentions of other agents'),
       attachments: z.array(z.string()).optional().describe('Array of file attachment IDs obtained from the upload_file tool'),
+      ...workspaceRoutingInputShape,
     },
     outputSchema: jsonResult,
     annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: false, openWorldHint: true },
-  }, async ({ channel, text, attachments }) => {
-    const client = getAgentClient();
+  }, async ({ channel, text, attachments, workspace_id, workspace_alias }) => {
+    const client = getAgentClient(workspaceRefFromArgs({ workspace_id, workspace_alias }));
     const msg = await client.send(channel, text, attachments ? { attachments } : undefined);
     return {
       content: [{ type: 'text' as const, text: JSON.stringify(msg, null, 2) }],
@@ -36,13 +41,14 @@ export function registerMessagingTools(
       limit: z.number().optional().describe('Maximum number of messages to return per page (default varies by server configuration)'),
       before: z.string().optional().describe('Message ID cursor — return only messages older than this ID, used for backward pagination'),
       after: z.string().optional().describe('Message ID cursor — return only messages newer than this ID, used for forward pagination'),
+      ...workspaceRoutingInputShape,
     },
     outputSchema: {
       messages: z.array(z.object({}).passthrough()).describe('Array of message objects with id, author, text, and timestamp'),
     },
     annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true, openWorldHint: true },
-  }, async ({ channel, limit, before, after }) => {
-    const client = getAgentClient();
+  }, async ({ channel, limit, before, after, workspace_id, workspace_alias }) => {
+    const client = getAgentClient(workspaceRefFromArgs({ workspace_id, workspace_alias }));
     const msgs = await client.messages(channel, { limit, before, after });
     return {
       content: [{ type: 'text' as const, text: JSON.stringify(msgs, null, 2) }],
@@ -56,11 +62,12 @@ export function registerMessagingTools(
     inputSchema: {
       message_id: z.string().describe('ID of the parent message to reply to, which becomes the thread root'),
       text: z.string().describe('The reply body text, which may include @mentions of other agents'),
+      ...workspaceRoutingInputShape,
     },
     outputSchema: jsonResult,
     annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: false, openWorldHint: true },
-  }, async ({ message_id, text }) => {
-    const client = getAgentClient();
+  }, async ({ message_id, text, workspace_id, workspace_alias }) => {
+    const client = getAgentClient(workspaceRefFromArgs({ workspace_id, workspace_alias }));
     const reply = await client.reply(message_id, text);
     return {
       content: [{ type: 'text' as const, text: JSON.stringify(reply, null, 2) }],
@@ -74,11 +81,12 @@ export function registerMessagingTools(
     inputSchema: {
       message_id: z.string().describe('ID of the parent message whose thread should be retrieved'),
       limit: z.number().optional().describe('Maximum number of replies to return (the parent message is always included)'),
+      ...workspaceRoutingInputShape,
     },
     outputSchema: jsonResult,
     annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true, openWorldHint: true },
-  }, async ({ message_id, limit }) => {
-    const client = getAgentClient();
+  }, async ({ message_id, limit, workspace_id, workspace_alias }) => {
+    const client = getAgentClient(workspaceRefFromArgs({ workspace_id, workspace_alias }));
     const thread = await client.thread(message_id, limit ? { limit } : undefined);
     return {
       content: [{ type: 'text' as const, text: JSON.stringify(thread, null, 2) }],
@@ -92,11 +100,12 @@ export function registerMessagingTools(
     inputSchema: {
       to: z.string().describe('Name of the registered agent to send the direct message to'),
       text: z.string().describe('The direct message body text'),
+      ...workspaceRoutingInputShape,
     },
     outputSchema: jsonResult,
     annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: false, openWorldHint: true },
-  }, async ({ to, text }) => {
-    const client = getAgentClient();
+  }, async ({ to, text, workspace_id, workspace_alias }) => {
+    const client = getAgentClient(workspaceRefFromArgs({ workspace_id, workspace_alias }));
     const result = await client.dm(to, text);
     return {
       content: [{ type: 'text' as const, text: JSON.stringify(result, null, 2) }],
@@ -109,13 +118,14 @@ export function registerMessagingTools(
     description: 'List all direct message conversations for the current agent. Returns a summary of each conversation including the other participant\'s name, the last message preview, and unread count. Use this to discover ongoing private conversations.',
     inputSchema: {
       limit: z.number().optional().describe('Maximum number of conversations to return'),
+      ...workspaceRoutingInputShape,
     },
     outputSchema: {
       conversations: z.array(z.object({}).passthrough()).describe('Array of DM conversation summaries'),
     },
     annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true, openWorldHint: true },
-  }, async () => {
-    const client = getAgentClient();
+  }, async ({ workspace_id, workspace_alias }) => {
+    const client = getAgentClient(workspaceRefFromArgs({ workspace_id, workspace_alias }));
     const convos = await client.dms.conversations();
     return {
       content: [{ type: 'text' as const, text: JSON.stringify(convos, null, 2) }],
@@ -130,11 +140,12 @@ export function registerMessagingTools(
       participants: z.array(z.string()).describe('Array of agent names to include in the group conversation'),
       name: z.string().optional().describe('Optional display name for the group conversation (e.g. "Backend Team", "Project Alpha")'),
       text: z.string().describe('The first message to send to the group, which initiates the conversation'),
+      ...workspaceRoutingInputShape,
     },
     outputSchema: jsonResult,
     annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: false, openWorldHint: true },
-  }, async ({ participants, name, text }) => {
-    const client = getAgentClient();
+  }, async ({ participants, name, text, workspace_id, workspace_alias }) => {
+    const client = getAgentClient(workspaceRefFromArgs({ workspace_id, workspace_alias }));
     const conversation = await client.dms.createGroup({ participants, name });
     const message = await client.dms.sendMessage(conversation.id, text);
     const result = { conversation, message };

--- a/packages/mcp/src/tools/programmability.ts
+++ b/packages/mcp/src/tools/programmability.ts
@@ -9,7 +9,7 @@ const jsonResult = z.object({}).passthrough();
 export function registerProgrammabilityTools(
   server: McpServer,
   getRelay: () => RelayCast,
-  getAgentClient: () => AgentClient,
+  getAgentClient: (wsRouting?: { workspace_id?: string; workspace_alias?: string }) => AgentClient,
 ): void {
   // === Inbound Webhooks ===
 

--- a/packages/mcp/src/tools/registration.ts
+++ b/packages/mcp/src/tools/registration.ts
@@ -21,6 +21,7 @@ const jsonResult = z.object({}).passthrough();
 const workspaceEntrySchema = z.object({
   workspace_ref: z.string().describe('Stable workspace reference accepted by "workspace.switch"'),
   workspace_key: z.string().describe('Masked workspace API key for display'),
+  workspace_name: z.string().nullable().describe('Human-readable workspace name if assigned during "workspace.join"'),
   agent_name: z.string().describe('Saved agent name for this workspace'),
   is_active: z.boolean().describe('True if this workspace is currently active in the session'),
 });
@@ -61,11 +62,15 @@ function saveWorkspaceContext(
   workspaceKey: string,
   agentToken: string,
   agentName: string,
+  workspaceName?: string,
 ): void {
+  const existing = session.workspaces.get(workspaceKey);
   session.workspaces.set(workspaceKey, {
     workspaceKey,
     agentToken,
     agentName,
+    // Preserve existing workspace name if not explicitly provided.
+    workspaceName: workspaceName ?? existing?.workspaceName,
     // Force bridge re-init when this workspace is restored.
     wsBridge: null,
     subscriptions: null,
@@ -324,6 +329,7 @@ export function registerRegistrationTools(
       const all = Array.from(session.workspaces.values()).map((ctx) => ({
         workspace_ref: createWorkspaceRef(ctx.workspaceKey),
         workspace_key: maskKey(ctx.workspaceKey),
+        workspace_name: ctx.workspaceName ?? null,
         agent_name: ctx.agentName,
         is_active: ctx.workspaceKey === session.workspaceKey,
       }));
@@ -352,13 +358,14 @@ export function registerRegistrationTools(
       inputSchema: {
         api_key: z.string().describe('Workspace API key starting with "rk_live_"'),
         name: z.string().describe('Agent name to register in the target workspace'),
+        workspace_name: z.string().optional().describe('Human-readable workspace name for easier switching (e.g. "Production", "Staging")'),
         type: z.enum(['agent', 'human']).optional().describe('Whether this identity represents an AI agent or a human user'),
         persona: z.string().optional().describe('Free-text persona description'),
       },
       outputSchema: jsonResult,
       annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: true, openWorldHint: true },
     },
-    async ({ api_key, name, type, persona }) => {
+    async ({ api_key, name, workspace_name, type, persona }) => {
       if (!api_key.startsWith('rk_live_')) {
         throw new Error('Workspace key must start with "rk_live_"');
       }
@@ -378,6 +385,10 @@ export function registerRegistrationTools(
       // Check if already joined this workspace.
       const existing = session.workspaces.get(api_key);
       if (existing) {
+        // Update workspace name if provided.
+        if (workspace_name && existing.workspaceName !== workspace_name) {
+          existing.workspaceName = workspace_name;
+        }
         setSession({
           workspaceKey: api_key,
           agentToken: existing.agentToken,
@@ -402,7 +413,7 @@ export function registerRegistrationTools(
 
       // Save the new workspace context.
       const updatedSession = getSession();
-      saveWorkspaceContext(updatedSession, api_key, regResult.token, name);
+      saveWorkspaceContext(updatedSession, api_key, regResult.token, name, workspace_name);
 
       const result = {
         message: `Joined workspace and registered as "${name}".`,
@@ -422,10 +433,11 @@ export function registerRegistrationTools(
     {
       title: 'Switch Workspace',
       description:
-        'Switch the active workspace to a previously joined workspace. Provide either a full api_key or the workspace_ref returned by "workspace.list". The agent identity and WebSocket connection for the target workspace are restored from the saved session context.',
+        'Switch the active workspace to a previously joined workspace. Provide either a full api_key, workspace_ref from "workspace.list", or workspace_name assigned during "workspace.join". The agent identity and WebSocket connection for the target workspace are restored from the saved session context.',
       inputSchema: {
         api_key: z.string().optional().describe('Full workspace API key to switch to (must have been previously joined)'),
         workspace_ref: z.string().optional().describe('Stable workspace reference from "workspace.list"'),
+        workspace_name: z.string().optional().describe('Human-readable workspace name assigned during "workspace.join"'),
       },
       outputSchema: {
         message: z.string().describe('Confirmation message'),
@@ -433,16 +445,16 @@ export function registerRegistrationTools(
       },
       annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: true, openWorldHint: false },
     },
-    async ({ api_key, workspace_ref }) => {
-      if (!api_key && !workspace_ref) {
-        throw new Error('Provide either "api_key" or "workspace_ref".');
+    async ({ api_key, workspace_ref, workspace_name }) => {
+      if (!api_key && !workspace_ref && !workspace_name) {
+        throw new Error('Provide "api_key", "workspace_ref", or "workspace_name".');
       }
       if (api_key && !api_key.startsWith('rk_live_')) {
         throw new Error('Workspace key must start with "rk_live_"');
       }
 
       const session = getSession();
-      const resolved = resolveSavedWorkspace(session, api_key, workspace_ref);
+      const resolved = resolveSavedWorkspace(session, api_key, workspace_ref, workspace_name);
       if (!resolved) {
         throw new Error(
           'Workspace not found in session. Use "workspace.join" to join it first, or "workspace.set_key" to connect without a saved context.',
@@ -487,6 +499,7 @@ function resolveSavedWorkspace(
   session: SessionState,
   apiKey?: string,
   workspaceRef?: string,
+  workspaceName?: string,
 ): { workspaceKey: string; context: WorkspaceContext } | null {
   if (apiKey) {
     const exact = session.workspaces.get(apiKey);
@@ -513,6 +526,21 @@ function resolveSavedWorkspace(
       if (createWorkspaceRef(workspaceKey) === workspaceRef) {
         return { workspaceKey, context };
       }
+    }
+  }
+
+  if (workspaceName) {
+    const nameMatches = Array.from(session.workspaces.entries()).filter(
+      ([, ctx]) => ctx.workspaceName?.toLowerCase() === workspaceName.toLowerCase(),
+    );
+    if (nameMatches.length > 1) {
+      throw new Error(
+        `Multiple workspaces match name "${workspaceName}". Use "workspace_ref" or "api_key" instead.`,
+      );
+    }
+    if (nameMatches.length === 1) {
+      const [workspaceKey, context] = nameMatches[0];
+      return { workspaceKey, context };
     }
   }
 

--- a/packages/mcp/src/tools/registration.ts
+++ b/packages/mcp/src/tools/registration.ts
@@ -6,6 +6,10 @@ import type { SessionState, WorkspaceContext } from '../types.js';
 
 type ApiOk<T> = { ok: true; data: T };
 type ApiErr = { ok: false; error?: { message?: string } };
+type WorkspaceMetadata = {
+  workspaceName?: string;
+  workspaceLabel?: string;
+};
 
 interface CreateWorkspaceResponse {
   workspace_id?: string;
@@ -21,7 +25,8 @@ const jsonResult = z.object({}).passthrough();
 const workspaceEntrySchema = z.object({
   workspace_ref: z.string().describe('Stable workspace reference accepted by "workspace.switch"'),
   workspace_key: z.string().describe('Masked workspace API key for display'),
-  workspace_name: z.string().nullable().describe('Human-readable workspace name if assigned during "workspace.join"'),
+  workspace_name: z.string().nullable().describe('Canonical workspace name from the Relaycast API'),
+  workspace_label: z.string().nullable().describe('Optional custom label saved during "workspace.join"'),
   agent_name: z.string().describe('Saved agent name for this workspace'),
   is_active: z.boolean().describe('True if this workspace is currently active in the session'),
 });
@@ -50,6 +55,30 @@ async function createWorkspace(
   return payload.data;
 }
 
+async function fetchWorkspaceName(
+  apiKey: string,
+  baseUrl?: string,
+): Promise<string | undefined> {
+  try {
+    const response = await fetch(`${normalizeBaseUrl(baseUrl)}/v1/workspace`, {
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+      },
+    });
+    if (!response.ok) return undefined;
+
+    const payload = (await response.json()) as ApiOk<{ name?: unknown }> | ApiErr;
+    if (!payload || typeof payload !== 'object' || !('ok' in payload) || !payload.ok) {
+      return undefined;
+    }
+
+    const name = payload.data?.name;
+    return typeof name === 'string' ? name : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
 function requireWorkspaceKey(session: SessionState): void {
   if (session.workspaceKey) return;
   throw new Error(
@@ -62,15 +91,16 @@ function saveWorkspaceContext(
   workspaceKey: string,
   agentToken: string,
   agentName: string,
-  workspaceName?: string,
+  metadata: WorkspaceMetadata = {},
 ): void {
   const existing = session.workspaces.get(workspaceKey);
   session.workspaces.set(workspaceKey, {
     workspaceKey,
     agentToken,
     agentName,
-    // Preserve existing workspace name if not explicitly provided.
-    workspaceName: workspaceName ?? existing?.workspaceName,
+    // Preserve existing workspace metadata if not explicitly provided.
+    workspaceName: metadata.workspaceName ?? existing?.workspaceName,
+    workspaceLabel: metadata.workspaceLabel ?? existing?.workspaceLabel,
     // Force bridge re-init when this workspace is restored.
     wsBridge: null,
     subscriptions: null,
@@ -234,6 +264,18 @@ export function registerRegistrationTools(
       // If already pre-registered with a token, skip the API call and return
       // the existing registration to avoid overwriting the pre-registered identity.
       if (session.agentToken && effectiveName && strictAgentName) {
+        const workspaceName = session.workspaceKey
+          ? await fetchWorkspaceName(session.workspaceKey, baseUrl)
+          : undefined;
+        if (session.workspaceKey) {
+          saveWorkspaceContext(
+            session,
+            session.workspaceKey,
+            session.agentToken,
+            effectiveName,
+            { workspaceName },
+          );
+        }
         const existing = {
           name: effectiveName,
           token: session.agentToken,
@@ -259,11 +301,13 @@ export function registerRegistrationTools(
       // Update multi-workspace context map.
       const updatedSession = getSession();
       if (updatedSession.workspaceKey) {
+        const workspaceName = await fetchWorkspaceName(updatedSession.workspaceKey, baseUrl);
         saveWorkspaceContext(
           updatedSession,
           updatedSession.workspaceKey,
           result.token,
           effectiveName,
+          { workspaceName },
         );
       }
       const payload = {
@@ -313,7 +357,7 @@ export function registerRegistrationTools(
     {
       title: 'List Joined Workspaces',
       description:
-        'List all workspaces this agent has joined in the current MCP session. Returns a stable workspace_ref for switching, the masked workspace key for display, the saved agent name, and whether the workspace is currently active.',
+        'List all workspaces this agent has joined in the current MCP session. Returns a stable workspace_ref for switching, the masked workspace key for display, the canonical workspace name, any saved label, the saved agent name, and whether the workspace is currently active.',
       inputSchema: {
         status: z.enum(['active', 'all']).optional().describe('Filter workspaces by status: "active" for only the current workspace, "all" (default) for every joined workspace'),
       },
@@ -330,6 +374,7 @@ export function registerRegistrationTools(
         workspace_ref: createWorkspaceRef(ctx.workspaceKey),
         workspace_key: maskKey(ctx.workspaceKey),
         workspace_name: ctx.workspaceName ?? null,
+        workspace_label: ctx.workspaceLabel ?? null,
         agent_name: ctx.agentName,
         is_active: ctx.workspaceKey === session.workspaceKey,
       }));
@@ -358,7 +403,7 @@ export function registerRegistrationTools(
       inputSchema: {
         api_key: z.string().describe('Workspace API key starting with "rk_live_"'),
         name: z.string().describe('Agent name to register in the target workspace'),
-        workspace_name: z.string().optional().describe('Human-readable workspace name for easier switching (e.g. "Production", "Staging")'),
+        workspace_name: z.string().optional().describe('Optional custom label to save for easier switching. The canonical workspace name is fetched automatically from the API.'),
         type: z.enum(['agent', 'human']).optional().describe('Whether this identity represents an AI agent or a human user'),
         persona: z.string().optional().describe('Free-text persona description'),
       },
@@ -371,6 +416,7 @@ export function registerRegistrationTools(
       }
 
       const session = getSession();
+      const canonicalWorkspaceName = await fetchWorkspaceName(api_key, baseUrl);
 
       // Save current workspace context before switching.
       if (session.workspaceKey && session.agentToken && session.agentName) {
@@ -385,9 +431,11 @@ export function registerRegistrationTools(
       // Check if already joined this workspace.
       const existing = session.workspaces.get(api_key);
       if (existing) {
-        // Update workspace name if provided.
-        if (workspace_name && existing.workspaceName !== workspace_name) {
-          existing.workspaceName = workspace_name;
+        if (canonicalWorkspaceName && existing.workspaceName !== canonicalWorkspaceName) {
+          existing.workspaceName = canonicalWorkspaceName;
+        }
+        if (workspace_name && existing.workspaceLabel !== workspace_name) {
+          existing.workspaceLabel = workspace_name;
         }
         setSession({
           workspaceKey: api_key,
@@ -413,7 +461,10 @@ export function registerRegistrationTools(
 
       // Save the new workspace context.
       const updatedSession = getSession();
-      saveWorkspaceContext(updatedSession, api_key, regResult.token, name, workspace_name);
+      saveWorkspaceContext(updatedSession, api_key, regResult.token, name, {
+        workspaceName: canonicalWorkspaceName,
+        workspaceLabel: workspace_name,
+      });
 
       const result = {
         message: `Joined workspace and registered as "${name}".`,
@@ -433,11 +484,11 @@ export function registerRegistrationTools(
     {
       title: 'Switch Workspace',
       description:
-        'Switch the active workspace to a previously joined workspace. Provide either a full api_key, workspace_ref from "workspace.list", or workspace_name assigned during "workspace.join". The agent identity and WebSocket connection for the target workspace are restored from the saved session context.',
+        'Switch the active workspace to a previously joined workspace. Provide either a full api_key, workspace_ref from "workspace.list", or workspace_name matching either the canonical workspace record name or a saved custom label. The agent identity and WebSocket connection for the target workspace are restored from the saved session context.',
       inputSchema: {
         api_key: z.string().optional().describe('Full workspace API key to switch to (must have been previously joined)'),
         workspace_ref: z.string().optional().describe('Stable workspace reference from "workspace.list"'),
-        workspace_name: z.string().optional().describe('Human-readable workspace name assigned during "workspace.join"'),
+        workspace_name: z.string().optional().describe('Canonical workspace name from the API, or a saved custom label from "workspace.join"'),
       },
       outputSchema: {
         message: z.string().describe('Confirmation message'),
@@ -531,7 +582,9 @@ function resolveSavedWorkspace(
 
   if (workspaceName) {
     const nameMatches = Array.from(session.workspaces.entries()).filter(
-      ([, ctx]) => ctx.workspaceName?.toLowerCase() === workspaceName.toLowerCase(),
+      ([, ctx]) =>
+        ctx.workspaceName?.toLowerCase() === workspaceName.toLowerCase()
+        || ctx.workspaceLabel?.toLowerCase() === workspaceName.toLowerCase(),
     );
     if (nameMatches.length > 1) {
       throw new Error(

--- a/packages/mcp/src/transports.ts
+++ b/packages/mcp/src/transports.ts
@@ -3,13 +3,133 @@ import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/
 import { createRelayMcpServer, MCP_VERSION, type McpServerOptions } from './server.js';
 import { randomUUID } from 'node:crypto';
 import { createMcpTelemetry } from './telemetry.js';
+import { createInternalRelayCast } from '@relaycast/sdk/internal';
+import type { McpWorkspaceConfig } from './workspaces.js';
+import { resolveDefaultWorkspaceId } from './workspaces.js';
+
+const mcpOrigin = {
+  surface: 'mcp' as const,
+  client: '@relaycast/mcp',
+  version: MCP_VERSION,
+};
+
+/**
+ * Bootstrap workspaces by verifying/refreshing tokens and joining each
+ * workspace into the MCP server's session via setSession + saveWorkspaceContext.
+ *
+ * This is called during startStdio when `workspaces` are provided.
+ */
+async function bootstrapWorkspaces(
+  workspaces: McpWorkspaceConfig[],
+  baseUrl?: string,
+): Promise<McpWorkspaceConfig[]> {
+  const bootstrapped: McpWorkspaceConfig[] = [];
+
+  for (const ws of workspaces) {
+    try {
+      const relay = createInternalRelayCast({
+        apiKey: ws.api_key,
+        baseUrl,
+      }, mcpOrigin);
+
+      let token = ws.agent_token;
+      let agentName = ws.agent_name ?? ws.workspace_alias ?? ws.workspace_id;
+
+      // If we have a token, verify it's still valid via an inbox call
+      if (token) {
+        try {
+          const client = relay.as(token);
+          await client.inbox();
+        } catch {
+          // Token is invalid, need to re-register
+          token = undefined;
+        }
+      }
+
+      // If no valid token, register or rotate
+      if (!token) {
+        const result = await relay.agents.registerOrRotate({
+          name: agentName,
+          type: 'agent',
+        });
+        token = result.token;
+      }
+
+      bootstrapped.push({
+        ...ws,
+        agent_token: token,
+        agent_name: agentName,
+      });
+    } catch (err) {
+      console.error(
+        `[bootstrap] Failed to bootstrap workspace ${ws.workspace_id}: ${err instanceof Error ? err.message : String(err)}`,
+      );
+      // Still include the workspace config even if bootstrap failed,
+      // so it can be retried later
+      bootstrapped.push(ws);
+    }
+  }
+
+  return bootstrapped;
+}
 
 /**
  * Start MCP server with stdio transport (single agent).
  * Reads from stdin, writes to stdout.
  */
 export async function startStdio(options: McpServerOptions): Promise<void> {
-  const mcpServer = createRelayMcpServer({ ...options, telemetryTransport: 'stdio' });
+  let effectiveOptions = { ...options, telemetryTransport: 'stdio' as const };
+
+  // If workspaces are provided, bootstrap them before creating the server
+  if (options.workspaces?.length) {
+    const bootstrapped = await bootstrapWorkspaces(options.workspaces, options.baseUrl);
+    effectiveOptions = { ...effectiveOptions, workspaces: bootstrapped };
+
+    // Set the default workspace's api key/token/name as the primary session
+    const defaultWsId = resolveDefaultWorkspaceId(bootstrapped, options.defaultWorkspace);
+    const defaultWs = bootstrapped.find(
+      w => w.workspace_id === defaultWsId && w.agent_token,
+    );
+    if (defaultWs) {
+      effectiveOptions.apiKey = effectiveOptions.apiKey ?? defaultWs.api_key;
+      effectiveOptions.agentToken = effectiveOptions.agentToken ?? defaultWs.agent_token;
+      effectiveOptions.agentName = effectiveOptions.agentName ?? defaultWs.agent_name;
+    }
+  }
+
+  const mcpServer = createRelayMcpServer(effectiveOptions);
+
+  // If workspaces were bootstrapped, save each into the session's workspaces Map
+  if (effectiveOptions.workspaces?.length) {
+    // Access the session through the server to save workspace contexts.
+    // The createRelayMcpServer already initialized the session, so we use
+    // a workspace.join-like approach by directly manipulating session state
+    // through the server's internal session reference.
+    // Since createRelayMcpServer returns a McpServer without direct session access,
+    // we rely on the fact that the session was initialized with the default workspace's
+    // credentials, and the workspace configs are passed through options.workspaces
+    // so getAgentClient can resolve them.
+    //
+    // We need to populate session.workspaces for routing to work.
+    // The cleanest way is to expose a hook. For now, we use the
+    // `_sessionRef` that createRelayMcpServer attaches to the server.
+    const sessionRef = (mcpServer as unknown as { _sessionRef?: { workspaces: Map<string, unknown> } })._sessionRef;
+    if (sessionRef) {
+      for (const ws of effectiveOptions.workspaces) {
+        if (ws.agent_token && ws.agent_name) {
+          sessionRef.workspaces.set(ws.api_key, {
+            workspaceKey: ws.api_key,
+            agentToken: ws.agent_token,
+            agentName: ws.agent_name,
+            wsBridge: null,
+            subscriptions: null,
+            wsInitAttempted: false,
+          });
+        }
+      }
+    }
+  }
+
   const transport = new StdioServerTransport();
   await mcpServer.connect(transport);
 }

--- a/packages/mcp/src/transports.ts
+++ b/packages/mcp/src/transports.ts
@@ -97,38 +97,9 @@ export async function startStdio(options: McpServerOptions): Promise<void> {
     }
   }
 
+  // createRelayMcpServer now populates session.workspaces from
+  // effectiveOptions.workspaces internally — no need to reach into internals.
   const mcpServer = createRelayMcpServer(effectiveOptions);
-
-  // If workspaces were bootstrapped, save each into the session's workspaces Map
-  if (effectiveOptions.workspaces?.length) {
-    // Access the session through the server to save workspace contexts.
-    // The createRelayMcpServer already initialized the session, so we use
-    // a workspace.join-like approach by directly manipulating session state
-    // through the server's internal session reference.
-    // Since createRelayMcpServer returns a McpServer without direct session access,
-    // we rely on the fact that the session was initialized with the default workspace's
-    // credentials, and the workspace configs are passed through options.workspaces
-    // so getAgentClient can resolve them.
-    //
-    // We need to populate session.workspaces for routing to work.
-    // The cleanest way is to expose a hook. For now, we use the
-    // `_sessionRef` that createRelayMcpServer attaches to the server.
-    const sessionRef = (mcpServer as unknown as { _sessionRef?: { workspaces: Map<string, unknown> } })._sessionRef;
-    if (sessionRef) {
-      for (const ws of effectiveOptions.workspaces) {
-        if (ws.agent_token && ws.agent_name) {
-          sessionRef.workspaces.set(ws.api_key, {
-            workspaceKey: ws.api_key,
-            agentToken: ws.agent_token,
-            agentName: ws.agent_name,
-            wsBridge: null,
-            subscriptions: null,
-            wsInitAttempted: false,
-          });
-        }
-      }
-    }
-  }
 
   const transport = new StdioServerTransport();
   await mcpServer.connect(transport);

--- a/packages/mcp/src/transports.ts
+++ b/packages/mcp/src/transports.ts
@@ -33,7 +33,7 @@ async function bootstrapWorkspaces(
       }, mcpOrigin);
 
       let token = ws.agent_token;
-      let agentName = ws.agent_name ?? ws.workspace_alias ?? ws.workspace_id;
+      const agentName = ws.agent_name ?? ws.workspace_alias ?? ws.workspace_id;
 
       // If we have a token, verify it's still valid via an inbox call
       if (token) {

--- a/packages/mcp/src/transports.ts
+++ b/packages/mcp/src/transports.ts
@@ -34,6 +34,14 @@ async function bootstrapWorkspaces(
 
       let token = ws.agent_token;
       const agentName = ws.agent_name ?? ws.workspace_alias ?? ws.workspace_id;
+      let workspaceName = ws.workspace_name;
+
+      try {
+        const workspace = await relay.workspace.info();
+        workspaceName = workspace.name;
+      } catch {
+        // Keep any pre-supplied name or leave undefined if workspace info is unavailable.
+      }
 
       // If we have a token, verify it's still valid via an inbox call
       if (token) {
@@ -59,6 +67,7 @@ async function bootstrapWorkspaces(
         ...ws,
         agent_token: token,
         agent_name: agentName,
+        workspace_name: workspaceName,
       });
     } catch (err) {
       console.error(

--- a/packages/mcp/src/types.ts
+++ b/packages/mcp/src/types.ts
@@ -6,6 +6,8 @@ export interface WorkspaceContext {
   workspaceKey: string;
   agentToken: string;
   agentName: string;
+  /** Human-readable workspace name, used for routing via workspace.switch. */
+  workspaceName?: string;
   wsBridge: WsBridge | null;
   subscriptions: SubscriptionManager | null;
   wsInitAttempted: boolean;

--- a/packages/mcp/src/types.ts
+++ b/packages/mcp/src/types.ts
@@ -6,8 +6,10 @@ export interface WorkspaceContext {
   workspaceKey: string;
   agentToken: string;
   agentName: string;
-  /** Human-readable workspace name, used for routing via workspace.switch. */
+  /** Canonical workspace name from the Relaycast API. */
   workspaceName?: string;
+  /** Optional user-saved label for switching. */
+  workspaceLabel?: string;
   wsBridge: WsBridge | null;
   subscriptions: SubscriptionManager | null;
   wsInitAttempted: boolean;

--- a/packages/mcp/src/workspaces.ts
+++ b/packages/mcp/src/workspaces.ts
@@ -106,23 +106,33 @@ export function workspaceRefFromArgs(
 }
 
 /**
- * Find a WorkspaceContext in the session by workspace_id or workspace_alias.
- * Scans the workspaces Map for matching entries.
+ * Find a WorkspaceContext in the session by workspace_id, workspace_alias,
+ * or workspace_name. Scans the workspaces Map for matching entries.
  */
 export function findWorkspaceContext(
   session: SessionState,
   ref: { workspace_id?: string; workspace_alias?: string },
-  configs: McpWorkspaceConfig[],
+  configs?: McpWorkspaceConfig[],
 ): WorkspaceContext | undefined {
   // Try to find the matching config first to get the api_key
-  const config = configs.find(c => {
+  const config = configs?.find(c => {
     if (ref.workspace_id && c.workspace_id === ref.workspace_id) return true;
     if (ref.workspace_alias && c.workspace_alias === ref.workspace_alias) return true;
     return false;
   });
 
-  if (!config) return undefined;
+  if (config) {
+    return session.workspaces.get(config.api_key);
+  }
 
-  // Look up by api_key in session.workspaces
-  return session.workspaces.get(config.api_key);
+  // Fall back to matching by workspace_alias against workspaceName in session
+  if (ref.workspace_alias) {
+    for (const ctx of session.workspaces.values()) {
+      if (ctx.workspaceName?.toLowerCase() === ref.workspace_alias.toLowerCase()) {
+        return ctx;
+      }
+    }
+  }
+
+  return undefined;
 }

--- a/packages/mcp/src/workspaces.ts
+++ b/packages/mcp/src/workspaces.ts
@@ -13,6 +13,15 @@ export interface McpWorkspaceConfig {
   agent_name?: string;
 }
 
+const mcpWorkspaceConfigSchema = z.object({
+  workspace_id: z.string({ error: 'is required and must be a string' }),
+  workspace_alias: z.string().optional(),
+  workspace_name: z.string().optional(),
+  api_key: z.string({ error: 'is required and must be a string' }),
+  agent_token: z.string().optional(),
+  agent_name: z.string().optional(),
+});
+
 /**
  * Parse RELAY_WORKSPACES_JSON env var into an array of workspace configs.
  * Returns an empty array if the env var is not set or empty.
@@ -39,23 +48,15 @@ export function parseWorkspaceEnv(raw?: string): McpWorkspaceConfig[] {
  */
 export function validateWorkspaceConfigs(configs: unknown[]): McpWorkspaceConfig[] {
   return configs.map((cfg, i) => {
-    if (!cfg || typeof cfg !== 'object') {
-      throw new Error(`RELAY_WORKSPACES_JSON[${i}] must be an object`);
+    const result = mcpWorkspaceConfigSchema.safeParse(cfg);
+    if (!result.success) {
+      const issue = result.error.issues[0];
+      if (!issue.path.length) {
+        throw new Error(`RELAY_WORKSPACES_JSON[${i}] must be an object`);
+      }
+      throw new Error(`RELAY_WORKSPACES_JSON[${i}].${issue.path.join('.')} ${issue.message}`);
     }
-    const obj = cfg as Record<string, unknown>;
-    if (!obj.workspace_id || typeof obj.workspace_id !== 'string') {
-      throw new Error(`RELAY_WORKSPACES_JSON[${i}].workspace_id is required and must be a string`);
-    }
-    if (!obj.api_key || typeof obj.api_key !== 'string') {
-      throw new Error(`RELAY_WORKSPACES_JSON[${i}].api_key is required and must be a string`);
-    }
-    return {
-      workspace_id: obj.workspace_id as string,
-      workspace_alias: typeof obj.workspace_alias === 'string' ? obj.workspace_alias : undefined,
-      api_key: obj.api_key as string,
-      agent_token: typeof obj.agent_token === 'string' ? obj.agent_token : undefined,
-      agent_name: typeof obj.agent_name === 'string' ? obj.agent_name : undefined,
-    };
+    return result.data;
   });
 }
 

--- a/packages/mcp/src/workspaces.ts
+++ b/packages/mcp/src/workspaces.ts
@@ -1,0 +1,128 @@
+import { z } from 'zod';
+import type { SessionState, WorkspaceContext } from './types.js';
+
+/**
+ * Configuration for a single workspace provided via RELAY_WORKSPACES_JSON.
+ */
+export interface McpWorkspaceConfig {
+  workspace_id: string;
+  workspace_alias?: string;
+  api_key: string;
+  agent_token?: string;
+  agent_name?: string;
+}
+
+/**
+ * Parse RELAY_WORKSPACES_JSON env var into an array of workspace configs.
+ * Returns an empty array if the env var is not set or empty.
+ */
+export function parseWorkspaceEnv(raw?: string): McpWorkspaceConfig[] {
+  if (!raw || !raw.trim()) return [];
+  try {
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) {
+      throw new Error('RELAY_WORKSPACES_JSON must be a JSON array');
+    }
+    return validateWorkspaceConfigs(parsed);
+  } catch (err) {
+    if (err instanceof SyntaxError) {
+      throw new Error(`RELAY_WORKSPACES_JSON is not valid JSON: ${err.message}`);
+    }
+    throw err;
+  }
+}
+
+/**
+ * Validate an array of workspace config objects.
+ * Ensures each entry has the required fields.
+ */
+export function validateWorkspaceConfigs(configs: unknown[]): McpWorkspaceConfig[] {
+  return configs.map((cfg, i) => {
+    if (!cfg || typeof cfg !== 'object') {
+      throw new Error(`RELAY_WORKSPACES_JSON[${i}] must be an object`);
+    }
+    const obj = cfg as Record<string, unknown>;
+    if (!obj.workspace_id || typeof obj.workspace_id !== 'string') {
+      throw new Error(`RELAY_WORKSPACES_JSON[${i}].workspace_id is required and must be a string`);
+    }
+    if (!obj.api_key || typeof obj.api_key !== 'string') {
+      throw new Error(`RELAY_WORKSPACES_JSON[${i}].api_key is required and must be a string`);
+    }
+    return {
+      workspace_id: obj.workspace_id as string,
+      workspace_alias: typeof obj.workspace_alias === 'string' ? obj.workspace_alias : undefined,
+      api_key: obj.api_key as string,
+      agent_token: typeof obj.agent_token === 'string' ? obj.agent_token : undefined,
+      agent_name: typeof obj.agent_name === 'string' ? obj.agent_name : undefined,
+    };
+  });
+}
+
+/**
+ * Resolve which workspace ID should be the default/active workspace.
+ * Falls back to the first workspace in the list.
+ */
+export function resolveDefaultWorkspaceId(
+  configs: McpWorkspaceConfig[],
+  defaultWorkspace?: string,
+): string | undefined {
+  if (!configs.length) return undefined;
+  if (defaultWorkspace) {
+    const match = configs.find(
+      c => c.workspace_id === defaultWorkspace || c.workspace_alias === defaultWorkspace,
+    );
+    if (match) return match.workspace_id;
+  }
+  return configs[0].workspace_id;
+}
+
+/**
+ * Optional workspace routing params added to messaging tools.
+ * When provided, the tool targets a specific workspace instead of the active one.
+ */
+export const workspaceRoutingInputShape = {
+  workspace_id: z.string().optional().describe(
+    'Target a specific workspace by its workspace_id (from RELAY_WORKSPACES_JSON). If omitted, uses the active workspace.',
+  ),
+  workspace_alias: z.string().optional().describe(
+    'Target a specific workspace by its alias (from RELAY_WORKSPACES_JSON). If omitted, uses the active workspace.',
+  ),
+};
+
+/**
+ * Extract workspace routing info from tool arguments.
+ * Returns the workspace_id or workspace_alias if provided, or undefined.
+ */
+export function workspaceRefFromArgs(
+  args: { workspace_id?: string; workspace_alias?: string },
+): { workspace_id?: string; workspace_alias?: string } | undefined {
+  if (args.workspace_id || args.workspace_alias) {
+    return {
+      workspace_id: args.workspace_id,
+      workspace_alias: args.workspace_alias,
+    };
+  }
+  return undefined;
+}
+
+/**
+ * Find a WorkspaceContext in the session by workspace_id or workspace_alias.
+ * Scans the workspaces Map for matching entries.
+ */
+export function findWorkspaceContext(
+  session: SessionState,
+  ref: { workspace_id?: string; workspace_alias?: string },
+  configs: McpWorkspaceConfig[],
+): WorkspaceContext | undefined {
+  // Try to find the matching config first to get the api_key
+  const config = configs.find(c => {
+    if (ref.workspace_id && c.workspace_id === ref.workspace_id) return true;
+    if (ref.workspace_alias && c.workspace_alias === ref.workspace_alias) return true;
+    return false;
+  });
+
+  if (!config) return undefined;
+
+  // Look up by api_key in session.workspaces
+  return session.workspaces.get(config.api_key);
+}

--- a/packages/mcp/src/workspaces.ts
+++ b/packages/mcp/src/workspaces.ts
@@ -7,6 +7,7 @@ import type { SessionState, WorkspaceContext } from './types.js';
 export interface McpWorkspaceConfig {
   workspace_id: string;
   workspace_alias?: string;
+  workspace_name?: string;
   api_key: string;
   agent_token?: string;
   agent_name?: string;
@@ -106,8 +107,8 @@ export function workspaceRefFromArgs(
 }
 
 /**
- * Find a WorkspaceContext in the session by workspace_id, workspace_alias,
- * or workspace_name. Scans the workspaces Map for matching entries.
+ * Find a WorkspaceContext in the session by workspace_id or workspace_alias.
+ * Falls back to matching a saved workspace label or canonical workspace name.
  */
 export function findWorkspaceContext(
   session: SessionState,
@@ -125,10 +126,14 @@ export function findWorkspaceContext(
     return session.workspaces.get(config.api_key);
   }
 
-  // Fall back to matching by workspace_alias against workspaceName in session
+  // Fall back to matching by workspace_alias against saved workspace metadata.
   if (ref.workspace_alias) {
+    const target = ref.workspace_alias.toLowerCase();
     for (const ctx of session.workspaces.values()) {
-      if (ctx.workspaceName?.toLowerCase() === ref.workspace_alias.toLowerCase()) {
+      if (
+        ctx.workspaceLabel?.toLowerCase() === target
+        || ctx.workspaceName?.toLowerCase() === target
+      ) {
         return ctx;
       }
     }


### PR DESCRIPTION
## Summary
- Add `RELAY_WORKSPACES_JSON` env var parsing to bootstrap multiple workspaces at MCP server startup, with `RELAY_DEFAULT_WORKSPACE` to select the active workspace
- Add per-tool workspace routing via optional `workspace_id` and `workspace_alias` params on messaging tools (`message.post`, `message.list`, `message.reply`, `message.get_thread`, `dm.send`, `dm.list`, `dm.send_group`)
- Add workspace bootstrap in stdio transport: verifies existing agent tokens via inbox call, falls back to `registerOrRotate` for fresh tokens
- Create `packages/mcp/src/workspaces.ts` with `McpWorkspaceConfig` interface, `parseWorkspaceEnv()`, `validateWorkspaceConfigs()`, `resolveDefaultWorkspaceId()`, `workspaceRoutingInputShape`, and `workspaceRefFromArgs()` helpers
- Update `getAgentClient` signature to accept optional workspace routing param, propagated through `enablePiggyback`, `registerMessagingTools`, `registerChannelTools`, `registerFeatureTools`, `registerProgrammabilityTools`
- Export `McpWorkspaceConfig` from package index

Built on top of PR #78 (`feat/multi-workspace-mcp`) architecture -- uses session's `workspaces` Map and `workspace.join`/`workspace.switch` tools, does NOT reintroduce `MultiWorkspaceSessionManager`.

## Test plan
- [x] `packages/mcp/src/__tests__/stdio.test.ts` -- tests `parseWorkspaceEnv`, `validateWorkspaceConfigs`, `resolveDefaultWorkspaceId`
- [x] `packages/mcp/src/__tests__/messaging-tools.test.ts` -- tests workspace routing params on messaging tools
- [x] `packages/mcp/src/__tests__/server-multi-workspace.test.ts` -- tests multi-workspace server setup and routing
- [x] All 178 tests pass (`npx vitest run` from `packages/mcp`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/agentworkforce/relaycast/pull/80" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
