### PR TITLE
fix(mcp): skip bootstrap for broker-spawned agents

### DIFF
--- a/packages/mcp/src/stdio.ts
+++ b/packages/mcp/src/stdio.ts
@@ -25,7 +25,11 @@ function parseAgentType(value: string | undefined): 'agent' | 'human' | undefine
   return undefined;
 }
 
-const workspaces = parseWorkspaceEnv(process.env.RELAY_WORKSPACES_JSON);
+// When RELAY_SKIP_BOOTSTRAP is set (broker-spawned agents with a pre-registered
+// token), omit workspaces to prevent redundant bootstrap HTTP calls that would
+// delay the MCP initialize handshake.
+const skipBootstrap = parseStrictAgentName(process.env.RELAY_SKIP_BOOTSTRAP);
+const workspaces = skipBootstrap ? [] : parseWorkspaceEnv(process.env.RELAY_WORKSPACES_JSON);
 
 startStdio({
   apiKey: resolveApiKey(),

--- a/packages/mcp/src/transports.ts
+++ b/packages/mcp/src/transports.ts
@@ -14,72 +14,96 @@ const mcpOrigin = {
 };
 
 /**
+ * Bootstrap a single workspace by verifying/refreshing its token.
+ * Wrapped with a per-workspace timeout enforced via Promise.race so
+ * one slow workspace doesn't block all others.
+ */
+async function bootstrapOneWorkspace(
+  ws: McpWorkspaceConfig,
+  baseUrl?: string,
+  timeoutMs = 5_000,
+): Promise<McpWorkspaceConfig> {
+  const doBootstrap = async (): Promise<McpWorkspaceConfig> => {
+    const relay = createInternalRelayCast({
+      apiKey: ws.api_key,
+      baseUrl,
+    }, mcpOrigin);
+
+    let token = ws.agent_token;
+    const agentName = ws.agent_name ?? ws.workspace_alias ?? ws.workspace_id;
+    let workspaceName = ws.workspace_name;
+
+    try {
+      const workspace = await relay.workspace.info();
+      workspaceName = workspace.name;
+    } catch {
+      // Keep any pre-supplied name or leave undefined if workspace info is unavailable.
+    }
+
+    // If we have a token, verify it's still valid via an inbox call
+    if (token) {
+      try {
+        const client = relay.as(token);
+        await client.inbox();
+      } catch {
+        // Token is invalid, need to re-register
+        token = undefined;
+      }
+    }
+
+    // If no valid token, register or rotate
+    if (!token) {
+      const result = await relay.agents.registerOrRotate({
+        name: agentName,
+        type: 'agent',
+      });
+      token = result.token;
+    }
+
+    return {
+      ...ws,
+      agent_token: token,
+      agent_name: agentName,
+      workspace_name: workspaceName,
+    };
+  };
+
+  try {
+    const timeout = new Promise<never>((_, reject) =>
+      setTimeout(() => reject(new Error(`Bootstrap timed out after ${timeoutMs}ms`)), timeoutMs),
+    );
+    return await Promise.race([doBootstrap(), timeout]);
+  } catch (err) {
+    console.error(
+      `[bootstrap] Failed to bootstrap workspace ${ws.workspace_id}: ${err instanceof Error ? err.message : String(err)}`,
+    );
+    // Still return the workspace config even if bootstrap failed,
+    // so it can be retried later
+    return ws;
+  }
+}
+
+/**
  * Bootstrap workspaces by verifying/refreshing tokens and joining each
  * workspace into the MCP server's session via setSession + saveWorkspaceContext.
  *
- * This is called during startStdio when `workspaces` are provided.
+ * All workspaces are bootstrapped concurrently with individual timeouts.
  */
 async function bootstrapWorkspaces(
   workspaces: McpWorkspaceConfig[],
   baseUrl?: string,
 ): Promise<McpWorkspaceConfig[]> {
-  const bootstrapped: McpWorkspaceConfig[] = [];
+  const results = await Promise.allSettled(
+    workspaces.map(ws => bootstrapOneWorkspace(ws, baseUrl)),
+  );
 
-  for (const ws of workspaces) {
-    try {
-      const relay = createInternalRelayCast({
-        apiKey: ws.api_key,
-        baseUrl,
-      }, mcpOrigin);
-
-      let token = ws.agent_token;
-      const agentName = ws.agent_name ?? ws.workspace_alias ?? ws.workspace_id;
-      let workspaceName = ws.workspace_name;
-
-      try {
-        const workspace = await relay.workspace.info();
-        workspaceName = workspace.name;
-      } catch {
-        // Keep any pre-supplied name or leave undefined if workspace info is unavailable.
-      }
-
-      // If we have a token, verify it's still valid via an inbox call
-      if (token) {
-        try {
-          const client = relay.as(token);
-          await client.inbox();
-        } catch {
-          // Token is invalid, need to re-register
-          token = undefined;
-        }
-      }
-
-      // If no valid token, register or rotate
-      if (!token) {
-        const result = await relay.agents.registerOrRotate({
-          name: agentName,
-          type: 'agent',
-        });
-        token = result.token;
-      }
-
-      bootstrapped.push({
-        ...ws,
-        agent_token: token,
-        agent_name: agentName,
-        workspace_name: workspaceName,
-      });
-    } catch (err) {
-      console.error(
-        `[bootstrap] Failed to bootstrap workspace ${ws.workspace_id}: ${err instanceof Error ? err.message : String(err)}`,
-      );
-      // Still include the workspace config even if bootstrap failed,
-      // so it can be retried later
-      bootstrapped.push(ws);
-    }
-  }
-
-  return bootstrapped;
+  return results.map((result, i) => {
+    if (result.status === 'fulfilled') return result.value;
+    console.error(
+      `[bootstrap] Workspace ${workspaces[i].workspace_id} rejected: ${result.reason}`,
+    );
+    return workspaces[i];
+  });
 }
 
 /**
@@ -89,24 +113,46 @@ async function bootstrapWorkspaces(
 export async function startStdio(options: McpServerOptions): Promise<void> {
   let effectiveOptions = { ...options, telemetryTransport: 'stdio' as const };
 
-  // If workspaces are provided, bootstrap them before creating the server
-  if (options.workspaces?.length) {
-    const bootstrapped = await bootstrapWorkspaces(options.workspaces, options.baseUrl);
-    effectiveOptions = { ...effectiveOptions, workspaces: bootstrapped };
+  const hasAgentToken = Boolean(options.agentToken);
+  const hasWorkspaces = Boolean(options.workspaces?.length);
 
-    // Set the default workspace's api key/token/name as the primary session
-    const defaultWsId = resolveDefaultWorkspaceId(bootstrapped, options.defaultWorkspace);
-    const defaultWs = bootstrapped.find(
-      w => w.workspace_id === defaultWsId && w.agent_token,
-    );
-    if (defaultWs) {
-      effectiveOptions.apiKey = effectiveOptions.apiKey ?? defaultWs.api_key;
-      effectiveOptions.agentToken = effectiveOptions.agentToken ?? defaultWs.agent_token;
-      effectiveOptions.agentName = effectiveOptions.agentName ?? defaultWs.agent_name;
+  if (hasWorkspaces) {
+    if (hasAgentToken) {
+      // When agentToken is pre-provided (broker-spawned), skip bootstrap entirely —
+      // the token is already valid. Use workspace configs as-is for routing context.
+      const withNames = options.workspaces!.map(ws => ({
+        ...ws,
+        agent_name: ws.agent_name ?? ws.workspace_alias ?? ws.workspace_id,
+      }));
+      effectiveOptions = { ...effectiveOptions, workspaces: withNames };
+
+      // Promote default workspace credentials so routing resolves correctly
+      const defaultWsId = resolveDefaultWorkspaceId(withNames, options.defaultWorkspace);
+      const defaultWs = withNames.find(w => w.workspace_id === defaultWsId);
+      if (defaultWs) {
+        effectiveOptions.apiKey = effectiveOptions.apiKey ?? defaultWs.api_key;
+        effectiveOptions.agentName = effectiveOptions.agentName ?? defaultWs.agent_name;
+      }
+    } else {
+      // CLI user with RELAY_WORKSPACES_JSON — bootstrap is needed but now
+      // runs all workspaces concurrently (with per-workspace timeouts).
+      const bootstrapped = await bootstrapWorkspaces(options.workspaces!, options.baseUrl);
+      effectiveOptions = { ...effectiveOptions, workspaces: bootstrapped };
+
+      // Set the default workspace's api key/token/name as the primary session
+      const defaultWsId = resolveDefaultWorkspaceId(bootstrapped, options.defaultWorkspace);
+      const defaultWs = bootstrapped.find(
+        w => w.workspace_id === defaultWsId && w.agent_token,
+      );
+      if (defaultWs) {
+        effectiveOptions.apiKey = effectiveOptions.apiKey ?? defaultWs.api_key;
+        effectiveOptions.agentToken = effectiveOptions.agentToken ?? defaultWs.agent_token;
+        effectiveOptions.agentName = effectiveOptions.agentName ?? defaultWs.agent_name;
+      }
     }
   }
 
-  // createRelayMcpServer now populates session.workspaces from
+  // createRelayMcpServer populates session.workspaces from
   // effectiveOptions.workspaces internally — no need to reach into internals.
   const mcpServer = createRelayMcpServer(effectiveOptions);
 


### PR DESCRIPTION
## Summary
- When the broker spawns a Claude agent with a pre-registered `RELAY_AGENT_TOKEN`, the MCP server's `bootstrapWorkspaces()` made sequential blocking HTTP calls (workspace.info, inbox verification, registerOrRotate) **before** `mcpServer.connect(transport)`. Claude Code's `initialize` handshake would timeout → zero tools loaded.
- **Layer 1**: When `agentToken` is present, skip bootstrap entirely — the token is already valid. Workspace configs are used as-is for routing context.
- **Layer 2**: When no `agentToken` (CLI user with `RELAY_WORKSPACES_JSON`), bootstrap now runs all workspaces concurrently via `Promise.allSettled()` with 5s per-workspace timeouts instead of sequentially.
- **Layer 3**: `RELAY_SKIP_BOOTSTRAP` env var support — when set, workspaces are omitted from `startStdio()` to prevent bootstrap even if `RELAY_WORKSPACES_JSON` leaks through process env inheritance. (Broker-side change to set this flag is in a separate relay repo PR.)

## Test plan
- [x] `cd packages/mcp && npm test` — all existing tests pass (180/180)
- [ ] Manual: run `npx -y @relaycast/mcp` with `RELAY_AGENT_TOKEN` set — verify `initialize` responds in <1s
- [ ] Manual: run with `RELAY_WORKSPACES_JSON` set (no token) — verify tools become available after concurrent bootstrap
- [ ] Broker-side: separate PR in relay repo adds `RELAY_SKIP_BOOTSTRAP=1` to env when `relay_agent_token` is present

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/agentworkforce/relaycast/pull/85" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
