### PR TITLE
fix(mcp): multi-agent session, resource routing, and bridge parity

### DIFF
--- a/packages/mcp/src/__tests__/channel-tools.test.ts
+++ b/packages/mcp/src/__tests__/channel-tools.test.ts
@@ -38,7 +38,7 @@ describe('channel tools', () => {
 
     const result = await client.callTool({
       name: 'channel.create',
-      arguments: { name: 'general', topic: 'Main' },
+      arguments: { name: 'general', topic: 'Main', as: 'OwnerBot' },
     });
     expect(mockAgentClient.channels.create).toHaveBeenCalledWith({
       name: 'general',
@@ -57,7 +57,7 @@ describe('channel tools', () => {
     mockAgentClient.channels.join.mockResolvedValue(undefined);
     const result = await client.callTool({
       name: 'channel.join',
-      arguments: { channel: 'general' },
+      arguments: { channel: 'general', as: 'OwnerBot' },
     });
     expect(mockAgentClient.channels.join).toHaveBeenCalledWith('general');
     expect(result.content).toEqual([
@@ -69,7 +69,7 @@ describe('channel tools', () => {
     mockAgentClient.channels.leave.mockResolvedValue(undefined);
     await client.callTool({
       name: 'channel.leave',
-      arguments: { channel: 'general' },
+      arguments: { channel: 'general', as: 'OwnerBot' },
     });
     expect(mockAgentClient.channels.leave).toHaveBeenCalledWith('general');
   });
@@ -78,7 +78,7 @@ describe('channel tools', () => {
     mockAgentClient.channels.invite.mockResolvedValue(undefined);
     await client.callTool({
       name: 'channel.invite',
-      arguments: { channel: 'general', agent: 'bot1' },
+      arguments: { channel: 'general', agent: 'bot1', as: 'OwnerBot' },
     });
     expect(mockAgentClient.channels.invite).toHaveBeenCalledWith('general', 'bot1');
   });
@@ -90,7 +90,7 @@ describe('channel tools', () => {
     });
     await client.callTool({
       name: 'channel.set_topic',
-      arguments: { channel: 'general', topic: 'New' },
+      arguments: { channel: 'general', topic: 'New', as: 'OwnerBot' },
     });
     expect(mockAgentClient.channels.setTopic).toHaveBeenCalledWith('general', 'New');
   });
@@ -99,7 +99,7 @@ describe('channel tools', () => {
     mockAgentClient.channels.archive.mockResolvedValue(undefined);
     const result = await client.callTool({
       name: 'channel.archive',
-      arguments: { channel: 'old' },
+      arguments: { channel: 'old', as: 'OwnerBot' },
     });
     expect(mockAgentClient.channels.archive).toHaveBeenCalledWith('old');
     expect(result.content).toEqual([
@@ -108,3 +108,117 @@ describe('channel tools', () => {
   });
 });
 
+describe('channel tools with identity overrides', () => {
+  let mcpServer: McpServer;
+  let client: Client;
+
+  const defaultClient = {
+    channels: {
+      create: vi.fn(),
+      list: vi.fn(),
+      join: vi.fn(),
+      leave: vi.fn(),
+      invite: vi.fn(),
+      setTopic: vi.fn(),
+      archive: vi.fn(),
+    },
+  };
+  const identityClient = {
+    channels: {
+      create: vi.fn(),
+      list: vi.fn(),
+      join: vi.fn(),
+      leave: vi.fn(),
+      invite: vi.fn(),
+      setTopic: vi.fn(),
+      archive: vi.fn(),
+    },
+  };
+
+  const getAgentClient = vi.fn((_wsRouting?: { workspace_id?: string; workspace_alias?: string }, as?: string) => {
+    if (as === 'OwnerBot') {
+      return identityClient as any;
+    }
+    return defaultClient as any;
+  });
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    mcpServer = new McpServer({ name: 'test', version: '0.1.0' });
+    registerChannelTools(mcpServer, getAgentClient);
+
+    client = new Client({ name: 'test-client', version: '0.1.0' });
+    const [ct, st] = InMemoryTransport.createLinkedPair();
+    await Promise.all([client.connect(ct), mcpServer.connect(st)]);
+  });
+
+  it('channel.create passes as to getAgentClient', async () => {
+    identityClient.channels.create.mockResolvedValue({ name: 'general', topic: 'Main' });
+    await client.callTool({
+      name: 'channel.create',
+      arguments: { name: 'general', topic: 'Main', as: 'OwnerBot' },
+    });
+    expect(getAgentClient).toHaveBeenCalledWith(undefined, 'OwnerBot');
+    expect(identityClient.channels.create).toHaveBeenCalledWith({ name: 'general', topic: 'Main' });
+  });
+
+  it('channel.list passes workspace routing and as to getAgentClient', async () => {
+    identityClient.channels.list.mockResolvedValue([]);
+    await client.callTool({
+      name: 'channel.list',
+      arguments: { workspace_alias: 'beta', as: 'OwnerBot' },
+    });
+    expect(getAgentClient).toHaveBeenCalledWith({ workspace_id: undefined, workspace_alias: 'beta' }, 'OwnerBot');
+    expect(identityClient.channels.list).toHaveBeenCalledWith(undefined);
+  });
+
+  it('channel.join falls back to the active identity when as is omitted', async () => {
+    defaultClient.channels.join.mockResolvedValue(undefined);
+    await client.callTool({
+      name: 'channel.join',
+      arguments: { channel: 'general' },
+    });
+    expect(getAgentClient).toHaveBeenCalledWith(undefined, undefined);
+    expect(defaultClient.channels.join).toHaveBeenCalledWith('general');
+  });
+
+  it('channel.leave passes as to getAgentClient', async () => {
+    identityClient.channels.leave.mockResolvedValue(undefined);
+    await client.callTool({
+      name: 'channel.leave',
+      arguments: { channel: 'general', as: 'OwnerBot' },
+    });
+    expect(getAgentClient).toHaveBeenCalledWith(undefined, 'OwnerBot');
+    expect(identityClient.channels.leave).toHaveBeenCalledWith('general');
+  });
+
+  it('channel.invite passes as to getAgentClient', async () => {
+    identityClient.channels.invite.mockResolvedValue(undefined);
+    await client.callTool({
+      name: 'channel.invite',
+      arguments: { channel: 'general', agent: 'bot1', as: 'OwnerBot' },
+    });
+    expect(getAgentClient).toHaveBeenCalledWith(undefined, 'OwnerBot');
+    expect(identityClient.channels.invite).toHaveBeenCalledWith('general', 'bot1');
+  });
+
+  it('channel.set_topic passes as to getAgentClient', async () => {
+    identityClient.channels.setTopic.mockResolvedValue({ name: 'general', topic: 'New' });
+    await client.callTool({
+      name: 'channel.set_topic',
+      arguments: { channel: 'general', topic: 'New', workspace_id: 'ws_beta', as: 'OwnerBot' },
+    });
+    expect(getAgentClient).toHaveBeenCalledWith({ workspace_id: 'ws_beta', workspace_alias: undefined }, 'OwnerBot');
+    expect(identityClient.channels.setTopic).toHaveBeenCalledWith('general', 'New');
+  });
+
+  it('channel.archive passes workspace routing and as to getAgentClient', async () => {
+    identityClient.channels.archive.mockResolvedValue(undefined);
+    await client.callTool({
+      name: 'channel.archive',
+      arguments: { channel: 'old', workspace_alias: 'beta', as: 'OwnerBot' },
+    });
+    expect(getAgentClient).toHaveBeenCalledWith({ workspace_id: undefined, workspace_alias: 'beta' }, 'OwnerBot');
+    expect(identityClient.channels.archive).toHaveBeenCalledWith('old');
+  });
+});

--- a/packages/mcp/src/__tests__/feature-tools.test.ts
+++ b/packages/mcp/src/__tests__/feature-tools.test.ts
@@ -30,7 +30,7 @@ describe('feature tools', () => {
     mockAgentClient.react.mockResolvedValue(undefined);
     const result = await client.callTool({
       name: 'message.reaction.add',
-      arguments: { message_id: 'msg1', emoji: '👍' },
+      arguments: { message_id: 'msg1', emoji: '👍', as: 'ReaderBot' },
     });
     expect(mockAgentClient.react).toHaveBeenCalledWith('msg1', '👍');
     expect(result.content).toEqual([{ type: 'text', text: 'Reacted with 👍' }]);
@@ -40,7 +40,7 @@ describe('feature tools', () => {
     mockAgentClient.unreact.mockResolvedValue(undefined);
     await client.callTool({
       name: 'message.reaction.remove',
-      arguments: { message_id: 'msg1', emoji: '👍' },
+      arguments: { message_id: 'msg1', emoji: '👍', as: 'ReaderBot' },
     });
     expect(mockAgentClient.unreact).toHaveBeenCalledWith('msg1', '👍');
   });
@@ -49,7 +49,7 @@ describe('feature tools', () => {
     mockAgentClient.search.mockResolvedValue([]);
     await client.callTool({
       name: 'message.search',
-      arguments: { query: 'hello' },
+      arguments: { query: 'hello', as: 'ReaderBot' },
     });
     expect(mockAgentClient.search).toHaveBeenCalledWith('hello', {
       channel: undefined,
@@ -60,7 +60,7 @@ describe('feature tools', () => {
 
   it('check_inbox calls inbox()', async () => {
     mockAgentClient.inbox.mockResolvedValue({ unread: 0 });
-    await client.callTool({ name: 'message.inbox.check', arguments: {} });
+    await client.callTool({ name: 'message.inbox.check', arguments: { as: 'ReaderBot' } });
     expect(mockAgentClient.inbox).toHaveBeenCalled();
   });
 
@@ -68,7 +68,7 @@ describe('feature tools', () => {
     mockAgentClient.markRead.mockResolvedValue(undefined);
     const result = await client.callTool({
       name: 'message.inbox.mark_read',
-      arguments: { message_id: 'msg1' },
+      arguments: { message_id: 'msg1', as: 'ReaderBot' },
     });
     expect(mockAgentClient.markRead).toHaveBeenCalledWith('msg1');
     expect(result.content).toEqual([
@@ -98,9 +98,119 @@ describe('feature tools', () => {
         filename: 'test.txt',
         content_type: 'text/plain',
         size_bytes: 100,
+        as: 'ReaderBot',
       },
     });
     expect(mockAgentClient.files.upload).toHaveBeenCalledWith({
+      filename: 'test.txt',
+      contentType: 'text/plain',
+      sizeBytes: 100,
+    });
+  });
+});
+
+describe('feature tools with identity overrides', () => {
+  let mcpServer: McpServer;
+  let client: Client;
+  const defaultClient = {
+    react: vi.fn(),
+    unreact: vi.fn(),
+    search: vi.fn(),
+    inbox: vi.fn(),
+    markRead: vi.fn(),
+    readers: vi.fn(),
+    files: { upload: vi.fn() },
+  };
+  const identityClient = {
+    react: vi.fn(),
+    unreact: vi.fn(),
+    search: vi.fn(),
+    inbox: vi.fn(),
+    markRead: vi.fn(),
+    readers: vi.fn(),
+    files: { upload: vi.fn() },
+  };
+
+  const getAgentClient = vi.fn((_wsRouting?: { workspace_id?: string; workspace_alias?: string }, as?: string) => {
+    if (as === 'ReaderBot') {
+      return identityClient as any;
+    }
+    return defaultClient as any;
+  });
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    mcpServer = new McpServer({ name: 'test', version: '0.1.0' });
+    registerFeatureTools(mcpServer, getAgentClient);
+    client = new Client({ name: 'test-client', version: '0.1.0' });
+    const [ct, st] = InMemoryTransport.createLinkedPair();
+    await Promise.all([client.connect(ct), mcpServer.connect(st)]);
+  });
+
+  it('message.reaction.add passes as to getAgentClient', async () => {
+    identityClient.react.mockResolvedValue(undefined);
+    await client.callTool({
+      name: 'message.reaction.add',
+      arguments: { message_id: 'msg1', emoji: '👍', as: 'ReaderBot' },
+    });
+    expect(getAgentClient).toHaveBeenCalledWith(undefined, 'ReaderBot');
+    expect(identityClient.react).toHaveBeenCalledWith('msg1', '👍');
+  });
+
+  it('message.reaction.remove passes as to getAgentClient', async () => {
+    identityClient.unreact.mockResolvedValue(undefined);
+    await client.callTool({
+      name: 'message.reaction.remove',
+      arguments: { message_id: 'msg1', emoji: '👍', as: 'ReaderBot' },
+    });
+    expect(getAgentClient).toHaveBeenCalledWith(undefined, 'ReaderBot');
+    expect(identityClient.unreact).toHaveBeenCalledWith('msg1', '👍');
+  });
+
+  it('message.search passes workspace routing and as to getAgentClient', async () => {
+    identityClient.search.mockResolvedValue([]);
+    await client.callTool({
+      name: 'message.search',
+      arguments: { query: 'hello', workspace_id: 'ws_beta', as: 'ReaderBot' },
+    });
+    expect(getAgentClient).toHaveBeenCalledWith({ workspace_id: 'ws_beta', workspace_alias: undefined }, 'ReaderBot');
+    expect(identityClient.search).toHaveBeenCalledWith('hello', {
+      channel: undefined,
+      from: undefined,
+      limit: undefined,
+    });
+  });
+
+  it('message.inbox.check falls back to the active identity when as is omitted', async () => {
+    defaultClient.inbox.mockResolvedValue({ unread: 0 });
+    await client.callTool({ name: 'message.inbox.check', arguments: {} });
+    expect(getAgentClient).toHaveBeenCalledWith(undefined, undefined);
+    expect(defaultClient.inbox).toHaveBeenCalled();
+  });
+
+  it('message.inbox.mark_read passes as to getAgentClient', async () => {
+    identityClient.markRead.mockResolvedValue(undefined);
+    await client.callTool({
+      name: 'message.inbox.mark_read',
+      arguments: { message_id: 'msg1', as: 'ReaderBot' },
+    });
+    expect(getAgentClient).toHaveBeenCalledWith(undefined, 'ReaderBot');
+    expect(identityClient.markRead).toHaveBeenCalledWith('msg1');
+  });
+
+  it('message.file.upload passes as to getAgentClient', async () => {
+    identityClient.files.upload.mockResolvedValue({ id: 'f1', upload_url: 'https://...' });
+    await client.callTool({
+      name: 'message.file.upload',
+      arguments: {
+        filename: 'test.txt',
+        content_type: 'text/plain',
+        size_bytes: 100,
+        as: 'ReaderBot',
+      },
+    });
+    expect(getAgentClient).toHaveBeenCalledWith(undefined, 'ReaderBot');
+    expect(identityClient.files.upload).toHaveBeenCalledWith({
       filename: 'test.txt',
       contentType: 'text/plain',
       sizeBytes: 100,

--- a/packages/mcp/src/__tests__/messaging-tools.test.ts
+++ b/packages/mcp/src/__tests__/messaging-tools.test.ts
@@ -33,7 +33,7 @@ describe('messaging tools', () => {
     mockAgentClient.send.mockResolvedValue({ id: 'msg1', text: 'hello' });
     const result = await client.callTool({
       name: 'message.post',
-      arguments: { channel: 'general', text: 'hello' },
+      arguments: { channel: 'general', text: 'hello', as: 'WriterBot' },
     });
     expect(mockAgentClient.send).toHaveBeenCalledWith('general', 'hello', undefined);
     expect(result.content).toBeDefined();
@@ -53,7 +53,7 @@ describe('messaging tools', () => {
     mockAgentClient.reply.mockResolvedValue({ id: 'reply1' });
     await client.callTool({
       name: 'message.reply',
-      arguments: { message_id: 'msg1', text: 'reply' },
+      arguments: { message_id: 'msg1', text: 'reply', as: 'WriterBot' },
     });
     expect(mockAgentClient.reply).toHaveBeenCalledWith('msg1', 'reply');
   });
@@ -66,13 +66,13 @@ describe('messaging tools', () => {
 
   it('send_dm calls dm()', async () => {
     mockAgentClient.dm.mockResolvedValue({});
-    await client.callTool({ name: 'message.dm.send', arguments: { to: 'bot2', text: 'hi' } });
+    await client.callTool({ name: 'message.dm.send', arguments: { to: 'bot2', text: 'hi', as: 'WriterBot' } });
     expect(mockAgentClient.dm).toHaveBeenCalledWith('bot2', 'hi');
   });
 
   it('get_dms calls dms.conversations()', async () => {
     mockAgentClient.dms.conversations.mockResolvedValue([]);
-    await client.callTool({ name: 'message.dm.list', arguments: {} });
+    await client.callTool({ name: 'message.dm.list', arguments: { as: 'WriterBot' } });
     expect(mockAgentClient.dms.conversations).toHaveBeenCalled();
   });
 
@@ -81,7 +81,7 @@ describe('messaging tools', () => {
     mockAgentClient.dms.sendMessage.mockResolvedValue({ id: 'msg1' });
     await client.callTool({
       name: 'message.dm.send_group',
-      arguments: { participants: ['a', 'b'], name: 'grp', text: 'hello group' },
+      arguments: { participants: ['a', 'b'], name: 'grp', text: 'hello group', as: 'WriterBot' },
     });
     expect(mockAgentClient.dms.createGroup).toHaveBeenCalledWith({
       participants: ['a', 'b'],
@@ -91,10 +91,22 @@ describe('messaging tools', () => {
   });
 });
 
-describe('messaging tools with workspace routing', () => {
+describe('messaging tools with workspace routing and identity overrides', () => {
   let mcpServer: McpServer;
   let client: Client;
   const defaultClient = {
+    send: vi.fn(),
+    messages: vi.fn(),
+    reply: vi.fn(),
+    thread: vi.fn(),
+    dm: vi.fn(),
+    dms: {
+      conversations: vi.fn(),
+      createGroup: vi.fn(),
+      sendMessage: vi.fn(),
+    },
+  };
+  const identityClient = {
     send: vi.fn(),
     messages: vi.fn(),
     reply: vi.fn(),
@@ -119,7 +131,10 @@ describe('messaging tools with workspace routing', () => {
     },
   };
 
-  const getAgentClient = vi.fn((wsRouting?: { workspace_id?: string; workspace_alias?: string }) => {
+  const getAgentClient = vi.fn((wsRouting?: { workspace_id?: string; workspace_alias?: string }, as?: string) => {
+    if (as === 'WriterBot') {
+      return identityClient as any;
+    }
     if (wsRouting?.workspace_id === 'ws_beta' || wsRouting?.workspace_alias === 'beta') {
       return routedClient as any;
     }
@@ -141,47 +156,70 @@ describe('messaging tools with workspace routing', () => {
       name: 'message.post',
       arguments: { channel: 'general', text: 'hello' },
     });
-    expect(getAgentClient).toHaveBeenCalledWith(undefined);
+    expect(getAgentClient).toHaveBeenCalledWith(undefined, undefined);
     expect(defaultClient.send).toHaveBeenCalledWith('general', 'hello', undefined);
   });
 
-  it('message.post with workspace_id routes to correct client', async () => {
-    routedClient.send.mockResolvedValue({ id: 'msg2', text: 'hello beta' });
+  it('message.post with workspace_alias and as routes to identity-scoped client', async () => {
+    identityClient.send.mockResolvedValue({ id: 'msg2', text: 'hello beta' });
     await client.callTool({
       name: 'message.post',
-      arguments: { channel: 'general', text: 'hello beta', workspace_id: 'ws_beta' },
+      arguments: {
+        channel: 'general',
+        text: 'hello beta',
+        workspace_alias: 'beta',
+        as: 'WriterBot',
+      },
     });
-    expect(getAgentClient).toHaveBeenCalledWith({ workspace_id: 'ws_beta', workspace_alias: undefined });
-    expect(routedClient.send).toHaveBeenCalledWith('general', 'hello beta', undefined);
+    expect(getAgentClient).toHaveBeenCalledWith({ workspace_id: undefined, workspace_alias: 'beta' }, 'WriterBot');
+    expect(identityClient.send).toHaveBeenCalledWith('general', 'hello beta', undefined);
   });
 
-  it('message.post with workspace_alias routes to correct client', async () => {
-    routedClient.send.mockResolvedValue({ id: 'msg3', text: 'hello beta alias' });
+  it('message.reply with workspace_id and as routes to identity-scoped client', async () => {
+    identityClient.reply.mockResolvedValue({ id: 'reply1' });
     await client.callTool({
-      name: 'message.post',
-      arguments: { channel: 'general', text: 'hello beta alias', workspace_alias: 'beta' },
+      name: 'message.reply',
+      arguments: { message_id: 'msg1', text: 'reply', workspace_id: 'ws_beta', as: 'WriterBot' },
     });
-    expect(getAgentClient).toHaveBeenCalledWith({ workspace_id: undefined, workspace_alias: 'beta' });
-    expect(routedClient.send).toHaveBeenCalledWith('general', 'hello beta alias', undefined);
+    expect(getAgentClient).toHaveBeenCalledWith({ workspace_id: 'ws_beta', workspace_alias: undefined }, 'WriterBot');
+    expect(identityClient.reply).toHaveBeenCalledWith('msg1', 'reply');
   });
 
-  it('message.dm.send with workspace_id routes correctly', async () => {
-    routedClient.dm.mockResolvedValue({});
+  it('message.dm.send with workspace_id and as routes to identity-scoped client', async () => {
+    identityClient.dm.mockResolvedValue({});
     await client.callTool({
       name: 'message.dm.send',
-      arguments: { to: 'bot2', text: 'hi', workspace_id: 'ws_beta' },
+      arguments: { to: 'bot2', text: 'hi', workspace_id: 'ws_beta', as: 'WriterBot' },
     });
-    expect(getAgentClient).toHaveBeenCalledWith({ workspace_id: 'ws_beta', workspace_alias: undefined });
-    expect(routedClient.dm).toHaveBeenCalledWith('bot2', 'hi');
+    expect(getAgentClient).toHaveBeenCalledWith({ workspace_id: 'ws_beta', workspace_alias: undefined }, 'WriterBot');
+    expect(identityClient.dm).toHaveBeenCalledWith('bot2', 'hi');
   });
 
-  it('message.list with workspace_alias routes correctly', async () => {
-    routedClient.messages.mockResolvedValue([]);
+  it('message.dm.list with as routes to identity-scoped client', async () => {
+    identityClient.dms.conversations.mockResolvedValue([]);
     await client.callTool({
-      name: 'message.list',
-      arguments: { channel: 'general', workspace_alias: 'beta' },
+      name: 'message.dm.list',
+      arguments: { as: 'WriterBot' },
     });
-    expect(getAgentClient).toHaveBeenCalledWith({ workspace_id: undefined, workspace_alias: 'beta' });
-    expect(routedClient.messages).toHaveBeenCalled();
+    expect(getAgentClient).toHaveBeenCalledWith(undefined, 'WriterBot');
+    expect(identityClient.dms.conversations).toHaveBeenCalled();
+  });
+
+  it('message.dm.send_group with workspace_alias and as routes to identity-scoped client', async () => {
+    identityClient.dms.createGroup.mockResolvedValue({ id: 'conv1' });
+    identityClient.dms.sendMessage.mockResolvedValue({ id: 'msg1' });
+    await client.callTool({
+      name: 'message.dm.send_group',
+      arguments: {
+        participants: ['a', 'b'],
+        name: 'grp',
+        text: 'hello group',
+        workspace_alias: 'beta',
+        as: 'WriterBot',
+      },
+    });
+    expect(getAgentClient).toHaveBeenCalledWith({ workspace_id: undefined, workspace_alias: 'beta' }, 'WriterBot');
+    expect(identityClient.dms.createGroup).toHaveBeenCalledWith({ participants: ['a', 'b'], name: 'grp' });
+    expect(identityClient.dms.sendMessage).toHaveBeenCalledWith('conv1', 'hello group');
   });
 });

--- a/packages/mcp/src/__tests__/multi-agent-bridge.test.ts
+++ b/packages/mcp/src/__tests__/multi-agent-bridge.test.ts
@@ -1,0 +1,199 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
+
+vi.mock('@relaycast/sdk/internal', () => {
+  const wsClients: Array<{
+    token: string;
+    on: ReturnType<typeof vi.fn>;
+    connect: ReturnType<typeof vi.fn>;
+    disconnect: ReturnType<typeof vi.fn>;
+    unsubscribe: ReturnType<typeof vi.fn>;
+  }> = [];
+
+  const createInternalWsClient = vi.fn().mockImplementation(({ token }) => {
+    const unsubscribe = vi.fn();
+    const client = {
+      token,
+      on: vi.fn().mockReturnValue(unsubscribe),
+      connect: vi.fn(),
+      disconnect: vi.fn(),
+      unsubscribe,
+    };
+    wsClients.push(client);
+    return client;
+  });
+
+  const createInternalRelayCast = vi.fn().mockImplementation(({ apiKey }) => ({
+    as: vi.fn(),
+    agents: {
+      registerOrRotate: vi.fn().mockImplementation(async ({ name }: { name?: string }) => ({
+        agent: { name: apiKey === 'rk_live_beta' ? 'BetaBot' : (name ?? 'AlphaBot') },
+        token: apiKey === 'rk_live_beta'
+          ? 'at_beta'
+          : name === 'AlphaBotRenamed'
+            ? 'at_alpha_2'
+            : 'at_alpha',
+      })),
+      list: vi.fn(),
+    },
+    webhooks: {
+      create: vi.fn(),
+      list: vi.fn(),
+      delete: vi.fn(),
+      trigger: vi.fn(),
+    },
+    subscriptions: {
+      create: vi.fn(),
+      list: vi.fn(),
+      get: vi.fn(),
+      delete: vi.fn(),
+    },
+    commands: {
+      register: vi.fn(),
+      list: vi.fn(),
+      delete: vi.fn(),
+    },
+  }));
+
+  return {
+    createInternalRelayCast,
+    createInternalWsClient,
+    __wsClients: wsClients,
+  };
+});
+
+import { createRelayMcpServer } from '../server.js';
+
+describe('multi-agent wsBridge lifecycle', () => {
+  let client: Client;
+  let mcpServer: ReturnType<typeof createRelayMcpServer>;
+  let originalFetch: typeof global.fetch;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    const internal = await import('@relaycast/sdk/internal') as any;
+    internal.__wsClients.length = 0;
+
+    originalFetch = global.fetch;
+    global.fetch = vi.fn(async (url: string | URL, init?: RequestInit) => {
+      const path = new URL(url.toString()).pathname;
+      const headers = new Headers(init?.headers);
+      const auth = headers.get('Authorization');
+
+      if (path === '/v1/workspace') {
+        return new Response(JSON.stringify({
+          ok: true,
+          data: {
+            id: auth === 'Bearer rk_live_beta' ? 'ws_beta' : 'ws_alpha',
+            name: auth === 'Bearer rk_live_beta' ? 'Beta Workspace' : 'Alpha Workspace',
+            system_prompt: null,
+            plan: 'free',
+            created_at: new Date().toISOString(),
+            metadata: {},
+          },
+        }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        });
+      }
+
+      return new Response(JSON.stringify({ ok: true, data: {} }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      });
+    }) as unknown as typeof global.fetch;
+
+    mcpServer = createRelayMcpServer({
+      apiKey: 'rk_live_alpha',
+      agentToken: 'at_alpha',
+      agentName: 'AlphaBot',
+      baseUrl: 'https://api.test.dev',
+    });
+
+    client = new Client({ name: 'multi-agent-bridge-client', version: '0.1.0' });
+    const [ct, st] = InMemoryTransport.createLinkedPair();
+    await Promise.all([client.connect(ct), mcpServer.connect(st)]);
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+  });
+
+  it('stops and recreates the bridge when the active agent token changes across workspaces', async () => {
+    const internal = await import('@relaycast/sdk/internal') as any;
+    const resourceUpdatedSpy = vi.spyOn(mcpServer.server, 'sendResourceUpdated').mockResolvedValue(undefined);
+
+    expect(internal.__wsClients).toHaveLength(1);
+    expect(internal.__wsClients[0].token).toBe('at_alpha');
+    expect(internal.__wsClients[0].connect).toHaveBeenCalledTimes(1);
+
+    const setKeyResult = await client.callTool({
+      name: 'workspace.set_key',
+      arguments: { api_key: 'rk_live_beta' },
+    });
+    expect(setKeyResult.isError).toBeFalsy();
+
+    const registerResult = await client.callTool({
+      name: 'agent.register',
+      arguments: { name: 'BetaBot' },
+    });
+    expect(registerResult.isError).toBeFalsy();
+
+    expect(internal.__wsClients[0].unsubscribe).toHaveBeenCalledTimes(1);
+    expect(internal.__wsClients[0].disconnect).toHaveBeenCalledTimes(1);
+    expect(internal.__wsClients).toHaveLength(2);
+    expect(internal.__wsClients[1].token).toBe('at_beta');
+    expect(internal.__wsClients[1].connect).toHaveBeenCalledTimes(1);
+
+    const switchResult = await client.callTool({
+      name: 'workspace.switch',
+      arguments: { api_key: 'rk_live_alpha' },
+    });
+    expect(switchResult.isError).toBeFalsy();
+
+    expect(internal.__wsClients[1].unsubscribe).toHaveBeenCalledTimes(1);
+    expect(internal.__wsClients[1].disconnect).toHaveBeenCalledTimes(1);
+    expect(internal.__wsClients).toHaveLength(3);
+    expect(internal.__wsClients[2].token).toBe('at_alpha');
+    expect(internal.__wsClients[2].connect).toHaveBeenCalledTimes(1);
+
+    await client.subscribeResource({ uri: 'relay://inbox' });
+    await client.subscribeResource({ uri: 'relay://channels' });
+    resourceUpdatedSpy.mockClear();
+
+    const switchBackResult = await client.callTool({
+      name: 'workspace.switch',
+      arguments: { api_key: 'rk_live_beta' },
+    });
+    expect(switchBackResult.isError).toBeFalsy();
+
+    expect(resourceUpdatedSpy).toHaveBeenCalledWith({ uri: 'relay://inbox' });
+    expect(resourceUpdatedSpy).toHaveBeenCalledWith({ uri: 'relay://channels' });
+  });
+
+  it('does not recreate the bridge when the agent token changes inside the same workspace', async () => {
+    const internal = await import('@relaycast/sdk/internal') as any;
+    const resourceUpdatedSpy = vi.spyOn(mcpServer.server, 'sendResourceUpdated').mockResolvedValue(undefined);
+
+    expect(internal.__wsClients).toHaveLength(1);
+    expect(internal.__wsClients[0].token).toBe('at_alpha');
+
+    await client.subscribeResource({ uri: 'relay://inbox' });
+    await client.subscribeResource({ uri: 'relay://channels' });
+    resourceUpdatedSpy.mockClear();
+
+    const registerResult = await client.callTool({
+      name: 'agent.register',
+      arguments: { name: 'AlphaBotRenamed' },
+    });
+    expect(registerResult.isError).toBeFalsy();
+
+    expect(internal.__wsClients).toHaveLength(1);
+    expect(internal.__wsClients[0].unsubscribe).not.toHaveBeenCalled();
+    expect(internal.__wsClients[0].disconnect).not.toHaveBeenCalled();
+    expect(internal.__wsClients[0].connect).toHaveBeenCalledTimes(1);
+    expect(resourceUpdatedSpy).toHaveBeenCalledWith({ uri: 'relay://inbox' });
+    expect(resourceUpdatedSpy).toHaveBeenCalledWith({ uri: 'relay://channels' });
+  });
+});

--- a/packages/mcp/src/__tests__/multi-agent-integration.test.ts
+++ b/packages/mcp/src/__tests__/multi-agent-integration.test.ts
@@ -1,0 +1,234 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
+import type { McpWorkspaceConfig } from '../workspaces.js';
+
+vi.mock('@relaycast/sdk/internal', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@relaycast/sdk/internal')>();
+  return {
+    ...actual,
+    createInternalWsClient: vi.fn().mockReturnValue({
+      on: vi.fn().mockReturnValue(() => {}),
+      connect: vi.fn(),
+      disconnect: vi.fn(),
+    }),
+  };
+});
+
+import { createRelayMcpServer } from '../server.js';
+
+interface CapturedRequest {
+  url: string;
+  method: string;
+  headers: Record<string, string>;
+  body: unknown;
+}
+
+describe('multi-agent integration routing', () => {
+  let client: Client;
+  let captured: CapturedRequest[];
+  let originalFetch: typeof global.fetch;
+
+  const workspaces: McpWorkspaceConfig[] = [
+    {
+      workspace_id: 'ws_alpha',
+      workspace_alias: 'alpha',
+      api_key: 'rk_live_alpha',
+      agent_token: 'at_alpha',
+      agent_name: 'AlphaBot',
+    },
+    {
+      workspace_id: 'ws_beta',
+      workspace_alias: 'beta',
+      api_key: 'rk_live_beta',
+      agent_token: 'at_beta',
+      agent_name: 'BetaBot',
+    },
+  ];
+
+  beforeEach(async () => {
+    captured = [];
+    originalFetch = global.fetch;
+
+    global.fetch = vi.fn(async (url: string | URL, init?: RequestInit) => {
+      const request: CapturedRequest = {
+        url: url.toString(),
+        method: (init?.method ?? 'GET').toUpperCase(),
+        headers: Object.fromEntries(
+          Object.entries(init?.headers ?? {}).map(([key, value]) => [key.toLowerCase(), String(value)]),
+        ),
+        body: init?.body ? JSON.parse(init.body as string) : undefined,
+      };
+      captured.push(request);
+
+      const path = new URL(url.toString()).pathname;
+
+      if (path.match(/\/v1\/channels\/[^/]+\/messages$/) && request.method === 'POST') {
+        return new Response(JSON.stringify({
+          ok: true,
+          data: {
+            id: 'msg_beta',
+            text: (request.body as { text?: string } | undefined)?.text ?? null,
+          },
+        }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        });
+      }
+
+      if (path === '/v1/workspace') {
+        const auth = request.headers.authorization;
+        const data = {
+          name: auth === 'Bearer rk_live_beta' ? 'Beta Workspace' : 'Alpha Workspace',
+        };
+
+        return new Response(JSON.stringify({ ok: true, data }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        });
+      }
+
+      if (path === '/v1/agents' && request.method === 'POST') {
+        const name = (request.body as { name?: string } | undefined)?.name ?? 'UnknownAgent';
+        const token = name === 'BetaWriter' ? 'at_beta_writer' : 'at_generated';
+
+        return new Response(JSON.stringify({
+          ok: true,
+          data: {
+            id: `agent_${name}`,
+            name,
+            token,
+            status: 'online',
+          },
+        }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        });
+      }
+
+      if (path === '/v1/inbox') {
+        const auth = request.headers.authorization;
+        const data = auth === 'Bearer at_beta_writer'
+          ? {
+              unread_channels: [{ channel_name: 'beta-writer', unread_count: 4 }],
+              mentions: [],
+              unread_dms: [],
+              recent_reactions: [],
+            }
+          : auth === 'Bearer at_beta'
+            ? {
+              unread_channels: [{ channel_name: 'beta', unread_count: 2 }],
+              mentions: [],
+              unread_dms: [],
+              recent_reactions: [],
+            }
+            : {
+              unread_channels: [],
+              mentions: [],
+              unread_dms: [],
+              recent_reactions: [],
+              };
+
+        return new Response(JSON.stringify({ ok: true, data }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        });
+      }
+
+      return new Response(JSON.stringify({ ok: true, data: {} }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      });
+    }) as unknown as typeof global.fetch;
+
+    const mcpServer = createRelayMcpServer({
+      apiKey: 'rk_live_alpha',
+      agentToken: 'at_alpha',
+      agentName: 'AlphaBot',
+      baseUrl: 'https://api.test.dev',
+      workspaces,
+    });
+
+    client = new Client({ name: 'multi-agent-integration-client', version: '0.1.0' });
+    const [ct, st] = InMemoryTransport.createLinkedPair();
+    await Promise.all([client.connect(ct), mcpServer.connect(st)]);
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+  });
+
+  it('uses the routed workspace for both message dispatch and piggyback inbox fetch', async () => {
+    const result = await client.callTool({
+      name: 'message.post',
+      arguments: {
+        channel: 'general',
+        text: 'hello beta',
+        workspace_id: 'ws_beta',
+      },
+    });
+
+    expect(result.isError).toBeFalsy();
+
+    const postRequest = captured.find((request) =>
+      request.method === 'POST' && request.url.endsWith('/v1/channels/general/messages'));
+    const inboxRequest = captured.find((request) =>
+      request.method === 'GET' && request.url.endsWith('/v1/inbox'));
+
+    expect(postRequest).toBeDefined();
+    expect(postRequest?.headers.authorization).toBe('Bearer at_beta');
+    expect(inboxRequest).toBeDefined();
+    expect(inboxRequest?.headers.authorization).toBe('Bearer at_beta');
+    expect(((result.content ?? []) as Array<{ text: string }>)[1]?.text).toContain('#beta: 2 unread');
+  });
+
+  it('uses the requested routed agent identity for both message dispatch and piggyback inbox fetches', async () => {
+    await client.callTool({
+      name: 'workspace.switch',
+      arguments: {
+        api_key: 'rk_live_beta',
+      },
+    });
+
+    const registerResult = await client.callTool({
+      name: 'agent.register',
+      arguments: {
+        name: 'BetaWriter',
+      },
+    });
+
+    expect(registerResult.isError).toBeFalsy();
+
+    await client.callTool({
+      name: 'workspace.switch',
+      arguments: {
+        api_key: 'rk_live_alpha',
+      },
+    });
+
+    captured = [];
+
+    const result = await client.callTool({
+      name: 'message.post',
+      arguments: {
+        channel: 'general',
+        text: 'hello beta writer',
+        workspace_id: 'ws_beta',
+        as: 'BetaWriter',
+      },
+    });
+
+    expect(result.isError).toBeFalsy();
+
+    const postRequest = captured.find((request) =>
+      request.method === 'POST' && request.url.endsWith('/v1/channels/general/messages'));
+    const inboxRequest = captured.find((request) =>
+      request.method === 'GET' && request.url.endsWith('/v1/inbox'));
+
+    expect(postRequest).toBeDefined();
+    expect(postRequest?.headers.authorization).toBe('Bearer at_beta_writer');
+    expect(inboxRequest).toBeDefined();
+    expect(inboxRequest?.headers.authorization).toBe('Bearer at_beta_writer');
+    expect(((result.content ?? []) as Array<{ text: string }>)[1]?.text).toContain('#beta-writer: 4 unread');
+  });
+});

--- a/packages/mcp/src/__tests__/multi-agent-piggyback.test.ts
+++ b/packages/mcp/src/__tests__/multi-agent-piggyback.test.ts
@@ -1,0 +1,218 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
+import { z } from 'zod';
+import { enablePiggyback } from '../piggyback.js';
+import type { SessionState } from '../types.js';
+
+describe('multi-agent piggyback routing', () => {
+  let mcpServer: McpServer;
+  let client: Client;
+  let session: SessionState;
+  let activeInbox: ReturnType<typeof vi.fn>;
+  let betaInbox: ReturnType<typeof vi.fn>;
+  let betaWriterInbox: ReturnType<typeof vi.fn>;
+  let getAgentClient: ReturnType<typeof vi.fn>;
+
+  beforeEach(async () => {
+    activeInbox = vi.fn();
+    betaInbox = vi.fn();
+    betaWriterInbox = vi.fn();
+    getAgentClient = vi.fn((wsRouting?: { workspace_id?: string; workspace_alias?: string }, asAgent?: string) => {
+      if (asAgent === 'BetaWriter') {
+        return { inbox: betaWriterInbox };
+      }
+      if (wsRouting?.workspace_id === 'ws_beta' || wsRouting?.workspace_alias === 'beta') {
+        return { inbox: betaInbox };
+      }
+      return { inbox: activeInbox };
+    });
+
+    session = {
+      workspaceKey: 'rk_live_alpha',
+      agentToken: 'at_alpha',
+      agentName: 'AlphaBot',
+      agents: new Map([['AlphaBot', { agentName: 'AlphaBot', agentToken: 'at_alpha' }]]),
+      wsBridge: null,
+      subscriptions: null,
+      wsInitAttempted: false,
+      workspaces: new Map(),
+    };
+
+    mcpServer = new McpServer({ name: 'test', version: '0.1.0' });
+    enablePiggyback(mcpServer, () => session, getAgentClient as any);
+
+    mcpServer.registerTool(
+      'message.post',
+      {
+        description: 'Routed tool for piggyback coverage',
+        inputSchema: {
+          channel: z.string(),
+          text: z.string(),
+          workspace_id: z.string().optional(),
+          workspace_alias: z.string().optional(),
+          as: z.string().optional(),
+        },
+      },
+      async () => ({
+        content: [{ type: 'text' as const, text: 'original result' }],
+      }),
+    );
+
+    client = new Client({ name: 'test-client', version: '0.1.0' });
+    const [ct, st] = InMemoryTransport.createLinkedPair();
+    await Promise.all([client.connect(ct), mcpServer.connect(st)]);
+  });
+
+  it('fetches piggyback inbox from the routed workspace_id context', async () => {
+    betaInbox.mockResolvedValue({
+      unreadChannels: [{ channelName: 'beta', unreadCount: 2 }],
+      mentions: [],
+      unreadDms: [],
+      recentReactions: [],
+    });
+    activeInbox.mockResolvedValue({
+      unreadChannels: [],
+      mentions: [],
+      unreadDms: [],
+      recentReactions: [],
+    });
+
+    const result = await client.callTool({
+      name: 'message.post',
+      arguments: {
+        channel: 'general',
+        text: 'hello beta',
+        workspace_id: 'ws_beta',
+      },
+    });
+
+    expect(getAgentClient).toHaveBeenCalledWith({
+      workspace_id: 'ws_beta',
+      workspace_alias: undefined,
+    }, undefined);
+    expect(betaInbox).toHaveBeenCalledTimes(1);
+    expect(activeInbox).not.toHaveBeenCalled();
+    expect(result.content).toHaveLength(2);
+    expect(((result.content ?? []) as Array<{ text: string }>)[1]?.text).toContain('#beta: 2 unread');
+  });
+
+  it('fetches piggyback inbox from the routed workspace_alias context', async () => {
+    betaInbox.mockResolvedValue({
+      unreadChannels: [{ channelName: 'beta-alias', unreadCount: 1 }],
+      mentions: [],
+      unreadDms: [],
+      recentReactions: [],
+    });
+    activeInbox.mockResolvedValue({
+      unreadChannels: [],
+      mentions: [],
+      unreadDms: [],
+      recentReactions: [],
+    });
+
+    const result = await client.callTool({
+      name: 'message.post',
+      arguments: {
+        channel: 'general',
+        text: 'hello beta alias',
+        workspace_alias: 'beta',
+      },
+    });
+
+    expect(getAgentClient).toHaveBeenCalledWith({
+      workspace_id: undefined,
+      workspace_alias: 'beta',
+    }, undefined);
+    expect(betaInbox).toHaveBeenCalledTimes(1);
+    expect(activeInbox).not.toHaveBeenCalled();
+    expect(result.content).toHaveLength(2);
+    expect(((result.content ?? []) as Array<{ text: string }>)[1]?.text).toContain('#beta-alias: 1 unread');
+  });
+
+  it('passes routed workspace and requested as identity to piggyback inbox fetches', async () => {
+    betaWriterInbox.mockResolvedValue({
+      unreadChannels: [{ channelName: 'beta-writer', unreadCount: 3 }],
+      mentions: [],
+      unreadDms: [],
+      recentReactions: [],
+    });
+    betaInbox.mockResolvedValue({
+      unreadChannels: [],
+      mentions: [],
+      unreadDms: [],
+      recentReactions: [],
+    });
+    activeInbox.mockResolvedValue({
+      unreadChannels: [],
+      mentions: [],
+      unreadDms: [],
+      recentReactions: [],
+    });
+
+    const result = await client.callTool({
+      name: 'message.post',
+      arguments: {
+        channel: 'general',
+        text: 'hello beta writer',
+        workspace_alias: 'beta',
+        as: 'BetaWriter',
+      },
+    });
+
+    expect(getAgentClient).toHaveBeenCalledWith({
+      workspace_id: undefined,
+      workspace_alias: 'beta',
+    }, 'BetaWriter');
+    expect(betaWriterInbox).toHaveBeenCalledTimes(1);
+    expect(betaInbox).not.toHaveBeenCalled();
+    expect(activeInbox).not.toHaveBeenCalled();
+    expect(result.content).toHaveLength(2);
+    expect(((result.content ?? []) as Array<{ text: string }>)[1]?.text).toContain('#beta-writer: 3 unread');
+  });
+
+  it('still piggybacks routed inbox state when the active session token is missing', async () => {
+    session.agentToken = null;
+    session.agentName = null;
+
+    betaWriterInbox.mockResolvedValue({
+      unreadChannels: [{ channelName: 'beta-fallback', unreadCount: 4 }],
+      mentions: [],
+      unreadDms: [],
+      recentReactions: [],
+    });
+    betaInbox.mockResolvedValue({
+      unreadChannels: [],
+      mentions: [],
+      unreadDms: [],
+      recentReactions: [],
+    });
+    activeInbox.mockResolvedValue({
+      unreadChannels: [],
+      mentions: [],
+      unreadDms: [],
+      recentReactions: [],
+    });
+
+    const result = await client.callTool({
+      name: 'message.post',
+      arguments: {
+        channel: 'general',
+        text: 'hello beta fallback',
+        workspace_id: 'ws_beta',
+        as: 'BetaWriter',
+      },
+    });
+
+    expect(getAgentClient).toHaveBeenCalledWith({
+      workspace_id: 'ws_beta',
+      workspace_alias: undefined,
+    }, 'BetaWriter');
+    expect(betaWriterInbox).toHaveBeenCalledTimes(1);
+    expect(betaInbox).not.toHaveBeenCalled();
+    expect(activeInbox).not.toHaveBeenCalled();
+    expect(result.content).toHaveLength(2);
+    expect(((result.content ?? []) as Array<{ text: string }>)[1]?.text).toContain('#beta-fallback: 4 unread');
+  });
+});

--- a/packages/mcp/src/__tests__/multi-agent-session.test.ts
+++ b/packages/mcp/src/__tests__/multi-agent-session.test.ts
@@ -1,0 +1,152 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
+import type { McpWorkspaceConfig } from '../workspaces.js';
+
+vi.mock('@relaycast/sdk/internal', () => {
+  const agentClients = new Map<string, {
+    send: ReturnType<typeof vi.fn>;
+    inbox: ReturnType<typeof vi.fn>;
+  }>();
+  const relayCalls: Array<{
+    apiKey: string;
+    relay: { as: ReturnType<typeof vi.fn> };
+  }> = [];
+
+  const getAgentClient = (token: string) => {
+    let client = agentClients.get(token);
+    if (!client) {
+      client = {
+        send: vi.fn().mockResolvedValue({ id: `msg-${token}` }),
+        inbox: vi.fn().mockResolvedValue({
+          unreadChannels: [],
+          mentions: [],
+          unreadDms: [],
+          recentReactions: [],
+        }),
+      };
+      agentClients.set(token, client);
+    }
+    return client;
+  };
+
+  const createInternalRelayCast = vi.fn().mockImplementation(({ apiKey }) => {
+    const relay = {
+      as: vi.fn().mockImplementation((agentToken: string) => getAgentClient(agentToken)),
+      agents: {
+        registerOrRotate: vi.fn(),
+        list: vi.fn(),
+      },
+      webhooks: {
+        create: vi.fn(),
+        list: vi.fn(),
+        delete: vi.fn(),
+        trigger: vi.fn(),
+      },
+      subscriptions: {
+        create: vi.fn(),
+        list: vi.fn(),
+        get: vi.fn(),
+        delete: vi.fn(),
+      },
+      commands: {
+        register: vi.fn(),
+        list: vi.fn(),
+        delete: vi.fn(),
+      },
+    };
+    relayCalls.push({ apiKey, relay });
+    return relay;
+  });
+
+  const createInternalWsClient = vi.fn().mockReturnValue({
+    on: vi.fn().mockReturnValue(() => {}),
+    connect: vi.fn(),
+    disconnect: vi.fn(),
+  });
+
+  return {
+    createInternalRelayCast,
+    createInternalWsClient,
+    __agentClients: agentClients,
+    __relayCalls: relayCalls,
+  };
+});
+
+import { createRelayMcpServer } from '../server.js';
+
+describe('multi-agent routed session dispatch', () => {
+  let client: Client;
+
+  const workspaces: McpWorkspaceConfig[] = [
+    {
+      workspace_id: 'ws_alpha',
+      workspace_alias: 'alpha',
+      api_key: 'rk_live_alpha',
+      agent_token: 'at_alpha',
+      agent_name: 'AlphaBot',
+    },
+    {
+      workspace_id: 'ws_beta',
+      workspace_alias: 'beta',
+      api_key: 'rk_live_beta',
+      agent_token: 'at_beta',
+      agent_name: 'BetaBot',
+    },
+  ];
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    const internal = await import('@relaycast/sdk/internal') as any;
+    internal.__agentClients.clear();
+    internal.__relayCalls.length = 0;
+
+    const mcpServer = createRelayMcpServer({
+      apiKey: 'rk_live_alpha',
+      agentToken: 'at_alpha',
+      agentName: 'AlphaBot',
+      workspaces,
+    });
+    client = new Client({ name: 'multi-agent-session-client', version: '0.1.0' });
+    const [ct, st] = InMemoryTransport.createLinkedPair();
+    await Promise.all([client.connect(ct), mcpServer.connect(st)]);
+  });
+
+  it('dispatches routed message.post calls through as(targetToken)', async () => {
+    const internal = await import('@relaycast/sdk/internal') as any;
+
+    const result = await client.callTool({
+      name: 'message.post',
+      arguments: {
+        channel: 'general',
+        text: 'hello beta',
+        workspace_id: 'ws_beta',
+      },
+    });
+
+    expect(result.isError).toBeFalsy();
+    const betaClient = internal.__agentClients.get('at_beta');
+    expect(betaClient).toBeDefined();
+    expect(betaClient.send).toHaveBeenCalledWith('general', 'hello beta', undefined);
+
+    const betaRelayCall = internal.__relayCalls.findLast((entry: any) => entry.apiKey === 'at_beta');
+    expect(betaRelayCall).toBeDefined();
+    expect(betaRelayCall.relay.as).toHaveBeenCalledWith('at_beta');
+  });
+
+  it('returns a clear error for unknown routed workspace contexts', async () => {
+    const result = await client.callTool({
+      name: 'message.post',
+      arguments: {
+        channel: 'general',
+        text: 'hello nowhere',
+        workspace_id: 'ws_unknown',
+      },
+    });
+
+    expect(result.isError).toBe(true);
+    const first = (result.content ?? [])[0] as { text?: string } | undefined;
+    expect(first?.text).toContain('Workspace not found: ws_unknown');
+    expect(first?.text).toContain('Join the workspace first');
+  });
+});

--- a/packages/mcp/src/__tests__/piggyback.test.ts
+++ b/packages/mcp/src/__tests__/piggyback.test.ts
@@ -12,6 +12,8 @@ describe('piggyback unread messages', () => {
   let session: SessionState;
   const mockInbox = vi.fn();
   const mockAgentClient = { inbox: mockInbox } as any;
+  const routedInbox = vi.fn();
+  const routedAgentClient = { inbox: routedInbox } as any;
 
   beforeEach(async () => {
     vi.clearAllMocks();
@@ -19,15 +21,41 @@ describe('piggyback unread messages', () => {
       workspaceKey: 'rk_live_test',
       agentToken: 'tok_test',
       agentName: 'bot1',
+      agents: new Map([['bot1', { agentName: 'bot1', agentToken: 'tok_test' }]]),
       wsBridge: null,
       subscriptions: null,
+      wsInitAttempted: false,
+      workspaces: new Map([
+        ['rk_live_test', {
+          workspaceKey: 'rk_live_test',
+          agentToken: 'tok_test',
+          agentName: 'bot1',
+          agents: new Map([['bot1', { agentName: 'bot1', agentToken: 'tok_test' }]]),
+          wsBridge: null,
+          subscriptions: null,
+          wsInitAttempted: false,
+        }],
+        ['rk_live_beta', {
+          workspaceKey: 'rk_live_beta',
+          agentToken: 'tok_beta',
+          agentName: 'beta-bot',
+          agents: new Map([['beta-bot', { agentName: 'beta-bot', agentToken: 'tok_beta' }]]),
+          wsBridge: null,
+          subscriptions: null,
+          wsInitAttempted: false,
+        }],
+      ]),
     };
     mcpServer = new McpServer({ name: 'test', version: '0.1.0' });
 
     enablePiggyback(
       mcpServer,
       () => session,
-      () => mockAgentClient,
+      (routing) => routing?.workspace_id === 'ws_beta' ? routedAgentClient : mockAgentClient,
+      undefined,
+      (routing) => routing?.workspace_id === 'ws_beta'
+        ? { agentName: 'beta-bot' }
+        : { agentName: 'bot1' },
     );
 
     mcpServer.registerTool(
@@ -329,5 +357,115 @@ describe('piggyback unread messages', () => {
 
     expect(result.content).toHaveLength(1);
     expect((result.content as any[])[0].text).toBe('original result');
+  });
+
+  it('filters self-authored items using the routed workspace identity', async () => {
+    routedInbox.mockResolvedValue({
+      unreadChannels: [],
+      mentions: [
+        { agentName: 'beta-bot', channelName: 'ops', text: 'self mention' },
+        { agentName: 'alice', channelName: 'ops', text: 'real mention' },
+      ],
+      unreadDms: [
+        { from: 'beta-bot', unreadCount: 2 },
+        { from: 'carol', unreadCount: 1 },
+      ],
+    });
+
+    const server2 = new McpServer({ name: 'test2', version: '0.1.0' });
+    enablePiggyback(
+      server2,
+      () => session,
+      (routing) => routing?.workspace_id === 'ws_beta' ? routedAgentClient : mockAgentClient,
+      undefined,
+      (routing) => routing?.workspace_id === 'ws_beta'
+        ? { agentName: 'beta-bot' }
+        : { agentName: 'bot1' },
+    );
+    server2.registerTool(
+      'routed_tool',
+      {
+        description: 'A test tool with routing',
+        inputSchema: {
+          arg: z.string(),
+          workspace_id: z.string().optional(),
+        },
+      },
+      async () => ({
+        content: [{ type: 'text' as const, text: 'original result' }],
+      }),
+    );
+    const client2 = new Client({ name: 'test-client2', version: '0.1.0' });
+    const [ct2, st2] = InMemoryTransport.createLinkedPair();
+    await Promise.all([client2.connect(ct2), server2.connect(st2)]);
+
+    const result = await client2.callTool({
+      name: 'routed_tool',
+      arguments: { arg: 'test', workspace_id: 'ws_beta' },
+    });
+
+    expect(result.content).toHaveLength(2);
+    const piggyback = (result.content as any[])[1];
+    expect(piggyback.text).toContain('@alice in #ops');
+    expect(piggyback.text).toContain('From carol: 1 unread');
+    expect(piggyback.text).not.toContain('@beta-bot');
+    expect(piggyback.text).not.toContain('From beta-bot');
+  });
+
+  it('falls back to routing.as for self-filtering when no identity resolver is provided', async () => {
+    routedInbox.mockResolvedValue({
+      unreadChannels: [],
+      mentions: [
+        { agentName: 'BetaWriter', channelName: 'ops', text: 'self mention' },
+        { agentName: 'alice', channelName: 'ops', text: 'real mention' },
+      ],
+      unreadDms: [
+        { from: ' @betawriter ', unreadCount: 2 },
+        { from: 'carol', unreadCount: 1 },
+      ],
+      recentReactions: [
+        { emoji: 'thumbsup', channelName: 'ops', agentName: 'BETAWRITER' },
+        { emoji: 'rocket', channelName: 'ops', agentName: 'alice' },
+      ],
+    });
+
+    const server2 = new McpServer({ name: 'test2', version: '0.1.0' });
+    enablePiggyback(
+      server2,
+      () => session,
+      (routing, asAgent) => routing?.workspace_id === 'ws_beta' && asAgent === 'BetaWriter'
+        ? routedAgentClient
+        : mockAgentClient,
+    );
+    server2.registerTool(
+      'routed_tool',
+      {
+        description: 'A test tool with routing and identity override',
+        inputSchema: {
+          arg: z.string(),
+          workspace_id: z.string().optional(),
+          as: z.string().optional(),
+        },
+      },
+      async () => ({
+        content: [{ type: 'text' as const, text: 'original result' }],
+      }),
+    );
+    const client2 = new Client({ name: 'test-client2', version: '0.1.0' });
+    const [ct2, st2] = InMemoryTransport.createLinkedPair();
+    await Promise.all([client2.connect(ct2), server2.connect(st2)]);
+
+    const result = await client2.callTool({
+      name: 'routed_tool',
+      arguments: { arg: 'test', workspace_id: 'ws_beta', as: 'BetaWriter' },
+    });
+
+    expect(result.content).toHaveLength(2);
+    const piggyback = (result.content as any[])[1];
+    expect(piggyback.text).toContain('@alice in #ops');
+    expect(piggyback.text).toContain('From carol: 1 unread');
+    expect(piggyback.text).toContain(':rocket: on your message in #ops by @alice');
+    expect(piggyback.text).not.toContain('BetaWriter');
+    expect(piggyback.text).not.toContain('betawriter');
   });
 });

--- a/packages/mcp/src/__tests__/programmability-tools.test.ts
+++ b/packages/mcp/src/__tests__/programmability-tools.test.ts
@@ -4,38 +4,38 @@ import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
 import { registerProgrammabilityTools } from '../tools/programmability.js';
 
+const mockRelay = {
+  webhooks: {
+    create: vi.fn(),
+    list: vi.fn(),
+    delete: vi.fn(),
+    trigger: vi.fn(),
+  },
+  subscriptions: {
+    create: vi.fn(),
+    list: vi.fn(),
+    get: vi.fn(),
+    delete: vi.fn(),
+  },
+  commands: {
+    register: vi.fn(),
+    list: vi.fn(),
+    delete: vi.fn(),
+  },
+};
+
+const mockAgentClient = {
+  client: {
+    post: vi.fn(),
+  },
+  commands: {
+    invoke: vi.fn(),
+  },
+};
+
 describe('programmability tools', () => {
   let mcpServer: McpServer;
   let client: Client;
-
-  const mockRelay = {
-    webhooks: {
-      create: vi.fn(),
-      list: vi.fn(),
-      delete: vi.fn(),
-      trigger: vi.fn(),
-    },
-    subscriptions: {
-      create: vi.fn(),
-      list: vi.fn(),
-      get: vi.fn(),
-      delete: vi.fn(),
-    },
-    commands: {
-      register: vi.fn(),
-      list: vi.fn(),
-      delete: vi.fn(),
-    },
-  };
-
-  const mockAgentClient = {
-    client: {
-      post: vi.fn(),
-    },
-    commands: {
-      invoke: vi.fn(),
-    },
-  };
 
   beforeEach(async () => {
     vi.clearAllMocks();
@@ -254,6 +254,79 @@ describe('programmability tools', () => {
       channel: 'ops',
       args: undefined,
       parameters: { replicas: 3 },
+    });
+  });
+});
+
+describe('programmability tools with identity overrides', () => {
+  let mcpServer: McpServer;
+  let client: Client;
+
+  const defaultClient = {
+    commands: {
+      invoke: vi.fn(),
+    },
+  };
+  const identityClient = {
+    commands: {
+      invoke: vi.fn(),
+    },
+  };
+
+  const getAgentClient = vi.fn((_wsRouting?: { workspace_id?: string; workspace_alias?: string }, as?: string) => {
+    if (as === 'InvokerBot') {
+      return identityClient as any;
+    }
+    return defaultClient as any;
+  });
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    mcpServer = new McpServer({ name: 'test', version: '0.1.0' });
+    registerProgrammabilityTools(
+      mcpServer,
+      () => mockRelay as any,
+      getAgentClient,
+    );
+    client = new Client({ name: 'test-client', version: '0.1.0' });
+    const [ct, st] = InMemoryTransport.createLinkedPair();
+    await Promise.all([client.connect(ct), mcpServer.connect(st)]);
+  });
+
+  it('integration.command.invoke passes workspace routing and as to getAgentClient', async () => {
+    identityClient.commands.invoke.mockResolvedValue({ id: 'inv_3', command: 'deploy', channel: 'ops' });
+    await client.callTool({
+      name: 'integration.command.invoke',
+      arguments: {
+        command: 'deploy',
+        channel: 'ops',
+        args: '--force',
+        workspace_alias: 'beta',
+        as: 'InvokerBot',
+      },
+    });
+    expect(getAgentClient).toHaveBeenCalledWith({ workspace_id: undefined, workspace_alias: 'beta' }, 'InvokerBot');
+    expect(identityClient.commands.invoke).toHaveBeenCalledWith('deploy', {
+      channel: 'ops',
+      args: '--force',
+      parameters: undefined,
+    });
+  });
+
+  it('integration.command.invoke falls back to the active identity when as is omitted', async () => {
+    defaultClient.commands.invoke.mockResolvedValue({ id: 'inv_4', command: 'deploy', channel: 'ops' });
+    await client.callTool({
+      name: 'integration.command.invoke',
+      arguments: {
+        command: 'deploy',
+        channel: 'ops',
+      },
+    });
+    expect(getAgentClient).toHaveBeenCalledWith(undefined, undefined);
+    expect(defaultClient.commands.invoke).toHaveBeenCalledWith('deploy', {
+      channel: 'ops',
+      args: undefined,
+      parameters: undefined,
     });
   });
 });

--- a/packages/mcp/src/__tests__/registration-tools.test.ts
+++ b/packages/mcp/src/__tests__/registration-tools.test.ts
@@ -145,6 +145,7 @@ describe('registration tools', () => {
       workspaceKey: 'rk_live_ws2',
       agentToken: 'at_live_ws2',
       agentName: 'bot-ws2',
+      agents: new Map([['bot-ws2', { agentName: 'bot-ws2', agentToken: 'at_live_ws2' }]]),
       wsBridge: null,
       subscriptions: null,
       wsInitAttempted: false,
@@ -189,7 +190,52 @@ describe('registration tools', () => {
     });
     expect(session.agentToken).toBe('tok_abc');
     expect(session.agentName).toBe('bot1');
+    expect(session.agents.get('bot1')).toEqual({ agentName: 'bot1', agentToken: 'tok_abc' });
     expect(result.content).toBeDefined();
+  });
+
+  it('strict register prefers the configured broker identity from the registry', async () => {
+    const strictSession = createInitialSession({
+      workspaceKey: 'rk_live_test',
+      agentToken: 'tok_worker',
+      agentName: 'worker-bot',
+    });
+    strictSession.agents.set('Lead', { agentName: 'Lead', agentToken: 'tok_lead' });
+
+    const strictServer = new McpServer({ name: 'strict-test', version: '0.1.0' });
+    registerRegistrationTools(
+      strictServer,
+      () => mockRelay as any,
+      () => strictSession,
+      (partial) => {
+        Object.assign(strictSession, partial);
+      },
+      'https://api.test.dev',
+      true,
+      'Lead',
+      'agent',
+    );
+
+    const strictClient = new Client({ name: 'strict-client', version: '0.1.0' });
+    const [strictCt, strictSt] = InMemoryTransport.createLinkedPair();
+    await Promise.all([strictClient.connect(strictCt), strictServer.connect(strictSt)]);
+
+    const result = await strictClient.callTool({
+      name: 'agent.register',
+      arguments: { name: 'someone-else', type: 'human' },
+    });
+
+    expect(result.isError).toBeFalsy();
+    expect(mockRelay.agents.registerOrRotate).not.toHaveBeenCalled();
+    expect(strictSession.agentToken).toBe('tok_lead');
+    expect(strictSession.agentName).toBe('Lead');
+    expect(strictSession.agents.get('Lead')).toEqual({ agentName: 'Lead', agentToken: 'tok_lead' });
+
+    const parsed = JSON.parse((result.content as any)[0].text);
+    expect(parsed.token).toBe('tok_lead');
+    expect(parsed.registered_name).toBe('Lead');
+    expect(parsed.warnings.some((warning: string) => warning.includes('ignoring requested name'))).toBe(true);
+    expect(parsed.warnings.some((warning: string) => warning.includes('ignoring requested type'))).toBe(true);
   });
 
   it('list_agents tool calls relay.agents.list', async () => {
@@ -226,6 +272,7 @@ describe('registration tools', () => {
       workspaceKey: 'rk_live_ws1_abcdefgh',
       agentToken: 'at_live_ws1',
       agentName: 'bot1',
+      agents: new Map([['bot1', { agentName: 'bot1', agentToken: 'at_live_ws1' }]]),
       wsBridge: null,
       subscriptions: null,
       wsInitAttempted: false,
@@ -234,6 +281,7 @@ describe('registration tools', () => {
       workspaceKey: 'rk_live_ws2_abcdefgh',
       agentToken: 'at_live_ws2',
       agentName: 'bot2',
+      agents: new Map([['bot2', { agentName: 'bot2', agentToken: 'at_live_ws2' }]]),
       wsBridge: null,
       subscriptions: null,
       wsInitAttempted: false,
@@ -281,6 +329,7 @@ describe('registration tools', () => {
       workspaceKey: 'rk_live_ws2',
       agentToken: 'at_live_ws2',
       agentName: 'bot2',
+      agents: new Map([['bot2', { agentName: 'bot2', agentToken: 'at_live_ws2' }]]),
       wsBridge: null,
       subscriptions: null,
       wsInitAttempted: false,
@@ -324,6 +373,7 @@ describe('registration tools', () => {
       workspaceKey: 'rk_live_ws1',
       agentToken: 'at_live_ws1',
       agentName: 'bot1',
+      agents: new Map([['bot1', { agentName: 'bot1', agentToken: 'at_live_ws1' }]]),
       wsBridge: null,
       subscriptions: null,
       wsInitAttempted: false,
@@ -332,6 +382,7 @@ describe('registration tools', () => {
       workspaceKey: 'rk_live_ws2',
       agentToken: 'at_live_ws2',
       agentName: 'bot2',
+      agents: new Map([['bot2', { agentName: 'bot2', agentToken: 'at_live_ws2' }]]),
       wsBridge: null,
       subscriptions: null,
       wsInitAttempted: false,
@@ -356,6 +407,7 @@ describe('registration tools', () => {
       workspaceKey: 'rk_live_ws1',
       agentToken: 'at_live_ws1',
       agentName: 'bot1',
+      agents: new Map([['bot1', { agentName: 'bot1', agentToken: 'at_live_ws1' }]]),
       wsBridge: null,
       subscriptions: null,
       wsInitAttempted: false,
@@ -364,6 +416,7 @@ describe('registration tools', () => {
       workspaceKey: 'rk_live_ws2',
       agentToken: 'at_live_ws2',
       agentName: 'bot2',
+      agents: new Map([['bot2', { agentName: 'bot2', agentToken: 'at_live_ws2' }]]),
       wsBridge: null,
       subscriptions: null,
       wsInitAttempted: false,
@@ -392,6 +445,7 @@ describe('registration tools', () => {
       workspaceKey: 'rk_live_ws1',
       agentToken: 'at_live_ws1',
       agentName: 'bot1',
+      agents: new Map([['bot1', { agentName: 'bot1', agentToken: 'at_live_ws1' }]]),
       workspaceName: 'Primary Workspace',
       wsBridge: null,
       subscriptions: null,
@@ -401,6 +455,7 @@ describe('registration tools', () => {
       workspaceKey: 'rk_live_ws2',
       agentToken: 'at_live_ws2',
       agentName: 'bot2',
+      agents: new Map([['bot2', { agentName: 'bot2', agentToken: 'at_live_ws2' }]]),
       workspaceName: 'Workspace Two',
       wsBridge: null,
       subscriptions: null,
@@ -446,5 +501,40 @@ describe('registration tools', () => {
     expect(saved!.agentToken).toBe('tok_abc');
     expect(saved!.agentName).toBe('bot1');
     expect(saved!.workspaceName).toBe('Test Workspace');
+  });
+
+  it('register preserves prior agent identities in the workspace registry', async () => {
+    session.workspaceKey = 'rk_live_test';
+    mockRelay.agents.registerOrRotate
+      .mockResolvedValueOnce({
+        agent: { name: 'bot1' },
+        token: 'tok_abc',
+      })
+      .mockResolvedValueOnce({
+        agent: { name: 'bot2' },
+        token: 'tok_def',
+      });
+
+    await client.callTool({
+      name: 'agent.register',
+      arguments: { name: 'bot1' },
+    });
+    await client.callTool({
+      name: 'agent.register',
+      arguments: { name: 'bot2' },
+    });
+
+    const saved = session.workspaces.get('rk_live_test');
+    expect(saved).toBeDefined();
+    expect(saved!.agentName).toBe('bot2');
+    expect(saved!.agentToken).toBe('tok_def');
+    expect(saved!.agents?.get('bot1')).toEqual({
+      agentName: 'bot1',
+      agentToken: 'tok_abc',
+    });
+    expect(saved!.agents?.get('bot2')).toEqual({
+      agentName: 'bot2',
+      agentToken: 'tok_def',
+    });
   });
 });

--- a/packages/mcp/src/__tests__/resource-definitions.test.ts
+++ b/packages/mcp/src/__tests__/resource-definitions.test.ts
@@ -1,0 +1,149 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { registerResourceDefinitions } from '../resources/definitions.js';
+
+describe('resource definitions with routing metadata', () => {
+  let mcpServer: McpServer;
+  let client: Client;
+
+  const activeClient = {
+    inbox: vi.fn(),
+    channels: {
+      list: vi.fn(),
+    },
+    messages: vi.fn(),
+    thread: vi.fn(),
+    dms: {
+      messages: vi.fn(),
+    },
+  };
+  const identityClient = {
+    inbox: vi.fn(),
+    channels: {
+      list: vi.fn(),
+    },
+    messages: vi.fn(),
+    thread: vi.fn(),
+    dms: {
+      messages: vi.fn(),
+    },
+  };
+  const activeRelay = {
+    agents: {
+      list: vi.fn(),
+    },
+  };
+  const identityRelay = {
+    agents: {
+      list: vi.fn(),
+    },
+  };
+
+  const getAgentClient = vi.fn((_wsRouting?: { workspace_id?: string; workspace_alias?: string }, as?: string) => {
+    if (as === 'ReaderBot') {
+      return identityClient as any;
+    }
+    return activeClient as any;
+  });
+  const getRelay = vi.fn((_wsRouting?: { workspace_id?: string; workspace_alias?: string }, as?: string) => {
+    if (as === 'ReaderBot') {
+      return identityRelay as any;
+    }
+    return activeRelay as any;
+  });
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    mcpServer = new McpServer({ name: 'test', version: '0.1.0' });
+    registerResourceDefinitions(mcpServer, getAgentClient, getRelay);
+
+    client = new Client({ name: 'test-client', version: '0.1.0' });
+    const [ct, st] = InMemoryTransport.createLinkedPair();
+    await Promise.all([client.connect(ct), mcpServer.connect(st)]);
+  });
+
+  it('resources/list keeps literal resource URIs stable', async () => {
+    const result = await client.listResources();
+
+    expect(result.resources.map(resource => resource.uri)).toEqual(expect.arrayContaining([
+      'relay://inbox',
+      'relay://agents',
+      'relay://channels',
+    ]));
+    expect(result.resources.some(resource => resource.uri.includes('/workspaces/'))).toBe(false);
+  });
+
+  it('resources/templates/list keeps literal template URIs stable', async () => {
+    const result = await client.listResourceTemplates();
+
+    expect(result.resourceTemplates.map(template => template.uriTemplate)).toEqual(expect.arrayContaining([
+      'relay://channels/{name}/messages',
+      'relay://messages/{id}/thread',
+      'relay://dm/{conversation_id}',
+    ]));
+    expect(result.resourceTemplates.some(template => template.uriTemplate.includes('/workspaces/'))).toBe(false);
+  });
+
+  it('relay://agents reads use routed workspace and as metadata', async () => {
+    identityRelay.agents.list.mockResolvedValue([{ name: 'ReaderBot' }]);
+
+    const result = await client.readResource({
+      uri: 'relay://agents',
+      _meta: {
+        workspace_id: 'ws_beta',
+        as: 'ReaderBot',
+      },
+    });
+
+    expect(getRelay).toHaveBeenCalledWith({ workspace_id: 'ws_beta', workspace_alias: undefined }, 'ReaderBot');
+    expect(JSON.parse((result.contents[0] as { text: string }).text)).toEqual([{ name: 'ReaderBot' }]);
+  });
+
+  it('relay://channels falls back to the active identity when routing metadata is omitted', async () => {
+    activeClient.channels.list.mockResolvedValue([{ name: 'general' }]);
+
+    const result = await client.readResource({
+      uri: 'relay://channels',
+    });
+
+    expect(getAgentClient).toHaveBeenCalledWith(undefined, undefined);
+    expect((result.contents[0] as { uri: string }).uri).toBe('relay://channels');
+    expect(JSON.parse((result.contents[0] as { text: string }).text)).toEqual([{ name: 'general' }]);
+  });
+
+  it('relay://channels/{name}/messages reads use routed workspace_alias and as metadata', async () => {
+    identityClient.messages.mockResolvedValue([{ id: 'msg_beta' }]);
+
+    const result = await client.readResource({
+      uri: 'relay://channels/general/messages',
+      _meta: {
+        workspace_alias: 'beta',
+        as: 'ReaderBot',
+      },
+    });
+
+    expect(getAgentClient).toHaveBeenCalledWith({ workspace_id: undefined, workspace_alias: 'beta' }, 'ReaderBot');
+    expect((result.contents[0] as { uri: string }).uri).toBe('relay://channels/general/messages');
+    expect(JSON.parse((result.contents[0] as { text: string }).text)).toEqual([{ id: 'msg_beta' }]);
+  });
+
+  it('relay://inbox reads use routed workspace metadata and keep the literal URI', async () => {
+    identityClient.inbox.mockResolvedValue({ unreadChannels: [{ channelName: 'ops', unreadCount: 2 }] });
+
+    const result = await client.readResource({
+      uri: 'relay://inbox',
+      _meta: {
+        workspace_alias: 'beta',
+        as: 'ReaderBot',
+      },
+    });
+
+    expect(getAgentClient).toHaveBeenCalledWith({ workspace_id: undefined, workspace_alias: 'beta' }, 'ReaderBot');
+    expect((result.contents[0] as { uri: string }).uri).toBe('relay://inbox');
+    expect(JSON.parse((result.contents[0] as { text: string }).text)).toEqual({
+      unreadChannels: [{ channelName: 'ops', unreadCount: 2 }],
+    });
+  });
+});

--- a/packages/mcp/src/__tests__/server-multi-workspace.test.ts
+++ b/packages/mcp/src/__tests__/server-multi-workspace.test.ts
@@ -116,7 +116,7 @@ describe('multi-workspace server setup', () => {
   });
 
   it('message.post with workspace_id routes to correct workspace', async () => {
-    const { createInternalRelayCast, __mockClient } = await import('@relaycast/sdk/internal') as any;
+    const { createInternalRelayCast, __mockClient, __mockRelay } = await import('@relaycast/sdk/internal') as any;
 
     // Workspace contexts are now populated during server creation
     const server = createRelayMcpServer({
@@ -143,7 +143,110 @@ describe('multi-workspace server setup', () => {
     });
 
     expect(result.content).toBeDefined();
-    // The createInternalRelayCast should have been called with beta's token
-    expect(createInternalRelayCast).toHaveBeenCalled();
+    expect(createInternalRelayCast).toHaveBeenCalledWith(
+      expect.objectContaining({
+        apiKey: 'at_beta',
+      }),
+      expect.anything(),
+    );
+    expect(__mockRelay.as).toHaveBeenLastCalledWith('at_beta');
+  });
+
+  it('message.post without workspace routing uses the active workspace identity', async () => {
+    const { createInternalRelayCast, __mockClient, __mockRelay } = await import('@relaycast/sdk/internal') as any;
+
+    const server = createRelayMcpServer({
+      apiKey: 'rk_live_alpha_key_full',
+      agentToken: 'at_alpha',
+      agentName: 'AlphaBot',
+      workspaces,
+    });
+
+    const client = new Client({ name: 'test-client', version: '0.1.0' });
+    const [ct, st] = InMemoryTransport.createLinkedPair();
+    await Promise.all([client.connect(ct), server.connect(st)]);
+
+    __mockClient.send.mockResolvedValue({ id: 'msg_alpha', text: 'hello alpha' });
+
+    const result = await client.callTool({
+      name: 'message.post',
+      arguments: {
+        channel: 'general',
+        text: 'hello alpha',
+      },
+    });
+
+    expect(result.content).toBeDefined();
+    expect(createInternalRelayCast).toHaveBeenCalledWith(
+      expect.objectContaining({
+        apiKey: 'at_alpha',
+      }),
+      expect.anything(),
+    );
+    expect(__mockRelay.as).toHaveBeenLastCalledWith('at_alpha');
+  });
+
+  it('message.post with workspace_id and as uses the registered workspace identity', async () => {
+    const { createInternalRelayCast, __mockClient, __mockRelay } = await import('@relaycast/sdk/internal') as any;
+
+    const server = createRelayMcpServer({
+      apiKey: 'rk_live_alpha_key_full',
+      agentToken: 'at_alpha',
+      agentName: 'AlphaBot',
+      workspaces,
+    });
+
+    const client = new Client({ name: 'test-client', version: '0.1.0' });
+    const [ct, st] = InMemoryTransport.createLinkedPair();
+    await Promise.all([client.connect(ct), server.connect(st)]);
+
+    __mockRelay.as.mockClear();
+    __mockClient.send.mockResolvedValue({ id: 'msg_beta_as', text: 'hello beta as beta' });
+
+    const result = await client.callTool({
+      name: 'message.post',
+      arguments: {
+        channel: 'general',
+        text: 'hello beta as beta',
+        workspace_id: 'ws_beta',
+        as: 'BetaBot',
+      },
+    });
+
+    expect(result.isError).toBeFalsy();
+    expect(createInternalRelayCast).toHaveBeenCalledWith(
+      expect.objectContaining({
+        apiKey: 'at_beta',
+      }),
+      expect.anything(),
+    );
+    expect(__mockRelay.as).toHaveBeenLastCalledWith('at_beta');
+  });
+
+  it('message.post returns an error for unknown as identity in a routed workspace', async () => {
+    const server = createRelayMcpServer({
+      apiKey: 'rk_live_alpha_key_full',
+      agentToken: 'at_alpha',
+      agentName: 'AlphaBot',
+      workspaces,
+    });
+
+    const client = new Client({ name: 'test-client', version: '0.1.0' });
+    const [ct, st] = InMemoryTransport.createLinkedPair();
+    await Promise.all([client.connect(ct), server.connect(st)]);
+
+    const result = await client.callTool({
+      name: 'message.post',
+      arguments: {
+        channel: 'general',
+        text: 'ghost write',
+        workspace_id: 'ws_beta',
+        as: 'GhostBot',
+      },
+    });
+
+    expect(result.isError).toBe(true);
+    const firstContent = result.content?.[0] as { text?: string } | undefined;
+    expect(firstContent?.text).toContain('Unknown agent identity "GhostBot"');
   });
 });

--- a/packages/mcp/src/__tests__/server.test.ts
+++ b/packages/mcp/src/__tests__/server.test.ts
@@ -331,6 +331,38 @@ describe('createRelayMcpServer', () => {
     expect(result.isError).toBeFalsy();
   });
 
+  it('lists the bootstrapped active workspace in workspace.list', async () => {
+    const bootstrappedServer = createRelayMcpServer({
+      apiKey: 'rk_live_bootstrap123',
+      agentToken: 'tok_preregistered',
+      agentName: 'pre-registered-bot',
+    });
+    const bootstrappedClient = new Client({ name: 'workspace-list-client', version: '0.1.0' });
+    const [ct, st] = InMemoryTransport.createLinkedPair();
+    await Promise.all([bootstrappedClient.connect(ct), bootstrappedServer.connect(st)]);
+
+    const result = await bootstrappedClient.callTool({
+      name: 'workspace.list',
+      arguments: {},
+    });
+
+    expect(result.isError).toBeFalsy();
+    const firstContent = result.content?.[0] as { text?: string } | undefined;
+    const text = typeof firstContent?.text === 'string' ? firstContent.text : '{}';
+    const payload = JSON.parse(text) as {
+      active_workspace_ref?: string | null;
+      workspaces?: Array<{ agent_name: string; is_active: boolean }>;
+    };
+
+    expect(payload.active_workspace_ref).toMatch(/^ws_[a-f0-9]{12}$/);
+    expect(payload.workspaces).toEqual([
+      expect.objectContaining({
+        agent_name: 'pre-registered-bot',
+        is_active: true,
+      }),
+    ]);
+  });
+
   it('retries WS bridge initialization after switching away from a token that failed WS init', async () => {
     const wsFactory = vi.mocked(createInternalWsClient);
     wsFactory.mockImplementationOnce(() => {

--- a/packages/mcp/src/__tests__/ws-bridge.test.ts
+++ b/packages/mcp/src/__tests__/ws-bridge.test.ts
@@ -1,6 +1,72 @@
-import { describe, it, expect } from 'vitest';
-import { eventToResourceUris } from '../resources/ws-bridge.js';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
 import type { WsClientEvent } from '@relaycast/sdk';
+
+vi.mock('@relaycast/sdk/internal', () => {
+  const wsClients: Array<{
+    token: string;
+    on: ReturnType<typeof vi.fn>;
+    connect: ReturnType<typeof vi.fn>;
+    disconnect: ReturnType<typeof vi.fn>;
+    unsubscribe: ReturnType<typeof vi.fn>;
+  }> = [];
+
+  const createInternalWsClient = vi.fn().mockImplementation(({ token }) => {
+    const unsubscribe = vi.fn();
+    const client = {
+      token,
+      on: vi.fn().mockReturnValue(unsubscribe),
+      connect: vi.fn(),
+      disconnect: vi.fn(),
+      unsubscribe,
+    };
+    wsClients.push(client);
+    return client;
+  });
+
+  const createInternalRelayCast = vi.fn().mockImplementation(() => ({
+    as: vi.fn(),
+    agents: {
+      registerOrRotate: vi.fn().mockImplementation(async ({ name }: { name: string }) => ({
+        agent: { name },
+        token:
+          name === 'BetaBot'
+            ? 'at_beta'
+            : name === 'AlphaBotV2'
+              ? 'at_alpha_v2'
+              : 'at_alpha',
+      })),
+      list: vi.fn(),
+    },
+    webhooks: {
+      create: vi.fn(),
+      list: vi.fn(),
+      delete: vi.fn(),
+      trigger: vi.fn(),
+    },
+    subscriptions: {
+      create: vi.fn(),
+      list: vi.fn(),
+      get: vi.fn(),
+      delete: vi.fn(),
+    },
+    commands: {
+      register: vi.fn(),
+      list: vi.fn(),
+      delete: vi.fn(),
+    },
+  }));
+
+  return {
+    createInternalRelayCast,
+    createInternalWsClient,
+    __wsClients: wsClients,
+  };
+});
+
+import { createRelayMcpServer } from '../server.js';
+import { eventToResourceUris } from '../resources/ws-bridge.js';
 
 describe('eventToResourceUris', () => {
   it('maps message.created to inbox and channel', () => {
@@ -168,5 +234,117 @@ describe('eventToResourceUris', () => {
       agentName: 'bot',
     } as WsClientEvent;
     expect(eventToResourceUris(event)).toEqual(['relay://inbox']);
+  });
+});
+
+describe('WsBridge lifecycle', () => {
+  let client: Client;
+  let originalFetch: typeof global.fetch;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    const internal = await import('@relaycast/sdk/internal') as any;
+    internal.__wsClients.length = 0;
+
+    originalFetch = global.fetch;
+    global.fetch = vi.fn(async (url: string | URL, init?: RequestInit) => {
+      const path = new URL(url.toString()).pathname;
+      const headers = new Headers(init?.headers);
+      const auth = headers.get('Authorization');
+
+      if (path === '/v1/workspace') {
+        return new Response(JSON.stringify({
+          ok: true,
+          data: {
+            id: auth === 'Bearer rk_live_beta' ? 'ws_beta' : 'ws_alpha',
+            name: auth === 'Bearer rk_live_beta' ? 'Beta Workspace' : 'Alpha Workspace',
+            system_prompt: null,
+            plan: 'free',
+            created_at: new Date().toISOString(),
+            metadata: {},
+          },
+        }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        });
+      }
+
+      return new Response(JSON.stringify({ ok: true, data: {} }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      });
+    }) as unknown as typeof global.fetch;
+
+    const mcpServer = createRelayMcpServer({
+      apiKey: 'rk_live_alpha',
+      agentToken: 'at_alpha',
+      agentName: 'AlphaBot',
+      baseUrl: 'https://api.test.dev',
+    });
+
+    client = new Client({ name: 'ws-bridge-client', version: '0.1.0' });
+    const [ct, st] = InMemoryTransport.createLinkedPair();
+    await Promise.all([client.connect(ct), mcpServer.connect(st)]);
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+  });
+
+  it('does not recreate the bridge when the active agent token changes inside the same workspace', async () => {
+    const internal = await import('@relaycast/sdk/internal') as any;
+
+    expect(internal.__wsClients).toHaveLength(1);
+    expect(internal.__wsClients[0].token).toBe('at_alpha');
+    expect(internal.__wsClients[0].connect).toHaveBeenCalledTimes(1);
+
+    const registerResult = await client.callTool({
+      name: 'agent.register',
+      arguments: { name: 'AlphaBotV2' },
+    });
+    expect(registerResult.isError).toBeFalsy();
+
+    expect(internal.__wsClients).toHaveLength(1);
+    expect(internal.__wsClients[0].unsubscribe).not.toHaveBeenCalled();
+    expect(internal.__wsClients[0].disconnect).not.toHaveBeenCalled();
+    expect(internal.__wsClients[0].connect).toHaveBeenCalledTimes(1);
+  });
+
+  it('stops and recreates the bridge when the active workspace changes', async () => {
+    const internal = await import('@relaycast/sdk/internal') as any;
+
+    expect(internal.__wsClients).toHaveLength(1);
+    expect(internal.__wsClients[0].token).toBe('at_alpha');
+    expect(internal.__wsClients[0].connect).toHaveBeenCalledTimes(1);
+
+    const setKeyResult = await client.callTool({
+      name: 'workspace.set_key',
+      arguments: { api_key: 'rk_live_beta' },
+    });
+    expect(setKeyResult.isError).toBeFalsy();
+
+    const registerResult = await client.callTool({
+      name: 'agent.register',
+      arguments: { name: 'BetaBot' },
+    });
+    expect(registerResult.isError).toBeFalsy();
+
+    expect(internal.__wsClients[0].unsubscribe).toHaveBeenCalledTimes(1);
+    expect(internal.__wsClients[0].disconnect).toHaveBeenCalledTimes(1);
+    expect(internal.__wsClients).toHaveLength(2);
+    expect(internal.__wsClients[1].token).toBe('at_beta');
+    expect(internal.__wsClients[1].connect).toHaveBeenCalledTimes(1);
+
+    const switchResult = await client.callTool({
+      name: 'workspace.switch',
+      arguments: { api_key: 'rk_live_alpha' },
+    });
+    expect(switchResult.isError).toBeFalsy();
+
+    expect(internal.__wsClients[1].unsubscribe).toHaveBeenCalledTimes(1);
+    expect(internal.__wsClients[1].disconnect).toHaveBeenCalledTimes(1);
+    expect(internal.__wsClients).toHaveLength(3);
+    expect(internal.__wsClients[2].token).toBe('at_alpha');
+    expect(internal.__wsClients[2].connect).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/mcp/src/piggyback.ts
+++ b/packages/mcp/src/piggyback.ts
@@ -28,6 +28,9 @@ type RegisterToolFn = (
   handler: ToolHandler | undefined,
 ) => unknown;
 type ContentCarrier = { content: Array<Record<string, unknown>> };
+type WorkspaceRouting = { workspace_id?: string; workspace_alias?: string };
+type AgentRouting = WorkspaceRouting & { as?: string };
+type ResolvedAgentIdentity = { agentName: string };
 
 function hasContentArray(value: unknown): value is ContentCarrier {
   return (
@@ -37,11 +40,26 @@ function hasContentArray(value: unknown): value is ContentCarrier {
   );
 }
 
+function extractAgentRouting(args: unknown[]): AgentRouting | undefined {
+  const [input] = args;
+  if (typeof input !== 'object' || input === null) return undefined;
+
+  const raw = input as Record<string, unknown>;
+  const workspace_id = typeof raw.workspace_id === 'string' ? raw.workspace_id : undefined;
+  const workspace_alias = typeof raw.workspace_alias === 'string' ? raw.workspace_alias : undefined;
+  const as = typeof raw.as === 'string' ? raw.as : undefined;
+
+  if (!workspace_id && !workspace_alias && !as) return undefined;
+
+  return { workspace_id, workspace_alias, as };
+}
+
 export function enablePiggyback(
   mcpServer: McpServer,
   getSession: () => SessionState,
-  getAgentClient: (wsRouting?: { workspace_id?: string; workspace_alias?: string }) => AgentClient,
+  getAgentClient: (wsRouting?: WorkspaceRouting, asAgent?: string) => AgentClient,
   telemetry?: McpTelemetry,
+  resolveAgentIdentity?: (routing?: AgentRouting) => ResolvedAgentIdentity,
 ): void {
   const original = mcpServer.registerTool.bind(mcpServer) as RegisterToolFn;
   const mutableServer = mcpServer as unknown as { registerTool: RegisterToolFn };
@@ -101,10 +119,18 @@ export function enablePiggyback(
         });
       }
 
-      if (!shouldPiggybackInbox || !getSession().agentToken) return result;
+      const routing = extractAgentRouting(args);
+      const hasRoutedIdentity = Boolean(routing?.workspace_id || routing?.workspace_alias || routing?.as);
+      if (!shouldPiggybackInbox || (!getSession().agentToken && !hasRoutedIdentity)) return result;
 
       try {
-        const client = getAgentClient();
+        const workspaceRouting = routing?.workspace_id || routing?.workspace_alias
+          ? {
+              workspace_id: routing.workspace_id,
+              workspace_alias: routing.workspace_alias,
+            }
+          : undefined;
+        const client = getAgentClient(workspaceRouting, routing?.as);
         const inbox = await client.inbox();
 
         const hasUnread =
@@ -121,7 +147,7 @@ export function enablePiggyback(
         );
 
         if (hasUnread && hasContentArray(result)) {
-          const selfName = getSession().agentName;
+          const selfName = resolveAgentIdentity?.(routing)?.agentName ?? routing?.as ?? getSession().agentName;
           const inboxText = formatInbox(inbox, selfName);
           if (inboxText) {
             result.content.push({

--- a/packages/mcp/src/resources/definitions.ts
+++ b/packages/mcp/src/resources/definitions.ts
@@ -1,19 +1,52 @@
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { ResourceTemplate } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type { RequestHandlerExtra } from '@modelcontextprotocol/sdk/shared/protocol.js';
 import type { AgentClient, RelayCast } from '@relaycast/sdk';
+import type { ServerNotification, ServerRequest } from '@modelcontextprotocol/sdk/types.js';
+import { parseAgentRouting } from '../workspaces.js';
+
+type WorkspaceRouting = {
+  workspace_id?: string;
+  workspace_alias?: string;
+};
 
 export function registerResourceDefinitions(
   server: McpServer,
-  getAgentClient: () => AgentClient,
-  getRelay: () => RelayCast,
+  getAgentClient: (wsRouting?: WorkspaceRouting, as?: string) => AgentClient,
+  getRelay: (wsRouting?: WorkspaceRouting, as?: string) => RelayCast,
 ): void {
+  const routingFromExtra = (
+    extra?: RequestHandlerExtra<ServerRequest, ServerNotification>,
+  ): { workspace_id?: string; workspace_alias?: string; as?: string } | undefined => {
+    const meta = (extra as { _meta?: unknown } | undefined)?._meta;
+    if (!meta) {
+      return undefined;
+    }
+    return parseAgentRouting(meta);
+  };
+  const splitRouting = (
+    routing: { workspace_id?: string; workspace_alias?: string; as?: string } | undefined,
+  ): [{ workspace_id?: string; workspace_alias?: string } | undefined, string | undefined] => {
+    if (!routing) {
+      return [undefined, undefined];
+    }
+    return [
+      {
+        workspace_id: routing.workspace_id,
+        workspace_alias: routing.workspace_alias,
+      },
+      routing.as,
+    ];
+  };
+
   // Static resource: inbox
   server.registerResource(
     'inbox',
     'relay://inbox',
     { title: 'Inbox', description: 'Unread messages, mentions, and DMs', mimeType: 'application/json' },
-    async (uri) => {
-      const client = getAgentClient();
+    async (uri, extra) => {
+      const routing = splitRouting(routingFromExtra(extra as RequestHandlerExtra<ServerRequest, ServerNotification>));
+      const client = getAgentClient(...routing);
       const inbox = await client.inbox();
       return { contents: [{ uri: uri.href, text: JSON.stringify(inbox) }] };
     },
@@ -24,8 +57,9 @@ export function registerResourceDefinitions(
     'agents',
     'relay://agents',
     { title: 'Agents', description: 'Online and offline agents in the workspace', mimeType: 'application/json' },
-    async (uri) => {
-      const relay = getRelay();
+    async (uri, extra) => {
+      const routing = splitRouting(routingFromExtra(extra as RequestHandlerExtra<ServerRequest, ServerNotification>));
+      const relay = getRelay(...routing);
       const agents = await relay.agents.list();
       return { contents: [{ uri: uri.href, text: JSON.stringify(agents) }] };
     },
@@ -36,8 +70,9 @@ export function registerResourceDefinitions(
     'channels',
     'relay://channels',
     { title: 'Channels', description: 'Available channels in the workspace', mimeType: 'application/json' },
-    async (uri) => {
-      const client = getAgentClient();
+    async (uri, extra) => {
+      const routing = splitRouting(routingFromExtra(extra as RequestHandlerExtra<ServerRequest, ServerNotification>));
+      const client = getAgentClient(...routing);
       const channels = await client.channels.list();
       return { contents: [{ uri: uri.href, text: JSON.stringify(channels) }] };
     },
@@ -48,8 +83,9 @@ export function registerResourceDefinitions(
     'channel-messages',
     new ResourceTemplate('relay://channels/{name}/messages', { list: undefined }),
     { title: 'Channel Messages', description: 'Messages in a specific channel', mimeType: 'application/json' },
-    async (uri, params) => {
-      const client = getAgentClient();
+    async (uri, params, extra) => {
+      const routing = splitRouting(routingFromExtra(extra as RequestHandlerExtra<ServerRequest, ServerNotification>));
+      const client = getAgentClient(...routing);
       const messages = await client.messages(params.name as string);
       return { contents: [{ uri: uri.href, text: JSON.stringify(messages) }] };
     },
@@ -60,8 +96,9 @@ export function registerResourceDefinitions(
     'message-thread',
     new ResourceTemplate('relay://messages/{id}/thread', { list: undefined }),
     { title: 'Message Thread', description: 'Thread replies on a message', mimeType: 'application/json' },
-    async (uri, params) => {
-      const client = getAgentClient();
+    async (uri, params, extra) => {
+      const routing = splitRouting(routingFromExtra(extra as RequestHandlerExtra<ServerRequest, ServerNotification>));
+      const client = getAgentClient(...routing);
       const thread = await client.thread(params.id as string);
       return { contents: [{ uri: uri.href, text: JSON.stringify(thread) }] };
     },
@@ -72,8 +109,9 @@ export function registerResourceDefinitions(
     'dm-conversation',
     new ResourceTemplate('relay://dm/{conversation_id}', { list: undefined }),
     { title: 'DM Conversation', description: 'Direct message conversation', mimeType: 'application/json' },
-    async (uri, params) => {
-      const client = getAgentClient();
+    async (uri, params, extra) => {
+      const routing = splitRouting(routingFromExtra(extra as RequestHandlerExtra<ServerRequest, ServerNotification>));
+      const client = getAgentClient(...routing);
       const messages = await client.dms.messages(params.conversation_id as string);
       return { contents: [{ uri: uri.href, text: JSON.stringify(messages) }] };
     },

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -121,7 +121,7 @@ export function createRelayMcpServer(options: McpServerOptions): McpServer {
     return createInternalRelayCast({
       apiKey: identity.workspaceKey,
       baseUrl: options.baseUrl,
-    }, mcpOrigin).as(identity.agentToken);
+    }, mcpOrigin);
   };
   const syncActiveWorkspaceContext = () => {
     if (!session.workspaceKey || !session.agentToken || !session.agentName) {

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -2,6 +2,8 @@ import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import {
   CallToolRequestSchema,
   ListToolsRequestSchema,
+  SubscribeRequestSchema,
+  UnsubscribeRequestSchema,
   type CallToolRequest,
   type ListToolsRequest,
   type ListToolsResult,
@@ -150,13 +152,23 @@ export function createRelayMcpServer(options: McpServerOptions): McpServer {
       wsInitAttempted: session.wsInitAttempted,
     });
   };
+  const notifySubscribers = () => {
+    const uris = session.subscriptions?.getAll() ?? [];
+    for (const uri of uris) {
+      mcpServer.server.sendResourceUpdated({ uri }).catch(() => {});
+    }
+  };
+
   const setSession = (partial: Partial<SessionState>) => {
     const switchingWorkspace = partial.workspaceKey !== undefined && partial.workspaceKey !== session.workspaceKey;
+    const changingToken = partial.agentToken !== undefined && partial.agentToken !== session.agentToken;
 
     // In a single MCP process the bridge tracks the active workspace, not
     // every agent token update inside that workspace. Rebuild it only when
     // the workspace itself changes.
     if (switchingWorkspace) {
+      // Notify subscribers before tearing down so clients know data changed
+      notifySubscribers();
       session.wsBridge?.stop();
       session.subscriptions?.clear();
       session.wsBridge = null;
@@ -166,6 +178,12 @@ export function createRelayMcpServer(options: McpServerOptions): McpServer {
 
     // Apply the partial state update
     Object.assign(session, partial);
+
+    // When the agent token changes within the same workspace, notify
+    // subscribers that resource data may have changed.
+    if (!switchingWorkspace && changingToken) {
+      notifySubscribers();
+    }
 
     // If we have a token but no bridge yet, and we haven't failed initialization, try to start it.
     if (session.agentToken && !session.wsBridge && !session.wsInitAttempted) {
@@ -275,6 +293,16 @@ export function createRelayMcpServer(options: McpServerOptions): McpServer {
 
   // Register resource definitions (inbox, agents, channels, etc.)
   registerResourceDefinitions(mcpServer, getAgentClient, getRelay);
+
+  // Register subscribe/unsubscribe handlers so clients can track resource changes
+  mcpServer.server.setRequestHandler(SubscribeRequestSchema, async (req) => {
+    session.subscriptions?.subscribe(req.params.uri);
+    return {};
+  });
+  mcpServer.server.setRequestHandler(UnsubscribeRequestSchema, async (req) => {
+    session.subscriptions?.unsubscribe(req.params.uri);
+    return {};
+  });
 
   // Register all tools
   registerRegistrationTools(

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -101,17 +101,27 @@ export function createRelayMcpServer(options: McpServerOptions): McpServer {
   });
 
   const getSession = () => session;
-  const getRelay = () => {
-    const workspaceKey = session.workspaceKey;
-    if (!workspaceKey) {
+  const getRelay = (
+    wsRouting?: { workspace_id?: string; workspace_alias?: string },
+    asAgent?: string,
+  ) => {
+    if (!session.workspaceKey) {
       throw new Error(
         'Workspace key not configured. Set RELAY_API_KEY at startup, or call "workspace.create" or "workspace.set_key" first.',
       );
     }
+    if (!wsRouting && !asAgent) {
+      return createInternalRelayCast({
+        apiKey: session.workspaceKey,
+        baseUrl: options.baseUrl,
+      }, mcpOrigin);
+    }
+
+    const identity = resolveAgentIdentity(wsRouting, asAgent);
     return createInternalRelayCast({
-      apiKey: workspaceKey,
+      apiKey: identity.workspaceKey,
       baseUrl: options.baseUrl,
-    }, mcpOrigin);
+    }, mcpOrigin).as(identity.agentToken);
   };
   const syncActiveWorkspaceContext = () => {
     if (!session.workspaceKey || !session.agentToken || !session.agentName) {

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -27,6 +27,7 @@ import { createMcpTelemetry, type McpTelemetry } from './telemetry.js';
 import { resolveToolName } from './tool-aliases.js';
 import type { McpWorkspaceConfig } from './workspaces.js';
 import { findWorkspaceContext } from './workspaces.js';
+import type { RegisteredAgent } from './types.js';
 
 export const MCP_VERSION = '0.1.2';
 
@@ -48,6 +49,18 @@ export interface McpServerOptions {
   /** Default workspace ID or alias to use as the active workspace. */
   defaultWorkspace?: string;
 }
+
+type AgentRouting = {
+  workspace_id?: string;
+  workspace_alias?: string;
+  as?: string;
+};
+
+type ResolvedAgentIdentity = {
+  workspaceKey: string;
+  agentToken: string;
+  agentName: string;
+};
 
 type ServerRequestHandler<TRequest, TResult extends ServerResult = ServerResult> = (
   request: TRequest,
@@ -100,17 +113,44 @@ export function createRelayMcpServer(options: McpServerOptions): McpServer {
       baseUrl: options.baseUrl,
     }, mcpOrigin);
   };
-  const setSession = (partial: Partial<SessionState>) => {
-    const switchingToken = partial.agentToken !== undefined && partial.agentToken !== session.agentToken;
+  const syncActiveWorkspaceContext = () => {
+    if (!session.workspaceKey || !session.agentToken || !session.agentName) {
+      return;
+    }
 
-    if (switchingToken && session.wsBridge) {
-      session.wsBridge.stop();
+    const existing = session.workspaces.get(session.workspaceKey);
+    const agents = new Map(existing?.agents ?? []);
+    for (const [agentName, agent] of session.agents) {
+      agents.set(agentName, agent);
+    }
+    agents.set(session.agentName, {
+      agentName: session.agentName,
+      agentToken: session.agentToken,
+    });
+
+    session.workspaces.set(session.workspaceKey, {
+      workspaceKey: session.workspaceKey,
+      agentToken: session.agentToken,
+      agentName: session.agentName,
+      agents,
+      workspaceName: existing?.workspaceName,
+      workspaceLabel: existing?.workspaceLabel,
+      wsBridge: session.wsBridge,
+      subscriptions: session.subscriptions,
+      wsInitAttempted: session.wsInitAttempted,
+    });
+  };
+  const setSession = (partial: Partial<SessionState>) => {
+    const switchingWorkspace = partial.workspaceKey !== undefined && partial.workspaceKey !== session.workspaceKey;
+
+    // In a single MCP process the bridge tracks the active workspace, not
+    // every agent token update inside that workspace. Rebuild it only when
+    // the workspace itself changes.
+    if (switchingWorkspace) {
+      session.wsBridge?.stop();
       session.subscriptions?.clear();
       session.wsBridge = null;
       session.subscriptions = null;
-    }
-
-    if (switchingToken) {
       session.wsInitAttempted = false;
     }
 
@@ -150,12 +190,22 @@ export function createRelayMcpServer(options: McpServerOptions): McpServer {
         agent_name: session.agentName,
       });
     }
+
+    syncActiveWorkspaceContext();
   };
 
-  const getAgentClient = (
+  const resolveRegisteredToken = (
+    agents: Map<string, RegisteredAgent>,
+    agentName?: string,
+  ): string | null => {
+    if (!agentName) return null;
+    return agents.get(agentName)?.agentToken ?? null;
+  };
+
+  const resolveAgentIdentity = (
     wsRouting?: { workspace_id?: string; workspace_alias?: string },
-  ): AgentClient => {
-    // If workspace routing is specified, resolve the target workspace context
+    asAgent?: string,
+  ): ResolvedAgentIdentity => {
     if (wsRouting && (wsRouting.workspace_id || wsRouting.workspace_alias)) {
       const ctx = findWorkspaceContext(session, wsRouting, options.workspaces);
       if (!ctx) {
@@ -164,25 +214,54 @@ export function createRelayMcpServer(options: McpServerOptions): McpServer {
           'Join the workspace first via "workspace.join" or bootstrap via RELAY_WORKSPACES_JSON.',
         );
       }
-      return createInternalRelayCast({
-        apiKey: ctx.agentToken,
-        baseUrl: options.baseUrl,
-      }, mcpOrigin).as(ctx.agentToken);
+      const routedToken = resolveRegisteredToken(ctx.agents, asAgent) ?? ctx.agentToken;
+      if (asAgent && !resolveRegisteredToken(ctx.agents, asAgent)) {
+        throw new Error(
+          `Unknown agent identity "${asAgent}" for workspace ${wsRouting.workspace_id ?? wsRouting.workspace_alias}. Register it first.`,
+        );
+      }
+      return {
+        workspaceKey: ctx.workspaceKey,
+        agentToken: routedToken,
+        agentName: asAgent ?? ctx.agentName,
+      };
     }
 
-    if (!session.agentToken) {
+    const activeToken = resolveRegisteredToken(session.agents, asAgent) ?? session.agentToken;
+    if (asAgent && !resolveRegisteredToken(session.agents, asAgent)) {
+      throw new Error(`Unknown agent identity "${asAgent}". Register it first.`);
+    }
+
+    if (!activeToken) {
       throw new Error('Not registered. Call the "agent.register" tool first.');
     }
+
+    return {
+      workspaceKey: session.workspaceKey ?? activeToken,
+      agentToken: activeToken,
+      agentName: asAgent ?? session.agentName ?? '',
+    };
+  };
+
+  const getAgentClient = (
+    wsRouting?: { workspace_id?: string; workspace_alias?: string },
+    asAgent?: string,
+  ): AgentClient => {
+    const identity = resolveAgentIdentity(wsRouting, asAgent);
     return createInternalRelayCast({
-      apiKey: session.agentToken,
+      apiKey: identity.agentToken,
       baseUrl: options.baseUrl,
-    }, mcpOrigin).as(
-      session.agentToken,
-    );
+    }, mcpOrigin).as(identity.agentToken);
   };
 
   // Enable piggybacking of unread messages on all tool responses
-  enablePiggyback(mcpServer, getSession, getAgentClient, telemetry);
+  enablePiggyback(
+    mcpServer,
+    getSession,
+    getAgentClient,
+    telemetry,
+    (routing?: AgentRouting) => resolveAgentIdentity(routing, routing?.as),
+  );
 
   // Register resource definitions (inbox, agents, channels, etc.)
   registerResourceDefinitions(mcpServer, getAgentClient, getRelay);
@@ -260,17 +339,40 @@ export function createRelayMcpServer(options: McpServerOptions): McpServer {
   if (options.workspaces?.length) {
     for (const ws of options.workspaces) {
       if (ws.agent_token && ws.agent_name) {
+        const existing = session.workspaces.get(ws.api_key);
+        const agents = new Map(existing?.agents ?? []);
+        agents.set(ws.agent_name, {
+          agentName: ws.agent_name,
+          agentToken: ws.agent_token,
+        });
         session.workspaces.set(ws.api_key, {
           workspaceKey: ws.api_key,
           agentToken: ws.agent_token,
           agentName: ws.agent_name,
-          workspaceName: ws.workspace_name,
+          agents,
+          workspaceName: ws.workspace_name ?? existing?.workspaceName,
+          workspaceLabel: existing?.workspaceLabel,
           wsBridge: null,
           subscriptions: null,
           wsInitAttempted: false,
         });
       }
     }
+  }
+
+  if (session.workspaceKey && session.agentToken && session.agentName) {
+    const existing = session.workspaces.get(session.workspaceKey);
+    session.workspaces.set(session.workspaceKey, {
+      workspaceKey: session.workspaceKey,
+      agentToken: session.agentToken,
+      agentName: session.agentName,
+      agents: new Map(session.agents),
+      workspaceName: existing?.workspaceName,
+      workspaceLabel: existing?.workspaceLabel,
+      wsBridge: existing?.wsBridge ?? session.wsBridge,
+      subscriptions: existing?.subscriptions ?? session.subscriptions,
+      wsInitAttempted: existing?.wsInitAttempted ?? session.wsInitAttempted,
+    });
   }
 
   return mcpServer;

--- a/packages/mcp/src/stdio.ts
+++ b/packages/mcp/src/stdio.ts
@@ -25,7 +25,11 @@ function parseAgentType(value: string | undefined): 'agent' | 'human' | undefine
   return undefined;
 }
 
-const workspaces = parseWorkspaceEnv(process.env.RELAY_WORKSPACES_JSON);
+// When RELAY_SKIP_BOOTSTRAP is set (broker-spawned agents with a pre-registered
+// token), omit workspaces to prevent redundant bootstrap HTTP calls that would
+// delay the MCP initialize handshake.
+const skipBootstrap = parseStrictAgentName(process.env.RELAY_SKIP_BOOTSTRAP);
+const workspaces = skipBootstrap ? [] : parseWorkspaceEnv(process.env.RELAY_WORKSPACES_JSON);
 
 startStdio({
   apiKey: resolveApiKey(),

--- a/packages/mcp/src/tools/channels.ts
+++ b/packages/mcp/src/tools/channels.ts
@@ -1,13 +1,18 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
-import { AgentClient } from '@relaycast/sdk';
+import type { AgentClient } from '@relaycast/sdk';
+import {
+  identityOverrideInputShape,
+  workspaceRoutingInputShape,
+  workspaceRefFromArgs,
+} from '../workspaces.js';
 
 /** Passthrough object schema for dynamic API responses. */
 const jsonResult = z.object({}).passthrough();
 
 export function registerChannelTools(
   server: McpServer,
-  getAgentClient: (wsRouting?: { workspace_id?: string; workspace_alias?: string }) => AgentClient,
+  getAgentClient: (wsRouting?: { workspace_id?: string; workspace_alias?: string }, as?: string) => AgentClient,
 ): void {
   server.registerTool(
     'channel.create',
@@ -17,12 +22,13 @@ export function registerChannelTools(
       inputSchema: {
         name: z.string().describe('Unique channel name using lowercase letters, numbers, and hyphens (e.g. "build-alerts", "team-chat")'),
         topic: z.string().optional().describe('Short description of the channel\'s purpose, visible to all members when they view channel details'),
+        ...identityOverrideInputShape,
       },
       outputSchema: jsonResult,
       annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: false, openWorldHint: true },
     },
-    async ({ name, topic }) => {
-      const client = getAgentClient();
+    async ({ name, topic, as: asIdentity }) => {
+      const client = getAgentClient(undefined, asIdentity);
       const channel = await client.channels.create({ name, topic });
       return {
         content: [{ type: 'text', text: JSON.stringify(channel, null, 2) }],
@@ -38,14 +44,19 @@ export function registerChannelTools(
       description: 'List all channels available in the workspace. Returns each channel\'s name, topic, member count, and creation date. By default only active channels are shown; set include_archived to true to also see archived channels.',
       inputSchema: {
         include_archived: z.boolean().optional().describe('When true, include archived channels in the response alongside active ones'),
+        ...workspaceRoutingInputShape,
+        ...identityOverrideInputShape,
       },
       outputSchema: {
         channels: z.array(z.object({}).passthrough()).describe('Array of channel objects with name, topic, and member details'),
       },
       annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true, openWorldHint: true },
     },
-    async ({ include_archived }) => {
-      const client = getAgentClient();
+    async ({ include_archived, workspace_id, workspace_alias, as: asIdentity }) => {
+      const client = getAgentClient(
+        workspaceRefFromArgs({ workspace_id, workspace_alias }),
+        asIdentity,
+      );
       const channels = await client.channels.list(
         include_archived ? { includeArchived: include_archived } : undefined,
       );
@@ -63,14 +74,15 @@ export function registerChannelTools(
       description: 'Join an existing channel to start receiving its messages. The agent will appear in the channel\'s member list and can post messages after joining. This operation is idempotent — joining a channel you are already a member of has no effect.',
       inputSchema: {
         channel: z.string().describe('Name of the channel to join (e.g. "general", "build-alerts")'),
+        ...identityOverrideInputShape,
       },
       outputSchema: {
         message: z.string().describe('Confirmation message indicating the channel was joined'),
       },
       annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: true, openWorldHint: true },
     },
-    async ({ channel }) => {
-      const client = getAgentClient();
+    async ({ channel, as: asIdentity }) => {
+      const client = getAgentClient(undefined, asIdentity);
       await client.channels.join(channel);
       const message = `Joined channel #${channel}`;
       return {
@@ -87,14 +99,15 @@ export function registerChannelTools(
       description: 'Leave a channel to stop receiving its messages. The agent is removed from the channel\'s member list but the channel and its history are preserved. You can rejoin at any time. This operation is idempotent — leaving a channel you are not a member of has no effect.',
       inputSchema: {
         channel: z.string().describe('Name of the channel to leave (e.g. "general", "build-alerts")'),
+        ...identityOverrideInputShape,
       },
       outputSchema: {
         message: z.string().describe('Confirmation message indicating the channel was left'),
       },
       annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: true, openWorldHint: true },
     },
-    async ({ channel }) => {
-      const client = getAgentClient();
+    async ({ channel, as: asIdentity }) => {
+      const client = getAgentClient(undefined, asIdentity);
       await client.channels.leave(channel);
       const message = `Left channel #${channel}`;
       return {
@@ -112,14 +125,15 @@ export function registerChannelTools(
       inputSchema: {
         channel: z.string().describe('Name of the channel to invite the agent to (e.g. "general", "build-alerts")'),
         agent: z.string().describe('Name of the registered agent to invite into the channel'),
+        ...identityOverrideInputShape,
       },
       outputSchema: {
         message: z.string().describe('Confirmation message indicating the agent was invited'),
       },
       annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: true, openWorldHint: true },
     },
-    async ({ channel, agent }) => {
-      const client = getAgentClient();
+    async ({ channel, agent, as: asIdentity }) => {
+      const client = getAgentClient(undefined, asIdentity);
       await client.channels.invite(channel, agent);
       const message = `Invited ${agent} to #${channel}`;
       return {
@@ -137,12 +151,17 @@ export function registerChannelTools(
       inputSchema: {
         channel: z.string().describe('Name of the channel whose topic should be updated'),
         topic: z.string().describe('New topic text describing the channel\'s purpose or current focus'),
+        ...workspaceRoutingInputShape,
+        ...identityOverrideInputShape,
       },
       outputSchema: jsonResult,
       annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: true, openWorldHint: true },
     },
-    async ({ channel, topic }) => {
-      const client = getAgentClient();
+    async ({ channel, topic, workspace_id, workspace_alias, as: asIdentity }) => {
+      const client = getAgentClient(
+        workspaceRefFromArgs({ workspace_id, workspace_alias }),
+        asIdentity,
+      );
       const updated = await client.channels.setTopic(channel, topic);
       return {
         content: [{ type: 'text', text: JSON.stringify(updated, null, 2) }],
@@ -158,14 +177,19 @@ export function registerChannelTools(
       description: 'Archive a channel to remove it from the active channel list. Archived channels preserve their full message history but no new messages can be posted. This is a soft delete — the channel can be restored later if needed. Use this to clean up channels that are no longer in use.',
       inputSchema: {
         channel: z.string().describe('Name of the channel to archive (e.g. "old-project", "temp-discussion")'),
+        ...workspaceRoutingInputShape,
+        ...identityOverrideInputShape,
       },
       outputSchema: {
         message: z.string().describe('Confirmation message indicating the channel was archived'),
       },
       annotations: { readOnlyHint: false, destructiveHint: true, idempotentHint: true, openWorldHint: true },
     },
-    async ({ channel }) => {
-      const client = getAgentClient();
+    async ({ channel, workspace_id, workspace_alias, as: asIdentity }) => {
+      const client = getAgentClient(
+        workspaceRefFromArgs({ workspace_id, workspace_alias }),
+        asIdentity,
+      );
       await client.channels.archive(channel);
       const message = `Archived channel #${channel}`;
       return {

--- a/packages/mcp/src/tools/features.ts
+++ b/packages/mcp/src/tools/features.ts
@@ -2,13 +2,18 @@ import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
 import type { AgentClient } from '@relaycast/sdk';
 import { resolveEmoji } from '@relaycast/types';
+import {
+  identityOverrideInputShape,
+  workspaceRoutingInputShape,
+  workspaceRefFromArgs,
+} from '../workspaces.js';
 
 /** Passthrough object schema for dynamic API responses. */
 const jsonResult = z.object({}).passthrough();
 
 export function registerFeatureTools(
   server: McpServer,
-  getAgentClient: (wsRouting?: { workspace_id?: string; workspace_alias?: string }) => AgentClient,
+  getAgentClient: (wsRouting?: { workspace_id?: string; workspace_alias?: string }, as?: string) => AgentClient,
 ): void {
   server.registerTool('message.reaction.add', {
     title: 'Add Reaction',
@@ -16,13 +21,14 @@ export function registerFeatureTools(
     inputSchema: {
       message_id: z.string().describe('ID of the message to react to'),
       emoji: z.string().describe('Emoji character or shortcode to react with (e.g. "thumbsup", "rocket", "check")'),
+      ...identityOverrideInputShape,
     },
     outputSchema: {
       message: z.string().describe('Confirmation message indicating the reaction was added'),
     },
     annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: true, openWorldHint: true },
-  }, async ({ message_id, emoji }) => {
-    const client = getAgentClient();
+  }, async ({ message_id, emoji, as: asIdentity }) => {
+    const client = getAgentClient(undefined, asIdentity);
     const resolved = resolveEmoji(emoji);
     await client.react(message_id, resolved);
     const message = `Reacted with ${resolved}`;
@@ -38,13 +44,14 @@ export function registerFeatureTools(
     inputSchema: {
       message_id: z.string().describe('ID of the message to remove the reaction from'),
       emoji: z.string().describe('Emoji character or shortcode to remove (must match a reaction previously added by this agent)'),
+      ...identityOverrideInputShape,
     },
     outputSchema: {
       message: z.string().describe('Confirmation message indicating the reaction was removed'),
     },
     annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: true, openWorldHint: true },
-  }, async ({ message_id, emoji }) => {
-    const client = getAgentClient();
+  }, async ({ message_id, emoji, as: asIdentity }) => {
+    const client = getAgentClient(undefined, asIdentity);
     const resolved = resolveEmoji(emoji);
     await client.unreact(message_id, resolved);
     const message = `Removed reaction ${resolved}`;
@@ -62,13 +69,18 @@ export function registerFeatureTools(
       channel: z.string().optional().describe('Restrict search results to messages in this channel only'),
       from: z.string().optional().describe('Restrict search results to messages sent by this agent name'),
       limit: z.number().optional().describe('Maximum number of search results to return'),
+      ...workspaceRoutingInputShape,
+      ...identityOverrideInputShape,
     },
     outputSchema: {
       results: z.array(z.object({}).passthrough()).describe('Array of matching message objects'),
     },
     annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true, openWorldHint: true },
-  }, async ({ query, channel, from, limit }) => {
-    const client = getAgentClient();
+  }, async ({ query, channel, from, limit, workspace_id, workspace_alias, as: asIdentity }) => {
+    const client = getAgentClient(
+      workspaceRefFromArgs({ workspace_id, workspace_alias }),
+      asIdentity,
+    );
     const results = await client.search(query, { channel, from, limit });
     return {
       content: [{ type: 'text' as const, text: JSON.stringify(results, null, 2) }],
@@ -81,11 +93,12 @@ export function registerFeatureTools(
     description: 'Check the current agent\'s inbox for unread messages, @mentions, and direct messages. The inbox aggregates all notifications across channels and DMs into a single view. Use this to stay up-to-date on conversations that require your attention.',
     inputSchema: {
       limit: z.number().optional().describe('Maximum number of inbox items to return'),
+      ...identityOverrideInputShape,
     },
     outputSchema: jsonResult,
     annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true, openWorldHint: true },
-  }, async ({ limit }) => {
-    const client = getAgentClient();
+  }, async ({ limit, as: asIdentity }) => {
+    const client = getAgentClient(undefined, asIdentity);
     const inbox = await client.inbox(limit != null ? { limit } : undefined);
     return {
       content: [{ type: 'text' as const, text: JSON.stringify(inbox, null, 2) }],
@@ -98,13 +111,14 @@ export function registerFeatureTools(
     description: 'Mark a specific message as read by the current agent. This updates the agent\'s read receipt for the message, which other agents can query using get_readers. Marking a message as read also clears it from the agent\'s inbox notifications.',
     inputSchema: {
       message_id: z.string().describe('ID of the message to mark as read by the current agent'),
+      ...identityOverrideInputShape,
     },
     outputSchema: {
       message: z.string().describe('Confirmation message indicating the message was marked as read'),
     },
     annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: true, openWorldHint: true },
-  }, async ({ message_id }) => {
-    const client = getAgentClient();
+  }, async ({ message_id, as: asIdentity }) => {
+    const client = getAgentClient(undefined, asIdentity);
     await client.markRead(message_id);
     const message = `Marked message ${message_id} as read`;
     return {
@@ -139,11 +153,12 @@ export function registerFeatureTools(
       filename: z.string().describe('Name of the file including extension (e.g. "report.pdf", "screenshot.png")'),
       content_type: z.string().describe('MIME type of the file content (e.g. "text/plain", "image/png", "application/pdf")'),
       size_bytes: z.number().describe('Size of the file in bytes, used for upload validation and storage allocation'),
+      ...identityOverrideInputShape,
     },
     outputSchema: jsonResult,
     annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: false, openWorldHint: true },
-  }, async ({ filename, content_type, size_bytes }) => {
-    const client = getAgentClient();
+  }, async ({ filename, content_type, size_bytes, as: asIdentity }) => {
+    const client = getAgentClient(undefined, asIdentity);
     const upload = await client.files.upload({ filename, contentType: content_type, sizeBytes: size_bytes });
     return {
       content: [{ type: 'text' as const, text: JSON.stringify(upload, null, 2) }],

--- a/packages/mcp/src/tools/messaging.ts
+++ b/packages/mcp/src/tools/messaging.ts
@@ -1,7 +1,11 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
 import type { AgentClient } from '@relaycast/sdk';
-import { workspaceRoutingInputShape, workspaceRefFromArgs } from '../workspaces.js';
+import {
+  identityOverrideInputShape,
+  workspaceRoutingInputShape,
+  workspaceRefFromArgs,
+} from '../workspaces.js';
 
 /** Workspace routing arg type extracted from tool input. */
 type WsRouting = { workspace_id?: string; workspace_alias?: string };
@@ -11,7 +15,7 @@ const jsonResult = z.object({}).passthrough();
 
 export function registerMessagingTools(
   server: McpServer,
-  getAgentClient: (wsRouting?: WsRouting) => AgentClient,
+  getAgentClient: (wsRouting?: WsRouting, as?: string) => AgentClient,
 ): void {
   server.registerTool('message.post', {
     title: 'Post Message',
@@ -21,11 +25,12 @@ export function registerMessagingTools(
       text: z.string().describe('The message body text, which may include @mentions of other agents'),
       attachments: z.array(z.string()).optional().describe('Array of file attachment IDs obtained from the upload_file tool'),
       ...workspaceRoutingInputShape,
+      ...identityOverrideInputShape,
     },
     outputSchema: jsonResult,
     annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: false, openWorldHint: true },
-  }, async ({ channel, text, attachments, workspace_id, workspace_alias }) => {
-    const client = getAgentClient(workspaceRefFromArgs({ workspace_id, workspace_alias }));
+  }, async ({ channel, text, attachments, workspace_id, workspace_alias, as: asIdentity }) => {
+    const client = getAgentClient(workspaceRefFromArgs({ workspace_id, workspace_alias }), asIdentity);
     const msg = await client.send(channel, text, attachments ? { attachments } : undefined);
     return {
       content: [{ type: 'text' as const, text: JSON.stringify(msg, null, 2) }],
@@ -63,11 +68,12 @@ export function registerMessagingTools(
       message_id: z.string().describe('ID of the parent message to reply to, which becomes the thread root'),
       text: z.string().describe('The reply body text, which may include @mentions of other agents'),
       ...workspaceRoutingInputShape,
+      ...identityOverrideInputShape,
     },
     outputSchema: jsonResult,
     annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: false, openWorldHint: true },
-  }, async ({ message_id, text, workspace_id, workspace_alias }) => {
-    const client = getAgentClient(workspaceRefFromArgs({ workspace_id, workspace_alias }));
+  }, async ({ message_id, text, workspace_id, workspace_alias, as: asIdentity }) => {
+    const client = getAgentClient(workspaceRefFromArgs({ workspace_id, workspace_alias }), asIdentity);
     const reply = await client.reply(message_id, text);
     return {
       content: [{ type: 'text' as const, text: JSON.stringify(reply, null, 2) }],
@@ -101,11 +107,12 @@ export function registerMessagingTools(
       to: z.string().describe('Name of the registered agent to send the direct message to'),
       text: z.string().describe('The direct message body text'),
       ...workspaceRoutingInputShape,
+      ...identityOverrideInputShape,
     },
     outputSchema: jsonResult,
     annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: false, openWorldHint: true },
-  }, async ({ to, text, workspace_id, workspace_alias }) => {
-    const client = getAgentClient(workspaceRefFromArgs({ workspace_id, workspace_alias }));
+  }, async ({ to, text, workspace_id, workspace_alias, as: asIdentity }) => {
+    const client = getAgentClient(workspaceRefFromArgs({ workspace_id, workspace_alias }), asIdentity);
     const result = await client.dm(to, text);
     return {
       content: [{ type: 'text' as const, text: JSON.stringify(result, null, 2) }],
@@ -119,13 +126,14 @@ export function registerMessagingTools(
     inputSchema: {
       limit: z.number().optional().describe('Maximum number of conversations to return'),
       ...workspaceRoutingInputShape,
+      ...identityOverrideInputShape,
     },
     outputSchema: {
       conversations: z.array(z.object({}).passthrough()).describe('Array of DM conversation summaries'),
     },
     annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true, openWorldHint: true },
-  }, async ({ workspace_id, workspace_alias }) => {
-    const client = getAgentClient(workspaceRefFromArgs({ workspace_id, workspace_alias }));
+  }, async ({ workspace_id, workspace_alias, as: asIdentity }) => {
+    const client = getAgentClient(workspaceRefFromArgs({ workspace_id, workspace_alias }), asIdentity);
     const convos = await client.dms.conversations();
     return {
       content: [{ type: 'text' as const, text: JSON.stringify(convos, null, 2) }],
@@ -141,11 +149,12 @@ export function registerMessagingTools(
       name: z.string().optional().describe('Optional display name for the group conversation (e.g. "Backend Team", "Project Alpha")'),
       text: z.string().describe('The first message to send to the group, which initiates the conversation'),
       ...workspaceRoutingInputShape,
+      ...identityOverrideInputShape,
     },
     outputSchema: jsonResult,
     annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: false, openWorldHint: true },
-  }, async ({ participants, name, text, workspace_id, workspace_alias }) => {
-    const client = getAgentClient(workspaceRefFromArgs({ workspace_id, workspace_alias }));
+  }, async ({ participants, name, text, workspace_id, workspace_alias, as: asIdentity }) => {
+    const client = getAgentClient(workspaceRefFromArgs({ workspace_id, workspace_alias }), asIdentity);
     const conversation = await client.dms.createGroup({ participants, name });
     const message = await client.dms.sendMessage(conversation.id, text);
     const result = { conversation, message };

--- a/packages/mcp/src/tools/programmability.ts
+++ b/packages/mcp/src/tools/programmability.ts
@@ -2,6 +2,11 @@ import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
 import type { RelayCast, AgentClient } from '@relaycast/sdk';
 import { SubscribableEventTypeSchema } from '@relaycast/types';
+import {
+  identityOverrideInputShape,
+  workspaceRoutingInputShape,
+  workspaceRefFromArgs,
+} from '../workspaces.js';
 
 /** Passthrough object schema for dynamic API responses. */
 const jsonResult = z.object({}).passthrough();
@@ -9,7 +14,7 @@ const jsonResult = z.object({}).passthrough();
 export function registerProgrammabilityTools(
   server: McpServer,
   getRelay: () => RelayCast,
-  getAgentClient: (wsRouting?: { workspace_id?: string; workspace_alias?: string }) => AgentClient,
+  getAgentClient: (wsRouting?: { workspace_id?: string; workspace_alias?: string }, as?: string) => AgentClient,
 ): void {
   // === Inbound Webhooks ===
 
@@ -255,11 +260,16 @@ export function registerProgrammabilityTools(
       channel: z.string().describe('Name of the channel providing context for the command invocation'),
       args: z.string().optional().describe('Raw argument string passed to the command handler (e.g. "production --force")'),
       parameters: z.string().optional().describe('JSON-encoded object of structured parameters matching the command\'s parameter definitions'),
+      ...workspaceRoutingInputShape,
+      ...identityOverrideInputShape,
     },
     outputSchema: jsonResult,
     annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: false, openWorldHint: true },
-  }, async ({ command, channel, args, parameters }) => {
-    const client = getAgentClient();
+  }, async ({ command, channel, args, parameters, workspace_id, workspace_alias, as: asIdentity }) => {
+    const client = getAgentClient(
+      workspaceRefFromArgs({ workspace_id, workspace_alias }),
+      asIdentity,
+    );
     const parsedParams = parameters ? JSON.parse(parameters) : undefined;
     const result = await client.commands.invoke(command, { channel, args, parameters: parsedParams });
     return {

--- a/packages/mcp/src/tools/programmability.ts
+++ b/packages/mcp/src/tools/programmability.ts
@@ -13,7 +13,10 @@ const jsonResult = z.object({}).passthrough();
 
 export function registerProgrammabilityTools(
   server: McpServer,
-  getRelay: () => RelayCast,
+  getRelay: (
+    wsRouting?: { workspace_id?: string; workspace_alias?: string },
+    asIdentity?: string,
+  ) => RelayCast,
   getAgentClient: (wsRouting?: { workspace_id?: string; workspace_alias?: string }, as?: string) => AgentClient,
 ): void {
   // === Inbound Webhooks ===

--- a/packages/mcp/src/tools/registration.ts
+++ b/packages/mcp/src/tools/registration.ts
@@ -2,7 +2,7 @@ import { createHash } from 'node:crypto';
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
 import { RelayCast } from '@relaycast/sdk';
-import type { SessionState, WorkspaceContext } from '../types.js';
+import type { RegisteredAgent, SessionState, WorkspaceContext } from '../types.js';
 
 type ApiOk<T> = { ok: true; data: T };
 type ApiErr = { ok: false; error?: { message?: string } };
@@ -98,6 +98,7 @@ function saveWorkspaceContext(
     workspaceKey,
     agentToken,
     agentName,
+    agents: new Map(session.agents),
     // Preserve existing workspace metadata if not explicitly provided.
     workspaceName: metadata.workspaceName ?? existing?.workspaceName,
     workspaceLabel: metadata.workspaceLabel ?? existing?.workspaceLabel,
@@ -106,6 +107,10 @@ function saveWorkspaceContext(
     subscriptions: null,
     wsInitAttempted: false,
   });
+}
+
+function createRegisteredAgent(agentName: string, agentToken: string): RegisteredAgent {
+  return { agentName, agentToken };
 }
 
 export function registerRegistrationTools(
@@ -148,7 +153,7 @@ export function registerRegistrationTools(
           session.agentName,
         );
       }
-      setSession({ workspaceKey, agentToken: null, agentName: null });
+      setSession({ workspaceKey, agentToken: null, agentName: null, agents: new Map() });
 
       return {
         content: [{ type: 'text', text: JSON.stringify(workspace, null, 2) }],
@@ -197,9 +202,10 @@ export function registerRegistrationTools(
             workspaceKey: api_key,
             agentToken: saved.agentToken,
             agentName: saved.agentName,
+            agents: new Map(saved.agents),
           });
         } else {
-          setSession({ workspaceKey: api_key, agentToken: null, agentName: null });
+          setSession({ workspaceKey: api_key, agentToken: null, agentName: null, agents: new Map() });
         }
       } else {
         setSession({ workspaceKey: api_key });
@@ -239,10 +245,18 @@ export function registerRegistrationTools(
       const session = getSession();
       requireWorkspaceKey(session);
 
-      const configuredName = session.agentName
-        ?? preferredAgentName?.trim()
-        ?? null;
+      const configuredName = strictAgentName
+        ? preferredAgentName?.trim()
+          ?? session.agentName
+          ?? null
+        : session.agentName
+          ?? preferredAgentName?.trim()
+          ?? null;
       const warnings: string[] = [];
+      const registeredConfiguredToken = configuredName
+        ? session.agents.get(configuredName)?.agentToken
+          ?? (session.agentName === configuredName ? session.agentToken : null)
+        : null;
 
       // In strict mode, enforce the pre-registered name from the broker.
       // This prevents spawned agents from re-registering under a different name.
@@ -263,22 +277,30 @@ export function registerRegistrationTools(
 
       // If already pre-registered with a token, skip the API call and return
       // the existing registration to avoid overwriting the pre-registered identity.
-      if (session.agentToken && effectiveName && strictAgentName) {
+      if (registeredConfiguredToken && effectiveName && strictAgentName) {
         const workspaceName = session.workspaceKey
           ? await fetchWorkspaceName(session.workspaceKey, baseUrl)
           : undefined;
+        setSession({
+          agentToken: registeredConfiguredToken,
+          agentName: effectiveName,
+          agents: new Map(session.agents).set(
+            effectiveName,
+            createRegisteredAgent(effectiveName, registeredConfiguredToken),
+          ),
+        });
         if (session.workspaceKey) {
           saveWorkspaceContext(
             session,
             session.workspaceKey,
-            session.agentToken,
+            registeredConfiguredToken,
             effectiveName,
             { workspaceName },
           );
         }
         const existing = {
           name: effectiveName,
-          token: session.agentToken,
+          token: registeredConfiguredToken,
           registered_name: effectiveName,
           warnings,
         };
@@ -295,8 +317,10 @@ export function registerRegistrationTools(
         persona,
         metadata,
       });
+      const nextAgents = new Map(session.agents);
+      nextAgents.set(effectiveName, createRegisteredAgent(effectiveName, result.token));
       // Store the agent token in session state
-      setSession({ agentToken: result.token, agentName: effectiveName });
+      setSession({ agentToken: result.token, agentName: effectiveName, agents: nextAgents });
 
       // Update multi-workspace context map.
       const updatedSession = getSession();
@@ -441,6 +465,7 @@ export function registerRegistrationTools(
           workspaceKey: api_key,
           agentToken: existing.agentToken,
           agentName: existing.agentName,
+          agents: new Map(existing.agents),
         });
         const result = {
           message: `Already joined workspace as "${existing.agentName}". Switched to it.`,
@@ -453,11 +478,15 @@ export function registerRegistrationTools(
       }
 
       // Switch to new workspace and register.
-      setSession({ workspaceKey: api_key, agentToken: null, agentName: null });
+      setSession({ workspaceKey: api_key, agentToken: null, agentName: null, agents: new Map() });
 
       const relay = getRelay();
       const regResult = await relay.agents.registerOrRotate({ name, type, persona });
-      setSession({ agentToken: regResult.token, agentName: name });
+      setSession({
+        agentToken: regResult.token,
+        agentName: name,
+        agents: new Map([[name, createRegisteredAgent(name, regResult.token)]]),
+      });
 
       // Save the new workspace context.
       const updatedSession = getSession();
@@ -528,6 +557,7 @@ export function registerRegistrationTools(
         workspaceKey: targetWorkspaceKey,
         agentToken: saved.agentToken,
         agentName: saved.agentName,
+        agents: new Map(saved.agents),
       });
 
       const result = {

--- a/packages/mcp/src/tools/registration.ts
+++ b/packages/mcp/src/tools/registration.ts
@@ -115,7 +115,10 @@ function createRegisteredAgent(agentName: string, agentToken: string): Registere
 
 export function registerRegistrationTools(
   server: McpServer,
-  getRelay: () => RelayCast,
+  getRelay: (
+    wsRouting?: { workspace_id?: string; workspace_alias?: string },
+    asIdentity?: string,
+  ) => RelayCast,
   getSession: () => SessionState,
   setSession: (state: Partial<SessionState>) => void,
   baseUrl?: string,

--- a/packages/mcp/src/transports.ts
+++ b/packages/mcp/src/transports.ts
@@ -14,72 +14,96 @@ const mcpOrigin = {
 };
 
 /**
+ * Bootstrap a single workspace by verifying/refreshing its token.
+ * Wrapped with a per-workspace timeout enforced via Promise.race so
+ * one slow workspace doesn't block all others.
+ */
+async function bootstrapOneWorkspace(
+  ws: McpWorkspaceConfig,
+  baseUrl?: string,
+  timeoutMs = 5_000,
+): Promise<McpWorkspaceConfig> {
+  const doBootstrap = async (): Promise<McpWorkspaceConfig> => {
+    const relay = createInternalRelayCast({
+      apiKey: ws.api_key,
+      baseUrl,
+    }, mcpOrigin);
+
+    let token = ws.agent_token;
+    const agentName = ws.agent_name ?? ws.workspace_alias ?? ws.workspace_id;
+    let workspaceName = ws.workspace_name;
+
+    try {
+      const workspace = await relay.workspace.info();
+      workspaceName = workspace.name;
+    } catch {
+      // Keep any pre-supplied name or leave undefined if workspace info is unavailable.
+    }
+
+    // If we have a token, verify it's still valid via an inbox call
+    if (token) {
+      try {
+        const client = relay.as(token);
+        await client.inbox();
+      } catch {
+        // Token is invalid, need to re-register
+        token = undefined;
+      }
+    }
+
+    // If no valid token, register or rotate
+    if (!token) {
+      const result = await relay.agents.registerOrRotate({
+        name: agentName,
+        type: 'agent',
+      });
+      token = result.token;
+    }
+
+    return {
+      ...ws,
+      agent_token: token,
+      agent_name: agentName,
+      workspace_name: workspaceName,
+    };
+  };
+
+  try {
+    const timeout = new Promise<never>((_, reject) =>
+      setTimeout(() => reject(new Error(`Bootstrap timed out after ${timeoutMs}ms`)), timeoutMs),
+    );
+    return await Promise.race([doBootstrap(), timeout]);
+  } catch (err) {
+    console.error(
+      `[bootstrap] Failed to bootstrap workspace ${ws.workspace_id}: ${err instanceof Error ? err.message : String(err)}`,
+    );
+    // Still return the workspace config even if bootstrap failed,
+    // so it can be retried later
+    return ws;
+  }
+}
+
+/**
  * Bootstrap workspaces by verifying/refreshing tokens and joining each
  * workspace into the MCP server's session via setSession + saveWorkspaceContext.
  *
- * This is called during startStdio when `workspaces` are provided.
+ * All workspaces are bootstrapped concurrently with individual timeouts.
  */
 async function bootstrapWorkspaces(
   workspaces: McpWorkspaceConfig[],
   baseUrl?: string,
 ): Promise<McpWorkspaceConfig[]> {
-  const bootstrapped: McpWorkspaceConfig[] = [];
+  const results = await Promise.allSettled(
+    workspaces.map(ws => bootstrapOneWorkspace(ws, baseUrl)),
+  );
 
-  for (const ws of workspaces) {
-    try {
-      const relay = createInternalRelayCast({
-        apiKey: ws.api_key,
-        baseUrl,
-      }, mcpOrigin);
-
-      let token = ws.agent_token;
-      const agentName = ws.agent_name ?? ws.workspace_alias ?? ws.workspace_id;
-      let workspaceName = ws.workspace_name;
-
-      try {
-        const workspace = await relay.workspace.info();
-        workspaceName = workspace.name;
-      } catch {
-        // Keep any pre-supplied name or leave undefined if workspace info is unavailable.
-      }
-
-      // If we have a token, verify it's still valid via an inbox call
-      if (token) {
-        try {
-          const client = relay.as(token);
-          await client.inbox();
-        } catch {
-          // Token is invalid, need to re-register
-          token = undefined;
-        }
-      }
-
-      // If no valid token, register or rotate
-      if (!token) {
-        const result = await relay.agents.registerOrRotate({
-          name: agentName,
-          type: 'agent',
-        });
-        token = result.token;
-      }
-
-      bootstrapped.push({
-        ...ws,
-        agent_token: token,
-        agent_name: agentName,
-        workspace_name: workspaceName,
-      });
-    } catch (err) {
-      console.error(
-        `[bootstrap] Failed to bootstrap workspace ${ws.workspace_id}: ${err instanceof Error ? err.message : String(err)}`,
-      );
-      // Still include the workspace config even if bootstrap failed,
-      // so it can be retried later
-      bootstrapped.push(ws);
-    }
-  }
-
-  return bootstrapped;
+  return results.map((result, i) => {
+    if (result.status === 'fulfilled') return result.value;
+    console.error(
+      `[bootstrap] Workspace ${workspaces[i].workspace_id} rejected: ${result.reason}`,
+    );
+    return workspaces[i];
+  });
 }
 
 /**
@@ -89,24 +113,46 @@ async function bootstrapWorkspaces(
 export async function startStdio(options: McpServerOptions): Promise<void> {
   let effectiveOptions = { ...options, telemetryTransport: 'stdio' as const };
 
-  // If workspaces are provided, bootstrap them before creating the server
-  if (options.workspaces?.length) {
-    const bootstrapped = await bootstrapWorkspaces(options.workspaces, options.baseUrl);
-    effectiveOptions = { ...effectiveOptions, workspaces: bootstrapped };
+  const hasAgentToken = Boolean(options.agentToken);
+  const hasWorkspaces = Boolean(options.workspaces?.length);
 
-    // Set the default workspace's api key/token/name as the primary session
-    const defaultWsId = resolveDefaultWorkspaceId(bootstrapped, options.defaultWorkspace);
-    const defaultWs = bootstrapped.find(
-      w => w.workspace_id === defaultWsId && w.agent_token,
-    );
-    if (defaultWs) {
-      effectiveOptions.apiKey = effectiveOptions.apiKey ?? defaultWs.api_key;
-      effectiveOptions.agentToken = effectiveOptions.agentToken ?? defaultWs.agent_token;
-      effectiveOptions.agentName = effectiveOptions.agentName ?? defaultWs.agent_name;
+  if (hasWorkspaces) {
+    if (hasAgentToken) {
+      // When agentToken is pre-provided (broker-spawned), skip bootstrap entirely —
+      // the token is already valid. Use workspace configs as-is for routing context.
+      const withNames = options.workspaces!.map(ws => ({
+        ...ws,
+        agent_name: ws.agent_name ?? ws.workspace_alias ?? ws.workspace_id,
+      }));
+      effectiveOptions = { ...effectiveOptions, workspaces: withNames };
+
+      // Promote default workspace credentials so routing resolves correctly
+      const defaultWsId = resolveDefaultWorkspaceId(withNames, options.defaultWorkspace);
+      const defaultWs = withNames.find(w => w.workspace_id === defaultWsId);
+      if (defaultWs) {
+        effectiveOptions.apiKey = effectiveOptions.apiKey ?? defaultWs.api_key;
+        effectiveOptions.agentName = effectiveOptions.agentName ?? defaultWs.agent_name;
+      }
+    } else {
+      // CLI user with RELAY_WORKSPACES_JSON — bootstrap is needed but now
+      // runs all workspaces concurrently (with per-workspace timeouts).
+      const bootstrapped = await bootstrapWorkspaces(options.workspaces!, options.baseUrl);
+      effectiveOptions = { ...effectiveOptions, workspaces: bootstrapped };
+
+      // Set the default workspace's api key/token/name as the primary session
+      const defaultWsId = resolveDefaultWorkspaceId(bootstrapped, options.defaultWorkspace);
+      const defaultWs = bootstrapped.find(
+        w => w.workspace_id === defaultWsId && w.agent_token,
+      );
+      if (defaultWs) {
+        effectiveOptions.apiKey = effectiveOptions.apiKey ?? defaultWs.api_key;
+        effectiveOptions.agentToken = effectiveOptions.agentToken ?? defaultWs.agent_token;
+        effectiveOptions.agentName = effectiveOptions.agentName ?? defaultWs.agent_name;
+      }
     }
   }
 
-  // createRelayMcpServer now populates session.workspaces from
+  // createRelayMcpServer populates session.workspaces from
   // effectiveOptions.workspaces internally — no need to reach into internals.
   const mcpServer = createRelayMcpServer(effectiveOptions);
 

--- a/packages/mcp/src/types.ts
+++ b/packages/mcp/src/types.ts
@@ -1,11 +1,18 @@
 import type { WsBridge } from './resources/ws-bridge.js';
 import type { SubscriptionManager } from './resources/subscriptions.js';
 
+export interface RegisteredAgent {
+  agentName: string;
+  agentToken: string;
+}
+
 /** Saved context for a single workspace membership. */
 export interface WorkspaceContext {
   workspaceKey: string;
   agentToken: string;
   agentName: string;
+  /** Registered agent tokens for this workspace, keyed by agent name. */
+  agents: Map<string, RegisteredAgent>;
   /** Canonical workspace name from the Relaycast API. */
   workspaceName?: string;
   /** Optional user-saved label for switching. */
@@ -19,6 +26,8 @@ export interface SessionState {
   workspaceKey: string | null;
   agentToken: string | null;
   agentName: string | null;
+  /** Registered agent tokens for the active workspace, keyed by agent name. */
+  agents: Map<string, RegisteredAgent>;
   wsBridge: WsBridge | null;
   subscriptions: SubscriptionManager | null;
   wsInitAttempted: boolean;
@@ -44,6 +53,10 @@ export function createInitialSession(
     workspaceKey: opts.workspaceKey ?? null,
     agentToken: opts.agentToken ?? null,
     agentName: opts.agentName ?? null,
+    agents:
+      opts.agentName && opts.agentToken
+        ? new Map([[opts.agentName, { agentName: opts.agentName, agentToken: opts.agentToken }]])
+        : new Map(),
     wsBridge: null,
     subscriptions: null,
     wsInitAttempted: false,

--- a/packages/mcp/src/workspaces.ts
+++ b/packages/mcp/src/workspaces.ts
@@ -1,6 +1,15 @@
 import { z } from 'zod';
 import type { SessionState, WorkspaceContext } from './types.js';
 
+export type WorkspaceRouting = {
+  workspace_id?: string;
+  workspace_alias?: string;
+};
+
+export type AgentRouting = WorkspaceRouting & {
+  as?: string;
+};
+
 /**
  * Configuration for a single workspace provided via RELAY_WORKSPACES_JSON.
  */
@@ -92,12 +101,42 @@ export const workspaceRoutingInputShape = {
 };
 
 /**
+ * Optional agent identity override for tools whose behavior depends on the
+ * authenticated agent.
+ */
+export const identityOverrideInputShape = {
+  as: z.string().optional().describe(
+    'Act as a specific registered agent name in the target workspace. If omitted, uses the active agent identity.',
+  ),
+};
+
+const agentRoutingSchema = z.object({
+  ...workspaceRoutingInputShape,
+  ...identityOverrideInputShape,
+}).passthrough();
+
+/**
+ * Extract optional workspace and identity routing from loose request params.
+ * Throws on invalid types so resource requests match tool-layer validation.
+ */
+export function parseAgentRouting(raw: unknown): AgentRouting | undefined {
+  const parsed = agentRoutingSchema.parse(raw ?? {});
+  const { workspace_id, workspace_alias, as } = parsed;
+
+  if (!workspace_id && !workspace_alias && !as) {
+    return undefined;
+  }
+
+  return { workspace_id, workspace_alias, as };
+}
+
+/**
  * Extract workspace routing info from tool arguments.
  * Returns the workspace_id or workspace_alias if provided, or undefined.
  */
 export function workspaceRefFromArgs(
-  args: { workspace_id?: string; workspace_alias?: string },
-): { workspace_id?: string; workspace_alias?: string } | undefined {
+  args: WorkspaceRouting,
+): WorkspaceRouting | undefined {
   if (args.workspace_id || args.workspace_alias) {
     return {
       workspace_id: args.workspace_id,


### PR DESCRIPTION
## Summary
- Multi-agent routing now supports per-request workspace + `as` overrides for resources and piggyback, without changing legacy resource URIs.
- WsBridge lifecycle is preserved across same-workspace agent token rotations (no second WsClient), while cross-workspace changes recreate the bridge.
- Resource subscription behavior remains on literal `relay://` URIs to preserve MCP compatibility.
- Added routing/bridge/resource parity tests and fixed unknown-agent validation for routed `as`.

## Verification
- npx vitest run packages/mcp/src/__tests__/resource-definitions.test.ts
- npx vitest run packages/mcp/src/__tests__/multi-agent-bridge.test.ts packages/mcp/src/__tests__/multi-agent-piggyback.test.ts packages/mcp/src/__tests__/multi-agent-session.test.ts packages/mcp/src/__tests__/multi-agent-integration.test.ts packages/mcp/src/__tests__/server-multi-workspace.test.ts
- npm test (packages/mcp)
- npm run lint (packages/mcp)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/agentworkforce/relaycast/pull/86" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
