### PR TITLE
fix(mcp): clear timeout timer in bootstrapOneWorkspace

### DIFF
--- a/packages/mcp/src/transports.ts
+++ b/packages/mcp/src/transports.ts
@@ -69,10 +69,13 @@ async function bootstrapOneWorkspace(
   };
 
   try {
-    const timeout = new Promise<never>((_, reject) =>
-      setTimeout(() => reject(new Error(`Bootstrap timed out after ${timeoutMs}ms`)), timeoutMs),
-    );
-    return await Promise.race([doBootstrap(), timeout]);
+    let timer: ReturnType<typeof setTimeout>;
+    const timeout = new Promise<never>((_, reject) => {
+      timer = setTimeout(() => reject(new Error(`Bootstrap timed out after ${timeoutMs}ms`)), timeoutMs);
+    });
+    const result = await Promise.race([doBootstrap(), timeout]);
+    clearTimeout(timer!);
+    return result;
   } catch (err) {
     console.error(
       `[bootstrap] Failed to bootstrap workspace ${ws.workspace_id}: ${err instanceof Error ? err.message : String(err)}`,


### PR DESCRIPTION
When `doBootstrap()` resolves before the timeout, the `setTimeout` timer was never cleared, holding a ref on the event loop for up to `timeoutMs` (default 5s) and preventing clean process shutdown.

**Fix:** Store the timer reference and `clearTimeout()` on success.

Addresses [Devin review comment](https://github.com/AgentWorkforce/relaycast/pull/86#discussion_r2936519615) on PR #86.

All 222 MCP tests passing.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/agentworkforce/relaycast/pull/88" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
