### PR TITLE
feat(send): support steer mode end-to-end for relay send path

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -118,6 +118,10 @@ components:
           type: object
         content_type:
           type: string
+        injection_mode:
+          type: string
+          enum: [wait, steer]
+          description: Delivery/injection mode used when the message was sent
         thread_id:
           type: string
         reply_count:
@@ -1029,6 +1033,11 @@ paths:
                   type: object
                 content_type:
                   type: string
+                mode:
+                  type: string
+                  enum: [wait, steer]
+                  default: wait
+                  description: Injection mode for relay delivery
       responses:
         '201':
           description: Message posted

--- a/packages/sdk-python/src/relay_sdk/agent.py
+++ b/packages/sdk-python/src/relay_sdk/agent.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, Literal
 from urllib.parse import quote
 
 from .client import AsyncHttpClient, HttpClient
@@ -174,10 +174,15 @@ class AgentClient:
     # ── Messages ──
 
     def send(
-        self, channel: str, text: str, *, attachments: list[str] | None = None
+        self,
+        channel: str,
+        text: str,
+        *,
+        attachments: list[str] | None = None,
+        mode: Literal["wait", "steer"] = "wait",
     ) -> MessageWithMeta:
         name = _strip_hash(channel)
-        body: dict[str, Any] = {"text": text}
+        body: dict[str, Any] = {"text": text, "mode": mode}
         if attachments:
             body["attachments"] = attachments
         result = self.client.post(f"/v1/channels/{_enc(name)}/messages", body)
@@ -430,10 +435,15 @@ class AsyncAgentClient:
     # ── Messages ──
 
     async def send(
-        self, channel: str, text: str, *, attachments: list[str] | None = None
+        self,
+        channel: str,
+        text: str,
+        *,
+        attachments: list[str] | None = None,
+        mode: Literal["wait", "steer"] = "wait",
     ) -> MessageWithMeta:
         name = _strip_hash(channel)
-        body: dict[str, Any] = {"text": text}
+        body: dict[str, Any] = {"text": text, "mode": mode}
         if attachments:
             body["attachments"] = attachments
         result = await self.client.post(f"/v1/channels/{_enc(name)}/messages", body)

--- a/packages/sdk-python/src/relay_sdk/models.py
+++ b/packages/sdk-python/src/relay_sdk/models.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from typing import Any, Literal
 
+MessageInjectionMode = Literal["wait", "steer"]
+
 from pydantic import BaseModel, Field
 
 
@@ -151,6 +153,7 @@ class MessageWithMeta(BaseModel):
     reply_count: int = 0
     reactions: list[ReactionGroup] = Field(default_factory=list)
     read_by_count: int = 0
+    injection_mode: MessageInjectionMode | None = None
 
 
 class Message(BaseModel):
@@ -170,6 +173,7 @@ class PostMessageRequest(BaseModel):
     text: str
     attachments: list[str] | None = None
     data: dict[str, Any] | None = None
+    mode: MessageInjectionMode = "wait"
 
 
 class MessageListQuery(BaseModel):
@@ -350,6 +354,7 @@ class MessageEventPayload(BaseModel):
     agent_name: str
     text: str
     attachments: list[FileAttachment] = Field(default_factory=list)
+    injection_mode: MessageInjectionMode | None = None
 
 
 class MessageUpdatedPayload(BaseModel):

--- a/packages/sdk-python/tests/test_agent.py
+++ b/packages/sdk-python/tests/test_agent.py
@@ -1,5 +1,7 @@
 """Tests for AgentClient and AsyncAgentClient."""
 
+import json
+
 import httpx
 import pytest
 import respx

--- a/packages/sdk-python/tests/test_agent.py
+++ b/packages/sdk-python/tests/test_agent.py
@@ -81,6 +81,23 @@ class TestAgentClientMessages:
         c = AgentClient(HttpClient(TOKEN, BASE))
         c.send("general", "See file", attachments=["f1", "f2"])
         assert route.called
+        assert route.calls[0].request.content == b'{"text":"See file","mode":"wait","attachments":["f1","f2"]}'
+
+    @respx.mock
+    def test_send_defaults_mode_wait(self):
+        route = respx.post(f"{BASE}/v1/channels/general/messages").mock(return_value=ok(MSG))
+        c = AgentClient(HttpClient(TOKEN, BASE))
+        c.send("general", "Hello")
+        assert route.called
+        assert route.calls[0].request.content == b'{"text":"Hello","mode":"wait"}'
+
+    @respx.mock
+    def test_send_forwards_steer_mode(self):
+        route = respx.post(f"{BASE}/v1/channels/general/messages").mock(return_value=ok(MSG))
+        c = AgentClient(HttpClient(TOKEN, BASE))
+        c.send("general", "Hello", mode="steer")
+        assert route.called
+        assert route.calls[0].request.content == b'{"text":"Hello","mode":"steer"}'
 
     @respx.mock
     def test_messages_with_pagination(self):
@@ -405,10 +422,20 @@ class TestAsyncAgentClient:
     @pytest.mark.asyncio
     @respx.mock
     async def test_send(self):
-        respx.post(f"{BASE}/v1/channels/general/messages").mock(return_value=ok(MSG))
+        route = respx.post(f"{BASE}/v1/channels/general/messages").mock(return_value=ok(MSG))
         c = AsyncAgentClient(AsyncHttpClient(TOKEN, BASE))
         result = await c.send("#general", "Hello")
         assert isinstance(result, MessageWithMeta)
+        assert route.calls[0].request.content == b'{"text":"Hello","mode":"wait"}'
+        await c.client.close()
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_send_steer_mode(self):
+        route = respx.post(f"{BASE}/v1/channels/general/messages").mock(return_value=ok(MSG))
+        c = AsyncAgentClient(AsyncHttpClient(TOKEN, BASE))
+        await c.send("#general", "Hello", mode="steer")
+        assert route.calls[0].request.content == b'{"text":"Hello","mode":"steer"}'
         await c.client.close()
 
     @pytest.mark.asyncio

--- a/packages/sdk-python/tests/test_agent.py
+++ b/packages/sdk-python/tests/test_agent.py
@@ -28,6 +28,10 @@ def ok(data):
     return httpx.Response(200, json={"ok": True, "data": data})
 
 
+def request_json(request: httpx.Request):
+    return json.loads(request.content.decode())
+
+
 MSG = {
     "id": "m1",
     "agent_name": "Bot",
@@ -81,7 +85,7 @@ class TestAgentClientMessages:
         c = AgentClient(HttpClient(TOKEN, BASE))
         c.send("general", "See file", attachments=["f1", "f2"])
         assert route.called
-        assert route.calls[0].request.content == b'{"text":"See file","mode":"wait","attachments":["f1","f2"]}'
+        assert request_json(route.calls[0].request) == {"text": "See file", "mode": "wait", "attachments": ["f1", "f2"]}
 
     @respx.mock
     def test_send_defaults_mode_wait(self):
@@ -89,7 +93,7 @@ class TestAgentClientMessages:
         c = AgentClient(HttpClient(TOKEN, BASE))
         c.send("general", "Hello")
         assert route.called
-        assert route.calls[0].request.content == b'{"text":"Hello","mode":"wait"}'
+        assert request_json(route.calls[0].request) == {"text": "Hello", "mode": "wait"}
 
     @respx.mock
     def test_send_forwards_steer_mode(self):

--- a/packages/sdk-python/tests/test_models.py
+++ b/packages/sdk-python/tests/test_models.py
@@ -204,6 +204,11 @@ def test_message_with_meta_creation_with_nested_attachment_and_reaction_group():
     assert msg.reactions[0].agents == ["ag_1", "ag_2"]
 
 
+def test_message_with_meta_accepts_injection_mode():
+    msg = MessageWithMeta(**_message_with_meta_dict(injection_mode="steer"))
+    assert msg.injection_mode == "steer"
+
+
 def test_message_with_meta_defaults_empty_lists_and_counters():
     msg = MessageWithMeta(
         id="m_1",
@@ -303,11 +308,13 @@ def test_ws_message_created_event_model():
                 "attachments": [
                     {"file_id": "f_1", "filename": "a.txt", "url": "https://x/y", "size": 1}
                 ],
+                "injection_mode": "wait",
             },
         }
     )
     assert ev.type == "message.created"
     assert ev.message.attachments[0].file_id == "f_1"
+    assert ev.message.injection_mode == "wait"
 
 
 def test_ws_message_created_event_rejects_wrong_type_literal():

--- a/packages/sdk-typescript/src/__tests__/agent-messaging.test.ts
+++ b/packages/sdk-typescript/src/__tests__/agent-messaging.test.ts
@@ -31,7 +31,7 @@ describe('AgentClient', () => {
       const [url, init] = mockFetch.mock.calls[0]!;
       expect(url).toBe('https://api.relaycast.dev/v1/channels/general/messages');
       expect(init.method).toBe('POST');
-      expect(init.body).toBe(JSON.stringify({ text: 'hello' }));
+      expect(init.body).toBe(JSON.stringify({ text: 'hello', mode: 'wait' }));
     });
 
     it('strips # prefix from channel name', async () => {
@@ -58,7 +58,25 @@ describe('AgentClient', () => {
       await me.send('#general', 'hello', { attachments: ['att_1', 'att_2'] });
 
       const [, init] = mockFetch.mock.calls[0]!;
-      expect(init.body).toBe(JSON.stringify({ text: 'hello', attachments: ['att_1', 'att_2'] }));
+      expect(init.body).toBe(JSON.stringify({ text: 'hello', attachments: ['att_1', 'att_2'], mode: 'wait' }));
+    });
+
+    it('defaults mode to wait when omitted', async () => {
+      mockFetch.mockImplementation(() => mockResponse({ id: 'm_1' }));
+
+      await me.send('#general', 'hello');
+
+      const [, init] = mockFetch.mock.calls[0]!;
+      expect(init.body).toBe(JSON.stringify({ text: 'hello', mode: 'wait' }));
+    });
+
+    it('forwards steer mode when requested', async () => {
+      mockFetch.mockImplementation(() => mockResponse({ id: 'm_1' }));
+
+      await me.send('#general', 'hello', { mode: 'steer' });
+
+      const [, init] = mockFetch.mock.calls[0]!;
+      expect(init.body).toBe(JSON.stringify({ text: 'hello', mode: 'steer' }));
     });
 
     it('forwards Idempotency-Key when provided', async () => {

--- a/packages/sdk-typescript/src/agent.ts
+++ b/packages/sdk-typescript/src/agent.ts
@@ -261,13 +261,19 @@ export class AgentClient {
   async send(
     channel: string,
     text: string,
-    opts?: { attachments?: string[]; blocks?: MessageBlock[]; idempotencyKey?: string },
+    opts?: {
+      attachments?: string[];
+      blocks?: MessageBlock[];
+      mode?: 'wait' | 'steer';
+      idempotencyKey?: string;
+    },
   ): Promise<MessageWithMeta> {
     const name = stripHash(channel);
     const body: PostMessageRequest = {
       text,
       ...(opts?.attachments ? { attachments: opts.attachments } : {}),
       ...(opts?.blocks ? { blocks: opts.blocks } : {}),
+      mode: opts?.mode ?? 'wait',
     };
     return this.client.post(
       `/v1/channels/${encodeURIComponent(name)}/messages`,

--- a/packages/server/src/engine/message.ts
+++ b/packages/server/src/engine/message.ts
@@ -41,7 +41,14 @@ export async function postMessage(
   workspaceId: string,
   channelId: string,
   agentId: string,
-  data: { text: string; blocks?: unknown[] | null; attachments?: string[]; data?: Record<string, unknown> | null; content_type?: string },
+  data: {
+    text: string;
+    blocks?: unknown[] | null;
+    attachments?: string[];
+    data?: Record<string, unknown> | null;
+    content_type?: string;
+    mode?: 'wait' | 'steer';
+  },
 ) {
   const messageId = generateId();
 
@@ -95,6 +102,7 @@ export async function postMessage(
     created_at: message.createdAt.toISOString(),
     mentions: mentionMatches.map((m: string) => m.slice(1)),
     attachments,
+    injection_mode: data.mode ?? 'wait',
   };
 }
 

--- a/packages/server/src/engine/wsTransform.ts
+++ b/packages/server/src/engine/wsTransform.ts
@@ -25,6 +25,7 @@ export function transformForClient(event: WsEvent): Record<string, unknown> {
           agent_name: d.from_name as string,
           text: d.text as string,
           attachments: (d.attachments as unknown[]) ?? [],
+          injection_mode: d.injection_mode as 'wait' | 'steer' | undefined,
         },
       };
 

--- a/packages/server/src/routes/__tests__/message.test.ts
+++ b/packages/server/src/routes/__tests__/message.test.ts
@@ -95,10 +95,13 @@ describe('POST /v1/channels/:name/messages', () => {
     expect(body.ok).toBe(true);
     expect(body.data.text).toBe('Hello world');
     expect(body.data.id).toBe('msg_001');
+    expect(vi.mocked(messageEngine.postMessage).mock.calls[0]?.[1]).toBe(FAKE_WORKSPACE.id);
+    expect(vi.mocked(messageEngine.postMessage).mock.calls[0]?.[2]).toBe('ch_789');
+    expect(vi.mocked(messageEngine.postMessage).mock.calls[0]?.[4]).toEqual(expect.objectContaining({ mode: 'wait' }));
     expect(bindings.WEBHOOK_QUEUE.send).toHaveBeenCalledWith(expect.objectContaining({
       type: 'message.created',
       workspaceId: FAKE_WORKSPACE.id,
-      data: expect.objectContaining({ channel_name: 'general' }),
+      data: expect.objectContaining({ channel_name: 'general', injection_mode: 'wait' }),
     }));
     expect(emitServerEvent).toHaveBeenCalledWith(
       expect.anything(),
@@ -108,6 +111,33 @@ describe('POST /v1/channels/:name/messages', () => {
         channel_id: 'ch_789',
       }),
     );
+  });
+
+  it('forwards steer mode through fanout payloads', async () => {
+    vi.mocked(messageEngine.postMessage).mockResolvedValue({
+      id: 'msg_steer',
+      channel_id: 'ch_789',
+      agent_id: 'agent_456',
+      text: 'Take control',
+      has_attachments: false,
+      thread_id: null,
+      created_at: '2025-01-01T00:00:00.000Z',
+      mentions: [],
+    });
+
+    const res = await app.request('/v1/channels/general/messages', {
+      method: 'POST',
+      headers: agentAuthHeaders(),
+      body: JSON.stringify({ text: 'Take control', mode: 'steer' }),
+    }, bindings);
+
+    expect(res.status).toBe(201);
+    expect(vi.mocked(messageEngine.postMessage).mock.calls[0]?.[1]).toBe(FAKE_WORKSPACE.id);
+    expect(vi.mocked(messageEngine.postMessage).mock.calls[0]?.[2]).toBe('ch_789');
+    expect(vi.mocked(messageEngine.postMessage).mock.calls[0]?.[4]).toEqual(expect.objectContaining({ mode: 'steer' }));
+    expect(bindings.WEBHOOK_QUEUE.send).toHaveBeenCalledWith(expect.objectContaining({
+      data: expect.objectContaining({ injection_mode: 'steer' }),
+    }));
   });
 
   it('returns 400 when text is missing', async () => {

--- a/packages/server/src/routes/message.ts
+++ b/packages/server/src/routes/message.ts
@@ -93,7 +93,12 @@ messageRoutes.post(
       // Durable event queue for webhook delivery; real-time pub/sub still fire-and-forget.
       // Only publish for fresh writes, not idempotent replays.
       if (!idempotent.replayed) {
-        const eventData = { ...idempotent.data, channel_name: channelName, from_name: agent?.name, injection_mode: mode };
+        const eventData = {
+          ...idempotent.data,
+          channel_name: channelName,
+          from_name: agent?.name,
+          injection_mode: idempotent.data.injection_mode ?? mode,
+        };
         runInBackground(c, fanoutToChannel(c, channel.id, 'message.created', eventData), 'fanout message.created');
         runInBackground(
           c,

--- a/packages/server/src/routes/message.ts
+++ b/packages/server/src/routes/message.ts
@@ -18,6 +18,7 @@ const postMessageSchema = z.object({
   attachments: z.array(z.string()).optional(),
   data: z.record(z.string(), z.unknown()).nullable().optional(),
   content_type: z.string().optional(),
+  mode: z.enum(['wait', 'steer']).default('wait'),
 });
 
 // POST /v1/channels/:name/messages - post a message
@@ -37,7 +38,7 @@ messageRoutes.post(
           error: { code: 'invalid_request', message: 'text is required' },
         }, 400);
       }
-      const { text, blocks, attachments, data, content_type } = parsed.data;
+      const { text, blocks, attachments, data, content_type, mode } = parsed.data;
 
       const { key: idempotencyKey, error: idempotencyError } = parseIdempotencyKey(c.req.header('Idempotency-Key'));
       if (idempotencyError) {
@@ -73,7 +74,7 @@ messageRoutes.post(
         scope: `channel-message:${channel.id}`,
         key: idempotencyKey,
         status: 201,
-        fingerprint: JSON.stringify({ channelId: channel.id, text, blocks, attachments, data, content_type }),
+        fingerprint: JSON.stringify({ channelId: channel.id, text, blocks, attachments, data, content_type, mode }),
         kv: c.env.KV,
         operation: () =>
           messageEngine.postMessage(
@@ -81,7 +82,7 @@ messageRoutes.post(
             workspace.id,
             channel.id,
             agentId,
-            { text, blocks, attachments, data, content_type },
+            { text, blocks, attachments, data, content_type, mode },
           ),
       });
 
@@ -92,7 +93,7 @@ messageRoutes.post(
       // Durable event queue for webhook delivery; real-time pub/sub still fire-and-forget.
       // Only publish for fresh writes, not idempotent replays.
       if (!idempotent.replayed) {
-        const eventData = { ...idempotent.data, channel_name: channelName, from_name: agent?.name };
+        const eventData = { ...idempotent.data, channel_name: channelName, from_name: agent?.name, injection_mode: mode };
         runInBackground(c, fanoutToChannel(c, channel.id, 'message.created', eventData), 'fanout message.created');
         runInBackground(
           c,

--- a/packages/types/src/events.ts
+++ b/packages/types/src/events.ts
@@ -40,6 +40,7 @@ export const MessageCreatedEventSchema = z.object({
       content_type: z.string(),
       size_bytes: z.number(),
     })),
+    injection_mode: z.enum(['wait', 'steer']).optional(),
   }),
 });
 export type MessageCreatedEvent = z.infer<typeof MessageCreatedEventSchema>;

--- a/packages/types/src/message.ts
+++ b/packages/types/src/message.ts
@@ -82,6 +82,7 @@ export const MessageWithMetaSchema = z.object({
   reactions: z.array(ReactionGroupSchema),
   read_by_count: z.number(),
   mentions: z.array(z.string()).optional(),
+  injection_mode: z.enum(['wait', 'steer']).optional(),
 });
 export type MessageWithMeta = z.infer<typeof MessageWithMetaSchema>;
 

--- a/packages/types/src/message.ts
+++ b/packages/types/src/message.ts
@@ -85,12 +85,16 @@ export const MessageWithMetaSchema = z.object({
 });
 export type MessageWithMeta = z.infer<typeof MessageWithMetaSchema>;
 
+export const MessageInjectionModeSchema = z.enum(['wait', 'steer']);
+export type MessageInjectionMode = z.infer<typeof MessageInjectionModeSchema>;
+
 export const PostMessageRequestSchema = z.object({
   text: z.string(),
   blocks: z.array(MessageBlockSchema).optional(),
   attachments: z.array(z.string()).optional(),
   data: z.record(z.string(), z.unknown()).nullable().optional(),
   content_type: z.string().optional(),
+  mode: MessageInjectionModeSchema.default('wait'),
 });
 export type PostMessageRequest = z.infer<typeof PostMessageRequestSchema>;
 


### PR DESCRIPTION
## Summary
- add message injection mode support (`wait`/`steer`) to typed post-message requests
- default send mode to `wait` in TypeScript and Python SDK send paths
- forward `steer` mode through API routing and websocket fanout payloads (`injection_mode`)
- add/adjust tests for default wait behavior and explicit steer propagation

## Context
This mirrors the relay-side mode work from Relay PR #573 and wires the Relaycast send path to preserve injection mode semantics end-to-end.

## Validation
- `npm -w @relaycast/sdk test -- src/__tests__/agent-messaging.test.ts`
- `npm -w @relaycast/server test -- src/routes/__tests__/message.test.ts`
- `uv run --with pytest --with pytest-asyncio --with respx pytest tests/test_agent.py -q` (in `packages/sdk-python`)

## Notes
- `npm -w @relaycast/server run build` currently fails in this environment due to pre-existing workspace resolution issues for `@relaycast/mcp` (unrelated to this change).

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/agentworkforce/relaycast/pull/89" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
