### PR TITLE
fix: add default + require exports to @relaycast/sdk

### DIFF
--- a/packages/sdk-typescript/package.json
+++ b/packages/sdk-typescript/package.json
@@ -7,11 +7,15 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.js"
+      "import": "./dist/index.js",
+      "require": "./dist/index.js",
+      "default": "./dist/index.js"
     },
     "./internal": {
       "types": "./dist/internal.d.ts",
-      "import": "./dist/internal.js"
+      "import": "./dist/internal.js",
+      "require": "./dist/internal.js",
+      "default": "./dist/internal.js"
     }
   },
   "scripts": {

--- a/packages/sdk-typescript/package.json
+++ b/packages/sdk-typescript/package.json
@@ -8,13 +8,11 @@
     ".": {
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js",
-      "require": "./dist/index.js",
       "default": "./dist/index.js"
     },
     "./internal": {
       "types": "./dist/internal.d.ts",
       "import": "./dist/internal.js",
-      "require": "./dist/internal.js",
       "default": "./dist/internal.js"
     }
   },


### PR DESCRIPTION
## Problem

tsx (and other CJS-in-ESM resolvers like ts-node) fails with `ERR_PACKAGE_PATH_NOT_EXPORTED` when only `import` is specified in the exports map.

```
Error [ERR_PACKAGE_PATH_NOT_EXPORTED]: No "exports" main defined in @relaycast/sdk/package.json
```

This breaks any consumer using `@agent-relay/sdk` (which depends on `@relaycast/sdk`) via tsx or mixed CJS/ESM environments.

## Fix

Add `default` and `require` entries to the exports map for both `.` and `./internal` subpaths. Since the package is ESM (`"type": "module"`), all three point to the same `./dist/*.js` files — Node resolves correctly regardless of the consumer's module system.

## Testing

Before:
```
npx tsx -e "import { RelayCast } from '@relaycast/sdk'"
# ERR_PACKAGE_PATH_NOT_EXPORTED
```

After:
```
npx tsx -e "import { RelayCast } from '@relaycast/sdk'; console.log('OK')"
# OK
```
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/agentworkforce/relaycast/pull/90" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
