### PR TITLE
feat(sdk-rust): add injection mode parity for send + websocket payloads

### DIFF
--- a/packages/sdk-rust/src/agent.rs
+++ b/packages/sdk-rust/src/agent.rs
@@ -146,7 +146,7 @@ impl AgentClient {
             text,
             attachments,
             blocks,
-            Some(MessageInjectionMode::Wait),
+            MessageInjectionMode::Wait,
             idempotency_key,
         )
         .await
@@ -159,7 +159,7 @@ impl AgentClient {
         text: &str,
         attachments: Option<Vec<String>>,
         blocks: Option<Vec<MessageBlock>>,
-        mode: Option<MessageInjectionMode>,
+        mode: MessageInjectionMode,
         idempotency_key: Option<String>,
     ) -> Result<MessageWithMeta> {
         let name = strip_hash(channel);
@@ -168,7 +168,7 @@ impl AgentClient {
             attachments,
             blocks,
             data: None,
-            mode,
+            mode: Some(mode),
         };
         let options = idempotency_key.map(RequestOptions::with_idempotency_key);
         self.client

--- a/packages/sdk-rust/src/agent.rs
+++ b/packages/sdk-rust/src/agent.rs
@@ -132,7 +132,7 @@ impl AgentClient {
 
     // === Messages ===
 
-    /// Send a message to a channel.
+    /// Send a message to a channel (defaults mode to `wait`).
     pub async fn send(
         &self,
         channel: &str,
@@ -141,12 +141,34 @@ impl AgentClient {
         blocks: Option<Vec<MessageBlock>>,
         idempotency_key: Option<String>,
     ) -> Result<MessageWithMeta> {
+        self.send_with_mode(
+            channel,
+            text,
+            attachments,
+            blocks,
+            Some(MessageInjectionMode::Wait),
+            idempotency_key,
+        )
+        .await
+    }
+
+    /// Send a message to a channel with explicit injection mode.
+    pub async fn send_with_mode(
+        &self,
+        channel: &str,
+        text: &str,
+        attachments: Option<Vec<String>>,
+        blocks: Option<Vec<MessageBlock>>,
+        mode: Option<MessageInjectionMode>,
+        idempotency_key: Option<String>,
+    ) -> Result<MessageWithMeta> {
         let name = strip_hash(channel);
         let body = PostMessageRequest {
             text: text.to_string(),
             attachments,
             blocks,
             data: None,
+            mode,
         };
         let options = idempotency_key.map(RequestOptions::with_idempotency_key);
         self.client

--- a/packages/sdk-rust/src/lib.rs
+++ b/packages/sdk-rust/src/lib.rs
@@ -143,6 +143,7 @@ pub use types::{
     // Messages
     MessageBlock,
     MessageCreatedEvent,
+    MessageInjectionMode,
     MessageListQuery,
     MessageReadEvent,
     MessageUpdatedEvent,

--- a/packages/sdk-rust/src/types.rs
+++ b/packages/sdk-rust/src/types.rs
@@ -319,6 +319,13 @@ pub struct ReactionGroup {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum MessageInjectionMode {
+    Wait,
+    Steer,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct MessageWithMeta {
     pub id: String,
     pub agent_name: String,
@@ -336,6 +343,8 @@ pub struct MessageWithMeta {
     pub reactions: Vec<ReactionGroup>,
     #[serde(default)]
     pub read_by_count: i64,
+    #[serde(default)]
+    pub injection_mode: Option<MessageInjectionMode>,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -347,6 +356,8 @@ pub struct PostMessageRequest {
     pub attachments: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub data: Option<serde_json::Map<String, serde_json::Value>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub mode: Option<MessageInjectionMode>,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -759,6 +770,8 @@ pub struct MessageEventPayload {
     pub agent_name: String,
     pub text: String,
     pub attachments: Vec<FileAttachment>,
+    #[serde(default)]
+    pub injection_mode: Option<MessageInjectionMode>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/packages/sdk-rust/tests/parity.rs
+++ b/packages/sdk-rust/tests/parity.rs
@@ -1,6 +1,6 @@
 use relaycast::{
-    AgentClient, DmConversationSummary, MessageListQuery, RelayCast, RelayCastOptions,
-    ReleaseAgentRequest, SpawnAgentRequest, WsEvent,
+    AgentClient, DmConversationSummary, MessageInjectionMode, MessageListQuery, RelayCast,
+    RelayCastOptions, ReleaseAgentRequest, SpawnAgentRequest, WsEvent,
 };
 use serde_json::json;
 use wiremock::matchers::{body_json, header, method, path, query_param};
@@ -185,6 +185,83 @@ async fn list_messages_strips_hash_and_passes_pagination_query() {
 }
 
 #[tokio::test]
+async fn send_defaults_mode_wait() {
+    let server = MockServer::start().await;
+    let agent = AgentClient::new("at_live_test", Some(server.uri()))
+        .expect("failed to create agent client");
+
+    Mock::given(method("POST"))
+        .and(path("/v1/channels/general/messages"))
+        .and(body_json(json!({
+            "text": "Hello",
+            "mode": "wait"
+        })))
+        .respond_with(ok(json!({
+            "id": "m_1",
+            "agent_name": "alice",
+            "agent_id": "a_1",
+            "text": "Hello",
+            "created_at": "2026-01-01T00:00:00.000Z",
+            "reply_count": 0,
+            "reactions": [],
+            "read_by_count": 0,
+            "attachments": [],
+            "injection_mode": "wait"
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let sent = agent
+        .send("#general", "Hello", None, None, None)
+        .await
+        .expect("send failed");
+    assert!(matches!(sent.injection_mode, Some(MessageInjectionMode::Wait)));
+}
+
+#[tokio::test]
+async fn send_with_mode_forwards_steer() {
+    let server = MockServer::start().await;
+    let agent = AgentClient::new("at_live_test", Some(server.uri()))
+        .expect("failed to create agent client");
+
+    Mock::given(method("POST"))
+        .and(path("/v1/channels/general/messages"))
+        .and(body_json(json!({
+            "text": "Ping",
+            "mode": "steer"
+        })))
+        .respond_with(ok(json!({
+            "id": "m_2",
+            "agent_name": "alice",
+            "agent_id": "a_1",
+            "text": "Ping",
+            "created_at": "2026-01-01T00:00:00.000Z",
+            "reply_count": 0,
+            "reactions": [],
+            "read_by_count": 0,
+            "attachments": [],
+            "injection_mode": "steer"
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let sent = agent
+        .send_with_mode(
+            "#general",
+            "Ping",
+            None,
+            None,
+            Some(MessageInjectionMode::Steer),
+            None,
+        )
+        .await
+        .expect("send_with_mode failed");
+    assert!(matches!(sent.injection_mode, Some(MessageInjectionMode::Steer)));
+}
+
+#[tokio::test]
 async fn create_workspace_sends_origin_headers() {
     let server = MockServer::start().await;
 
@@ -236,7 +313,8 @@ fn ws_message_created_deserializes_optional_agent_id() {
             "agent_id": "a_123",
             "agent_name": "alice",
             "text": "hello",
-            "attachments": []
+            "attachments": [],
+            "injection_mode": "steer"
         }
     }))
     .expect("failed to parse ws message.created");
@@ -245,6 +323,7 @@ fn ws_message_created_deserializes_optional_agent_id() {
         WsEvent::MessageCreated(msg) => {
             assert_eq!(msg.message.agent_id.as_deref(), Some("a_123"));
             assert_eq!(msg.message.agent_name, "alice");
+            assert!(matches!(msg.message.injection_mode, Some(MessageInjectionMode::Steer)));
         }
         other => panic!("unexpected event variant: {other:?}"),
     }

--- a/packages/sdk-rust/tests/parity.rs
+++ b/packages/sdk-rust/tests/parity.rs
@@ -253,7 +253,7 @@ async fn send_with_mode_forwards_steer() {
             "Ping",
             None,
             None,
-            Some(MessageInjectionMode::Steer),
+            MessageInjectionMode::Steer,
             None,
         )
         .await


### PR DESCRIPTION
## Summary
Bring Rust SDK into parity with the recently merged send-mode changes:

- add `MessageInjectionMode` (`wait|steer`) enum
- include optional `injection_mode` in `MessageWithMeta`
- include optional `injection_mode` in WS `MessageEventPayload`
- extend `PostMessageRequest` with optional `mode`
- keep `send(...)` backward-compatible while defaulting to `wait`
- add `send_with_mode(...)` for explicit `steer`/`wait` requests
- export `MessageInjectionMode` from crate root
- add parity tests for default wait mode, explicit steer mode, and WS payload parsing

## Validation
- `cd packages/sdk-rust && cargo test`
- all tests passed (unit + parity + doc tests)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/agentworkforce/relaycast/pull/91" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
