### PR TITLE
feat: support DM injection mode (wait|steer) across Relaycast

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -137,19 +137,19 @@ components:
           type: string
         conversation_id:
           type: string
-        from_id:
+        from_agent_id:
           type: string
-        from_name:
-          type: string
-        to_id:
-          type: string
-        to_name:
+        to:
           type: string
         text:
           type: string
         created_at:
           type: string
           format: date-time
+        injection_mode:
+          type: string
+          enum: [wait, steer]
+          description: Delivery/injection mode used when the DM was sent
 
     Conversation:
       type: object
@@ -1332,6 +1332,11 @@ paths:
                   description: Recipient agent name
                 text:
                   type: string
+                mode:
+                  type: string
+                  enum: [wait, steer]
+                  default: wait
+                  description: Injection mode for the DM
       responses:
         '201':
           description: DM sent

--- a/packages/sdk-python/src/relay_sdk/agent.py
+++ b/packages/sdk-python/src/relay_sdk/agent.py
@@ -235,8 +235,8 @@ class AgentClient:
 
     # ── DMs ──
 
-    def dm(self, agent: str, text: str) -> Any:
-        return self.client.post("/v1/dm", {"to": agent, "text": text})
+    def dm(self, agent: str, text: str, mode: MessageInjectionMode = "wait") -> Any:
+        return self.client.post("/v1/dm", {"to": agent, "text": text, "mode": mode})
 
     # ── Reactions ──
 
@@ -496,8 +496,8 @@ class AsyncAgentClient:
 
     # ── DMs ──
 
-    async def dm(self, agent: str, text: str) -> Any:
-        return await self.client.post("/v1/dm", {"to": agent, "text": text})
+    async def dm(self, agent: str, text: str, mode: MessageInjectionMode = "wait") -> Any:
+        return await self.client.post("/v1/dm", {"to": agent, "text": text, "mode": mode})
 
     # ── Reactions ──
 

--- a/packages/sdk-python/src/relay_sdk/agent.py
+++ b/packages/sdk-python/src/relay_sdk/agent.py
@@ -15,6 +15,7 @@ from .models import (
     DmConversationSummary,
     FileInfo,
     InboxResponse,
+    MessageInjectionMode,
     MessageWithMeta,
     ReactionGroup,
     ReaderInfo,

--- a/packages/sdk-python/src/relay_sdk/models.py
+++ b/packages/sdk-python/src/relay_sdk/models.py
@@ -222,6 +222,7 @@ class DmConversationSummary(BaseModel):
 class SendDmRequest(BaseModel):
     to: str
     text: str
+    mode: MessageInjectionMode = "wait"
 
 
 class CreateGroupDmRequest(BaseModel):

--- a/packages/sdk-python/tests/test_agent.py
+++ b/packages/sdk-python/tests/test_agent.py
@@ -148,6 +148,14 @@ class TestAgentClientDMs:
         c = AgentClient(HttpClient(TOKEN, BASE))
         c.dm("Alice", "Hi")
         assert route.called
+        assert route.calls[0].request.content == b'{"to":"Alice","text":"Hi","mode":"wait"}'
+
+    @respx.mock
+    def test_dm_steer_mode(self):
+        route = respx.post(f"{BASE}/v1/dm").mock(return_value=ok({"sent": True}))
+        c = AgentClient(HttpClient(TOKEN, BASE))
+        c.dm("Alice", "Hi", mode="steer")
+        assert route.calls[0].request.content == b'{"to":"Alice","text":"Hi","mode":"steer"}'
 
     @respx.mock
     def test_dms_conversations(self):
@@ -470,6 +478,16 @@ class TestAsyncAgentClient:
         c = AsyncAgentClient(AsyncHttpClient(TOKEN, BASE))
         await c.dm("Alice", "Hi")
         assert route.called
+        assert route.calls[0].request.content == b'{"to":"Alice","text":"Hi","mode":"wait"}'
+        await c.client.close()
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_dm_steer_mode(self):
+        route = respx.post(f"{BASE}/v1/dm").mock(return_value=ok({"sent": True}))
+        c = AsyncAgentClient(AsyncHttpClient(TOKEN, BASE))
+        await c.dm("Alice", "Hi", mode="steer")
+        assert route.calls[0].request.content == b'{"to":"Alice","text":"Hi","mode":"steer"}'
         await c.client.close()
 
     @pytest.mark.asyncio

--- a/packages/sdk-rust/src/agent.rs
+++ b/packages/sdk-rust/src/agent.rs
@@ -295,31 +295,57 @@ impl AgentClient {
 
     // === DMs ===
 
-    /// Send a direct message to another agent.
+    /// Send a direct message to another agent (defaults mode to `wait`).
     pub async fn dm(
         &self,
         agent: &str,
         text: &str,
         idempotency_key: Option<String>,
     ) -> Result<serde_json::Value> {
+        self.dm_with_mode(agent, text, MessageInjectionMode::Wait, idempotency_key)
+            .await
+    }
+
+    /// Send a direct message to another agent with explicit injection mode.
+    pub async fn dm_with_mode(
+        &self,
+        agent: &str,
+        text: &str,
+        mode: MessageInjectionMode,
+        idempotency_key: Option<String>,
+    ) -> Result<serde_json::Value> {
         let body = SendDmRequest {
             to: agent.to_string(),
             text: text.to_string(),
+            mode: Some(mode),
         };
         let options = idempotency_key.map(RequestOptions::with_idempotency_key);
         self.client.post("/v1/dm", Some(body), options).await
     }
 
-    /// Send a direct message to another agent (typed response).
+    /// Send a direct message to another agent (typed response, defaults mode to `wait`).
     pub async fn dm_typed(
         &self,
         agent: &str,
         text: &str,
         idempotency_key: Option<String>,
     ) -> Result<DmSendResponse> {
+        self.dm_typed_with_mode(agent, text, MessageInjectionMode::Wait, idempotency_key)
+            .await
+    }
+
+    /// Send a direct message to another agent with explicit injection mode (typed response).
+    pub async fn dm_typed_with_mode(
+        &self,
+        agent: &str,
+        text: &str,
+        mode: MessageInjectionMode,
+        idempotency_key: Option<String>,
+    ) -> Result<DmSendResponse> {
         let body = SendDmRequest {
             to: agent.to_string(),
             text: text.to_string(),
+            mode: Some(mode),
         };
         let options = idempotency_key.map(RequestOptions::with_idempotency_key);
         self.client.post("/v1/dm", Some(body), options).await

--- a/packages/sdk-rust/src/types.rs
+++ b/packages/sdk-rust/src/types.rs
@@ -388,6 +388,8 @@ pub struct ThreadResponse {
 pub struct SendDmRequest {
     pub to: String,
     pub text: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub mode: Option<MessageInjectionMode>,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -419,6 +421,8 @@ pub struct DmSendResponse {
     pub to: String,
     pub text: String,
     pub created_at: String,
+    #[serde(default)]
+    pub injection_mode: Option<MessageInjectionMode>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -799,6 +803,8 @@ pub struct DmEventPayload {
     pub agent_id: Option<String>,
     pub agent_name: String,
     pub text: String,
+    #[serde(default)]
+    pub injection_mode: Option<MessageInjectionMode>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/packages/sdk-typescript/src/__tests__/agent-messaging.test.ts
+++ b/packages/sdk-typescript/src/__tests__/agent-messaging.test.ts
@@ -218,7 +218,16 @@ describe('AgentClient', () => {
       const [url, init] = mockFetch.mock.calls[0]!;
       expect(url).toBe('https://api.relaycast.dev/v1/dm');
       expect(init.method).toBe('POST');
-      expect(init.body).toBe(JSON.stringify({ to: 'Worker-1', text: 'hi' }));
+      expect(init.body).toBe(JSON.stringify({ to: 'Worker-1', text: 'hi', mode: 'wait' }));
+    });
+
+    it('forwards steer mode when provided', async () => {
+      mockFetch.mockImplementation(() => mockResponse({ id: 'dm_1' }));
+
+      await me.dm('Worker-1', 'hi', { mode: 'steer' });
+
+      const [, init] = mockFetch.mock.calls[0]!;
+      expect(init.body).toBe(JSON.stringify({ to: 'Worker-1', text: 'hi', mode: 'steer' }));
     });
 
     it('forwards Idempotency-Key when provided', async () => {

--- a/packages/sdk-typescript/src/agent.ts
+++ b/packages/sdk-typescript/src/agent.ts
@@ -333,8 +333,12 @@ export class AgentClient {
 
   // === DMs ===
 
-  async dm(agent: string, text: string, opts?: IdempotencyOption): Promise<SendDmResponse> {
-    const body: SendDmRequest = { to: agent, text };
+  async dm(
+    agent: string,
+    text: string,
+    opts?: (IdempotencyOption & { mode?: 'wait' | 'steer' }),
+  ): Promise<SendDmResponse> {
+    const body: SendDmRequest = { to: agent, text, mode: opts?.mode ?? 'wait' };
     return this.client.post('/v1/dm', body, idempotencyHeaders(opts));
   }
 

--- a/packages/server/src/engine/dm.ts
+++ b/packages/server/src/engine/dm.ts
@@ -26,7 +26,7 @@ export async function sendDm(
   db: Db,
   workspaceId: string,
   fromAgentId: string,
-  data: { to: string; text: string },
+  data: { to: string; text: string; mode?: 'wait' | 'steer' },
 ) {
   // Resolve the target agent by name
   const [toAgent] = await db
@@ -116,6 +116,7 @@ export async function sendDm(
       agentId: fromAgentId,
       body: data.text,
       hasAttachments: false,
+      metadata: { injection_mode: data.mode ?? 'wait' },
     })
     .returning();
 
@@ -126,6 +127,7 @@ export async function sendDm(
     to: data.to,
     text: message.body,
     created_at: message.createdAt.toISOString(),
+    injection_mode: data.mode ?? 'wait',
   };
 }
 

--- a/packages/server/src/engine/wsTransform.ts
+++ b/packages/server/src/engine/wsTransform.ts
@@ -79,6 +79,7 @@ export function transformForClient(event: WsEvent): Record<string, unknown> {
           agent_id: (d.from_agent_id ?? d.agent_id) as string,
           agent_name: d.from_name as string,
           text: d.text as string,
+          injection_mode: d.injection_mode as 'wait' | 'steer' | undefined,
         },
       };
 

--- a/packages/server/src/routes/__tests__/dm.test.ts
+++ b/packages/server/src/routes/__tests__/dm.test.ts
@@ -84,6 +84,32 @@ describe('POST /v1/dm', () => {
     expect(body.error.code).toBe('invalid_request');
   });
 
+  it('forwards steer mode to dm engine', async () => {
+    vi.mocked(dmEngine.sendDm).mockResolvedValue({
+      id: 'msg_002',
+      conversation_id: 'conv_456',
+      from_agent_id: 'agent_456',
+      to: 'OtherBot',
+      text: 'Take over',
+      created_at: '2025-01-01T00:00:00.000Z',
+      injection_mode: 'steer',
+    });
+
+    const res = await app.request('/v1/dm', {
+      method: 'POST',
+      headers: agentAuthHeaders(),
+      body: JSON.stringify({ to: 'OtherBot', text: 'Take over', mode: 'steer' }),
+    }, bindings);
+
+    expect(res.status).toBe(201);
+    expect(vi.mocked(dmEngine.sendDm)).toHaveBeenCalledWith(
+      expect.anything(),
+      FAKE_WORKSPACE.id,
+      'agent_123',
+      expect.objectContaining({ to: 'OtherBot', text: 'Take over', mode: 'steer' }),
+    );
+  });
+
   it('returns 400 when text is missing', async () => {
     const res = await app.request('/v1/dm', {
       method: 'POST',

--- a/packages/server/src/routes/__tests__/dm.test.ts
+++ b/packages/server/src/routes/__tests__/dm.test.ts
@@ -102,12 +102,19 @@ describe('POST /v1/dm', () => {
     }, bindings);
 
     expect(res.status).toBe(201);
+    const body = await res.json() as any;
+    expect(body.data.injection_mode).toBe('steer');
     expect(vi.mocked(dmEngine.sendDm)).toHaveBeenCalledWith(
       expect.anything(),
       FAKE_WORKSPACE.id,
       'agent_123',
       expect.objectContaining({ to: 'OtherBot', text: 'Take over', mode: 'steer' }),
     );
+    expect(bindings.WEBHOOK_QUEUE.send).toHaveBeenCalledWith(expect.objectContaining({
+      type: 'dm.received',
+      workspaceId: FAKE_WORKSPACE.id,
+      data: expect.objectContaining({ conversation_id: 'conv_456', injection_mode: 'steer' }),
+    }));
   });
 
   it('returns 400 when text is missing', async () => {

--- a/packages/server/src/routes/__tests__/dm.test.ts
+++ b/packages/server/src/routes/__tests__/dm.test.ts
@@ -51,6 +51,7 @@ describe('POST /v1/dm', () => {
       to: 'OtherBot',
       text: 'Hello DM',
       created_at: '2025-01-01T00:00:00.000Z',
+      injection_mode: 'wait',
     });
 
     const res = await app.request('/v1/dm', {
@@ -63,6 +64,7 @@ describe('POST /v1/dm', () => {
     const body = await res.json() as any;
     expect(body.ok).toBe(true);
     expect(body.data.conversation_id).toBe('conv_123');
+    expect(body.data.injection_mode).toBe('wait');
     expect(bindings.WEBHOOK_QUEUE.send).toHaveBeenCalledWith(expect.objectContaining({
       type: 'dm.received',
       workspaceId: FAKE_WORKSPACE.id,

--- a/packages/server/src/routes/dm.ts
+++ b/packages/server/src/routes/dm.ts
@@ -62,7 +62,9 @@ dmRoutes.post(
         scope: 'dm:direct',
         key: idempotencyKey,
         status: 201,
-        fingerprint: JSON.stringify({ to, text, mode }),
+        // Backward compatibility: historical fingerprint excluded mode (equivalent to wait).
+        // Only include mode when explicit steer is requested.
+        fingerprint: mode === 'steer' ? JSON.stringify({ to, text, mode }) : JSON.stringify({ to, text }),
         kv: c.env.KV,
         operation: () => dmEngine.sendDm(db, workspace.id, agent!.id, { to, text, mode }),
       });

--- a/packages/server/src/routes/dm.ts
+++ b/packages/server/src/routes/dm.ts
@@ -16,6 +16,7 @@ export const dmRoutes = new Hono<AppEnv>();
 const sendDmSchema = z.object({
   to: z.string().min(1),
   text: z.string().min(1),
+  mode: z.enum(['wait', 'steer']).default('wait'),
 });
 
 // POST /v1/dm - send a DM
@@ -45,7 +46,7 @@ dmRoutes.post(
           },
         }, 400);
       }
-      const { to, text } = parsed.data;
+      const { to, text, mode } = parsed.data;
 
       const { key: idempotencyKey, error: idempotencyError } = parseIdempotencyKey(c.req.header('Idempotency-Key'));
       if (idempotencyError) {
@@ -61,9 +62,9 @@ dmRoutes.post(
         scope: 'dm:direct',
         key: idempotencyKey,
         status: 201,
-        fingerprint: JSON.stringify({ to, text }),
+        fingerprint: JSON.stringify({ to, text, mode }),
         kv: c.env.KV,
-        operation: () => dmEngine.sendDm(db, workspace.id, agent!.id, { to, text }),
+        operation: () => dmEngine.sendDm(db, workspace.id, agent!.id, { to, text, mode }),
       });
 
       if (idempotent.replayed) {

--- a/packages/types/src/dm.ts
+++ b/packages/types/src/dm.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import { MessageInjectionModeSchema } from './message.js';
 
 export const DmTypeSchema = z.enum(['1:1', 'group']);
 export type DmType = z.infer<typeof DmTypeSchema>;
@@ -21,7 +22,7 @@ export const DmParticipantSchema = z.object({
 });
 export type DmParticipant = z.infer<typeof DmParticipantSchema>;
 
-export const DmInjectionModeSchema = z.enum(['wait', 'steer']);
+export const DmInjectionModeSchema = MessageInjectionModeSchema;
 
 export const SendDmRequestSchema = z.object({
   to: z.string(),

--- a/packages/types/src/dm.ts
+++ b/packages/types/src/dm.ts
@@ -21,9 +21,12 @@ export const DmParticipantSchema = z.object({
 });
 export type DmParticipant = z.infer<typeof DmParticipantSchema>;
 
+export const MessageInjectionModeSchema = z.enum(['wait', 'steer']);
+
 export const SendDmRequestSchema = z.object({
   to: z.string(),
   text: z.string(),
+  mode: MessageInjectionModeSchema.default('wait'),
 });
 export type SendDmRequest = z.infer<typeof SendDmRequestSchema>;
 

--- a/packages/types/src/dm.ts
+++ b/packages/types/src/dm.ts
@@ -21,12 +21,12 @@ export const DmParticipantSchema = z.object({
 });
 export type DmParticipant = z.infer<typeof DmParticipantSchema>;
 
-export const MessageInjectionModeSchema = z.enum(['wait', 'steer']);
+export const DmInjectionModeSchema = z.enum(['wait', 'steer']);
 
 export const SendDmRequestSchema = z.object({
   to: z.string(),
   text: z.string(),
-  mode: MessageInjectionModeSchema.default('wait'),
+  mode: DmInjectionModeSchema.default('wait'),
 });
 export type SendDmRequest = z.infer<typeof SendDmRequestSchema>;
 
@@ -68,6 +68,7 @@ export const SendDmResponseSchema = z.object({
   to: z.string(),
   text: z.string(),
   created_at: z.string(),
+  injection_mode: DmInjectionModeSchema.optional(),
 });
 export type SendDmResponse = z.infer<typeof SendDmResponseSchema>;
 

--- a/packages/types/src/events.ts
+++ b/packages/types/src/events.ts
@@ -79,7 +79,13 @@ export type ReactionRemovedEvent = z.infer<typeof ReactionRemovedEventSchema>;
 export const DmReceivedEventSchema = z.object({
   type: z.literal('dm.received'),
   conversation_id: z.string(),
-  message: z.object({ id: z.string(), agent_id: z.string().optional(), agent_name: z.string(), text: z.string() }),
+  message: z.object({
+    id: z.string(),
+    agent_id: z.string().optional(),
+    agent_name: z.string(),
+    text: z.string(),
+    injection_mode: z.enum(['wait', 'steer']).optional(),
+  }),
 });
 export type DmReceivedEvent = z.infer<typeof DmReceivedEventSchema>;
 


### PR DESCRIPTION
## Summary
Adds end-to-end DM injection mode support so callers can pass `mode: "wait" | "steer"` for direct messages, with default `wait` behavior preserved.

### Included
- **Types**
  - `SendDmRequest.mode` (default `wait`)
  - `SendDmResponse.injection_mode`
  - `dm.received` WS event message now includes optional `injection_mode`
- **Server**
  - `/v1/dm` route accepts/validates `mode` and forwards to DM engine
  - DM engine persists mode in message metadata and returns `injection_mode`
  - WS transform forwards `injection_mode` for `dm.received` events
- **SDKs**
  - TypeScript: `agent.dm(..., { mode })` support with tests
  - Python: sync + async `dm(..., mode=...)` support with tests
  - Rust: DM request supports mode; `dm` defaults to wait; added explicit mode variants

## Validation
- `packages/server`: `npm test -- --run src/routes/__tests__/dm.test.ts`
- `packages/sdk-typescript`: `npm test -- --run src/__tests__/agent-messaging.test.ts`
- `packages/sdk-python`: `uv run --extra dev pytest tests/test_agent.py tests/test_models.py`
- `packages/sdk-rust`: `cargo test -p relaycast --tests`

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/agentworkforce/relaycast/pull/92" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
