### PR TITLE
Add PostHog exception capture and reporting

### DIFF
--- a/packages/server/src/lib/logger.ts
+++ b/packages/server/src/lib/logger.ts
@@ -251,3 +251,114 @@ export function toErrorDetails(error: unknown): { error_name: string; error_mess
     error_message: String(error),
   };
 }
+
+/* ------------------------------------------------------------------ */
+/*  PostHog Error Tracking — $exception capture                       */
+/* ------------------------------------------------------------------ */
+
+interface ExceptionFrame {
+  filename?: string;
+  function?: string;
+  lineno?: number;
+  colno?: number;
+  in_app?: boolean;
+}
+
+interface ExceptionEntry {
+  type: string;
+  value: string;
+  mechanism?: { type: string; handled: boolean };
+  stacktrace?: { frames: ExceptionFrame[] };
+}
+
+function parseStackFrames(stack: string): ExceptionFrame[] {
+  const frames: ExceptionFrame[] = [];
+  for (const line of stack.split('\n')) {
+    const match = line.match(/^\s+at\s+(.+?)\s+\((.+):(\d+):(\d+)\)/) ??
+                  line.match(/^\s+at\s+(.+):(\d+):(\d+)/);
+    if (!match) continue;
+    if (match.length === 5) {
+      frames.push({
+        function: match[1],
+        filename: match[2],
+        lineno: Number(match[3]),
+        colno: Number(match[4]),
+        in_app: !match[2].includes('node_modules'),
+      });
+    } else if (match.length === 4) {
+      frames.push({
+        filename: match[1],
+        lineno: Number(match[2]),
+        colno: Number(match[3]),
+        in_app: !match[1].includes('node_modules'),
+      });
+    }
+  }
+  // PostHog expects frames in caller-first order (outermost first).
+  return frames;
+}
+
+function buildExceptionList(error: unknown): ExceptionEntry[] {
+  if (error instanceof Error) {
+    const entry: ExceptionEntry = {
+      type: error.name,
+      value: error.message,
+      mechanism: { type: 'generic', handled: false },
+    };
+    if (error.stack) {
+      entry.stacktrace = { frames: parseStackFrames(error.stack) };
+    }
+    return [entry];
+  }
+  return [{ type: 'NonError', value: String(error), mechanism: { type: 'generic', handled: false } }];
+}
+
+export interface CaptureExceptionOptions {
+  /** Extra properties merged into the PostHog event. */
+  properties?: Record<string, unknown>;
+  /** Override the distinct_id (defaults to SERVICE_NAME). */
+  distinctId?: string;
+}
+
+/**
+ * Sends a `$exception` event to PostHog Error Tracking.
+ *
+ * Returns a promise that resolves once the HTTP request completes (best-effort).
+ * Safe to fire-and-forget or pass to `waitUntil`.
+ */
+export async function captureException(
+  env: CloudflareBindings,
+  error: unknown,
+  options: CaptureExceptionOptions = {},
+): Promise<void> {
+  const apiKey = env.POSTHOG_API_KEY;
+  if (!apiKey) return;
+
+  const exceptionList = buildExceptionList(error);
+  const payload = {
+    api_key: apiKey,
+    event: '$exception',
+    distinct_id: options.distinctId ?? SERVICE_NAME,
+    properties: {
+      $exception_list: exceptionList,
+      $exception_type: exceptionList[0]?.type,
+      $exception_message: exceptionList[0]?.value,
+      $exception_level: 'error',
+      service_name: SERVICE_NAME,
+      environment: env.ENVIRONMENT,
+      app_version: getAppVersion(env),
+      ...(options.properties ?? {}),
+    },
+    timestamp: new Date().toISOString(),
+  };
+
+  try {
+    await fetch(`${getPostHogHost(env)}/capture/`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+    });
+  } catch {
+    // Best effort — never break request handling for telemetry.
+  }
+}

--- a/packages/server/src/worker.ts
+++ b/packages/server/src/worker.ts
@@ -26,7 +26,7 @@ import { inboundWebhookRoutes } from './routes/inboundWebhook.js';
 import { eventSubscriptionRoutes } from './routes/eventSubscription.js';
 import { commandRoutes } from './routes/command.js';
 import { isWorkspaceStreamEnabled } from './lib/workspaceStream.js';
-import { createLogger, getRequestLogger, toErrorDetails } from './lib/logger.js';
+import { captureException, createLogger, getRequestLogger, toErrorDetails } from './lib/logger.js';
 import { requiredOriginInfo } from './lib/origin.js';
 import { emitServerEvent } from './lib/serverTelemetry.js';
 
@@ -279,10 +279,28 @@ app.onError((err, c) => {
     ...toErrorDetails(error),
   });
 
+  // Send to PostHog Error Tracking (fire-and-forget via waitUntil when available)
+  const status = error.status || 500;
+  if (status >= 500) {
+    const exceptionPromise = captureException(c.env, error, {
+      properties: {
+        path: c.req.path,
+        method: c.req.method,
+        status_code: status,
+        error_code: error.code ?? 'internal_error',
+        request_id: c.get('requestId'),
+      },
+    });
+    try {
+      c.executionCtx?.waitUntil(exceptionPromise);
+    } catch {
+      void exceptionPromise;
+    }
+  }
+
   if (error.message?.includes('JSON')) {
     return c.json({ ok: false, error: { code: 'invalid_json', message: 'Malformed JSON in request body' } }, 400);
   }
-  const status = error.status || 500;
   return c.json({
     ok: false,
     error: {
@@ -315,6 +333,9 @@ async function handleQueue(batch: MessageBatch, env: AppEnv['Bindings']) {
     } catch (error) {
       logger.error('Webhook queue message processing failed; retrying', {
         ...toErrorDetails(error),
+      });
+      void captureException(env, error, {
+        properties: { source: 'worker.queue', event_type: (msg.body as { type?: string }).type },
       });
       msg.retry();
     }


### PR DESCRIPTION
Introduce captureException in logger.ts to send $exception events to PostHog Error Tracking. Includes stack parsing (parseStackFrames), exception structures, and CaptureExceptionOptions (properties and distinctId). Wire up captureException in worker.ts: report server errors (5xx) from app.onError using waitUntil when available, and best-effort reporting for queue handler failures. The implementation is non-blocking and safe to fire-and-forget; HTTP errors during telemetry are swallowed to avoid affecting request handling.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/agentworkforce/relaycast/pull/94" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
