### PR TITLE
feat(rust-sdk): tolerate sparse spawn request events

### DIFF
--- a/packages/sdk-rust/CHANGELOG.md
+++ b/packages/sdk-rust/CHANGELOG.md
@@ -7,7 +7,9 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
 ## [Unreleased]
 
 ### Changed
-- No unreleased changes yet.
+- Made `agent.spawn_requested` websocket parsing tolerant of missing or `null` `task`, `channel`, and `already_existed` fields.
+- Kept `AgentSpawnRequestedPayload.task` as a `String` for API compatibility by deserializing missing or `null` values to an empty string.
+- Added websocket parity coverage for tolerant spawn-request event parsing.
 
 ## [0.2.6] - 2026-02-25
 

--- a/packages/sdk-rust/src/types.rs
+++ b/packages/sdk-rust/src/types.rs
@@ -486,6 +486,13 @@ where
         .collect())
 }
 
+fn deserialize_string_or_default<'de, D>(deserializer: D) -> std::result::Result<String, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    Ok(Option::<String>::deserialize(deserializer)?.unwrap_or_default())
+}
+
 #[derive(Debug, Clone, Deserialize)]
 #[serde(untagged)]
 enum DmLastMessageValue {
@@ -947,8 +954,11 @@ pub struct AgentSpawnRequestedEvent {
 pub struct AgentSpawnRequestedPayload {
     pub name: String,
     pub cli: String,
+    #[serde(default, deserialize_with = "deserialize_string_or_default")]
     pub task: String,
+    #[serde(default)]
     pub channel: Option<String>,
+    #[serde(default)]
     pub already_existed: bool,
 }
 

--- a/packages/sdk-rust/tests/parity.rs
+++ b/packages/sdk-rust/tests/parity.rs
@@ -354,6 +354,52 @@ fn ws_command_invoked_deserializes_handler_agent_id() {
 }
 
 #[test]
+fn ws_agent_spawn_requested_tolerates_missing_or_null_optional_fields() {
+    let missing = serde_json::from_value::<WsEvent>(json!({
+        "type": "agent.spawn_requested",
+        "agent": {
+            "name": "worker-1",
+            "cli": "codex"
+        }
+    }))
+    .expect("failed to parse spawn request with missing fields");
+
+    match missing {
+        WsEvent::AgentSpawnRequested(event) => {
+            assert_eq!(event.agent.name, "worker-1");
+            assert_eq!(event.agent.cli, "codex");
+            assert_eq!(event.agent.task, "");
+            assert_eq!(event.agent.channel, None);
+            assert!(!event.agent.already_existed);
+        }
+        other => panic!("unexpected event variant: {other:?}"),
+    }
+
+    let nulled = serde_json::from_value::<WsEvent>(json!({
+        "type": "agent.spawn_requested",
+        "agent": {
+            "name": "worker-2",
+            "cli": "claude",
+            "task": null,
+            "channel": null,
+            "already_existed": true
+        }
+    }))
+    .expect("failed to parse spawn request with null task/channel");
+
+    match nulled {
+        WsEvent::AgentSpawnRequested(event) => {
+            assert_eq!(event.agent.name, "worker-2");
+            assert_eq!(event.agent.cli, "claude");
+            assert_eq!(event.agent.task, "");
+            assert_eq!(event.agent.channel, None);
+            assert!(event.agent.already_existed);
+        }
+        other => panic!("unexpected event variant: {other:?}"),
+    }
+}
+
+#[test]
 fn ws_command_invoked_requires_handler_agent_id() {
     let err = serde_json::from_value::<WsEvent>(json!({
         "type": "command.invoked",


### PR DESCRIPTION
## Summary
- make Rust `agent.spawn_requested` websocket parsing tolerant of missing or `null` optional fields
- default `task` to an empty string while preserving the existing public type shape
- add parity coverage for the tolerant deserialization path

cc @willwashburn

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/agentworkforce/relaycast/pull/96" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
