### PR TITLE
feat(python-sdk): add rotation and presence lifecycle helpers

### DIFF
--- a/packages/sdk-python/README.md
+++ b/packages/sdk-python/README.md
@@ -14,13 +14,15 @@ pip install relay-sdk
 from relay_sdk import Relay
 
 relay = Relay(api_key="rk_live_xxx")
-agent = relay.agents.register(name="Coder", persona="Senior developer")
+agent = relay.agents.register_or_rotate(name="Coder", persona="Senior developer")
 
 me = relay.as_agent(agent.token)
+me.mark_online()
 me.send("#general", "Hello from Python")
 
 msgs = me.messages("#general", limit=20)
 inbox = me.inbox()
+me.mark_offline()  # alias: me.disconnect()
 ```
 
 Local mode:
@@ -40,7 +42,16 @@ relay = Relay(api_key="rk_live_...", local=True)
 from relay_sdk import AsyncRelay
 
 async with AsyncRelay(api_key="rk_live_xxx") as relay:
-    agent = await relay.agents.register(name="Coder", persona="Senior developer")
+    agent = await relay.agents.register_or_rotate(name="Coder", persona="Senior developer")
     me = relay.as_agent(agent.token)
+    await me.mark_online()
     await me.send("#general", "Hello from Python")
+    await me.disconnect()
 ```
+
+Lifecycle/auth helpers added for SDK-first worker ownership:
+
+- `relay.agents.register_or_rotate(...)` — register a new agent, or rotate the token for an existing name on conflict.
+- `relay.agents.rotate_token(name)` — explicitly rotate an agent token using a workspace key.
+- `me.mark_online()` / `me.heartbeat()` — refresh presence using the agent token.
+- `me.mark_offline()` / `me.disconnect()` — explicitly mark the agent offline.

--- a/packages/sdk-python/src/relay_sdk/agent.py
+++ b/packages/sdk-python/src/relay_sdk/agent.py
@@ -177,7 +177,7 @@ class _PresenceNamespace:
         self._client = client
 
     def mark_online(self) -> None:
-        self._client.post("/v1/agents/heartbeat", {})
+        self.heartbeat()
 
     def heartbeat(self) -> None:
         self._client.post("/v1/agents/heartbeat", {})
@@ -494,7 +494,7 @@ class _AsyncPresenceNamespace:
         self._client = client
 
     async def mark_online(self) -> None:
-        await self._client.post("/v1/agents/heartbeat", {})
+        await self.heartbeat()
 
     async def heartbeat(self) -> None:
         await self._client.post("/v1/agents/heartbeat", {})

--- a/packages/sdk-python/src/relay_sdk/agent.py
+++ b/packages/sdk-python/src/relay_sdk/agent.py
@@ -170,6 +170,25 @@ class _FilesNamespace:
         return [FileInfo.model_validate(f) for f in result]
 
 
+class _PresenceNamespace:
+    """Sync presence lifecycle helpers."""
+
+    def __init__(self, client: HttpClient) -> None:
+        self._client = client
+
+    def mark_online(self) -> None:
+        self._client.post("/v1/agents/heartbeat", {})
+
+    def heartbeat(self) -> None:
+        self._client.post("/v1/agents/heartbeat", {})
+
+    def mark_offline(self) -> None:
+        self._client.post("/v1/agents/disconnect", {})
+
+    def disconnect(self) -> None:
+        self.mark_offline()
+
+
 # ── Main AgentClient ──────────────────────────────────────────────
 
 
@@ -181,6 +200,7 @@ class AgentClient:
         self.dms = _DmsNamespace(client)
         self.channels = _ChannelsNamespace(client)
         self.files = _FilesNamespace(client)
+        self.presence = _PresenceNamespace(client)
 
     # ── Messages ──
 
@@ -300,6 +320,20 @@ class AgentClient:
     def inbox(self) -> InboxResponse:
         result = self.client.get("/v1/inbox")
         return InboxResponse.model_validate(result)
+
+    # ── Presence ──
+
+    def mark_online(self) -> None:
+        self.presence.mark_online()
+
+    def heartbeat(self) -> None:
+        self.presence.heartbeat()
+
+    def mark_offline(self) -> None:
+        self.presence.mark_offline()
+
+    def disconnect(self) -> None:
+        self.presence.disconnect()
 
     # ── Read Receipts ──
 
@@ -453,6 +487,25 @@ class _AsyncFilesNamespace:
         return [FileInfo.model_validate(f) for f in result]
 
 
+class _AsyncPresenceNamespace:
+    """Async presence lifecycle helpers."""
+
+    def __init__(self, client: AsyncHttpClient) -> None:
+        self._client = client
+
+    async def mark_online(self) -> None:
+        await self._client.post("/v1/agents/heartbeat", {})
+
+    async def heartbeat(self) -> None:
+        await self._client.post("/v1/agents/heartbeat", {})
+
+    async def mark_offline(self) -> None:
+        await self._client.post("/v1/agents/disconnect", {})
+
+    async def disconnect(self) -> None:
+        await self.mark_offline()
+
+
 class AsyncAgentClient:
     """Asynchronous agent client for messaging, channels, DMs, files, etc."""
 
@@ -461,6 +514,7 @@ class AsyncAgentClient:
         self.dms = _AsyncDmsNamespace(client)
         self.channels = _AsyncChannelsNamespace(client)
         self.files = _AsyncFilesNamespace(client)
+        self.presence = _AsyncPresenceNamespace(client)
 
     # ── Messages ──
 
@@ -580,6 +634,20 @@ class AsyncAgentClient:
     async def inbox(self) -> InboxResponse:
         result = await self.client.get("/v1/inbox")
         return InboxResponse.model_validate(result)
+
+    # ── Presence ──
+
+    async def mark_online(self) -> None:
+        await self.presence.mark_online()
+
+    async def heartbeat(self) -> None:
+        await self.presence.heartbeat()
+
+    async def mark_offline(self) -> None:
+        await self.presence.mark_offline()
+
+    async def disconnect(self) -> None:
+        await self.presence.disconnect()
 
     # ── Read Receipts ──
 

--- a/packages/sdk-python/src/relay_sdk/models.py
+++ b/packages/sdk-python/src/relay_sdk/models.py
@@ -57,6 +57,10 @@ class CreateAgentResponse(BaseModel):
     created_at: str
 
 
+class TokenRotateResponse(BaseModel):
+    token: str
+
+
 # ── Workspace ─────────────────────────────────────────────────────
 
 class Workspace(BaseModel):

--- a/packages/sdk-python/src/relay_sdk/relay.py
+++ b/packages/sdk-python/src/relay_sdk/relay.py
@@ -7,8 +7,9 @@ from urllib.parse import quote
 
 from .agent import AgentClient, AsyncAgentClient
 from .client import AsyncHttpClient, HttpClient
+from .errors import RelayError
 from .local_runtime import ensure_local_runtime
-from .models import Agent, CreateAgentRequest, CreateAgentResponse, Workspace
+from .models import Agent, CreateAgentRequest, CreateAgentResponse, TokenRotateResponse, Workspace
 
 
 def _enc(value: str) -> str:
@@ -58,6 +59,30 @@ class _AgentsNamespace:
         result = self._client.post("/v1/agents", data.model_dump(exclude_none=True))
         return CreateAgentResponse.model_validate(result)
 
+    def register_or_rotate(
+        self,
+        name: str,
+        *,
+        type: str | None = None,
+        persona: str | None = None,
+        metadata: dict[str, Any] | None = None,
+    ) -> CreateAgentResponse:
+        try:
+            return self.register(name, type=type, persona=persona, metadata=metadata)
+        except RelayError as err:
+            if err.code != "name_conflict":
+                raise
+
+        agent = self.get(name)
+        rotated = self.rotate_token(agent.name)
+        return CreateAgentResponse(
+            id=agent.id,
+            name=agent.name,
+            token=rotated.token,
+            status=agent.status,
+            created_at=agent.created_at,
+        )
+
     def list(self, *, status: str | None = None) -> list[Agent]:
         query: dict[str, str] = {}
         if status:
@@ -68,6 +93,10 @@ class _AgentsNamespace:
     def get(self, name: str) -> Agent:
         result = self._client.get(f"/v1/agents/{_enc(name)}")
         return Agent.model_validate(result)
+
+    def rotate_token(self, name: str) -> TokenRotateResponse:
+        result = self._client.post(f"/v1/agents/{_enc(name)}/rotate-token", {})
+        return TokenRotateResponse.model_validate(result)
 
 
 class Relay:
@@ -182,6 +211,30 @@ class _AsyncAgentsNamespace:
         result = await self._client.post("/v1/agents", data.model_dump(exclude_none=True))
         return CreateAgentResponse.model_validate(result)
 
+    async def register_or_rotate(
+        self,
+        name: str,
+        *,
+        type: str | None = None,
+        persona: str | None = None,
+        metadata: dict[str, Any] | None = None,
+    ) -> CreateAgentResponse:
+        try:
+            return await self.register(name, type=type, persona=persona, metadata=metadata)
+        except RelayError as err:
+            if err.code != "name_conflict":
+                raise
+
+        agent = await self.get(name)
+        rotated = await self.rotate_token(agent.name)
+        return CreateAgentResponse(
+            id=agent.id,
+            name=agent.name,
+            token=rotated.token,
+            status=agent.status,
+            created_at=agent.created_at,
+        )
+
     async def list(self, *, status: str | None = None) -> list[Agent]:
         query: dict[str, str] = {}
         if status:
@@ -192,6 +245,10 @@ class _AsyncAgentsNamespace:
     async def get(self, name: str) -> Agent:
         result = await self._client.get(f"/v1/agents/{_enc(name)}")
         return Agent.model_validate(result)
+
+    async def rotate_token(self, name: str) -> TokenRotateResponse:
+        result = await self._client.post(f"/v1/agents/{_enc(name)}/rotate-token", {})
+        return TokenRotateResponse.model_validate(result)
 
 
 class AsyncRelay:

--- a/packages/sdk-python/src/relay_sdk/relay.py
+++ b/packages/sdk-python/src/relay_sdk/relay.py
@@ -16,6 +16,10 @@ def _enc(value: str) -> str:
     return quote(value, safe="")
 
 
+def _is_duplicate_agent_error(err: RelayError) -> bool:
+    return err.status == 409 and err.code in {"agent_already_exists", "name_conflict"}
+
+
 class _WorkspaceNamespace:
     """Sync workspace operations."""
 
@@ -70,7 +74,7 @@ class _AgentsNamespace:
         try:
             return self.register(name, type=type, persona=persona, metadata=metadata)
         except RelayError as err:
-            if err.code != "name_conflict":
+            if not _is_duplicate_agent_error(err):
                 raise
 
         agent = self.get(name)
@@ -222,7 +226,7 @@ class _AsyncAgentsNamespace:
         try:
             return await self.register(name, type=type, persona=persona, metadata=metadata)
         except RelayError as err:
-            if err.code != "name_conflict":
+            if not _is_duplicate_agent_error(err):
                 raise
 
         agent = await self.get(name)

--- a/packages/sdk-python/tests/test_agent.py
+++ b/packages/sdk-python/tests/test_agent.py
@@ -551,3 +551,64 @@ class TestAsyncAgentClient:
         result = await c.files.upload("test.txt", "text/plain", 1024)
         assert isinstance(result, UploadResponse)
         await c.client.close()
+
+
+class TestAgentPresence:
+    @respx.mock
+    def test_presence_mark_online_posts_heartbeat(self):
+        route = respx.post(f"{BASE}/v1/agents/heartbeat").mock(return_value=ok(None))
+        c = AgentClient(HttpClient(TOKEN, BASE))
+        c.mark_online()
+        assert route.called
+        assert route.calls[0].request.content == b"{}"
+
+    @respx.mock
+    def test_presence_heartbeat_posts_heartbeat(self):
+        route = respx.post(f"{BASE}/v1/agents/heartbeat").mock(return_value=ok(None))
+        c = AgentClient(HttpClient(TOKEN, BASE))
+        c.heartbeat()
+        assert route.called
+
+    @respx.mock
+    def test_presence_mark_offline_posts_disconnect(self):
+        route = respx.post(f"{BASE}/v1/agents/disconnect").mock(return_value=ok(None))
+        c = AgentClient(HttpClient(TOKEN, BASE))
+        c.mark_offline()
+        assert route.called
+        assert route.calls[0].request.content == b"{}"
+
+    @respx.mock
+    def test_presence_disconnect_alias_posts_disconnect(self):
+        route = respx.post(f"{BASE}/v1/agents/disconnect").mock(return_value=ok(None))
+        c = AgentClient(HttpClient(TOKEN, BASE))
+        c.disconnect()
+        assert route.called
+
+
+class TestAsyncAgentPresence:
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_presence_mark_online_posts_heartbeat(self):
+        route = respx.post(f"{BASE}/v1/agents/heartbeat").mock(return_value=ok(None))
+        c = AsyncAgentClient(AsyncHttpClient(TOKEN, BASE))
+        await c.mark_online()
+        assert route.called
+        await c.client.close()
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_presence_mark_offline_posts_disconnect(self):
+        route = respx.post(f"{BASE}/v1/agents/disconnect").mock(return_value=ok(None))
+        c = AsyncAgentClient(AsyncHttpClient(TOKEN, BASE))
+        await c.mark_offline()
+        assert route.called
+        await c.client.close()
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_presence_disconnect_alias_posts_disconnect(self):
+        route = respx.post(f"{BASE}/v1/agents/disconnect").mock(return_value=ok(None))
+        c = AsyncAgentClient(AsyncHttpClient(TOKEN, BASE))
+        await c.disconnect()
+        assert route.called
+        await c.client.close()

--- a/packages/sdk-python/tests/test_relay.py
+++ b/packages/sdk-python/tests/test_relay.py
@@ -135,11 +135,12 @@ class TestRelay:
         assert created.token == "at_xxx"
 
     @respx.mock
-    def test_agents_register_or_rotate_rotates_existing_agent(self):
+    @pytest.mark.parametrize("error_code", ["agent_already_exists", "name_conflict"])
+    def test_agents_register_or_rotate_rotates_existing_agent(self, error_code):
         respx.post(f"{BASE}/v1/agents").mock(
             return_value=httpx.Response(
                 409,
-                json={"ok": False, "error": {"code": "name_conflict", "message": "exists"}},
+                json={"ok": False, "error": {"code": error_code, "message": "exists"}},
             )
         )
         get_route = respx.get(f"{BASE}/v1/agents/Coder").mock(return_value=ok(AGENT_DATA))
@@ -221,12 +222,13 @@ class TestAsyncRelay:
             assert rotated.token == "at_rotated"
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("error_code", ["agent_already_exists", "name_conflict"])
     @respx.mock
-    async def test_agents_register_or_rotate_rotates_existing_agent(self):
+    async def test_agents_register_or_rotate_rotates_existing_agent(self, error_code):
         respx.post(f"{BASE}/v1/agents").mock(
             return_value=httpx.Response(
                 409,
-                json={"ok": False, "error": {"code": "name_conflict", "message": "exists"}},
+                json={"ok": False, "error": {"code": error_code, "message": "exists"}},
             )
         )
         respx.get(f"{BASE}/v1/agents/Coder").mock(return_value=ok(AGENT_DATA))

--- a/packages/sdk-python/tests/test_relay.py
+++ b/packages/sdk-python/tests/test_relay.py
@@ -117,6 +117,42 @@ class TestRelay:
         agent = r.agents.get("Coder")
         assert agent.name == "Coder"
 
+    @respx.mock
+    def test_agents_rotate_token(self):
+        route = respx.post(f"{BASE}/v1/agents/Coder/rotate-token").mock(
+            return_value=ok({"token": "at_rotated"})
+        )
+        r = Relay(KEY, base_url=BASE)
+        rotated = r.agents.rotate_token("Coder")
+        assert rotated.token == "at_rotated"
+        assert route.called
+
+    @respx.mock
+    def test_agents_register_or_rotate_registers_new_agent(self):
+        respx.post(f"{BASE}/v1/agents").mock(return_value=ok(CREATE_AGENT_DATA))
+        r = Relay(KEY, base_url=BASE)
+        created = r.agents.register_or_rotate("Coder", persona="Senior dev")
+        assert created.token == "at_xxx"
+
+    @respx.mock
+    def test_agents_register_or_rotate_rotates_existing_agent(self):
+        respx.post(f"{BASE}/v1/agents").mock(
+            return_value=httpx.Response(
+                409,
+                json={"ok": False, "error": {"code": "name_conflict", "message": "exists"}},
+            )
+        )
+        get_route = respx.get(f"{BASE}/v1/agents/Coder").mock(return_value=ok(AGENT_DATA))
+        rotate_route = respx.post(f"{BASE}/v1/agents/Coder/rotate-token").mock(
+            return_value=ok({"token": "at_rotated"})
+        )
+        r = Relay(KEY, base_url=BASE)
+        created = r.agents.register_or_rotate("Coder")
+        assert created.id == "a1"
+        assert created.token == "at_rotated"
+        assert get_route.called
+        assert rotate_route.called
+
     def test_as_agent_returns_agent_client(self):
         r = Relay(KEY, base_url=BASE)
         ac = r.as_agent("at_xxx")
@@ -175,6 +211,30 @@ class TestAsyncRelay:
         async with AsyncRelay(KEY, base_url=BASE) as r:
             agent = await r.agents.get("Coder")
             assert agent.status == "online"
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_agents_rotate_token(self):
+        respx.post(f"{BASE}/v1/agents/Coder/rotate-token").mock(return_value=ok({"token": "at_rotated"}))
+        async with AsyncRelay(KEY, base_url=BASE) as r:
+            rotated = await r.agents.rotate_token("Coder")
+            assert rotated.token == "at_rotated"
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_agents_register_or_rotate_rotates_existing_agent(self):
+        respx.post(f"{BASE}/v1/agents").mock(
+            return_value=httpx.Response(
+                409,
+                json={"ok": False, "error": {"code": "name_conflict", "message": "exists"}},
+            )
+        )
+        respx.get(f"{BASE}/v1/agents/Coder").mock(return_value=ok(AGENT_DATA))
+        respx.post(f"{BASE}/v1/agents/Coder/rotate-token").mock(return_value=ok({"token": "at_rotated"}))
+        async with AsyncRelay(KEY, base_url=BASE) as r:
+            created = await r.agents.register_or_rotate("Coder")
+            assert created.id == "a1"
+            assert created.token == "at_rotated"
 
     @pytest.mark.asyncio
     async def test_as_agent_returns_async_client(self):


### PR DESCRIPTION
## Summary
- add Python SDK `register_or_rotate()` and `rotate_token()` helpers for agent ownership flows
- add sync + async presence lifecycle helpers (`mark_online`, `heartbeat`, `mark_offline`, `disconnect`)
- document and test the new lifecycle/auth helper APIs

cc @willwashburn

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/agentworkforce/relaycast/pull/97" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
