### PR TITLE
feat(ts-sdk): add workspace lookup and ensure helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,21 @@ npx tsx quickstart.ts
 
 That is the canonical onboarding loop: create workspace, register agents, connect realtime streams, and watch messages flow live.
 
+If you want idempotent setup by workspace name, use `ensureWorkspace()`:
+
+```ts
+const ensured = await RelayCast.ensureWorkspace('my-project');
+
+if (ensured.existed) {
+  console.log(`Workspace already exists as ${ensured.id}`);
+  // Existing workspace keys are not recoverable from the API.
+  // Reuse the known rk_live_* key you already have for this workspace.
+} else {
+  console.log(`Created ${ensured.workspaceId}`);
+  console.log(`New workspace key: ${ensured.apiKey}`);
+}
+```
+
 ## Why Relaycast
 
 Most multi-agent stacks need a communication layer but don’t want to build one.

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -50,6 +50,22 @@ components:
           type: string
           format: date-time
 
+    WorkspaceLookup:
+      type: object
+      required:
+        - id
+        - name
+        - created_at
+      properties:
+        id:
+          type: string
+          description: Snowflake ID
+        name:
+          type: string
+        created_at:
+          type: string
+          format: date-time
+
     Agent:
       type: object
       properties:
@@ -363,6 +379,44 @@ paths:
                 $ref: '#/components/schemas/ErrorResponse'
         '409':
           description: Workspace name already exists
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+  /workspaces/by-name/{name}:
+    get:
+      summary: Lookup workspace by name
+      description: Look up public workspace metadata by name. No authentication required.
+      tags:
+        - Workspaces
+      security: []
+      parameters:
+        - name: name
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Public workspace metadata
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                  data:
+                    $ref: '#/components/schemas/WorkspaceLookup'
+        '404':
+          description: Workspace not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '429':
+          description: Rate limit exceeded
           content:
             application/json:
               schema:

--- a/packages/local/src/main.rs
+++ b/packages/local/src/main.rs
@@ -708,6 +708,27 @@ async fn health() -> Response {
         .into_response()
 }
 
+async fn get_workspace_by_name(
+    State(state): State<AppState>,
+    Path(name): Path<String>,
+) -> Response {
+    let store = state.store.read().await;
+
+    let Some(ws) = store.workspaces.values().find(|ws| ws.name == name) else {
+        return err(
+            StatusCode::NOT_FOUND,
+            "workspace_not_found",
+            "Workspace not found",
+        );
+    };
+
+    ok(json!({
+        "id": ws.id,
+        "name": ws.name,
+        "created_at": ws.created_at,
+    }))
+}
+
 async fn get_workspace(State(state): State<AppState>, headers: HeaderMap) -> Response {
     let store = state.store.read().await;
     let workspace_id = match auth_workspace(&store, &headers) {
@@ -4883,6 +4904,10 @@ fn app_router(state: AppState) -> Router {
         .route("/health", get(health))
         .route("/v1/ws", get(ws_upgrade))
         .route("/v1/workspaces", post(create_workspace))
+        .route(
+            "/v1/workspaces/by-name/{name}",
+            get(get_workspace_by_name),
+        )
         .route(
             "/v1/workspace",
             get(get_workspace)

--- a/packages/local/src/main.rs
+++ b/packages/local/src/main.rs
@@ -330,6 +330,10 @@ fn random_token(prefix: &str) -> String {
     format!("{prefix}{suffix}")
 }
 
+fn normalize_workspace_name(name: &str) -> &str {
+    name.trim()
+}
+
 fn ws_agent_key(workspace_id: &str, name: &str) -> String {
     format!("{workspace_id}:{name}")
 }
@@ -630,7 +634,8 @@ async fn create_workspace(
         return json_error();
     };
 
-    if payload.name.trim().is_empty() {
+    let workspace_name = normalize_workspace_name(&payload.name);
+    if workspace_name.is_empty() {
         return err(
             StatusCode::BAD_REQUEST,
             "invalid_request",
@@ -638,7 +643,7 @@ async fn create_workspace(
         );
     }
 
-    let workspace_name = payload.name.trim().to_string();
+    let workspace_name = workspace_name.to_string();
     let workspace_id = new_id("ws");
     let api_key = random_token("rk_live_");
     let created_at = now_iso();
@@ -713,8 +718,9 @@ async fn get_workspace_by_name(
     Path(name): Path<String>,
 ) -> Response {
     let store = state.store.read().await;
+    let lookup_name = normalize_workspace_name(&name);
 
-    let Some(ws) = store.workspaces.values().find(|ws| ws.name == name) else {
+    let Some(ws) = store.workspaces.values().find(|ws| ws.name == lookup_name) else {
         return err(
             StatusCode::NOT_FOUND,
             "workspace_not_found",
@@ -777,14 +783,15 @@ async fn patch_workspace(
     };
 
     if let Some(name) = payload.name {
-        if name.trim().is_empty() {
+        let name = normalize_workspace_name(&name);
+        if name.is_empty() {
             return err(
                 StatusCode::BAD_REQUEST,
                 "invalid_request",
                 "name cannot be empty",
             );
         }
-        ws.name = name.trim().to_string();
+        ws.name = name.to_string();
     }
 
     if let Some(prompt) = payload.system_prompt {
@@ -5066,7 +5073,17 @@ async fn main() -> anyhow::Result<()> {
 
 #[cfg(test)]
 mod tests {
-    use super::normalize_initial_group_dm_text;
+    use super::{normalize_initial_group_dm_text, normalize_workspace_name};
+
+    #[test]
+    fn normalize_workspace_name_trims_surrounding_whitespace() {
+        assert_eq!(normalize_workspace_name("  test  "), "test");
+    }
+
+    #[test]
+    fn normalize_workspace_name_preserves_inner_whitespace() {
+        assert_eq!(normalize_workspace_name("  test workspace  "), "test workspace");
+    }
 
     #[test]
     fn normalize_initial_group_dm_text_accepts_absent_text() {

--- a/packages/sdk-typescript/CHANGELOG.md
+++ b/packages/sdk-typescript/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 - Normalized core SDK request options to camelCase (`includeArchived`, `contentType`, `sizeBytes`, `uploadedBy`, `handlerAgent`, `paymentMethod`).
 - Exported camelized SDK type aliases from the package root.
 - Updated tests to keep camelCase as the canonical SDK style.
+- Added `RelayCast.lookupWorkspace()` and `RelayCast.ensureWorkspace()` for name-based workspace setup flows.
 
 ## [0.3.2] - 2026-02-20
 

--- a/packages/sdk-typescript/src/__tests__/relay.test.ts
+++ b/packages/sdk-typescript/src/__tests__/relay.test.ts
@@ -464,6 +464,115 @@ describe('RelayCast', () => {
     });
   });
 
+  describe('RelayCast.lookupWorkspace', () => {
+    it('calls GET /v1/workspaces/by-name/:name without auth', async () => {
+      const { RelayCast } = await import('../relay.js');
+
+      mockFetch.mockImplementation(() =>
+        Promise.resolve({
+          ok: true,
+          status: 200,
+          json: () =>
+            Promise.resolve({
+              ok: true,
+              data: { id: 'ws_1', name: 'My Workspace', created_at: '2024-01-01' },
+            }),
+        }),
+      );
+
+      const result = await RelayCast.lookupWorkspace('My Workspace');
+
+      const [url, init] = mockFetch.mock.calls[0]!;
+      expect(url).toBe('https://api.relaycast.dev/v1/workspaces/by-name/My%20Workspace');
+      expect(init.method).toBe('GET');
+      expect(init.headers.Authorization).toBeUndefined();
+      expect(result).toEqual({ id: 'ws_1', name: 'My Workspace', createdAt: '2024-01-01' });
+    });
+
+    it('returns null on 404', async () => {
+      const { RelayCast } = await import('../relay.js');
+
+      mockFetch.mockImplementation(() =>
+        Promise.resolve({
+          ok: false,
+          status: 404,
+          json: () =>
+            Promise.resolve({
+              ok: false,
+              error: { code: 'workspace_not_found', message: 'Missing' },
+            }),
+        }),
+      );
+
+      await expect(RelayCast.lookupWorkspace('Missing')).resolves.toBeNull();
+    });
+  });
+
+  describe('RelayCast.ensureWorkspace', () => {
+    it('returns a created workspace when the name is available', async () => {
+      const { RelayCast } = await import('../relay.js');
+
+      mockFetch.mockImplementation(() =>
+        Promise.resolve({
+          ok: true,
+          status: 200,
+          json: () =>
+            Promise.resolve({
+              ok: true,
+              data: { workspace_id: 'ws_1', api_key: 'rk_live_new', created_at: '2024-01-01' },
+            }),
+        }),
+      );
+
+      const result = await RelayCast.ensureWorkspace('Fresh Workspace');
+      expect(result).toEqual({
+        existed: false,
+        name: 'Fresh Workspace',
+        workspaceId: 'ws_1',
+        apiKey: 'rk_live_new',
+        createdAt: '2024-01-01',
+      });
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+    });
+
+    it('looks up existing workspace metadata after a create conflict', async () => {
+      const { RelayCast } = await import('../relay.js');
+
+      mockFetch
+        .mockImplementationOnce(() =>
+          Promise.resolve({
+            ok: false,
+            status: 409,
+            json: () =>
+              Promise.resolve({
+                ok: false,
+                error: { code: 'workspace_already_exists', message: 'Already exists' },
+              }),
+          }),
+        )
+        .mockImplementationOnce(() =>
+          Promise.resolve({
+            ok: true,
+            status: 200,
+            json: () =>
+              Promise.resolve({
+                ok: true,
+                data: { id: 'ws_existing', name: 'Taken Workspace', created_at: '2024-01-02' },
+              }),
+          }),
+        );
+
+      const result = await RelayCast.ensureWorkspace('Taken Workspace');
+      expect(result).toEqual({
+        existed: true,
+        id: 'ws_existing',
+        name: 'Taken Workspace',
+        createdAt: '2024-01-02',
+      });
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+    });
+  });
+
   describe('agents.registerOrGet', () => {
     it('returns register result when agent does not exist', async () => {
       const { RelayCast } = await import('../relay.js');

--- a/packages/sdk-typescript/src/index.ts
+++ b/packages/sdk-typescript/src/index.ts
@@ -3,6 +3,7 @@ export { RelayCast, RelayCast as Relay } from './relay.js';
 export type {
   RelayCastOptions,
   RelayCastOptions as RelayOptions,
+  EnsureWorkspaceResponse,
 } from './relay.js';
 export { AgentClient } from './agent.js';
 export type { AgentClientOptions } from './agent.js';

--- a/packages/sdk-typescript/src/relay.ts
+++ b/packages/sdk-typescript/src/relay.ts
@@ -36,7 +36,7 @@ import type {
   ReleaseAgentRequest,
   ReleaseAgentResponse,
 } from './types.js';
-import { ApiErrorSchema, CreateWorkspaceResponseSchema, WorkspaceLookupSchema } from '@relaycast/types';
+import { ApiResponseSchema, CreateWorkspaceResponseSchema, WorkspaceLookupSchema } from '@relaycast/types';
 import { AgentClient, type AgentClientOptions } from './agent.js';
 import { HttpClient, type RetryPolicyInput } from './client.js';
 import { RelayError, relayErrorFromApi } from './errors.js';
@@ -127,7 +127,8 @@ export class RelayCast {
       );
     }
 
-    if (typeof parsed !== 'object' || parsed === null || !('ok' in parsed) || typeof parsed.ok !== 'boolean') {
+    const envelope = ApiResponseSchema(CreateWorkspaceResponseSchema).safeParse(parsed);
+    if (!envelope.success) {
       throw new RelayError(
         'transport_error',
         'Response is not a valid Relay API response object',
@@ -135,23 +136,11 @@ export class RelayCast {
       );
     }
 
-    if (!parsed.ok) {
-      const errResult = ApiErrorSchema.safeParse(parsed);
-      const rawCode = errResult.success ? errResult.data.error.code : undefined;
-      const message = errResult.success ? errResult.data.error.message : 'Unknown error';
-      throw relayErrorFromApi(rawCode, message, res.status);
+    if (!envelope.data.ok) {
+      throw relayErrorFromApi(envelope.data.error.code, envelope.data.error.message, res.status);
     }
 
-    if (!('data' in parsed)) {
-      throw new RelayError(
-        'transport_error',
-        'Response is missing required "data" field',
-        { statusCode: res.status, retryable: false },
-      );
-    }
-
-    const data = (parsed as { data: unknown }).data;
-    return camelizeKeys(CreateWorkspaceResponseSchema.parse(data));
+    return camelizeKeys(envelope.data.data);
   }
 
   static async lookupWorkspace(name: string, baseUrl?: string): Promise<WorkspaceLookup | null> {
@@ -180,7 +169,8 @@ export class RelayCast {
       );
     }
 
-    if (typeof parsed !== 'object' || parsed === null || !('ok' in parsed) || typeof parsed.ok !== 'boolean') {
+    const envelope = ApiResponseSchema(WorkspaceLookupSchema).safeParse(parsed);
+    if (!envelope.success) {
       throw new RelayError(
         'transport_error',
         'Response is not a valid Relay API response object',
@@ -188,26 +178,14 @@ export class RelayCast {
       );
     }
 
-    if (!parsed.ok) {
-      const errResult = ApiErrorSchema.safeParse(parsed);
-      const rawCode = errResult.success ? errResult.data.error.code : undefined;
-      const message = errResult.success ? errResult.data.error.message : 'Unknown error';
+    if (!envelope.data.ok) {
       if (res.status === 404) {
         return null;
       }
-      throw relayErrorFromApi(rawCode, message, res.status);
+      throw relayErrorFromApi(envelope.data.error.code, envelope.data.error.message, res.status);
     }
 
-    if (!('data' in parsed)) {
-      throw new RelayError(
-        'transport_error',
-        'Response is missing required "data" field',
-        { statusCode: res.status, retryable: false },
-      );
-    }
-
-    const data = (parsed as { data: unknown }).data;
-    return camelizeKeys(WorkspaceLookupSchema.parse(data));
+    return camelizeKeys(envelope.data.data);
   }
 
   static async ensureWorkspace(name: string, baseUrl?: string): Promise<EnsureWorkspaceResponse> {

--- a/packages/sdk-typescript/src/relay.ts
+++ b/packages/sdk-typescript/src/relay.ts
@@ -10,6 +10,7 @@ import type {
   UpdateWorkspaceRequest,
   Workspace,
   CreateWorkspaceResponse,
+  WorkspaceLookup,
   SystemPrompt,
   SetSystemPromptRequest,
   CreateWebhookRequest,
@@ -35,7 +36,7 @@ import type {
   ReleaseAgentRequest,
   ReleaseAgentResponse,
 } from './types.js';
-import { ApiErrorSchema, CreateWorkspaceResponseSchema } from '@relaycast/types';
+import { ApiErrorSchema, CreateWorkspaceResponseSchema, WorkspaceLookupSchema } from '@relaycast/types';
 import { AgentClient, type AgentClientOptions } from './agent.js';
 import { HttpClient, type RetryPolicyInput } from './client.js';
 import { RelayError, relayErrorFromApi } from './errors.js';
@@ -62,6 +63,10 @@ export interface WorkspaceStreamConfig {
   defaultEnabled: boolean;
   override: boolean | null;
 }
+
+export type EnsureWorkspaceResponse =
+  | ({ existed: false; name: string } & CreateWorkspaceResponse)
+  | ({ existed: true } & WorkspaceLookup);
 
 interface ChannelListOptions {
   includeArchived?: boolean;
@@ -147,6 +152,81 @@ export class RelayCast {
 
     const data = (parsed as { data: unknown }).data;
     return camelizeKeys(CreateWorkspaceResponseSchema.parse(data));
+  }
+
+  static async lookupWorkspace(name: string, baseUrl?: string): Promise<WorkspaceLookup | null> {
+    const requestBaseUrl = baseUrl ?? 'https://api.relaycast.dev';
+
+    const url = new URL(`/v1/workspaces/by-name/${encodeURIComponent(name)}`, requestBaseUrl);
+    const res = await fetch(url.toString(), {
+      method: 'GET',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-SDK-Version': SDK_VERSION,
+        'X-Relaycast-Origin-Surface': SDK_ORIGIN.surface,
+        'X-Relaycast-Origin-Client': SDK_ORIGIN.client,
+        'X-Relaycast-Origin-Version': SDK_ORIGIN.version,
+      },
+    });
+
+    let parsed: unknown;
+    try {
+      parsed = await res.json();
+    } catch (err) {
+      throw new RelayError(
+        'transport_error',
+        `Failed to parse response as JSON: ${err instanceof Error ? err.message : 'unknown error'}`,
+        { statusCode: res.status, retryable: false, cause: err },
+      );
+    }
+
+    if (typeof parsed !== 'object' || parsed === null || !('ok' in parsed) || typeof parsed.ok !== 'boolean') {
+      throw new RelayError(
+        'transport_error',
+        'Response is not a valid Relay API response object',
+        { statusCode: res.status, retryable: false },
+      );
+    }
+
+    if (!parsed.ok) {
+      const errResult = ApiErrorSchema.safeParse(parsed);
+      const rawCode = errResult.success ? errResult.data.error.code : undefined;
+      const message = errResult.success ? errResult.data.error.message : 'Unknown error';
+      if (res.status === 404) {
+        return null;
+      }
+      throw relayErrorFromApi(rawCode, message, res.status);
+    }
+
+    if (!('data' in parsed)) {
+      throw new RelayError(
+        'transport_error',
+        'Response is missing required "data" field',
+        { statusCode: res.status, retryable: false },
+      );
+    }
+
+    const data = (parsed as { data: unknown }).data;
+    return camelizeKeys(WorkspaceLookupSchema.parse(data));
+  }
+
+  static async ensureWorkspace(name: string, baseUrl?: string): Promise<EnsureWorkspaceResponse> {
+    try {
+      const created = await RelayCast.createWorkspace(name, baseUrl);
+      return { ...created, existed: false, name };
+    } catch (err) {
+      const statusCode = err instanceof RelayError ? err.statusCode : undefined;
+      if (statusCode !== 409) {
+        throw err;
+      }
+
+      const existing = await RelayCast.lookupWorkspace(name, baseUrl);
+      if (!existing) {
+        throw err;
+      }
+
+      return { ...existing, existed: true };
+    }
   }
 
   private rememberIdentity(agentId: string, name: string): void {

--- a/packages/sdk-typescript/src/types.ts
+++ b/packages/sdk-typescript/src/types.ts
@@ -32,6 +32,7 @@ export type CreateSubscriptionResponse = Camelize<Raw.CreateSubscriptionResponse
 export type CreateWebhookRequest = Camelize<Raw.CreateWebhookRequest>;
 export type CreateWebhookResponse = Camelize<Raw.CreateWebhookResponse>;
 export type CreateWorkspaceResponse = Camelize<Raw.CreateWorkspaceResponse>;
+export type WorkspaceLookup = Camelize<Raw.WorkspaceLookup>;
 export type SendDmResponse = Camelize<Raw.SendDmResponse>;
 export type DmMessage = Camelize<Raw.DmMessage>;
 export type DmConversationSummary = Camelize<Raw.DmConversationSummary>;

--- a/packages/server/src/engine/workspace.ts
+++ b/packages/server/src/engine/workspace.ts
@@ -50,6 +50,20 @@ export async function createWorkspace(db: Db, name: string) {
   };
 }
 
+export async function getWorkspaceByName(db: Db, name: string) {
+  const [workspace] = await db
+    .select()
+    .from(workspaces)
+    .where(eq(workspaces.name, name));
+  if (!workspace) return null;
+
+  return {
+    id: workspace.id,
+    name: workspace.name,
+    created_at: workspace.createdAt.toISOString(),
+  };
+}
+
 export async function getWorkspace(db: Db, workspaceId: string) {
   const [workspace] = await db
     .select()

--- a/packages/server/src/engine/workspace.ts
+++ b/packages/server/src/engine/workspace.ts
@@ -52,7 +52,11 @@ export async function createWorkspace(db: Db, name: string) {
 
 export async function getWorkspaceByName(db: Db, name: string) {
   const [workspace] = await db
-    .select()
+    .select({
+      id: workspaces.id,
+      name: workspaces.name,
+      createdAt: workspaces.createdAt,
+    })
     .from(workspaces)
     .where(eq(workspaces.name, name));
   if (!workspace) return null;

--- a/packages/server/src/routes/__tests__/workspace.test.ts
+++ b/packages/server/src/routes/__tests__/workspace.test.ts
@@ -56,6 +56,7 @@ app.route('/v1', v1);
 describe('Dashboard routes', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    (bindings as any).RATE_LIMIT_DO = createMockBindings().RATE_LIMIT_DO;
   });
 
   describe('GET /v1/workspaces/by-name/:name', () => {
@@ -97,6 +98,38 @@ describe('Dashboard routes', () => {
       const body = await res.json();
       expect(body.ok).toBe(false);
       expect(body.error.code).toBe('workspace_not_found');
+    });
+
+    it('rate limits repeated public lookups', async () => {
+      vi.mocked(getDb).mockReturnValue(mockDbForWorkspaceAuth());
+      vi.mocked(workspaceEngine.getWorkspaceByName).mockResolvedValue({
+        id: 'ws_lookup',
+        name: 'lookup-me',
+        created_at: '2026-03-19T00:00:00.000Z',
+      });
+
+      (bindings as any).RATE_LIMIT_DO = {
+        idFromName: vi.fn(() => 'public-lookup-do'),
+        get: vi.fn(() => ({
+          fetch: vi.fn(async () => Response.json({
+            ok: true,
+            data: { count: 31, limit: 30, remaining: 0, allowed: false },
+          })),
+        })),
+      } as unknown as DurableObjectNamespace;
+
+      const res = await app.request('/v1/workspaces/by-name/lookup-me', {
+        method: 'GET',
+        headers: {
+          'CF-Connecting-IP': '198.51.100.15',
+        },
+      });
+
+      expect(res.status).toBe(429);
+      const body = await res.json();
+      expect(body.ok).toBe(false);
+      expect(body.error.code).toBe('rate_limit_exceeded');
+      expect(res.headers.get('X-RateLimit-Limit')).toBe('30');
     });
   });
 

--- a/packages/server/src/routes/__tests__/workspace.test.ts
+++ b/packages/server/src/routes/__tests__/workspace.test.ts
@@ -4,6 +4,10 @@ vi.mock('../../engine/activity.js', () => ({
   getActivityFeed: vi.fn(),
 }));
 
+vi.mock('../../engine/workspace.js', () => ({
+  getWorkspaceByName: vi.fn(),
+}));
+
 vi.mock('../../engine/dmAll.js', () => ({
   listAllDmConversations: vi.fn(),
   getDmMessagesForWorkspace: vi.fn(),
@@ -26,6 +30,7 @@ import type { AppEnv } from '../../env.js';
 import { dbMiddleware } from '../../middleware/db.js';
 import { workspaceRoutes } from '../../routes/workspace.js';
 import * as activityEngine from '../../engine/activity.js';
+import * as workspaceEngine from '../../engine/workspace.js';
 import * as dmAllEngine from '../../engine/dmAll.js';
 import * as tokenRotateEngine from '../../engine/tokenRotate.js';
 import { getDb } from '../../db/index.js';
@@ -51,6 +56,48 @@ app.route('/v1', v1);
 describe('Dashboard routes', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+  });
+
+  describe('GET /v1/workspaces/by-name/:name', () => {
+    it('returns public workspace metadata without auth', async () => {
+      vi.mocked(getDb).mockReturnValue(mockDbForWorkspaceAuth());
+      vi.mocked(workspaceEngine.getWorkspaceByName).mockResolvedValue({
+        id: 'ws_lookup',
+        name: 'lookup-me',
+        created_at: '2026-03-19T00:00:00.000Z',
+      });
+
+      const res = await app.request('/v1/workspaces/by-name/lookup-me', {
+        method: 'GET',
+      });
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.ok).toBe(true);
+      expect(body.data).toEqual({
+        id: 'ws_lookup',
+        name: 'lookup-me',
+        created_at: '2026-03-19T00:00:00.000Z',
+      });
+      expect(workspaceEngine.getWorkspaceByName).toHaveBeenCalledWith(
+        expect.anything(),
+        'lookup-me',
+      );
+    });
+
+    it('returns 404 when workspace does not exist', async () => {
+      vi.mocked(getDb).mockReturnValue(mockDbForWorkspaceAuth());
+      vi.mocked(workspaceEngine.getWorkspaceByName).mockResolvedValue(null);
+
+      const res = await app.request('/v1/workspaces/by-name/missing', {
+        method: 'GET',
+      });
+
+      expect(res.status).toBe(404);
+      const body = await res.json();
+      expect(body.ok).toBe(false);
+      expect(body.error.code).toBe('workspace_not_found');
+    });
   });
 
   describe('GET /v1/activity', () => {

--- a/packages/server/src/routes/workspace.ts
+++ b/packages/server/src/routes/workspace.ts
@@ -50,6 +50,21 @@ workspaceRoutes.post('/workspaces', async (c) => {
   }
 });
 
+// GET /workspaces/by-name/:name - lookup public workspace metadata by name
+workspaceRoutes.get('/workspaces/by-name/:name', async (c) => {
+  try {
+    const db = c.get('db');
+    const workspace = await workspaceEngine.getWorkspaceByName(db, c.req.param('name'));
+    if (!workspace) {
+      return c.json({ ok: false, error: { code: 'workspace_not_found', message: 'Workspace not found' } }, 404);
+    }
+    return c.json({ ok: true, data: workspace });
+  } catch (err: unknown) {
+    const error = err as Error & { code?: string; status?: number };
+    return c.json({ ok: false, error: { code: error.code || 'internal_error', message: error.message } }, (error.status || 500) as any);
+  }
+});
+
 // GET /workspace - get current workspace
 workspaceRoutes.get('/workspace', requireWorkspaceKey, rateLimit, async (c) => {
   try {

--- a/packages/server/src/routes/workspace.ts
+++ b/packages/server/src/routes/workspace.ts
@@ -1,4 +1,6 @@
 import { Hono } from 'hono';
+import type { Context } from 'hono';
+import { createMiddleware } from 'hono/factory';
 import { z } from 'zod';
 import type { AppEnv } from '../env.js';
 import { requireWorkspaceKey } from '../middleware/auth.js';
@@ -30,6 +32,110 @@ const updateWorkspaceStreamSchema = z.object({
   mode: z.string().optional(),
 }).passthrough();
 
+const PUBLIC_WORKSPACE_LOOKUP_LIMIT = 30;
+const publicWorkspaceLookupBuckets = new Map<string, { count: number; lastSeen: number }>();
+let lastPublicWorkspaceLookupCleanup = Date.now();
+
+function getPublicLookupClientId(c: Context<AppEnv>) {
+  const forwardedFor = c.req.header('X-Forwarded-For');
+  const clientIp = c.req.header('CF-Connecting-IP')
+    ?? forwardedFor?.split(',')[0]?.trim()
+    ?? 'unknown';
+  return clientIp;
+}
+
+function inMemoryPublicLookupRateCheck(clientId: string, limit: number) {
+  const now = Date.now();
+
+  if (now - lastPublicWorkspaceLookupCleanup > 60_000) {
+    lastPublicWorkspaceLookupCleanup = now;
+    for (const [key, bucket] of publicWorkspaceLookupBuckets) {
+      if (now - bucket.lastSeen > 120_000) {
+        publicWorkspaceLookupBuckets.delete(key);
+      }
+    }
+  }
+
+  const window = Math.floor(now / 60_000);
+  const bucketKey = `${clientId}:${window}`;
+  const bucket = publicWorkspaceLookupBuckets.get(bucketKey) ?? { count: 0, lastSeen: now };
+  bucket.count += 1;
+  bucket.lastSeen = now;
+  publicWorkspaceLookupBuckets.set(bucketKey, bucket);
+
+  return {
+    allowed: bucket.count <= limit,
+    remaining: Math.max(0, limit - bucket.count),
+  };
+}
+
+const publicWorkspaceLookupRateLimit = createMiddleware<AppEnv>(async (c, next) => {
+  const clientId = getPublicLookupClientId(c);
+  const limit = PUBLIC_WORKSPACE_LOOKUP_LIMIT;
+  const window = Math.floor(Date.now() / 60_000);
+  const bucketKey = `GET:/workspaces/by-name:${window}`;
+
+  try {
+    const id = c.env.RATE_LIMIT_DO.idFromName(`public-workspace-lookup:${clientId}`);
+    const stub = c.env.RATE_LIMIT_DO.get(id);
+    const res = await stub.fetch(new Request('http://do/check', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        bucketKey,
+        limit,
+        windowMs: 60_000,
+      }),
+    }));
+
+    if (!res.ok) {
+      throw new Error(`RateLimitDO returned HTTP ${res.status}`);
+    }
+
+    const payload = await res.json() as {
+      ok?: boolean;
+      data?: {
+        count?: number;
+        remaining?: number;
+        allowed?: boolean;
+      };
+    };
+
+    const count = payload.data?.count ?? 1;
+    const remaining = payload.data?.remaining ?? Math.max(0, limit - count);
+    const allowed = payload.data?.allowed ?? count <= limit;
+
+    c.header('X-RateLimit-Limit', String(limit));
+    c.header('X-RateLimit-Remaining', String(remaining));
+
+    if (!allowed) {
+      return c.json({
+        ok: false,
+        error: {
+          code: 'rate_limit_exceeded',
+          message: `Rate limit exceeded. ${limit} requests per minute allowed for public workspace lookups.`,
+        },
+      }, 429);
+    }
+  } catch {
+    const { allowed, remaining } = inMemoryPublicLookupRateCheck(clientId, limit);
+    c.header('X-RateLimit-Limit', String(limit));
+    c.header('X-RateLimit-Remaining', String(remaining));
+
+    if (!allowed) {
+      return c.json({
+        ok: false,
+        error: {
+          code: 'rate_limit_exceeded',
+          message: `Rate limit exceeded. ${limit} requests per minute allowed for public workspace lookups.`,
+        },
+      }, 429);
+    }
+  }
+
+  await next();
+});
+
 // POST /workspaces - create workspace (no auth required)
 workspaceRoutes.post('/workspaces', async (c) => {
   try {
@@ -51,7 +157,7 @@ workspaceRoutes.post('/workspaces', async (c) => {
 });
 
 // GET /workspaces/by-name/:name - lookup public workspace metadata by name
-workspaceRoutes.get('/workspaces/by-name/:name', async (c) => {
+workspaceRoutes.get('/workspaces/by-name/:name', publicWorkspaceLookupRateLimit, async (c) => {
   try {
     const db = c.get('db');
     const workspace = await workspaceEngine.getWorkspaceByName(db, c.req.param('name'));

--- a/packages/types/src/__tests__/types.test.ts
+++ b/packages/types/src/__tests__/types.test.ts
@@ -3,6 +3,7 @@ import type {
   Workspace,
   CreateWorkspaceRequest,
   CreateWorkspaceResponse,
+  WorkspaceLookup,
   UpdateWorkspaceRequest,
   Agent,
   AgentType,
@@ -76,6 +77,12 @@ describe('Type definitions', () => {
   it('CreateWorkspaceResponse has api_key', () => {
     expectTypeOf<CreateWorkspaceResponse>().toHaveProperty('api_key');
     expectTypeOf<CreateWorkspaceResponse>().toHaveProperty('workspace_id');
+  });
+
+  it('WorkspaceLookup exposes public lookup fields', () => {
+    expectTypeOf<WorkspaceLookup>().toHaveProperty('id');
+    expectTypeOf<WorkspaceLookup>().toHaveProperty('name');
+    expectTypeOf<WorkspaceLookup>().toHaveProperty('created_at');
   });
 
   it('UpdateWorkspaceRequest fields are optional', () => {

--- a/packages/types/src/workspace.ts
+++ b/packages/types/src/workspace.ts
@@ -22,6 +22,13 @@ export const CreateWorkspaceResponseSchema = z.object({
 });
 export type CreateWorkspaceResponse = z.infer<typeof CreateWorkspaceResponseSchema>;
 
+export const WorkspaceLookupSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  created_at: z.string(),
+});
+export type WorkspaceLookup = z.infer<typeof WorkspaceLookupSchema>;
+
 export const UpdateWorkspaceRequestSchema = z.object({
   name: z.string().optional(),
   system_prompt: z.string().nullable().optional(),


### PR DESCRIPTION
## Summary
- add TypeScript SDK `RelayCast.lookupWorkspace()` and `RelayCast.ensureWorkspace()` helpers
- add the server workspace-by-name lookup route required by the SDK flow
- expose the shared workspace lookup type/schema and document the SDK usage

cc @willwashburn

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/agentworkforce/relaycast/pull/98" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
