### PR TITLE
fix(sdk): close WS before HTTP disconnect to prevent presence race

### DIFF
--- a/packages/sdk-typescript/src/__tests__/agent-ws.test.ts
+++ b/packages/sdk-typescript/src/__tests__/agent-ws.test.ts
@@ -125,14 +125,18 @@ describe('AgentClient WebSocket integration', () => {
     const ws = MockWebSocket.instances[0]!;
     ws.simulateOpen();
 
-    await agent.disconnect();
+    const p = agent.disconnect();
+    await vi.advanceTimersByTimeAsync(200);
+    await p;
     expect(ws.close).toHaveBeenCalled();
   });
 
   it('disconnect() allows reconnect with a fresh WebSocket', async () => {
     const agent = createAgent();
     agent.connect();
-    await agent.disconnect();
+    const p = agent.disconnect();
+    await vi.advanceTimersByTimeAsync(200);
+    await p;
 
     agent.connect();
     expect(MockWebSocket.instances).toHaveLength(2);
@@ -369,7 +373,9 @@ describe('AgentClient WebSocket integration', () => {
     vi.advanceTimersByTime(30_000);
     expect(mockFetch).toHaveBeenCalledTimes(2);
 
-    await agent.disconnect();
+    const p = agent.disconnect();
+    await vi.advanceTimersByTimeAsync(200);
+    await p;
     expect(mockFetch).toHaveBeenCalledTimes(3);
     expect(mockFetch.mock.calls[2]![0]).toBe('http://localhost:8080/v1/agents/disconnect');
 

--- a/packages/sdk-typescript/src/agent.ts
+++ b/packages/sdk-typescript/src/agent.ts
@@ -191,16 +191,12 @@ export class AgentClient {
     this.stopAutoHeartbeat();
     if (this.ws) {
       // Close the WebSocket first to stop the client ping timer. Server-side,
-      // each ping triggers a fire-and-forget heartbeat to PresenceDO. If we
-      // called markOffline() while the WS was still open, an in-flight
-      // heartbeat could land at PresenceDO *after* the disconnect, re-adding
-      // the agent as online.
+      // the ping handler now awaits the heartbeat to PresenceDO, and the DO
+      // runtime serializes handlers, so by the time webSocketClose fires the
+      // heartbeat has already settled. The HTTP disconnect below then arrives
+      // last and is the authoritative presence update.
       this.ws.disconnect();
       this.ws = null;
-      // Brief pause so any in-flight server-side heartbeat (from a recent
-      // ping) settles at PresenceDO before we send the authoritative
-      // disconnect.
-      await new Promise((r) => setTimeout(r, 150));
     }
     // Always send the HTTP disconnect — it works even without a WS and
     // serves as the authoritative presence update.

--- a/packages/sdk-typescript/src/agent.ts
+++ b/packages/sdk-typescript/src/agent.ts
@@ -190,12 +190,21 @@ export class AgentClient {
   async disconnect(): Promise<void> {
     this.stopAutoHeartbeat();
     if (this.ws) {
-      // Notify the server before closing the WebSocket so presence
-      // updates immediately (works around local DO hibernation issues).
-      await this.presence.markOffline().catch(() => {});
+      // Close the WebSocket first to stop the client ping timer. Server-side,
+      // each ping triggers a fire-and-forget heartbeat to PresenceDO. If we
+      // called markOffline() while the WS was still open, an in-flight
+      // heartbeat could land at PresenceDO *after* the disconnect, re-adding
+      // the agent as online.
       this.ws.disconnect();
       this.ws = null;
+      // Brief pause so any in-flight server-side heartbeat (from a recent
+      // ping) settles at PresenceDO before we send the authoritative
+      // disconnect.
+      await new Promise((r) => setTimeout(r, 150));
     }
+    // Always send the HTTP disconnect — it works even without a WS and
+    // serves as the authoritative presence update.
+    await this.client.post('/v1/agents/disconnect', {}).catch(() => {});
   }
 
   subscribe(channels: string[]): void {

--- a/packages/server/src/durable-objects/agent.ts
+++ b/packages/server/src/durable-objects/agent.ts
@@ -379,12 +379,16 @@ export class AgentDO implements DurableObject {
 
       if (parsed.type === 'ping') {
         ws.send(JSON.stringify({ type: 'pong' }));
-        // Refresh presence so the agent stays "online" in PresenceDO
+        // Refresh presence so the agent stays "online" in PresenceDO.
+        // Await the fetch so the heartbeat completes at PresenceDO before
+        // this handler returns. The DO runtime serializes message handlers
+        // and webSocketClose, so awaiting here guarantees the heartbeat
+        // settles before any subsequent disconnect is processed.
         const meta = await this.state.storage.get<{ workspaceId: string; agentId: string }>('meta');
         if (meta) {
           const doId = this.env.PRESENCE_DO.idFromName(meta.workspaceId);
           const stub = this.env.PRESENCE_DO.get(doId);
-          stub.fetch(new Request('http://do/heartbeat', {
+          await stub.fetch(new Request('http://do/heartbeat', {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({ agentId: meta.agentId, workspaceId: meta.workspaceId }),


### PR DESCRIPTION
## Summary
- Fixes e2e smoke test failure where `BackendAgent` stays "online" after `disconnect()`
- **Root cause**: Server-side ping handler fired a heartbeat to PresenceDO without `await`. If the heartbeat landed at PresenceDO *after* the client's HTTP disconnect, the agent was re-added as online.
- **Fix (server)**: `await` the heartbeat fetch in AgentDO's ping handler. The DO runtime serializes `webSocketMessage` and `webSocketClose`, so awaiting guarantees the heartbeat settles before any subsequent disconnect is processed.
- **Fix (client)**: Close the WebSocket *before* sending the HTTP disconnect. This stops the ping timer immediately. The HTTP call then arrives last as the authoritative presence update.
- Together these guarantee deterministic ordering at PresenceDO: `heartbeat → server disconnect → client HTTP disconnect`

## Test plan
- [x] All 628 SDK + server unit tests pass
- [ ] e2e smoke test should now reliably pass without `BackendAgent` staying online

🤖 Generated with [Claude Code](https://claude.com/claude-code)