### PR TITLE
fix: eliminate presence race by routing disconnect through AgentDO

### DIFF
--- a/packages/server/src/durable-objects/agent.ts
+++ b/packages/server/src/durable-objects/agent.ts
@@ -302,6 +302,10 @@ export class AgentDO implements DurableObject {
       return this.handleDeliver(request);
     }
 
+    if (request.method === 'POST' && url.pathname === '/force-disconnect') {
+      return this.handleForceDisconnect();
+    }
+
     return new Response('Not Found', { status: 404 });
   }
 
@@ -361,6 +365,34 @@ export class AgentDO implements DurableObject {
     this.broadcastToSockets(payload);
 
     return Response.json({ ok: true, agent_seq: seq });
+  }
+
+  /* ------------------------------------------------------------------ */
+  /*  POST /force-disconnect — close all sockets & disconnect presence   */
+  /* ------------------------------------------------------------------ */
+
+  private async handleForceDisconnect(): Promise<Response> {
+    // Close all WebSockets so no further pings can trigger heartbeats.
+    for (const ws of this.state.getWebSockets()) {
+      try { ws.close(1000, 'force-disconnect'); } catch { /* already closed */ }
+    }
+
+    // Send the authoritative disconnect to PresenceDO. Because the DO
+    // runtime serializes handlers, this runs AFTER any in-flight
+    // webSocketMessage (ping heartbeat), guaranteeing the agent ends
+    // up offline.
+    const meta = await this.state.storage.get<AgentConnectionMeta>('meta');
+    if (meta?.workspaceId && meta?.agentId) {
+      const doId = this.env.PRESENCE_DO.idFromName(meta.workspaceId);
+      const stub = this.env.PRESENCE_DO.get(doId);
+      await stub.fetch(new Request('http://do/disconnect', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ agentId: meta.agentId, workspaceId: meta.workspaceId }),
+      })).catch(() => {});
+    }
+
+    return Response.json({ ok: true });
   }
 
   /* ------------------------------------------------------------------ */

--- a/packages/server/src/routes/presence.ts
+++ b/packages/server/src/routes/presence.ts
@@ -49,10 +49,24 @@ presenceRoutes.post('/agents/heartbeat', requireAgentToken, rateLimit, async (c)
 });
 
 // POST /agents/disconnect — explicitly mark agent offline
+// Routes through AgentDO so the disconnect serializes after any in-flight
+// WS ping heartbeats, preventing a stale heartbeat from re-creating the
+// agent's presence entry after the disconnect.
 presenceRoutes.post('/agents/disconnect', requireAgentToken, rateLimit, async (c) => {
   try {
     const agent = c.get('agent')!;
     const workspace = c.get('workspace');
+
+    // Force-disconnect through AgentDO — closes WS and sends authoritative
+    // disconnect to PresenceDO, serialized after any in-flight ping heartbeat.
+    const agentDoId = c.env.AGENT_DO.idFromName(`${workspace.id}:${agent.id}`);
+    const agentDoStub = c.env.AGENT_DO.get(agentDoId);
+    await agentDoStub.fetch(new Request('http://do/force-disconnect', {
+      method: 'POST',
+    })).catch(() => {});
+
+    // Also send a direct disconnect to PresenceDO as a safety net
+    // (e.g. if the AgentDO has no stored meta yet).
     const doId = c.env.PRESENCE_DO.idFromName(workspace.id);
     const stub = c.env.PRESENCE_DO.get(doId);
     await stub.fetch(new Request('http://do/disconnect', {
@@ -60,6 +74,7 @@ presenceRoutes.post('/agents/disconnect', requireAgentToken, rateLimit, async (c
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ agentId: agent.id, workspaceId: workspace.id, agentName: agent.name }),
     }));
+
     emitServerEvent(c, workspace.id, 'relaycast_server_presence_disconnected', {
       agent_id: agent.id,
       agent_name: agent.name,


### PR DESCRIPTION
## Summary
- The HTTP disconnect route (`POST /v1/agents/disconnect`) now sends a `force-disconnect` to the AgentDO before hitting PresenceDO directly
- AgentDO's `/force-disconnect` handler closes all WebSockets and sends the authoritative disconnect to PresenceDO
- Because the DO runtime serializes all handlers, this guarantees the disconnect runs **after** any in-flight WS ping heartbeat, preventing a stale heartbeat from re-creating the agent's presence entry
- The direct PresenceDO disconnect still follows as a safety net

## Problem
When an agent disconnects, a WS ping heartbeat already in-flight on the AgentDO could arrive at PresenceDO **after** the HTTP disconnect deleted the agent entry, re-creating it. With no subsequent disconnect to clean it up, the agent would appear stuck "online" indefinitely.

## Test plan
- [ ] Deploy preview passes e2e smoke test (presence lifecycle section)
- [ ] `markOffline transitions agent to offline` no longer flakes
- [ ] `markOnline brings agent back online` still works after reconnect

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/agentworkforce/relaycast/pull/106" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
