### PR TITLE
fix: remove re-introduced workspace name uniqueness check

### DIFF
--- a/packages/server/src/__tests__/directory.test.ts
+++ b/packages/server/src/__tests__/directory.test.ts
@@ -16,7 +16,7 @@ PRAGMA foreign_keys = ON;
 
 CREATE TABLE workspaces (
   id TEXT PRIMARY KEY NOT NULL,
-  name TEXT NOT NULL UNIQUE,
+  name TEXT NOT NULL,
   api_key_hash TEXT NOT NULL UNIQUE,
   system_prompt TEXT,
   plan TEXT NOT NULL DEFAULT 'free',

--- a/packages/server/src/__tests__/routing.test.ts
+++ b/packages/server/src/__tests__/routing.test.ts
@@ -10,7 +10,7 @@ PRAGMA foreign_keys = ON;
 
 CREATE TABLE workspaces (
   id TEXT PRIMARY KEY NOT NULL,
-  name TEXT NOT NULL UNIQUE,
+  name TEXT NOT NULL,
   api_key_hash TEXT NOT NULL UNIQUE,
   system_prompt TEXT,
   plan TEXT NOT NULL DEFAULT 'free',

--- a/packages/server/src/db/migrations/0009_drop_workspace_name_unique.sql
+++ b/packages/server/src/db/migrations/0009_drop_workspace_name_unique.sql
@@ -1,0 +1,4 @@
+-- Drop global uniqueness constraint on workspace names.
+-- Workspace names are NOT globally unique — multiple workspaces can share a name.
+-- The apiKeyHash column remains globally unique for workspace identification.
+DROP INDEX IF EXISTS `workspaces_name_unique`;

--- a/packages/server/src/db/schema.ts
+++ b/packages/server/src/db/schema.ts
@@ -14,7 +14,7 @@ import type { AnySQLiteColumn } from 'drizzle-orm/sqlite-core';
 // ============================================
 export const workspaces = sqliteTable('workspaces', {
   id: text('id').primaryKey(),
-  name: text('name').notNull().unique(),
+  name: text('name').notNull(),
   apiKeyHash: text('api_key_hash').notNull().unique(),
   systemPrompt: text('system_prompt'),
   plan: text('plan').notNull().default('free'),

--- a/packages/server/src/engine/workspace.ts
+++ b/packages/server/src/engine/workspace.ts
@@ -7,17 +7,6 @@ import { generateId } from './snowflake.js';
 type Db = ReturnType<typeof getDb>;
 
 export async function createWorkspace(db: Db, name: string) {
-  // Check for duplicate name
-  const [existing] = await db
-    .select()
-    .from(workspaces)
-    .where(eq(workspaces.name, name));
-  if (existing) {
-    const err = new Error(`Workspace "${name}" already exists`);
-    Object.assign(err, { code: 'workspace_already_exists', status: 409 });
-    throw err;
-  }
-
   const workspaceId = generateId();
   const apiKey = `rk_live_${crypto.randomBytes(16).toString('hex')}`;
   const apiKeyHash = crypto


### PR DESCRIPTION
## Summary
Part 2 of 2 — merge after #113.

Removes the engine-level duplicate workspace name check that PR #78
re-introduced from a stale branch base. PR #77 originally removed it,
PR #76 dropped the DB constraint.

## Depends on
- #113 (schema + test alignment — merge first)

## Test plan
- [ ] Two workspaces with the same name can be created via API
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)