### PR TITLE
fix: remove unique constraint from workspace name in schema and tests

### DIFF
--- a/packages/server/src/__tests__/directory.test.ts
+++ b/packages/server/src/__tests__/directory.test.ts
@@ -16,7 +16,7 @@ PRAGMA foreign_keys = ON;
 
 CREATE TABLE workspaces (
   id TEXT PRIMARY KEY NOT NULL,
-  name TEXT NOT NULL UNIQUE,
+  name TEXT NOT NULL,
   api_key_hash TEXT NOT NULL UNIQUE,
   system_prompt TEXT,
   plan TEXT NOT NULL DEFAULT 'free',

--- a/packages/server/src/__tests__/routing.test.ts
+++ b/packages/server/src/__tests__/routing.test.ts
@@ -10,7 +10,7 @@ PRAGMA foreign_keys = ON;
 
 CREATE TABLE workspaces (
   id TEXT PRIMARY KEY NOT NULL,
-  name TEXT NOT NULL UNIQUE,
+  name TEXT NOT NULL,
   api_key_hash TEXT NOT NULL UNIQUE,
   system_prompt TEXT,
   plan TEXT NOT NULL DEFAULT 'free',

--- a/packages/server/src/db/migrations/0009_drop_workspace_name_unique.sql
+++ b/packages/server/src/db/migrations/0009_drop_workspace_name_unique.sql
@@ -1,0 +1,4 @@
+-- Drop global uniqueness constraint on workspace names.
+-- Workspace names are NOT globally unique — multiple workspaces can share a name.
+-- The apiKeyHash column remains globally unique for workspace identification.
+DROP INDEX IF EXISTS `workspaces_name_unique`;

--- a/packages/server/src/db/schema.ts
+++ b/packages/server/src/db/schema.ts
@@ -14,7 +14,7 @@ import type { AnySQLiteColumn } from 'drizzle-orm/sqlite-core';
 // ============================================
 export const workspaces = sqliteTable('workspaces', {
   id: text('id').primaryKey(),
-  name: text('name').notNull().unique(),
+  name: text('name').notNull(),
   apiKeyHash: text('api_key_hash').notNull().unique(),
   systemPrompt: text('system_prompt'),
   plan: text('plan').notNull().default('free'),


### PR DESCRIPTION
## Summary
Part 1 of 2 — deploy this first, then the engine check removal.

PR #76 added migration `0003_workspace_name_not_globally_unique.sql` to drop the unique index, but the Drizzle schema and test SQL weren't updated:
- `packages/server/src/db/schema.ts` — remove `.unique()` from `name` column
- `packages/server/src/__tests__/directory.test.ts` — remove `UNIQUE` from inline SQL
- `packages/server/src/__tests__/routing.test.ts` — remove `UNIQUE` from inline SQL

## Test plan
- [ ] CI tests pass
- [ ] Drizzle schema matches production DB (migration already applied)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/agentworkforce/relaycast/pull/113" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
