### PR TITLE
feat: idempotent workspace creation — same name+owner returns existing

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,13 +88,17 @@ npx tsx quickstart.ts
 
 That is the canonical onboarding loop: create workspace, register agents, connect realtime streams, and watch messages flow live.
 
-If you want idempotent setup by workspace name, use `ensureWorkspace()`:
+Workspace names are not globally unique. Workspace creation is idempotent for the same workspace name and API key: repeating that combination returns the existing workspace instead of creating another one.
+
+If you want an explicit SDK helper that tells you whether setup returned an existing workspace or created a new one, use `ensureWorkspace()`:
 
 ```ts
-const ensured = await RelayCast.ensureWorkspace('my-project');
+const ensured = await RelayCast.ensureWorkspace('my-project', {
+  apiKey: knownWorkspaceKey,
+});
 
 if (ensured.existed) {
-  console.log(`Workspace already exists as ${ensured.id}`);
+  console.log(`Workspace already exists as ${ensured.workspaceId}`);
   // Existing workspace keys are not recoverable from the API.
   // Reuse the known rk_live_* key you already have for this workspace.
 } else {
@@ -248,7 +252,9 @@ Remote Streamable HTTP config:
 ## REST Quick Start
 
 ```bash
-# Create workspace (names must be unique)
+# Create workspace
+# Workspace names are not globally unique.
+# Reusing the same name with the same Authorization bearer workspace key returns the existing workspace.
 curl -X POST https://api.relaycast.dev/v1/workspaces \
   -H "Content-Type: application/json" \
   -d '{"name": "my-project"}'

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -345,9 +345,12 @@ paths:
   /workspaces:
     post:
       summary: Create workspace
-      description: Create a new workspace and get an API key. Workspace names must be unique.
+      description: Create a workspace and get an API key when a new workspace is created. This operation is idempotent by workspace name for the same bearer workspace key: if you repeat the call with the same name and the same `Authorization: Bearer rk_*` key, the existing workspace is returned with a `200` response; otherwise a new workspace is created and returned with a `201` response.
       tags:
         - Workspaces
+      security:
+        - {}
+        - workspaceKey: []
       requestBody:
         required: true
         content:
@@ -360,6 +363,17 @@ paths:
                 name:
                   type: string
       responses:
+        '200':
+          description: Existing workspace returned (idempotent)
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                  data:
+                    $ref: '#/components/schemas/Workspace'
         '201':
           description: Workspace created
           content:
@@ -373,12 +387,6 @@ paths:
                     $ref: '#/components/schemas/Workspace'
         '400':
           description: Invalid request
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse'
-        '409':
-          description: Workspace name already exists
           content:
             application/json:
               schema:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -50,6 +50,22 @@ components:
           type: string
           format: date-time
 
+    CreateWorkspaceResponse:
+      type: object
+      required:
+        - workspace_id
+        - created_at
+      properties:
+        workspace_id:
+          type: string
+          description: Snowflake ID of the workspace
+        api_key:
+          type: string
+          description: Workspace API key (only returned on first creation)
+        created_at:
+          type: string
+          format: date-time
+
     WorkspaceLookup:
       type: object
       required:
@@ -373,7 +389,7 @@ paths:
                   ok:
                     type: boolean
                   data:
-                    $ref: '#/components/schemas/Workspace'
+                    $ref: '#/components/schemas/CreateWorkspaceResponse'
         '201':
           description: Workspace created
           content:
@@ -384,7 +400,7 @@ paths:
                   ok:
                     type: boolean
                   data:
-                    $ref: '#/components/schemas/Workspace'
+                    $ref: '#/components/schemas/CreateWorkspaceResponse'
         '400':
           description: Invalid request
           content:

--- a/packages/local/src/main.rs
+++ b/packages/local/src/main.rs
@@ -58,7 +58,7 @@ struct Store {
     channel_by_workspace_name: HashMap<String, String>,
     channel_members: HashMap<String, HashSet<String>>, // channel_id -> agent_ids
     #[serde(default)]
-    channel_muted: HashMap<String, HashSet<String>>,  // channel_id -> muted agent_ids
+    channel_muted: HashMap<String, HashSet<String>>, // channel_id -> muted agent_ids
 
     messages: HashMap<String, MessageRecord>,
     channel_messages: HashMap<String, Vec<String>>, // channel_id -> message_ids
@@ -630,6 +630,7 @@ struct CreateWorkspaceRequest {
 
 async fn create_workspace(
     State(state): State<AppState>,
+    headers: HeaderMap,
     payload: Result<Json<CreateWorkspaceRequest>, axum::extract::rejection::JsonRejection>,
 ) -> Response {
     let Ok(Json(payload)) = payload else {
@@ -646,6 +647,21 @@ async fn create_workspace(
     }
 
     let workspace_name = workspace_name.to_string();
+    let existing_api_key = auth_header_token(&headers).filter(|token| token.starts_with("rk_"));
+    let mut store = state.store.write().await;
+    if let Some(existing_workspace) = existing_api_key
+        .as_ref()
+        .and_then(|api_key| store.workspace_by_key.get(api_key))
+        .and_then(|workspace_id| store.workspaces.get(workspace_id))
+        .filter(|workspace| workspace.name == workspace_name)
+    {
+        return ok(json!({
+            "workspace_id": existing_workspace.id,
+            "api_key": existing_workspace.api_key,
+            "created_at": existing_workspace.created_at,
+        }));
+    }
+
     let workspace_id = new_id("ws");
     let api_key = random_token("rk_live_");
     let created_at = now_iso();
@@ -660,15 +676,6 @@ async fn create_workspace(
         metadata: Map::new(),
     };
 
-    let mut store = state.store.write().await;
-    let duplicate = store.workspaces.values().any(|ws| ws.name == workspace_name);
-    if duplicate {
-        return err(
-            StatusCode::CONFLICT,
-            "workspace_already_exists",
-            format!("Workspace \"{}\" already exists", workspace_name),
-        );
-    }
     store
         .workspace_by_key
         .insert(api_key.clone(), workspace_id.clone());
@@ -5031,54 +5038,127 @@ async fn ws_session(mut socket: WebSocket, state: AppState, auth: AuthContext) {
 // The local daemon does not implement the full A2A platform but exposes
 // stub endpoints so the contract-parity check passes.
 
-async fn a2a_register(State(_state): State<AppState>, headers: HeaderMap, Json(body): Json<Value>) -> Response {
+async fn a2a_register(
+    State(_state): State<AppState>,
+    headers: HeaderMap,
+    Json(body): Json<Value>,
+) -> Response {
     let store_guard = _state.store.read().await;
-    let workspace_id = match auth_workspace(&store_guard, &headers) { Ok(id) => id, Err(r) => return r };
+    let workspace_id = match auth_workspace(&store_guard, &headers) {
+        Ok(id) => id,
+        Err(r) => return r,
+    };
     drop(store_guard);
-    let name = body.get("agent_card").and_then(|c| c.get("name")).and_then(Value::as_str).unwrap_or("a2a-agent");
-    created(json!({ "relay_name": name, "relay_token": format!("at_live_{}", Uuid::new_v4()), "webhook_url": format!("/a2a/webhook/{}/{}", workspace_id, name) }))
+    let name = body
+        .get("agent_card")
+        .and_then(|c| c.get("name"))
+        .and_then(Value::as_str)
+        .unwrap_or("a2a-agent");
+    created(
+        json!({ "relay_name": name, "relay_token": format!("at_live_{}", Uuid::new_v4()), "webhook_url": format!("/a2a/webhook/{}/{}", workspace_id, name) }),
+    )
 }
 
 async fn a2a_list_agents(State(state): State<AppState>, headers: HeaderMap) -> Response {
     let store = state.store.read().await;
-    match auth_workspace(&store, &headers) { Ok(_) => ok(json!([])), Err(r) => r }
+    match auth_workspace(&store, &headers) {
+        Ok(_) => ok(json!([])),
+        Err(r) => r,
+    }
 }
 
-async fn a2a_get_agent_card(State(state): State<AppState>, headers: HeaderMap, Path(_name): Path<String>) -> Response {
+async fn a2a_get_agent_card(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+    Path(_name): Path<String>,
+) -> Response {
     let store = state.store.read().await;
-    match auth_workspace(&store, &headers) { Ok(_) => err(StatusCode::NOT_FOUND, "a2a_agent_not_found", "A2A agent not found"), Err(r) => r }
+    match auth_workspace(&store, &headers) {
+        Ok(_) => err(
+            StatusCode::NOT_FOUND,
+            "a2a_agent_not_found",
+            "A2A agent not found",
+        ),
+        Err(r) => r,
+    }
 }
 
-async fn a2a_delete_agent(State(state): State<AppState>, headers: HeaderMap, Path(_name): Path<String>) -> Response {
+async fn a2a_delete_agent(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+    Path(_name): Path<String>,
+) -> Response {
     let store = state.store.read().await;
-    match auth_workspace(&store, &headers) { Ok(_) => err(StatusCode::NOT_FOUND, "a2a_agent_not_found", "A2A agent not found"), Err(r) => r }
+    match auth_workspace(&store, &headers) {
+        Ok(_) => err(
+            StatusCode::NOT_FOUND,
+            "a2a_agent_not_found",
+            "A2A agent not found",
+        ),
+        Err(r) => r,
+    }
 }
 
-async fn a2a_rpc(State(state): State<AppState>, headers: HeaderMap, Json(_body): Json<Value>) -> Response {
+async fn a2a_rpc(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+    Json(_body): Json<Value>,
+) -> Response {
     let store = state.store.read().await;
-    match auth_workspace(&store, &headers) { Ok(_) => ok(json!({"jsonrpc":"2.0","id":null,"result":{}})), Err(r) => r }
+    match auth_workspace(&store, &headers) {
+        Ok(_) => ok(json!({"jsonrpc":"2.0","id":null,"result":{}})),
+        Err(r) => r,
+    }
 }
 
-async fn a2a_webhook(State(_state): State<AppState>, Path((_workspace_id, _name)): Path<(String, String)>, Json(_body): Json<Value>) -> Response {
-    err(StatusCode::NOT_FOUND, "a2a_agent_not_found", "A2A agent not found")
+async fn a2a_webhook(
+    State(_state): State<AppState>,
+    Path((_workspace_id, _name)): Path<(String, String)>,
+    Json(_body): Json<Value>,
+) -> Response {
+    err(
+        StatusCode::NOT_FOUND,
+        "a2a_agent_not_found",
+        "A2A agent not found",
+    )
 }
 
 async fn a2a_well_known_agent_card(State(state): State<AppState>, headers: HeaderMap) -> Response {
     let store = state.store.read().await;
     match auth_workspace(&store, &headers) {
-        Ok(_) => ok(json!({"name":"local","description":"Local Relaycast","url":"http://localhost:7528","version":"0.1.0","skills":[]})),
+        Ok(_) => ok(
+            json!({"name":"local","description":"Local Relaycast","url":"http://localhost:7528","version":"0.1.0","skills":[]}),
+        ),
         Err(r) => r,
     }
 }
 
-async fn certify_create(State(state): State<AppState>, headers: HeaderMap, Json(_body): Json<Value>) -> Response {
+async fn certify_create(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+    Json(_body): Json<Value>,
+) -> Response {
     let store = state.store.read().await;
-    match auth_workspace(&store, &headers) { Ok(_) => created(json!({"id": Uuid::new_v4().to_string(), "status":"pending"})), Err(r) => r }
+    match auth_workspace(&store, &headers) {
+        Ok(_) => created(json!({"id": Uuid::new_v4().to_string(), "status":"pending"})),
+        Err(r) => r,
+    }
 }
 
-async fn certify_get(State(state): State<AppState>, headers: HeaderMap, Path(_id): Path<String>) -> Response {
+async fn certify_get(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+    Path(_id): Path<String>,
+) -> Response {
     let store = state.store.read().await;
-    match auth_workspace(&store, &headers) { Ok(_) => err(StatusCode::NOT_FOUND, "not_found", "Certification not found"), Err(r) => r }
+    match auth_workspace(&store, &headers) {
+        Ok(_) => err(
+            StatusCode::NOT_FOUND,
+            "not_found",
+            "Certification not found",
+        ),
+        Err(r) => r,
+    }
 }
 
 async fn certify_badge(State(_state): State<AppState>, Path(_id): Path<String>) -> Response {
@@ -5086,99 +5166,216 @@ async fn certify_badge(State(_state): State<AppState>, Path(_id): Path<String>) 
     (StatusCode::OK, [("content-type", "image/svg+xml")], svg).into_response()
 }
 
-async fn certify_monitor(State(state): State<AppState>, headers: HeaderMap, Json(_body): Json<Value>) -> Response {
+async fn certify_monitor(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+    Json(_body): Json<Value>,
+) -> Response {
     let store = state.store.read().await;
-    match auth_workspace(&store, &headers) { Ok(_) => ok(json!({"enabled":true})), Err(r) => r }
+    match auth_workspace(&store, &headers) {
+        Ok(_) => ok(json!({"enabled":true})),
+        Err(r) => r,
+    }
 }
 
 async fn console_messages(State(state): State<AppState>, headers: HeaderMap) -> Response {
     let store = state.store.read().await;
-    match auth_workspace(&store, &headers) { Ok(_) => ok(json!([])), Err(r) => r }
+    match auth_workspace(&store, &headers) {
+        Ok(_) => ok(json!([])),
+        Err(r) => r,
+    }
 }
 
 async fn console_stats(State(state): State<AppState>, headers: HeaderMap) -> Response {
     let store = state.store.read().await;
-    match auth_workspace(&store, &headers) { Ok(_) => ok(json!({"messages":0,"agents":0,"channels":0})), Err(r) => r }
+    match auth_workspace(&store, &headers) {
+        Ok(_) => ok(json!({"messages":0,"agents":0,"channels":0})),
+        Err(r) => r,
+    }
 }
 
 async fn console_agents(State(state): State<AppState>, headers: HeaderMap) -> Response {
     let store = state.store.read().await;
-    match auth_workspace(&store, &headers) { Ok(_) => ok(json!([])), Err(r) => r }
+    match auth_workspace(&store, &headers) {
+        Ok(_) => ok(json!([])),
+        Err(r) => r,
+    }
 }
 
 async fn console_costs(State(state): State<AppState>, headers: HeaderMap) -> Response {
     let store = state.store.read().await;
-    match auth_workspace(&store, &headers) { Ok(_) => ok(json!([])), Err(r) => r }
+    match auth_workspace(&store, &headers) {
+        Ok(_) => ok(json!([])),
+        Err(r) => r,
+    }
 }
 
-async fn directory_create_agent(State(state): State<AppState>, headers: HeaderMap, Json(_body): Json<Value>) -> Response {
+async fn directory_create_agent(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+    Json(_body): Json<Value>,
+) -> Response {
     let store = state.store.read().await;
-    match auth_workspace(&store, &headers) { Ok(_) => created(json!({"id": Uuid::new_v4().to_string()})), Err(r) => r }
+    match auth_workspace(&store, &headers) {
+        Ok(_) => created(json!({"id": Uuid::new_v4().to_string()})),
+        Err(r) => r,
+    }
 }
 
 async fn directory_list_agents(State(state): State<AppState>, headers: HeaderMap) -> Response {
     let store = state.store.read().await;
-    match auth_workspace(&store, &headers) { Ok(_) => ok(json!([])), Err(r) => r }
+    match auth_workspace(&store, &headers) {
+        Ok(_) => ok(json!([])),
+        Err(r) => r,
+    }
 }
 
 async fn directory_search(State(state): State<AppState>, headers: HeaderMap) -> Response {
     let store = state.store.read().await;
-    match auth_workspace(&store, &headers) { Ok(_) => ok(json!([])), Err(r) => r }
+    match auth_workspace(&store, &headers) {
+        Ok(_) => ok(json!([])),
+        Err(r) => r,
+    }
 }
 
-async fn directory_get_agent(State(state): State<AppState>, headers: HeaderMap, Path(_slug): Path<String>) -> Response {
+async fn directory_get_agent(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+    Path(_slug): Path<String>,
+) -> Response {
     let store = state.store.read().await;
-    match auth_workspace(&store, &headers) { Ok(_) => err(StatusCode::NOT_FOUND, "not_found", "Directory agent not found"), Err(r) => r }
+    match auth_workspace(&store, &headers) {
+        Ok(_) => err(
+            StatusCode::NOT_FOUND,
+            "not_found",
+            "Directory agent not found",
+        ),
+        Err(r) => r,
+    }
 }
 
-async fn directory_patch_agent(State(state): State<AppState>, headers: HeaderMap, Path(_slug): Path<String>, Json(_body): Json<Value>) -> Response {
+async fn directory_patch_agent(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+    Path(_slug): Path<String>,
+    Json(_body): Json<Value>,
+) -> Response {
     let store = state.store.read().await;
-    match auth_workspace(&store, &headers) { Ok(_) => err(StatusCode::NOT_FOUND, "not_found", "Directory agent not found"), Err(r) => r }
+    match auth_workspace(&store, &headers) {
+        Ok(_) => err(
+            StatusCode::NOT_FOUND,
+            "not_found",
+            "Directory agent not found",
+        ),
+        Err(r) => r,
+    }
 }
 
-async fn directory_delete_agent(State(state): State<AppState>, headers: HeaderMap, Path(_slug): Path<String>) -> Response {
+async fn directory_delete_agent(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+    Path(_slug): Path<String>,
+) -> Response {
     let store = state.store.read().await;
-    match auth_workspace(&store, &headers) { Ok(_) => err(StatusCode::NOT_FOUND, "not_found", "Directory agent not found"), Err(r) => r }
+    match auth_workspace(&store, &headers) {
+        Ok(_) => err(
+            StatusCode::NOT_FOUND,
+            "not_found",
+            "Directory agent not found",
+        ),
+        Err(r) => r,
+    }
 }
 
-async fn directory_get_ratings(State(state): State<AppState>, headers: HeaderMap, Path(_slug): Path<String>) -> Response {
+async fn directory_get_ratings(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+    Path(_slug): Path<String>,
+) -> Response {
     let store = state.store.read().await;
-    match auth_workspace(&store, &headers) { Ok(_) => ok(json!([])), Err(r) => r }
+    match auth_workspace(&store, &headers) {
+        Ok(_) => ok(json!([])),
+        Err(r) => r,
+    }
 }
 
-async fn directory_post_rating(State(state): State<AppState>, headers: HeaderMap, Path(_slug): Path<String>, Json(_body): Json<Value>) -> Response {
+async fn directory_post_rating(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+    Path(_slug): Path<String>,
+    Json(_body): Json<Value>,
+) -> Response {
     let store = state.store.read().await;
-    match auth_workspace(&store, &headers) { Ok(_) => created(json!({"id": Uuid::new_v4().to_string()})), Err(r) => r }
+    match auth_workspace(&store, &headers) {
+        Ok(_) => created(json!({"id": Uuid::new_v4().to_string()})),
+        Err(r) => r,
+    }
 }
 
-async fn route_message(State(state): State<AppState>, headers: HeaderMap, Json(_body): Json<Value>) -> Response {
+async fn route_message(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+    Json(_body): Json<Value>,
+) -> Response {
     let store = state.store.read().await;
-    match auth_workspace(&store, &headers) { Ok(_) => ok(json!({"agent":null,"reason":"no routing config"})), Err(r) => r }
+    match auth_workspace(&store, &headers) {
+        Ok(_) => ok(json!({"agent":null,"reason":"no routing config"})),
+        Err(r) => r,
+    }
 }
 
-async fn route_feedback(State(state): State<AppState>, headers: HeaderMap, Json(_body): Json<Value>) -> Response {
+async fn route_feedback(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+    Json(_body): Json<Value>,
+) -> Response {
     let store = state.store.read().await;
-    match auth_workspace(&store, &headers) { Ok(_) => ok(json!({"recorded":true})), Err(r) => r }
+    match auth_workspace(&store, &headers) {
+        Ok(_) => ok(json!({"recorded":true})),
+        Err(r) => r,
+    }
 }
 
 async fn skills_search(State(state): State<AppState>, headers: HeaderMap) -> Response {
     let store = state.store.read().await;
-    match auth_workspace(&store, &headers) { Ok(_) => ok(json!([])), Err(r) => r }
+    match auth_workspace(&store, &headers) {
+        Ok(_) => ok(json!([])),
+        Err(r) => r,
+    }
 }
 
-async fn skills_sync(State(state): State<AppState>, headers: HeaderMap, Json(_body): Json<Value>) -> Response {
+async fn skills_sync(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+    Json(_body): Json<Value>,
+) -> Response {
     let store = state.store.read().await;
-    match auth_workspace(&store, &headers) { Ok(_) => ok(json!({"synced":0})), Err(r) => r }
+    match auth_workspace(&store, &headers) {
+        Ok(_) => ok(json!({"synced":0})),
+        Err(r) => r,
+    }
 }
 
 async fn routing_get_config(State(state): State<AppState>, headers: HeaderMap) -> Response {
     let store = state.store.read().await;
-    match auth_workspace(&store, &headers) { Ok(_) => ok(json!({"weights":{},"circuit_breaker_threshold":3,"circuit_breaker_cooldown_seconds":60})), Err(r) => r }
+    match auth_workspace(&store, &headers) {
+        Ok(_) => ok(
+            json!({"weights":{},"circuit_breaker_threshold":3,"circuit_breaker_cooldown_seconds":60}),
+        ),
+        Err(r) => r,
+    }
 }
 
-async fn routing_put_config(State(state): State<AppState>, headers: HeaderMap, Json(_body): Json<Value>) -> Response {
+async fn routing_put_config(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+    Json(_body): Json<Value>,
+) -> Response {
     let store = state.store.read().await;
-    match auth_workspace(&store, &headers) { Ok(_) => ok(json!({"updated":true})), Err(r) => r }
+    match auth_workspace(&store, &headers) {
+        Ok(_) => ok(json!({"updated":true})),
+        Err(r) => r,
+    }
 }
 
 fn app_router(state: AppState) -> Router {
@@ -5186,10 +5383,7 @@ fn app_router(state: AppState) -> Router {
         .route("/health", get(health))
         .route("/v1/ws", get(ws_upgrade))
         .route("/v1/workspaces", post(create_workspace))
-        .route(
-            "/v1/workspaces/by-name/{name}",
-            get(get_workspace_by_name),
-        )
+        .route("/v1/workspaces/by-name/{name}", get(get_workspace_by_name))
         .route(
             "/v1/workspace",
             get(get_workspace)
@@ -5291,7 +5485,10 @@ fn app_router(state: AppState) -> Router {
         .route("/v1/commands/{command}", delete(delete_command))
         .route("/v1/commands/{command}/invoke", post(invoke_command))
         // A2A
-        .route("/.well-known/agent-card.json", get(a2a_well_known_agent_card))
+        .route(
+            "/.well-known/agent-card.json",
+            get(a2a_well_known_agent_card),
+        )
         .route("/v1/a2a/register", post(a2a_register))
         .route("/v1/a2a/agents", get(a2a_list_agents))
         .route("/v1/a2a/agents/{name}/card", get(a2a_get_agent_card))
@@ -5309,16 +5506,30 @@ fn app_router(state: AppState) -> Router {
         .route("/v1/console/agents", get(console_agents))
         .route("/v1/console/costs", get(console_costs))
         // Directory
-        .route("/v1/directory/agents", post(directory_create_agent).get(directory_list_agents))
+        .route(
+            "/v1/directory/agents",
+            post(directory_create_agent).get(directory_list_agents),
+        )
         .route("/v1/directory/search", get(directory_search))
-        .route("/v1/directory/agents/{slug}", get(directory_get_agent).patch(directory_patch_agent).delete(directory_delete_agent))
-        .route("/v1/directory/agents/{slug}/ratings", get(directory_get_ratings).post(directory_post_rating))
+        .route(
+            "/v1/directory/agents/{slug}",
+            get(directory_get_agent)
+                .patch(directory_patch_agent)
+                .delete(directory_delete_agent),
+        )
+        .route(
+            "/v1/directory/agents/{slug}/ratings",
+            get(directory_get_ratings).post(directory_post_rating),
+        )
         // Routing & Skills
         .route("/v1/route", post(route_message))
         .route("/v1/route/feedback", post(route_feedback))
         .route("/v1/skills/search", get(skills_search))
         .route("/v1/skills/sync", post(skills_sync))
-        .route("/v1/routing/config", get(routing_get_config).put(routing_put_config))
+        .route(
+            "/v1/routing/config",
+            get(routing_get_config).put(routing_put_config),
+        )
         .fallback(|| async { err(StatusCode::NOT_FOUND, "not_found", "Route not found") })
         .layer(
             CorsLayer::new()
@@ -5388,7 +5599,10 @@ mod tests {
 
     #[test]
     fn normalize_workspace_name_preserves_inner_whitespace() {
-        assert_eq!(normalize_workspace_name("  test workspace  "), "test workspace");
+        assert_eq!(
+            normalize_workspace_name("  test workspace  "),
+            "test workspace"
+        );
     }
 
     #[test]

--- a/packages/sdk-typescript/src/__tests__/relay-connection.test.ts
+++ b/packages/sdk-typescript/src/__tests__/relay-connection.test.ts
@@ -54,4 +54,18 @@ describe('RelayCast baseUrl options', () => {
     const [url] = mockFetch.mock.calls[0]!;
     expect(url).toBe('https://api.relaycast.dev/v1/workspaces');
   });
+
+  it('createWorkspace supports options object with auth', async () => {
+    const { RelayCast } = await import('../relay.js');
+    mockFetch.mockImplementation(() => mockWorkspaceResponse());
+
+    await RelayCast.createWorkspace('Test Workspace', {
+      apiKey: 'rk_live_existing',
+      baseUrl: 'http://127.0.0.1:7528',
+    });
+
+    const [url, init] = mockFetch.mock.calls[0]!;
+    expect(url).toBe('http://127.0.0.1:7528/v1/workspaces');
+    expect(init.headers.Authorization).toBe('Bearer rk_live_existing');
+  });
 });

--- a/packages/sdk-typescript/src/__tests__/relay.test.ts
+++ b/packages/sdk-typescript/src/__tests__/relay.test.ts
@@ -691,7 +691,7 @@ describe('RelayCast', () => {
       mockFetch.mockImplementation(() =>
         Promise.resolve({
           ok: true,
-          status: 200,
+          status: 201,
           json: () =>
             Promise.resolve({
               ok: true,
@@ -734,23 +734,31 @@ describe('RelayCast', () => {
       expect(url).toBe('http://localhost:3000/v1/workspaces');
     });
 
-    it('throws RelayError on failure', async () => {
+    it('returns an existing workspace on idempotent duplicate create', async () => {
       const { RelayCast } = await import('../relay.js');
-      const { RelayError } = await import('../client.js');
 
       mockFetch.mockImplementation(() =>
         Promise.resolve({
-          ok: false,
-          status: 409,
+          ok: true,
+          status: 200,
           json: () =>
             Promise.resolve({
-              ok: false,
-              error: { code: 'workspace_exists', message: 'Already exists' },
+              ok: true,
+              data: { workspace_id: 'ws_existing', created_at: '2024-01-02' },
             }),
         }),
       );
 
-      await expect(RelayCast.createWorkspace('Dup')).rejects.toBeInstanceOf(RelayError);
+      await expect(
+        RelayCast.createWorkspace('Dup', { apiKey: 'rk_live_existing', baseUrl: 'http://localhost:3000' }),
+      ).resolves.toEqual({
+        workspaceId: 'ws_existing',
+        createdAt: '2024-01-02',
+      });
+
+      const [url, init] = mockFetch.mock.calls[0]!;
+      expect(url).toBe('http://localhost:3000/v1/workspaces');
+      expect(init.headers.Authorization).toBe('Bearer rk_live_existing');
     });
   });
 
@@ -805,7 +813,7 @@ describe('RelayCast', () => {
       mockFetch.mockImplementation(() =>
         Promise.resolve({
           ok: true,
-          status: 200,
+          status: 201,
           json: () =>
             Promise.resolve({
               ok: true,
@@ -825,41 +833,33 @@ describe('RelayCast', () => {
       expect(mockFetch).toHaveBeenCalledTimes(1);
     });
 
-    it('looks up existing workspace metadata after a create conflict', async () => {
+    it('returns the existing workspace when create is idempotent', async () => {
       const { RelayCast } = await import('../relay.js');
 
-      mockFetch
-        .mockImplementationOnce(() =>
-          Promise.resolve({
-            ok: false,
-            status: 409,
-            json: () =>
-              Promise.resolve({
-                ok: false,
-                error: { code: 'workspace_already_exists', message: 'Already exists' },
-              }),
-          }),
-        )
-        .mockImplementationOnce(() =>
-          Promise.resolve({
-            ok: true,
-            status: 200,
-            json: () =>
-              Promise.resolve({
-                ok: true,
-                data: { id: 'ws_existing', name: 'Taken Workspace', created_at: '2024-01-02' },
-              }),
-          }),
-        );
+      mockFetch.mockImplementation(() =>
+        Promise.resolve({
+          ok: true,
+          status: 200,
+          json: () =>
+            Promise.resolve({
+              ok: true,
+              data: { workspace_id: 'ws_existing', created_at: '2024-01-02' },
+            }),
+        }),
+      );
 
-      const result = await RelayCast.ensureWorkspace('Taken Workspace');
+      const result = await RelayCast.ensureWorkspace('Taken Workspace', {
+        apiKey: 'rk_live_existing',
+        baseUrl: 'http://localhost:3000',
+      });
       expect(result).toEqual({
         existed: true,
-        id: 'ws_existing',
         name: 'Taken Workspace',
+        workspaceId: 'ws_existing',
         createdAt: '2024-01-02',
       });
-      expect(mockFetch).toHaveBeenCalledTimes(2);
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+      expect(mockFetch.mock.calls[0]?.[1]?.headers.Authorization).toBe('Bearer rk_live_existing');
     });
   });
 

--- a/packages/sdk-typescript/src/relay.ts
+++ b/packages/sdk-typescript/src/relay.ts
@@ -77,9 +77,12 @@ export interface WorkspaceStreamConfig {
   override: boolean | null;
 }
 
-export type EnsureWorkspaceResponse =
-  | ({ existed: false; name: string } & CreateWorkspaceResponse)
-  | ({ existed: true } & WorkspaceLookup);
+export interface WorkspaceBootstrapOptions {
+  apiKey?: string;
+  baseUrl?: string;
+}
+
+export type EnsureWorkspaceResponse = { existed: boolean; name: string } & CreateWorkspaceResponse;
 
 interface ChannelListOptions {
   includeArchived?: boolean;
@@ -94,6 +97,15 @@ interface CommandRegisterInput {
 
 type RegisterTypedIdentityInput = Omit<CreateAgentRequest, 'type'>;
 type RegisterIdentityType = NonNullable<CreateAgentRequest['type']>;
+
+function resolveWorkspaceBootstrapOptions(
+  options?: string | WorkspaceBootstrapOptions,
+): WorkspaceBootstrapOptions {
+  if (typeof options === 'string') {
+    return { baseUrl: options };
+  }
+  return options ?? {};
+}
 
 export class RelayCast {
   private client: HttpClient;
@@ -112,8 +124,17 @@ export class RelayCast {
 
   static async createWorkspace(
     name: string,
-    baseUrl?: string,
+    options?: string | WorkspaceBootstrapOptions,
   ): Promise<CreateWorkspaceResponse> {
+    const { data } = await RelayCast.createWorkspaceWithStatus(name, options);
+    return data;
+  }
+
+  private static async createWorkspaceWithStatus(
+    name: string,
+    options?: string | WorkspaceBootstrapOptions,
+  ): Promise<{ data: CreateWorkspaceResponse; statusCode: number }> {
+    const { apiKey, baseUrl } = resolveWorkspaceBootstrapOptions(options);
     const requestBaseUrl = baseUrl ?? 'https://api.relaycast.dev';
 
     const url = new URL('/v1/workspaces', requestBaseUrl);
@@ -121,6 +142,7 @@ export class RelayCast {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
+        ...(apiKey ? { Authorization: `Bearer ${apiKey}` } : {}),
         'X-SDK-Version': SDK_VERSION,
         'X-Relaycast-Origin-Surface': SDK_ORIGIN.surface,
         'X-Relaycast-Origin-Client': SDK_ORIGIN.client,
@@ -153,7 +175,10 @@ export class RelayCast {
       throw relayErrorFromApi(envelope.data.error.code, envelope.data.error.message, res.status);
     }
 
-    return camelizeKeys(envelope.data.data);
+    return {
+      data: camelizeKeys(envelope.data.data),
+      statusCode: res.status,
+    };
   }
 
   static async lookupWorkspace(name: string, baseUrl?: string): Promise<WorkspaceLookup | null> {
@@ -201,23 +226,12 @@ export class RelayCast {
     return camelizeKeys(envelope.data.data);
   }
 
-  static async ensureWorkspace(name: string, baseUrl?: string): Promise<EnsureWorkspaceResponse> {
-    try {
-      const created = await RelayCast.createWorkspace(name, baseUrl);
-      return { ...created, existed: false, name };
-    } catch (err) {
-      const statusCode = err instanceof RelayError ? err.statusCode : undefined;
-      if (statusCode !== 409) {
-        throw err;
-      }
-
-      const existing = await RelayCast.lookupWorkspace(name, baseUrl);
-      if (!existing) {
-        throw err;
-      }
-
-      return { ...existing, existed: true };
-    }
+  static async ensureWorkspace(
+    name: string,
+    options?: string | WorkspaceBootstrapOptions,
+  ): Promise<EnsureWorkspaceResponse> {
+    const { data, statusCode } = await RelayCast.createWorkspaceWithStatus(name, options);
+    return { ...data, existed: statusCode === 200, name };
   }
 
   private rememberIdentity(agentId: string, name: string): void {

--- a/packages/server/src/__tests__/workspace-engine.test.ts
+++ b/packages/server/src/__tests__/workspace-engine.test.ts
@@ -1,0 +1,210 @@
+import { DatabaseSync } from 'node:sqlite';
+import crypto from 'node:crypto';
+import { drizzle } from 'drizzle-orm/d1';
+import { beforeEach, describe, expect, it } from 'vitest';
+import * as schema from '../db/schema.js';
+import { createWorkspace, getWorkspaceByName } from '../engine/workspace.js';
+
+const TEST_SCHEMA_SQL = `
+PRAGMA foreign_keys = ON;
+
+CREATE TABLE workspaces (
+  id TEXT PRIMARY KEY NOT NULL,
+  name TEXT NOT NULL,
+  api_key_hash TEXT NOT NULL UNIQUE,
+  system_prompt TEXT,
+  plan TEXT NOT NULL DEFAULT 'free',
+  created_at INTEGER NOT NULL DEFAULT (unixepoch()),
+  metadata TEXT DEFAULT '{}'
+);
+
+CREATE TABLE agents (
+  id TEXT PRIMARY KEY NOT NULL,
+  workspace_id TEXT NOT NULL REFERENCES workspaces(id) ON DELETE CASCADE,
+  name TEXT NOT NULL
+);
+
+CREATE TABLE channels (
+  id TEXT PRIMARY KEY NOT NULL,
+  workspace_id TEXT NOT NULL REFERENCES workspaces(id) ON DELETE CASCADE,
+  name TEXT NOT NULL,
+  channel_type INTEGER NOT NULL DEFAULT 0,
+  topic TEXT,
+  metadata TEXT DEFAULT '{}',
+  created_by TEXT REFERENCES agents(id),
+  created_at INTEGER NOT NULL DEFAULT (unixepoch()),
+  is_archived INTEGER NOT NULL DEFAULT 0
+);
+CREATE UNIQUE INDEX channels_workspace_name_unique ON channels(workspace_id, name);
+`;
+
+class FakeD1PreparedStatement {
+  private readonly sqlite: DatabaseSync;
+  private readonly query: string;
+  private readonly params: unknown[];
+
+  constructor(sqlite: DatabaseSync, query: string, params: unknown[] = []) {
+    this.sqlite = sqlite;
+    this.query = query;
+    this.params = params;
+  }
+
+  bind(...params: unknown[]) {
+    return new FakeD1PreparedStatement(this.sqlite, this.query, params);
+  }
+
+  async run() {
+    this.sqlite.prepare(this.query).run(...this.params);
+    return { success: true, meta: {}, results: [] };
+  }
+
+  async all() {
+    const rows = this.sqlite.prepare(this.query).all(...this.params) as Record<string, unknown>[];
+    return { success: true, meta: {}, results: rows };
+  }
+
+  async first() {
+    const rows = this.sqlite.prepare(this.query).all(...this.params) as Record<string, unknown>[];
+    return rows[0] ?? null;
+  }
+
+  async raw() {
+    const statement = this.sqlite.prepare(this.query);
+    statement.setReturnArrays(true);
+    return statement.all(...this.params);
+  }
+}
+
+class FakeD1Database {
+  readonly sqlite = new DatabaseSync(':memory:');
+
+  constructor() {
+    this.sqlite.exec(TEST_SCHEMA_SQL);
+  }
+
+  prepare(query: string) {
+    return new FakeD1PreparedStatement(this.sqlite, query);
+  }
+
+  async batch(statements: Array<FakeD1PreparedStatement>) {
+    return Promise.all(statements.map((statement) => statement.all()));
+  }
+}
+
+function hashApiKey(apiKey: string) {
+  return crypto.createHash('sha256').update(apiKey).digest('hex');
+}
+
+describe('createWorkspace (engine integration)', () => {
+  let db: ReturnType<typeof drizzle>;
+  let fakeD1: FakeD1Database;
+
+  beforeEach(() => {
+    fakeD1 = new FakeD1Database();
+    db = drizzle(fakeD1 as any, { schema });
+  });
+
+  it('creates a new workspace and returns created: true', async () => {
+    const result = await createWorkspace(db, 'my-project');
+
+    expect(result.created).toBe(true);
+    expect(result.workspace_id).toBeTruthy();
+    expect(result.api_key).toMatch(/^rk_live_/);
+    expect(result.created_at).toBeTruthy();
+  });
+
+  it('creates a #general channel for new workspaces', async () => {
+    const result = await createWorkspace(db, 'my-project');
+
+    const channels = fakeD1.sqlite
+      .prepare('SELECT * FROM channels WHERE workspace_id = ?')
+      .all(result.workspace_id) as Array<{ name: string }>;
+
+    expect(channels).toHaveLength(1);
+    expect(channels[0].name).toBe('general');
+  });
+
+  it('returns existing workspace when called with its own API key', async () => {
+    const first = await createWorkspace(db, 'shared-name');
+
+    // Second call with the workspace's own API key → idempotent return
+    const second = await createWorkspace(db, 'shared-name', {
+      ownerApiKey: first.api_key,
+    });
+
+    expect(first.created).toBe(true);
+    expect(second.created).toBe(false);
+    expect(second.workspace_id).toBe(first.workspace_id);
+  });
+
+  it('creates separate workspaces for same name from different owners', async () => {
+    const first = await createWorkspace(db, 'shared-name');
+    const second = await createWorkspace(db, 'shared-name');
+
+    // Different generated API keys → different workspaces
+    expect(first.created).toBe(true);
+    expect(second.created).toBe(true);
+    expect(second.workspace_id).not.toBe(first.workspace_id);
+  });
+
+  it('returns existing workspace using ownerApiKeyHash', async () => {
+    const first = await createWorkspace(db, 'hash-test');
+    const ownerApiKeyHash = hashApiKey(first.api_key);
+
+    const second = await createWorkspace(db, 'hash-test', { ownerApiKeyHash });
+
+    expect(first.created).toBe(true);
+    expect(second.created).toBe(false);
+    expect(second.workspace_id).toBe(first.workspace_id);
+  });
+
+  it('creates new workspace without owner key (anonymous)', async () => {
+    const first = await createWorkspace(db, 'anon-ws');
+    const second = await createWorkspace(db, 'anon-ws');
+
+    // Without owner key, no idempotency — both create new workspaces
+    expect(first.created).toBe(true);
+    expect(second.created).toBe(true);
+    expect(second.workspace_id).not.toBe(first.workspace_id);
+  });
+
+  it('throws when ownerApiKey and ownerApiKeyHash conflict', async () => {
+    await expect(
+      createWorkspace(db, 'conflict-test', {
+        ownerApiKey: 'rk_live_key_a',
+        ownerApiKeyHash: hashApiKey('rk_live_key_b'),
+      }),
+    ).rejects.toThrow('ownerApiKeyHash must match');
+  });
+});
+
+describe('getWorkspaceByName', () => {
+  let db: ReturnType<typeof drizzle>;
+
+  beforeEach(() => {
+    const fakeD1 = new FakeD1Database();
+    db = drizzle(fakeD1 as any, { schema });
+  });
+
+  it('returns workspace by name', async () => {
+    await createWorkspace(db, 'find-me');
+
+    const found = await getWorkspaceByName(db, 'find-me');
+    expect(found).not.toBeNull();
+    expect(found!.name).toBe('find-me');
+  });
+
+  it('returns null for non-existent workspace', async () => {
+    const found = await getWorkspaceByName(db, 'does-not-exist');
+    expect(found).toBeNull();
+  });
+
+  it('returns first match when multiple workspaces share the same name', async () => {
+    await createWorkspace(db, 'duplicate', { ownerApiKey: 'rk_live_a' });
+    await createWorkspace(db, 'duplicate', { ownerApiKey: 'rk_live_b' });
+
+    const found = await getWorkspaceByName(db, 'duplicate');
+    expect(found).not.toBeNull();
+    expect(found!.name).toBe('duplicate');
+  });
+});

--- a/packages/server/src/engine/workspace.ts
+++ b/packages/server/src/engine/workspace.ts
@@ -1,31 +1,71 @@
 import crypto from 'node:crypto';
-import { eq } from 'drizzle-orm';
+import { and, eq } from 'drizzle-orm';
 import type { getDb } from '../db/index.js';
 import { workspaces, channels } from '../db/schema.js';
 import { generateId } from './snowflake.js';
 
 type Db = ReturnType<typeof getDb>;
 
-export async function createWorkspace(db: Db, name: string) {
-  // Check for duplicate name
-  const [existing] = await db
-    .select()
-    .from(workspaces)
-    .where(eq(workspaces.name, name));
-  if (existing) {
-    const err = new Error(`Workspace "${name}" already exists`);
-    Object.assign(err, { code: 'workspace_already_exists', status: 409 });
+type CreateWorkspaceOptions =
+  | string
+  | {
+      ownerApiKey?: string;
+      ownerApiKeyHash?: string;
+    };
+
+function hashApiKey(apiKey: string) {
+  return crypto.createHash('sha256').update(apiKey).digest('hex');
+}
+
+function buildWorkspaceResponse(
+  workspace: typeof workspaces.$inferSelect,
+  apiKey?: string,
+) {
+  return {
+    workspace_id: workspace.id,
+    ...(apiKey ? { api_key: apiKey } : {}),
+    created_at: workspace.createdAt.toISOString(),
+  };
+}
+
+export async function createWorkspace(
+  db: Db,
+  name: string,
+  options?: CreateWorkspaceOptions,
+) {
+  const providedOwnerApiKeyHash = typeof options === 'string' ? undefined : options?.ownerApiKeyHash;
+  const providedOwnerApiKey = typeof options === 'string' ? options : options?.ownerApiKey;
+  const derivedOwnerApiKeyHash = providedOwnerApiKey ? hashApiKey(providedOwnerApiKey) : undefined;
+
+  if (providedOwnerApiKeyHash && derivedOwnerApiKeyHash && providedOwnerApiKeyHash !== derivedOwnerApiKeyHash) {
+    const err = new Error('ownerApiKeyHash must match the provided ownerApiKey');
+    Object.assign(err, { code: 'invalid_owner_api_key_hash', status: 400 });
     throw err;
+  }
+
+  const ownerApiKeyHash = providedOwnerApiKeyHash ?? derivedOwnerApiKeyHash;
+
+  // Repeated creates from the same owner/key should reuse the existing workspace.
+  if (ownerApiKeyHash) {
+    const [existing] = await db
+      .select()
+      .from(workspaces)
+      .where(and(eq(workspaces.name, name), eq(workspaces.apiKeyHash, ownerApiKeyHash)));
+    if (existing) {
+      const workspace = buildWorkspaceResponse(existing, providedOwnerApiKey);
+      return {
+        workspace,
+        created: false,
+        ...workspace,
+      };
+    }
   }
 
   const workspaceId = generateId();
   const apiKey = `rk_live_${crypto.randomBytes(16).toString('hex')}`;
-  const apiKeyHash = crypto
-    .createHash('sha256')
-    .update(apiKey)
-    .digest('hex');
+  const apiKeyHash = hashApiKey(apiKey);
 
-  const [workspace] = await db
+  const [createdWorkspace] = await db
     .insert(workspaces)
     .values({
       id: workspaceId,
@@ -43,10 +83,11 @@ export async function createWorkspace(db: Db, name: string) {
     topic: 'General discussion',
   });
 
+  const workspace = buildWorkspaceResponse(createdWorkspace, apiKey);
   return {
-    workspace_id: workspaceId,
-    api_key: apiKey,
-    created_at: workspace.createdAt.toISOString(),
+    workspace,
+    created: true,
+    ...workspace,
   };
 }
 

--- a/packages/server/src/routes/__tests__/workspace.test.ts
+++ b/packages/server/src/routes/__tests__/workspace.test.ts
@@ -5,6 +5,7 @@ vi.mock('../../engine/activity.js', () => ({
 }));
 
 vi.mock('../../engine/workspace.js', () => ({
+  createWorkspace: vi.fn(),
   getWorkspaceByName: vi.fn(),
 }));
 
@@ -25,6 +26,10 @@ vi.mock('../../db/index.js', () => ({
   getDb: vi.fn(),
 }));
 
+vi.mock('../../lib/serverTelemetry.js', () => ({
+  emitServerEvent: vi.fn(),
+}));
+
 import { Hono } from 'hono';
 import type { AppEnv } from '../../env.js';
 import { dbMiddleware } from '../../middleware/db.js';
@@ -34,6 +39,7 @@ import * as workspaceEngine from '../../engine/workspace.js';
 import * as dmAllEngine from '../../engine/dmAll.js';
 import * as tokenRotateEngine from '../../engine/tokenRotate.js';
 import { getDb } from '../../db/index.js';
+import { emitServerEvent } from '../../lib/serverTelemetry.js';
 import {
   mockDbForWorkspaceAuth,
   wsAuthHeaders,
@@ -57,6 +63,87 @@ describe('Dashboard routes', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     (bindings as any).RATE_LIMIT_DO = createMockBindings().RATE_LIMIT_DO;
+  });
+
+  describe('POST /v1/workspaces', () => {
+    it('creates a new workspace without auth and returns 201', async () => {
+      vi.mocked(getDb).mockReturnValue(mockDbForWorkspaceAuth());
+      vi.mocked(workspaceEngine.createWorkspace).mockResolvedValue({
+        workspace: {
+          workspace_id: 'ws_new',
+          api_key: 'rk_live_new',
+          created_at: '2026-03-31T00:00:00.000Z',
+        },
+        created: true,
+        workspace_id: 'ws_new',
+        api_key: 'rk_live_new',
+        created_at: '2026-03-31T00:00:00.000Z',
+      });
+
+      const res = await app.request('/v1/workspaces', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name: 'my-project' }),
+      });
+
+      expect(res.status).toBe(201);
+      expect(await res.json()).toEqual({
+        ok: true,
+        data: {
+          workspace_id: 'ws_new',
+          api_key: 'rk_live_new',
+          created_at: '2026-03-31T00:00:00.000Z',
+        },
+      });
+      expect(workspaceEngine.createWorkspace).toHaveBeenCalledWith(
+        expect.anything(),
+        'my-project',
+        undefined,
+      );
+      expect(emitServerEvent).toHaveBeenCalledWith(
+        expect.anything(),
+        'ws_new',
+        'relaycast_server_workspace_created',
+        { created_via: 'api' },
+      );
+    });
+
+    it('returns an existing workspace for the same owner key and skips telemetry', async () => {
+      vi.mocked(getDb).mockReturnValue(mockDbForWorkspaceAuth());
+      vi.mocked(workspaceEngine.createWorkspace).mockResolvedValue({
+        workspace: {
+          workspace_id: 'ws_existing',
+          api_key: 'rk_live_existing',
+          created_at: '2026-03-30T00:00:00.000Z',
+        },
+        created: false,
+        workspace_id: 'ws_existing',
+        api_key: 'rk_live_existing',
+        created_at: '2026-03-30T00:00:00.000Z',
+      });
+
+      const res = await app.request('/v1/workspaces', {
+        method: 'POST',
+        headers: wsAuthHeaders(),
+        body: JSON.stringify({ name: 'test-workspace' }),
+      });
+
+      expect(res.status).toBe(200);
+      expect(await res.json()).toEqual({
+        ok: true,
+        data: {
+          workspace_id: 'ws_existing',
+          api_key: 'rk_live_existing',
+          created_at: '2026-03-30T00:00:00.000Z',
+        },
+      });
+      expect(workspaceEngine.createWorkspace).toHaveBeenCalledWith(
+        expect.anything(),
+        'test-workspace',
+        { ownerApiKey: expect.stringMatching(/^rk_/) },
+      );
+      expect(emitServerEvent).not.toHaveBeenCalled();
+    });
   });
 
   describe('GET /v1/workspaces/by-name/:name', () => {

--- a/packages/server/src/routes/workspace.ts
+++ b/packages/server/src/routes/workspace.ts
@@ -70,6 +70,12 @@ function inMemoryPublicLookupRateCheck(clientId: string, limit: number) {
   };
 }
 
+function extractOwnerApiKey(authHeader: string | undefined) {
+  if (!authHeader?.startsWith('Bearer ')) return undefined;
+  const token = authHeader.slice(7);
+  return token.startsWith('rk_') ? token : undefined;
+}
+
 const publicWorkspaceLookupRateLimit = createMiddleware<AppEnv>(async (c, next) => {
   const clientId = getPublicLookupClientId(c);
   const limit = PUBLIC_WORKSPACE_LOOKUP_LIMIT;
@@ -137,7 +143,7 @@ const publicWorkspaceLookupRateLimit = createMiddleware<AppEnv>(async (c, next) 
   await next();
 });
 
-// POST /workspaces - create workspace (no auth required)
+// POST /workspaces - create workspace (no auth required, workspace key optional)
 workspaceRoutes.post('/workspaces', async (c) => {
   try {
     const parsed = createWorkspaceSchema.safeParse(await c.req.json());
@@ -146,11 +152,18 @@ workspaceRoutes.post('/workspaces', async (c) => {
     }
     const { name } = parsed.data;
     const db = c.get('db');
-    const result = await workspaceEngine.createWorkspace(db, name);
-    emitServerEvent(c, result.workspace_id, 'relaycast_server_workspace_created', {
-      created_via: 'api',
-    });
-    return c.json({ ok: true, data: result }, 201);
+    const ownerApiKey = extractOwnerApiKey(c.req.header('Authorization'));
+    const result = await workspaceEngine.createWorkspace(
+      db,
+      name,
+      ownerApiKey ? { ownerApiKey } : undefined,
+    );
+    if (result.created) {
+      emitServerEvent(c, result.workspace.workspace_id, 'relaycast_server_workspace_created', {
+        created_via: 'api',
+      });
+    }
+    return c.json({ ok: true, data: result.workspace }, result.created ? 201 : 200);
   } catch (err: unknown) {
     const error = err as Error & { code?: string; status?: number };
     return c.json({ ok: false, error: { code: error.code || 'internal_error', message: error.message } }, (error.status || 500) as ContentfulStatusCode);

--- a/packages/types/src/workspace.ts
+++ b/packages/types/src/workspace.ts
@@ -17,7 +17,7 @@ export type CreateWorkspaceRequest = z.infer<typeof CreateWorkspaceRequestSchema
 
 export const CreateWorkspaceResponseSchema = z.object({
   workspace_id: z.string(),
-  api_key: z.string(),
+  api_key: z.string().optional(),
   created_at: z.string(),
 });
 export type CreateWorkspaceResponse = z.infer<typeof CreateWorkspaceResponseSchema>;


### PR DESCRIPTION
## Summary
Replaces #112 and #114 with a clean PR (no noise files).

Same API key + same name → returns existing workspace (200).
Different API keys → can share workspace names (201).

## Changes
- `packages/server/src/engine/workspace.ts` — idempotent createWorkspace
- `packages/server/src/routes/workspace.ts` — 200 for existing, 201 for new
- `packages/sdk-typescript/src/relay.ts` — simplified ensureWorkspace
- `packages/local/src/main.rs` — matches server behavior
- `packages/types/src/workspace.ts` — CreateWorkspaceResult type
- `openapi.yaml` — 200 added, 409 removed
- `README.md` — updated docs
- Tests updated

## Depends on
- #113 (schema + migration — merge first)

## Test plan
- [ ] Two workspaces with same name + same API key → returns existing
- [ ] Two workspaces with same name + different API keys → both created
- [ ] SDK ensureWorkspace works without 409
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/agentworkforce/relaycast/pull/115" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
