### PR TITLE
Fix server tests on Node 22.14

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -12,7 +12,7 @@ runs:
     - name: Setup Node.js
       uses: actions/setup-node@v4
       with:
-        node-version: 22
+        node-version: "22.14.0"
         cache: npm
 
     - name: Install dependencies

--- a/.trajectories/completed/2026-04/traj_e3imqupgb81i.json
+++ b/.trajectories/completed/2026-04/traj_e3imqupgb81i.json
@@ -1,0 +1,65 @@
+{
+  "id": "traj_e3imqupgb81i",
+  "version": 1,
+  "task": {
+    "title": "Fix server tests failing on Node SQLite fake D1"
+  },
+  "status": "completed",
+  "startedAt": "2026-04-17T09:19:06.767Z",
+  "agents": [
+    {
+      "name": "default",
+      "role": "lead",
+      "joinedAt": "2026-04-17T09:31:18.022Z"
+    }
+  ],
+  "chapters": [
+    {
+      "id": "chap_4cnnppxyienx",
+      "title": "Work",
+      "agentName": "default",
+      "startedAt": "2026-04-17T09:31:18.022Z",
+      "events": [
+        {
+          "ts": 1776418278023,
+          "type": "decision",
+          "content": "Centralized fake D1 test harness with Node 22.14 compatibility: Centralized fake D1 test harness with Node 22.14 compatibility",
+          "raw": {
+            "question": "Centralized fake D1 test harness with Node 22.14 compatibility",
+            "chosen": "Centralized fake D1 test harness with Node 22.14 compatibility",
+            "alternatives": [],
+            "reasoning": "The failing suites duplicated a fake D1 implementation that assumed node:sqlite setReturnArrays and FTS5. A shared helper keeps Drizzle raw row mapping and directory FTS fallback consistent across directory, routing, and workspace engine tests."
+          },
+          "significance": "high"
+        },
+        {
+          "ts": 1776418278212,
+          "type": "decision",
+          "content": "Pinned shared CI setup to Node 22.14.0: Pinned shared CI setup to Node 22.14.0",
+          "raw": {
+            "question": "Pinned shared CI setup to Node 22.14.0",
+            "chosen": "Pinned shared CI setup to Node 22.14.0",
+            "alternatives": [],
+            "reasoning": "Publish workflow is pinned to Node 22.14.0 while CI used floating Node 22, so PR CI could run on a newer patch with SQLite FTS5 and setReturnArrays and miss publish failures."
+          },
+          "significance": "high"
+        }
+      ],
+      "endedAt": "2026-04-17T09:31:22.324Z"
+    }
+  ],
+  "commits": [],
+  "filesChanged": [],
+  "projectId": "/Users/khaliqgant/Projects/AgentWorkforce/relaycast",
+  "tags": [],
+  "_trace": {
+    "startRef": "89c4c95c83629858e29ec5a6d15b9751d5a9e4d0",
+    "endRef": "89c4c95c83629858e29ec5a6d15b9751d5a9e4d0"
+  },
+  "completedAt": "2026-04-17T09:31:22.324Z",
+  "retrospective": {
+    "summary": "Fixed Node 22.14 server test failures by centralizing fake D1, adding raw array compatibility and FTS fallback, and pinning shared CI setup to publish Node version.",
+    "approach": "Standard approach",
+    "confidence": 0.9
+  }
+}

--- a/.trajectories/completed/2026-04/traj_e3imqupgb81i.md
+++ b/.trajectories/completed/2026-04/traj_e3imqupgb81i.md
@@ -1,0 +1,36 @@
+# Trajectory: Fix server tests failing on Node SQLite fake D1
+
+> **Status:** ✅ Completed
+> **Confidence:** 90%
+> **Started:** April 17, 2026 at 11:19 AM
+> **Completed:** April 17, 2026 at 11:31 AM
+
+---
+
+## Summary
+
+Fixed Node 22.14 server test failures by centralizing fake D1, adding raw array compatibility and FTS fallback, and pinning shared CI setup to publish Node version.
+
+**Approach:** Standard approach
+
+---
+
+## Key Decisions
+
+### Centralized fake D1 test harness with Node 22.14 compatibility
+- **Chose:** Centralized fake D1 test harness with Node 22.14 compatibility
+- **Reasoning:** The failing suites duplicated a fake D1 implementation that assumed node:sqlite setReturnArrays and FTS5. A shared helper keeps Drizzle raw row mapping and directory FTS fallback consistent across directory, routing, and workspace engine tests.
+
+### Pinned shared CI setup to Node 22.14.0
+- **Chose:** Pinned shared CI setup to Node 22.14.0
+- **Reasoning:** Publish workflow is pinned to Node 22.14.0 while CI used floating Node 22, so PR CI could run on a newer patch with SQLite FTS5 and setReturnArrays and miss publish failures.
+
+---
+
+## Chapters
+
+### 1. Work
+*Agent: default*
+
+- Centralized fake D1 test harness with Node 22.14 compatibility: Centralized fake D1 test harness with Node 22.14 compatibility
+- Pinned shared CI setup to Node 22.14.0: Pinned shared CI setup to Node 22.14.0

--- a/.trajectories/index.json
+++ b/.trajectories/index.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "lastUpdated": "2026-03-26T11:01:41.987Z",
+  "lastUpdated": "2026-04-17T09:31:22.420Z",
   "trajectories": {
     "traj_o8g8ahqth5fx": {
       "title": "Wave 0: add repo infrastructure files (docker, turbo, tsconfig, env)",
@@ -1043,6 +1043,13 @@
       "startedAt": "2026-03-26T10:59:34.609Z",
       "completedAt": "2026-03-26T11:01:41.853Z",
       "path": "/Users/khaliqgant/Projects/AgentWorkforce/relaycast/.trajectories/completed/2026-03/traj_m2i8kuknj3d7.json"
+    },
+    "traj_e3imqupgb81i": {
+      "title": "Fix server tests failing on Node SQLite fake D1",
+      "status": "completed",
+      "startedAt": "2026-04-17T09:19:06.767Z",
+      "completedAt": "2026-04-17T09:31:22.324Z",
+      "path": "/Users/khaliqgant/Projects/AgentWorkforce/relaycast/.trajectories/completed/2026-04/traj_e3imqupgb81i.json"
     }
   }
 }

--- a/packages/server/src/__tests__/directory.test.ts
+++ b/packages/server/src/__tests__/directory.test.ts
@@ -1,7 +1,6 @@
-import { DatabaseSync } from 'node:sqlite';
-import { drizzle } from 'drizzle-orm/d1';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import * as schema from '../db/schema.js';
+import { createD1TestDb } from './fake-d1.js';
 import {
   createDirectoryAgent,
   listDirectoryAgents,
@@ -9,7 +8,6 @@ import {
   searchDirectory,
   upsertDirectoryRating,
 } from '../engine/directory.js';
-import { buildFtsQuery } from '../engine/searchQuery.js';
 
 const TEST_SCHEMA_SQL = `
 PRAGMA foreign_keys = ON;
@@ -168,71 +166,8 @@ AFTER DELETE ON directory_skills BEGIN
 END;
 `;
 
-class FakeD1PreparedStatement {
-  private readonly sqlite: DatabaseSync;
-  private readonly query: string;
-  private readonly params: unknown[];
-
-  constructor(sqlite: DatabaseSync, query: string, params: unknown[] = []) {
-    this.sqlite = sqlite;
-    this.query = query;
-    this.params = params;
-  }
-
-  bind(...params: unknown[]) {
-    return new FakeD1PreparedStatement(this.sqlite, this.query, params);
-  }
-
-  async run() {
-    this.sqlite.prepare(this.query).run(...this.params);
-    return { success: true, meta: {}, results: [] };
-  }
-
-  async all() {
-    return {
-      success: true,
-      meta: {},
-      results: this.sqlite.prepare(this.query).all(...this.params),
-    };
-  }
-
-  async raw() {
-    const statement = this.sqlite.prepare(this.query);
-    statement.setReturnArrays(true);
-    return statement.all(...this.params);
-  }
-
-  async first() {
-    return this.sqlite.prepare(this.query).get(...this.params);
-  }
-}
-
-class FakeD1Database {
-  readonly sqlite = new DatabaseSync(':memory:');
-
-  constructor() {
-    this.sqlite.exec(TEST_SCHEMA_SQL);
-  }
-
-  prepare(query: string) {
-    return new FakeD1PreparedStatement(this.sqlite, query);
-  }
-
-  async batch(statements: Array<FakeD1PreparedStatement>) {
-    return Promise.all(statements.map((statement) => statement.all()));
-  }
-
-  async exec(query: string) {
-    this.sqlite.exec(query);
-  }
-}
-
 function createTestDb() {
-  const d1 = new FakeD1Database();
-  return {
-    db: drizzle(d1 as unknown as D1Database, { schema }),
-    sqlite: d1.sqlite,
-  };
+  return createD1TestDb(TEST_SCHEMA_SQL);
 }
 
 async function seedWorkspace(db: ReturnType<typeof createTestDb>['db']) {
@@ -343,8 +278,8 @@ describe('directory engine', () => {
     expect(ratedEntries[0]?.rating_avg).toBe(4);
   });
 
-  it('matches FTS5 queries across skills and agent descriptions', async () => {
-    const { db, sqlite } = createTestDb();
+  it('matches search queries across skills and agent descriptions', async () => {
+    const { db } = createTestDb();
     await seedWorkspace(db);
     await seedAgent(db, { id: 'agent_research', name: 'ResearchBot' });
     await seedAgent(db, { id: 'agent_support', name: 'SupportBot' });
@@ -381,25 +316,14 @@ describe('directory engine', () => {
       ],
     });
 
-    const skillQuery = buildFtsQuery('entity extraction pipelines');
-    const skillMatchRows = sqlite.prepare(`
-      SELECT da.slug
-      FROM directory_skills_fts
-      JOIN directory_skills ds ON ds.rowid = directory_skills_fts.rowid
-      JOIN directory_agents da ON da.id = ds.directory_agent_id
-      WHERE directory_skills_fts MATCH ?
-      ORDER BY da.slug ASC
-    `).all(skillQuery) as Array<{ slug: string }>;
-    expect(skillMatchRows.map((row) => row.slug)).toContain('researchbot');
+    const skillResults = await searchDirectory(db, 'ws_test', {
+      q: 'entity extraction pipelines',
+    });
+    expect(skillResults.map((row) => row.slug)).toContain('researchbot');
 
-    const descriptionQuery = buildFtsQuery('subscription billing specialist');
-    const descriptionMatchRows = sqlite.prepare(`
-      SELECT da.slug
-      FROM directory_agents_fts
-      JOIN directory_agents da ON da.rowid = directory_agents_fts.rowid
-      WHERE directory_agents_fts MATCH ?
-      ORDER BY da.slug ASC
-    `).all(descriptionQuery) as Array<{ slug: string }>;
-    expect(descriptionMatchRows.map((row) => row.slug)).toContain('supportbot');
+    const descriptionResults = await searchDirectory(db, 'ws_test', {
+      q: 'subscription billing specialist',
+    });
+    expect(descriptionResults.map((row) => row.slug)).toContain('supportbot');
   });
 });

--- a/packages/server/src/__tests__/fake-d1.ts
+++ b/packages/server/src/__tests__/fake-d1.ts
@@ -1,0 +1,217 @@
+import { DatabaseSync } from 'node:sqlite';
+import { drizzle } from 'drizzle-orm/d1';
+import * as schema from '../db/schema.js';
+
+const DIRECTORY_AGENTS_FTS_FALLBACK = `
+CREATE TABLE IF NOT EXISTS directory_agents_fts (
+  id TEXT,
+  name TEXT,
+  description TEXT,
+  provider TEXT,
+  tags TEXT
+);
+
+CREATE TRIGGER IF NOT EXISTS directory_agents_fts_insert
+AFTER INSERT ON directory_agents BEGIN
+  INSERT INTO directory_agents_fts(rowid, id, name, description, provider, tags)
+  VALUES (NEW.rowid, NEW.id, NEW.name, COALESCE(NEW.description, ''), COALESCE(NEW.provider, ''), COALESCE(NEW.tags, '[]'));
+END;
+
+CREATE TRIGGER IF NOT EXISTS directory_agents_fts_update
+AFTER UPDATE OF name, description, provider, tags ON directory_agents BEGIN
+  DELETE FROM directory_agents_fts WHERE rowid = OLD.rowid;
+  INSERT INTO directory_agents_fts(rowid, id, name, description, provider, tags)
+  VALUES (NEW.rowid, NEW.id, NEW.name, COALESCE(NEW.description, ''), COALESCE(NEW.provider, ''), COALESCE(NEW.tags, '[]'));
+END;
+
+CREATE TRIGGER IF NOT EXISTS directory_agents_fts_delete
+AFTER DELETE ON directory_agents BEGIN
+  DELETE FROM directory_agents_fts WHERE rowid = OLD.rowid;
+END;
+`;
+
+const DIRECTORY_SKILLS_FTS_FALLBACK = `
+CREATE TABLE IF NOT EXISTS directory_skills_fts (
+  id TEXT,
+  directory_agent_id TEXT,
+  name TEXT,
+  description TEXT,
+  tags TEXT
+);
+
+CREATE TRIGGER IF NOT EXISTS directory_skills_fts_insert
+AFTER INSERT ON directory_skills BEGIN
+  INSERT INTO directory_skills_fts(rowid, id, directory_agent_id, name, description, tags)
+  VALUES (NEW.rowid, NEW.id, NEW.directory_agent_id, NEW.name, COALESCE(NEW.description, ''), COALESCE(NEW.tags, '[]'));
+END;
+
+CREATE TRIGGER IF NOT EXISTS directory_skills_fts_update
+AFTER UPDATE OF name, description, tags ON directory_skills BEGIN
+  DELETE FROM directory_skills_fts WHERE rowid = OLD.rowid;
+  INSERT INTO directory_skills_fts(rowid, id, directory_agent_id, name, description, tags)
+  VALUES (NEW.rowid, NEW.id, NEW.directory_agent_id, NEW.name, COALESCE(NEW.description, ''), COALESCE(NEW.tags, '[]'));
+END;
+
+CREATE TRIGGER IF NOT EXISTS directory_skills_fts_delete
+AFTER DELETE ON directory_skills BEGIN
+  DELETE FROM directory_skills_fts WHERE rowid = OLD.rowid;
+END;
+`;
+
+function sqliteSupportsFts5(sqlite: DatabaseSync) {
+  try {
+    sqlite.exec('CREATE VIRTUAL TABLE __fts5_probe USING fts5(value); DROP TABLE __fts5_probe;');
+    return true;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    if (message.includes('no such module: fts5')) return false;
+    throw error;
+  }
+}
+
+function useDirectoryFtsFallback(schemaSql: string) {
+  return schemaSql
+    .replace(/CREATE TRIGGER(?: IF NOT EXISTS)? directory_agents_fts_insert[\s\S]*?END;\s*/g, '')
+    .replace(/CREATE TRIGGER(?: IF NOT EXISTS)? directory_agents_fts_update[\s\S]*?END;\s*/g, '')
+    .replace(/CREATE TRIGGER(?: IF NOT EXISTS)? directory_agents_fts_delete[\s\S]*?END;\s*/g, '')
+    .replace(
+      /CREATE VIRTUAL TABLE(?: IF NOT EXISTS)? directory_agents_fts USING fts5\([\s\S]*?\);\s*/g,
+      DIRECTORY_AGENTS_FTS_FALLBACK,
+    )
+    .replace(/CREATE TRIGGER(?: IF NOT EXISTS)? directory_skills_fts_insert[\s\S]*?END;\s*/g, '')
+    .replace(/CREATE TRIGGER(?: IF NOT EXISTS)? directory_skills_fts_update[\s\S]*?END;\s*/g, '')
+    .replace(/CREATE TRIGGER(?: IF NOT EXISTS)? directory_skills_fts_delete[\s\S]*?END;\s*/g, '')
+    .replace(
+      /CREATE VIRTUAL TABLE(?: IF NOT EXISTS)? directory_skills_fts USING fts5\([\s\S]*?\);\s*/g,
+      DIRECTORY_SKILLS_FTS_FALLBACK,
+    );
+}
+
+function normalizeSearchText(value: unknown) {
+  return String(value ?? '')
+    .toLowerCase()
+    .replace(/[^a-z0-9\s"]/g, ' ');
+}
+
+function ftsMatch(document: unknown, query: unknown) {
+  const haystack = normalizeSearchText(document);
+  const terms = normalizeSearchText(query)
+    .split(/\s+/)
+    .map((term) => term.trim())
+    .filter(Boolean);
+
+  if (terms.length === 0) return 1;
+  return terms.every((term) => haystack.includes(term)) ? 1 : 0;
+}
+
+function rewriteFtsQueryForFallback(query: string) {
+  return query
+    .replace(/bm25\(directory_agents_fts\)/g, '0')
+    .replace(/bm25\(directory_skills_fts\)/g, '0')
+    .replace(
+      /directory_agents_fts\s+MATCH\s+\?/g,
+      "fts_match(COALESCE(directory_agents_fts.name, '') || ' ' || COALESCE(directory_agents_fts.description, '') || ' ' || COALESCE(directory_agents_fts.provider, '') || ' ' || COALESCE(directory_agents_fts.tags, ''), ?)",
+    )
+    .replace(
+      /directory_skills_fts\s+MATCH\s+\?/g,
+      "fts_match(COALESCE(directory_skills_fts.name, '') || ' ' || COALESCE(directory_skills_fts.description, '') || ' ' || COALESCE(directory_skills_fts.tags, ''), ?)",
+    );
+}
+
+function rowsToArrays(statement: ReturnType<DatabaseSync['prepare']>, rows: Record<string, unknown>[]) {
+  const columns = typeof statement.columns === 'function'
+    ? statement.columns().map((column) => column.name)
+    : Object.keys(rows[0] ?? {});
+  return rows.map((row) => columns.map((column) => row[column]));
+}
+
+export class FakeD1PreparedStatement {
+  private readonly sqlite: DatabaseSync;
+  private readonly query: string;
+  private readonly params: unknown[];
+  private readonly useFtsFallback: boolean;
+
+  constructor(
+    sqlite: DatabaseSync,
+    query: string,
+    params: unknown[] = [],
+    useFtsFallback = false,
+  ) {
+    this.sqlite = sqlite;
+    this.query = query;
+    this.params = params;
+    this.useFtsFallback = useFtsFallback;
+  }
+
+  private get sqliteQuery() {
+    return this.useFtsFallback ? rewriteFtsQueryForFallback(this.query) : this.query;
+  }
+
+  bind(...params: unknown[]) {
+    return new FakeD1PreparedStatement(this.sqlite, this.query, params, this.useFtsFallback);
+  }
+
+  async run() {
+    this.sqlite.prepare(this.sqliteQuery).run(...this.params);
+    return { success: true, meta: {}, results: [] };
+  }
+
+  async all() {
+    return {
+      success: true,
+      meta: {},
+      results: this.sqlite.prepare(this.sqliteQuery).all(...this.params),
+    };
+  }
+
+  async raw() {
+    const statement = this.sqlite.prepare(this.sqliteQuery);
+    if (typeof statement.setReturnArrays === 'function') {
+      statement.setReturnArrays(true);
+      return statement.all(...this.params);
+    }
+
+    return rowsToArrays(statement, statement.all(...this.params) as Record<string, unknown>[]);
+  }
+
+  async first() {
+    return this.sqlite.prepare(this.sqliteQuery).get(...this.params);
+  }
+}
+
+export class FakeD1Database {
+  readonly sqlite = new DatabaseSync(':memory:');
+  private readonly useFtsFallback: boolean;
+
+  constructor(schemaSql: string) {
+    const needsFts5 = /USING\s+fts5/i.test(schemaSql);
+    this.useFtsFallback = needsFts5 && !sqliteSupportsFts5(this.sqlite);
+
+    if (this.useFtsFallback) {
+      this.sqlite.function('fts_match', { deterministic: true }, ftsMatch);
+    }
+
+    this.sqlite.exec(this.useFtsFallback ? useDirectoryFtsFallback(schemaSql) : schemaSql);
+  }
+
+  prepare(query: string) {
+    return new FakeD1PreparedStatement(this.sqlite, query, [], this.useFtsFallback);
+  }
+
+  async batch(statements: Array<FakeD1PreparedStatement>) {
+    return Promise.all(statements.map((statement) => statement.all()));
+  }
+
+  async exec(query: string) {
+    this.sqlite.exec(this.useFtsFallback ? rewriteFtsQueryForFallback(query) : query);
+  }
+}
+
+export function createD1TestDb(schemaSql: string) {
+  const d1 = new FakeD1Database(schemaSql);
+  return {
+    d1,
+    db: drizzle(d1 as unknown as D1Database, { schema }),
+    sqlite: d1.sqlite,
+  };
+}

--- a/packages/server/src/__tests__/routing.test.ts
+++ b/packages/server/src/__tests__/routing.test.ts
@@ -1,9 +1,8 @@
-import { DatabaseSync } from 'node:sqlite';
-import { drizzle } from 'drizzle-orm/d1';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import * as schema from '../db/schema.js';
 import { createDirectoryAgent, upsertDirectoryRating } from '../engine/directory.js';
 import { routeBySkill, setRoutingConfig } from '../engine/routing.js';
+import { createD1TestDb } from './fake-d1.js';
 
 const TEST_SCHEMA_SQL = `
 PRAGMA foreign_keys = ON;
@@ -193,71 +192,8 @@ CREATE INDEX idx_routing_failures_circuit
   ON routing_failures(workspace_id, circuit_open_until);
 `;
 
-class FakeD1PreparedStatement {
-  private readonly sqlite: DatabaseSync;
-  private readonly query: string;
-  private readonly params: unknown[];
-
-  constructor(sqlite: DatabaseSync, query: string, params: unknown[] = []) {
-    this.sqlite = sqlite;
-    this.query = query;
-    this.params = params;
-  }
-
-  bind(...params: unknown[]) {
-    return new FakeD1PreparedStatement(this.sqlite, this.query, params);
-  }
-
-  async run() {
-    this.sqlite.prepare(this.query).run(...this.params);
-    return { success: true, meta: {}, results: [] };
-  }
-
-  async all() {
-    return {
-      success: true,
-      meta: {},
-      results: this.sqlite.prepare(this.query).all(...this.params),
-    };
-  }
-
-  async raw() {
-    const statement = this.sqlite.prepare(this.query);
-    statement.setReturnArrays(true);
-    return statement.all(...this.params);
-  }
-
-  async first() {
-    return this.sqlite.prepare(this.query).get(...this.params);
-  }
-}
-
-class FakeD1Database {
-  readonly sqlite = new DatabaseSync(':memory:');
-
-  constructor() {
-    this.sqlite.exec(TEST_SCHEMA_SQL);
-  }
-
-  prepare(query: string) {
-    return new FakeD1PreparedStatement(this.sqlite, query);
-  }
-
-  async batch(statements: Array<FakeD1PreparedStatement>) {
-    return Promise.all(statements.map((statement) => statement.all()));
-  }
-
-  async exec(query: string) {
-    this.sqlite.exec(query);
-  }
-}
-
 function createTestDb() {
-  const d1 = new FakeD1Database();
-  return {
-    db: drizzle(d1 as unknown as D1Database, { schema }),
-    sqlite: d1.sqlite,
-  };
+  return createD1TestDb(TEST_SCHEMA_SQL);
 }
 
 async function seedWorkspace(db: ReturnType<typeof createTestDb>['db']) {

--- a/packages/server/src/__tests__/workspace-engine.test.ts
+++ b/packages/server/src/__tests__/workspace-engine.test.ts
@@ -1,9 +1,7 @@
-import { DatabaseSync } from 'node:sqlite';
 import crypto from 'node:crypto';
-import { drizzle } from 'drizzle-orm/d1';
 import { beforeEach, describe, expect, it } from 'vitest';
-import * as schema from '../db/schema.js';
 import { createWorkspace, getWorkspaceByName } from '../engine/workspace.js';
+import { createD1TestDb, FakeD1Database } from './fake-d1.js';
 
 const TEST_SCHEMA_SQL = `
 PRAGMA foreign_keys = ON;
@@ -38,70 +36,18 @@ CREATE TABLE channels (
 CREATE UNIQUE INDEX channels_workspace_name_unique ON channels(workspace_id, name);
 `;
 
-class FakeD1PreparedStatement {
-  private readonly sqlite: DatabaseSync;
-  private readonly query: string;
-  private readonly params: unknown[];
-
-  constructor(sqlite: DatabaseSync, query: string, params: unknown[] = []) {
-    this.sqlite = sqlite;
-    this.query = query;
-    this.params = params;
-  }
-
-  bind(...params: unknown[]) {
-    return new FakeD1PreparedStatement(this.sqlite, this.query, params);
-  }
-
-  async run() {
-    this.sqlite.prepare(this.query).run(...this.params);
-    return { success: true, meta: {}, results: [] };
-  }
-
-  async all() {
-    const rows = this.sqlite.prepare(this.query).all(...this.params) as Record<string, unknown>[];
-    return { success: true, meta: {}, results: rows };
-  }
-
-  async first() {
-    const rows = this.sqlite.prepare(this.query).all(...this.params) as Record<string, unknown>[];
-    return rows[0] ?? null;
-  }
-
-  async raw() {
-    const statement = this.sqlite.prepare(this.query);
-    statement.setReturnArrays(true);
-    return statement.all(...this.params);
-  }
-}
-
-class FakeD1Database {
-  readonly sqlite = new DatabaseSync(':memory:');
-
-  constructor() {
-    this.sqlite.exec(TEST_SCHEMA_SQL);
-  }
-
-  prepare(query: string) {
-    return new FakeD1PreparedStatement(this.sqlite, query);
-  }
-
-  async batch(statements: Array<FakeD1PreparedStatement>) {
-    return Promise.all(statements.map((statement) => statement.all()));
-  }
-}
-
 function hashApiKey(apiKey: string) {
   return crypto.createHash('sha256').update(apiKey).digest('hex');
 }
 
 describe('createWorkspace (engine integration)', () => {
-  let db: ReturnType<typeof drizzle>;
+  let db: ReturnType<typeof createD1TestDb>['db'];
   let fakeD1: FakeD1Database;
 
   beforeEach(() => {
-    fakeD1 = new FakeD1Database();
-    db = drizzle(fakeD1 as any, { schema });
+    const testDb = createD1TestDb(TEST_SCHEMA_SQL);
+    db = testDb.db;
+    fakeD1 = testDb.d1;
   });
 
   it('creates a new workspace and returns created: true', async () => {
@@ -179,11 +125,10 @@ describe('createWorkspace (engine integration)', () => {
 });
 
 describe('getWorkspaceByName', () => {
-  let db: ReturnType<typeof drizzle>;
+  let db: ReturnType<typeof createD1TestDb>['db'];
 
   beforeEach(() => {
-    const fakeD1 = new FakeD1Database();
-    db = drizzle(fakeD1 as any, { schema });
+    db = createD1TestDb(TEST_SCHEMA_SQL).db;
   });
 
   it('returns workspace by name', async () => {


### PR DESCRIPTION
## Summary
- Centralize the fake D1 test harness for server engine tests
- Add compatibility for Node 22.14 node:sqlite without setReturnArrays or FTS5
- Pin shared CI setup to Node 22.14.0 so CI matches publish
- Include completed trajectory artifacts for this work

## Verification
- mise exec node@22.14.0 -- npm run test --workspace @relaycast/server
- mise exec node@22.14.0 -- npx turbo test --filter=@relaycast/server --force
- mise exec node@22.14.0 -- npx turbo lint --filter=@relaycast/server
- mise exec node@22.14.0 -- npm run local:parity

## Why CI Missed It
PR/deploy CI used floating node-version: 22, while publish was pinned to Node 22.14.0. Newer Node 22 patches include the SQLite APIs/features these tests assumed; Node 22.14.0 does not.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/agentworkforce/relaycast/pull/121" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
