### PR TITLE
Fix CLI npm package name

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -314,7 +314,7 @@ jobs:
             ### Install
             ```bash
             npm install @relaycast/sdk@${{ needs.build.outputs.new_version }}
-            npm install @relaycast/cli@${{ needs.build.outputs.new_version }}
+            npm install relaycast@${{ needs.build.outputs.new_version }}
             npm install @relaycast/react@${{ needs.build.outputs.new_version }}
             npm install @relaycast/mcp@${{ needs.build.outputs.new_version }}
             npm install @relaycast/openclaw@${{ needs.build.outputs.new_version }}
@@ -326,7 +326,7 @@ jobs:
             | @relaycast/types | ${{ needs.build.outputs.new_version }} |
             | @relaycast/server | ${{ needs.build.outputs.new_version }} |
             | @relaycast/sdk | ${{ needs.build.outputs.new_version }} |
-            | @relaycast/cli | ${{ needs.build.outputs.new_version }} |
+            | relaycast | ${{ needs.build.outputs.new_version }} |
             | @relaycast/mcp | ${{ needs.build.outputs.new_version }} |
             | @relaycast/react | ${{ needs.build.outputs.new_version }} |
             | @relaycast/openclaw | ${{ needs.build.outputs.new_version }} |

--- a/.trajectories/completed/2026-04/traj_l3sqbg3nztl2.json
+++ b/.trajectories/completed/2026-04/traj_l3sqbg3nztl2.json
@@ -1,0 +1,53 @@
+{
+  "id": "traj_l3sqbg3nztl2",
+  "version": 1,
+  "task": {
+    "title": "Fix Relaycast package publish name"
+  },
+  "status": "completed",
+  "startedAt": "2026-04-17T09:54:06.365Z",
+  "agents": [
+    {
+      "name": "default",
+      "role": "lead",
+      "joinedAt": "2026-04-17T09:56:24.841Z"
+    }
+  ],
+  "chapters": [
+    {
+      "id": "chap_sepk6ht7jd16",
+      "title": "Work",
+      "agentName": "default",
+      "startedAt": "2026-04-17T09:56:24.841Z",
+      "events": [
+        {
+          "ts": 1776419784842,
+          "type": "decision",
+          "content": "Publish CLI as unscoped relaycast package: Publish CLI as unscoped relaycast package",
+          "raw": {
+            "question": "Publish CLI as unscoped relaycast package",
+            "chosen": "Publish CLI as unscoped relaycast package",
+            "alternatives": [],
+            "reasoning": "The npm failure targeted @relaycast/cli, while packages/cli/package.json and the intended public package name should be relaycast; updating the manifest, lockfile, docs, release notes, and CLI identity keeps npm publish and user-facing output aligned."
+          },
+          "significance": "high"
+        }
+      ],
+      "endedAt": "2026-04-17T09:59:35.883Z"
+    }
+  ],
+  "commits": [],
+  "filesChanged": [],
+  "projectId": "/Users/khaliqgant/Projects/AgentWorkforce/relaycast",
+  "tags": [],
+  "_trace": {
+    "startRef": "9886a8e1a789264715ecf06143f9c6a400937378",
+    "endRef": "9886a8e1a789264715ecf06143f9c6a400937378"
+  },
+  "completedAt": "2026-04-17T09:59:35.883Z",
+  "retrospective": {
+    "summary": "Aligned the CLI package with the unscoped relaycast npm name, updated docs/release metadata, regenerated the workspace lockfile link, normalized package repository URLs, and verified CLI tests plus npm dry-run publish.",
+    "approach": "Standard approach",
+    "confidence": 0.92
+  }
+}

--- a/.trajectories/completed/2026-04/traj_l3sqbg3nztl2.md
+++ b/.trajectories/completed/2026-04/traj_l3sqbg3nztl2.md
@@ -1,0 +1,31 @@
+# Trajectory: Fix Relaycast package publish name
+
+> **Status:** ✅ Completed
+> **Confidence:** 92%
+> **Started:** April 17, 2026 at 11:54 AM
+> **Completed:** April 17, 2026 at 11:59 AM
+
+---
+
+## Summary
+
+Aligned the CLI package with the unscoped relaycast npm name, updated docs/release metadata, regenerated the workspace lockfile link, normalized package repository URLs, and verified CLI tests plus npm dry-run publish.
+
+**Approach:** Standard approach
+
+---
+
+## Key Decisions
+
+### Publish CLI as unscoped relaycast package
+- **Chose:** Publish CLI as unscoped relaycast package
+- **Reasoning:** The npm failure targeted @relaycast/cli, while packages/cli/package.json and the intended public package name should be relaycast; updating the manifest, lockfile, docs, release notes, and CLI identity keeps npm publish and user-facing output aligned.
+
+---
+
+## Chapters
+
+### 1. Work
+*Agent: default*
+
+- Publish CLI as unscoped relaycast package: Publish CLI as unscoped relaycast package

--- a/.trajectories/index.json
+++ b/.trajectories/index.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "lastUpdated": "2026-04-17T09:31:22.420Z",
+  "lastUpdated": "2026-04-17T09:59:35.979Z",
   "trajectories": {
     "traj_o8g8ahqth5fx": {
       "title": "Wave 0: add repo infrastructure files (docker, turbo, tsconfig, env)",
@@ -1050,6 +1050,13 @@
       "startedAt": "2026-04-17T09:19:06.767Z",
       "completedAt": "2026-04-17T09:31:22.324Z",
       "path": "/Users/khaliqgant/Projects/AgentWorkforce/relaycast/.trajectories/completed/2026-04/traj_e3imqupgb81i.json"
+    },
+    "traj_l3sqbg3nztl2": {
+      "title": "Fix Relaycast package publish name",
+      "status": "completed",
+      "startedAt": "2026-04-17T09:54:06.365Z",
+      "completedAt": "2026-04-17T09:59:35.883Z",
+      "path": "/Users/khaliqgant/Projects/AgentWorkforce/relaycast/.trajectories/completed/2026-04/traj_l3sqbg3nztl2.json"
     }
   }
 }

--- a/README.md
+++ b/README.md
@@ -254,7 +254,7 @@ Remote Streamable HTTP config:
 Use the same command surface as the MCP tools from a terminal:
 
 ```bash
-npm install -g @relaycast/cli
+npm install -g relaycast
 relaycast tools
 RELAY_API_KEY=rk_live_... RELAY_AGENT_TOKEN=at_live_... relaycast message.post --channel general --text "Hello"
 ```
@@ -429,7 +429,7 @@ Relaycast includes anonymous telemetry.
 | `@relaycast/server` | REST API + WebSocket server |
 | `@relaycast/sdk` | TypeScript SDK |
 | `@relaycast/types` | Shared type definitions |
-| `@relaycast/cli` | CLI for the MCP tool command surface |
+| `relaycast` | CLI for the MCP tool command surface |
 | `@relaycast/mcp` | MCP server |
 | `relay-sdk` (Python) | Python SDK |
 | `local` (Rust) | Local Relaycast-compatible daemon |

--- a/package-lock.json
+++ b/package-lock.json
@@ -3259,10 +3259,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@relaycast/cli": {
-      "resolved": "packages/cli",
-      "link": true
-    },
     "node_modules/@relaycast/mcp": {
       "resolved": "packages/mcp",
       "link": true
@@ -10083,6 +10079,10 @@
         "react": ">=18"
       }
     },
+    "node_modules/relaycast": {
+      "resolved": "packages/cli",
+      "link": true
+    },
     "node_modules/remark-breaks": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/remark-breaks/-/remark-breaks-4.0.0.tgz",
@@ -13331,7 +13331,7 @@
       }
     },
     "packages/cli": {
-      "name": "@relaycast/cli",
+      "name": "relaycast",
       "version": "1.1.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.26.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@relaycast/cli",
+  "name": "relaycast",
   "version": "1.1.0",
   "type": "module",
   "main": "dist/index.js",
@@ -30,7 +30,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/AgentWorkforce/relaycast",
+    "url": "git+https://github.com/AgentWorkforce/relaycast.git",
     "directory": "packages/cli"
   },
   "files": [

--- a/packages/cli/src/__tests__/cli.test.ts
+++ b/packages/cli/src/__tests__/cli.test.ts
@@ -4,7 +4,7 @@ import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
 import { createRelayMcpServer } from '@relaycast/mcp';
 import { listCliTools, runCli } from '../index.js';
 
-describe('@relaycast/cli', () => {
+describe('relaycast', () => {
   it('exposes the same command names as the MCP tool list', async () => {
     const mcpServer = createRelayMcpServer({});
     const client = new Client({ name: 'cli-parity-test', version: '0.1.0' });

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -63,13 +63,13 @@ const TOOL_JSON_FLAG_NAMES = new Set(['json-args', 'args-json']);
 export async function runCli(argv: string[], io: CliIo): Promise<number> {
   try {
     if (argv.length === 1 && (argv[0] === 'version' || argv[0] === '--version' || argv[0] === '-v')) {
-      io.stdout.write(`@relaycast/cli ${CLI_VERSION}\n`);
+      io.stdout.write(`relaycast ${CLI_VERSION}\n`);
       return 0;
     }
 
     const parsed = parseCliArgs(argv, io.env ?? process.env);
     if (parsed.command === 'version') {
-      io.stdout.write(`@relaycast/cli ${CLI_VERSION}\n`);
+      io.stdout.write(`relaycast ${CLI_VERSION}\n`);
       return 0;
     }
 
@@ -196,7 +196,7 @@ async function createCliMcpSession(config: CliConfig) {
     telemetryTransport: 'stdio',
   };
   const server = createRelayMcpServer(options);
-  const client = new Client({ name: '@relaycast/cli', version: CLI_VERSION });
+  const client = new Client({ name: 'relaycast', version: CLI_VERSION });
   const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
   await Promise.all([
     client.connect(clientTransport),

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -21,7 +21,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/AgentWorkforce/relaycast",
+    "url": "git+https://github.com/AgentWorkforce/relaycast.git",
     "directory": "packages/mcp"
   },
   "files": [

--- a/packages/openclaw/package.json
+++ b/packages/openclaw/package.json
@@ -15,7 +15,7 @@
   "homepage": "https://relaycast.dev",
   "repository": {
     "type": "git",
-    "url": "https://github.com/AgentWorkforce/relaycast",
+    "url": "git+https://github.com/AgentWorkforce/relaycast.git",
     "directory": "packages/openclaw"
   },
   "type": "module",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -15,7 +15,7 @@
   "homepage": "https://relaycast.dev",
   "repository": {
     "type": "git",
-    "url": "https://github.com/AgentWorkforce/relaycast",
+    "url": "git+https://github.com/AgentWorkforce/relaycast.git",
     "directory": "packages/react"
   },
   "type": "module",

--- a/packages/sdk-typescript/package.json
+++ b/packages/sdk-typescript/package.json
@@ -32,7 +32,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/AgentWorkforce/relaycast",
+    "url": "git+https://github.com/AgentWorkforce/relaycast.git",
     "directory": "packages/sdk-typescript"
   },
   "files": [

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -21,7 +21,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/AgentWorkforce/relaycast",
+    "url": "git+https://github.com/AgentWorkforce/relaycast.git",
     "directory": "packages/server"
   },
   "files": [

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -11,7 +11,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/AgentWorkforce/relaycast",
+    "url": "git+https://github.com/AgentWorkforce/relaycast.git",
     "directory": "packages/types"
   },
   "dependencies": {


### PR DESCRIPTION
## Summary
- publish the CLI workspace as the unscoped `relaycast` npm package
- update docs, release notes, lockfile, CLI display/client identity, and package repository URLs
- remove stale `@relaycast/cli` references so npm publish targets the intended package

## Verification
- `npm test -- --filter=./packages/cli`
- `npm_config_cache=/tmp/relaycast-npm-cache npm publish --dry-run --access public --tag latest --ignore-scripts`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/agentworkforce/relaycast/pull/122" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
