### PR TITLE
feat(a2a): publish shared schema package

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -9,6 +9,7 @@ on:
         type: choice
         options:
           - all
+          - a2a
           - types
           - server
           - sdk-typescript
@@ -184,6 +185,7 @@ jobs:
       max-parallel: 5
       matrix:
         package:
+          - a2a
           - types
           - server
           - sdk-typescript
@@ -313,6 +315,7 @@ jobs:
 
             ### Install
             ```bash
+            npm install @relaycast/a2a@${{ needs.build.outputs.new_version }}
             npm install @relaycast/sdk@${{ needs.build.outputs.new_version }}
             npm install relaycast@${{ needs.build.outputs.new_version }}
             npm install @relaycast/react@${{ needs.build.outputs.new_version }}
@@ -323,6 +326,7 @@ jobs:
             ### Packages
             | Package | Version |
             |---------|---------|
+            | @relaycast/a2a | ${{ needs.build.outputs.new_version }} |
             | @relaycast/types | ${{ needs.build.outputs.new_version }} |
             | @relaycast/server | ${{ needs.build.outputs.new_version }} |
             | @relaycast/sdk | ${{ needs.build.outputs.new_version }} |

--- a/package-lock.json
+++ b/package-lock.json
@@ -3279,6 +3279,10 @@
       "integrity": "sha512-h2FO7ut/BbfwpAXWpwdDHTzQgUo9ibDFEs6ZO+3cI3KPWQt5XwczK1OLAuPprcjm8T/jl0SH8jSFo5XdU4RbTg==",
       "license": "MIT"
     },
+    "node_modules/@relaycast/a2a": {
+      "resolved": "packages/a2a",
+      "link": true
+    },
     "node_modules/@relaycast/mcp": {
       "resolved": "packages/mcp",
       "link": true
@@ -7951,7 +7955,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -7973,7 +7976,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -7995,7 +7997,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -8017,7 +8018,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -8039,7 +8039,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -8061,7 +8060,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -8083,7 +8081,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -8105,7 +8102,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -8127,7 +8123,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -8149,7 +8144,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -8171,7 +8165,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -13364,6 +13357,13 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "packages/a2a": {
+      "name": "@relaycast/a2a",
+      "version": "1.1.3",
+      "dependencies": {
+        "zod": "^4.3.6"
+      }
+    },
     "packages/cli": {
       "name": "relaycast",
       "version": "1.1.3",
@@ -13952,6 +13952,7 @@
       "dependencies": {
         "@aws-sdk/client-s3": "^3.985.0",
         "@aws-sdk/s3-request-presigner": "^3.985.0",
+        "@relaycast/a2a": "1.1.3",
         "@relaycast/mcp": "1.1.3",
         "@relaycast/types": "1.1.3",
         "drizzle-orm": "^0.45.1",

--- a/packages/a2a/package.json
+++ b/packages/a2a/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@relaycast/a2a",
+  "version": "1.1.3",
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "build": "rm -rf dist tsconfig.tsbuildinfo && tsc",
+    "test": "vitest run",
+    "lint": "eslint src/"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/AgentWorkforce/relaycast.git",
+    "directory": "packages/a2a"
+  },
+  "dependencies": {
+    "zod": "^4.3.6"
+  },
+  "files": [
+    "dist"
+  ]
+}

--- a/packages/a2a/package.json
+++ b/packages/a2a/package.json
@@ -6,7 +6,7 @@
   "types": "dist/index.d.ts",
   "scripts": {
     "build": "rm -rf dist tsconfig.tsbuildinfo && tsc",
-    "test": "vitest run",
+    "test": "vitest run --passWithNoTests",
     "lint": "eslint src/"
   },
   "repository": {

--- a/packages/a2a/src/index.ts
+++ b/packages/a2a/src/index.ts
@@ -1,0 +1,127 @@
+import { z } from 'zod';
+
+export const A2aSkillSchema = z.object({
+  id: z.string().min(1).optional(),
+  name: z.string().min(1),
+  description: z.string().optional(),
+  tags: z.array(z.string()).optional(),
+});
+
+export const A2aAgentCardSchema = z.object({
+  name: z.string().min(1),
+  description: z.string().optional(),
+  url: z.string().url(),
+  version: z.string().min(1),
+  skills: z.array(A2aSkillSchema).min(1),
+  provider: z.record(z.string(), z.unknown()).optional(),
+  capabilities: z.record(z.string(), z.unknown()).optional(),
+  default_input_modes: z.array(z.string()).optional(),
+  default_output_modes: z.array(z.string()).optional(),
+  documentation_url: z.string().url().optional(),
+});
+
+export const A2aFilePartSchema = z.object({
+  kind: z.literal('file'),
+  file: z.object({
+    name: z.string().min(1),
+    mime_type: z.string().min(1).optional(),
+    uri: z.string().min(1).optional(),
+    bytes: z.number().int().nonnegative().optional(),
+  }),
+});
+
+export const A2aDataPartSchema = z.object({
+  kind: z.literal('data'),
+  data: z.record(z.string(), z.unknown()),
+});
+
+export const A2aTextPartSchema = z.object({
+  kind: z.literal('text'),
+  text: z.string(),
+});
+
+export const A2aPartSchema = z.discriminatedUnion('kind', [
+  A2aTextPartSchema,
+  A2aFilePartSchema,
+  A2aDataPartSchema,
+]);
+
+export const A2aMessageSchema = z.object({
+  message_id: z.string(),
+  role: z.enum(['user', 'agent', 'system']).default('user'),
+  context_id: z.string().optional(),
+  parts: z.array(A2aPartSchema).min(1),
+});
+
+export const A2aArtifactSchema = z.object({
+  name: z.string(),
+  description: z.string().optional(),
+  parts: z.array(A2aPartSchema).min(1),
+});
+
+export const A2aTaskStateSchema = z.enum([
+  'submitted',
+  'working',
+  'input-required',
+  'completed',
+  'failed',
+  'canceled',
+  'unknown',
+]);
+
+export const A2aTaskSchema = z.object({
+  id: z.string(),
+  context_id: z.string().optional(),
+  status: z.object({
+    state: A2aTaskStateSchema,
+    message: z.string().optional(),
+  }),
+  artifacts: z.array(A2aArtifactSchema).optional(),
+  history: z.array(A2aMessageSchema).optional(),
+  metadata: z.record(z.string(), z.unknown()).optional(),
+});
+
+export const JsonRpcRequestSchema = z.object({
+  jsonrpc: z.literal('2.0'),
+  id: z.union([z.string(), z.number()]).optional(),
+  method: z.string().min(1),
+  params: z.object({
+    message: A2aMessageSchema.optional(),
+  }).passthrough().optional(),
+});
+
+export const JsonRpcErrorSchema = z.object({
+  code: z.number(),
+  message: z.string(),
+  data: z.unknown().optional(),
+});
+
+export const JsonRpcResponseSchema = z.object({
+  jsonrpc: z.literal('2.0'),
+  id: z.union([z.string(), z.number()]).optional(),
+  result: z.object({
+    task: A2aTaskSchema.optional(),
+    message: A2aMessageSchema.optional(),
+  }).passthrough().optional(),
+  error: JsonRpcErrorSchema.optional(),
+});
+
+export const A2aResponseSchema = z.object({
+  task: A2aTaskSchema.optional(),
+  message: A2aMessageSchema.optional(),
+  response: JsonRpcResponseSchema.optional(),
+});
+
+export type A2aSkill = z.infer<typeof A2aSkillSchema>;
+export type A2aAgentCard = z.infer<typeof A2aAgentCardSchema>;
+export type A2aFilePart = z.infer<typeof A2aFilePartSchema>;
+export type A2aDataPart = z.infer<typeof A2aDataPartSchema>;
+export type A2aTextPart = z.infer<typeof A2aTextPartSchema>;
+export type A2aPart = z.infer<typeof A2aPartSchema>;
+export type A2aMessage = z.infer<typeof A2aMessageSchema>;
+export type A2aArtifact = z.infer<typeof A2aArtifactSchema>;
+export type A2aTaskState = z.infer<typeof A2aTaskStateSchema>;
+export type A2aTask = z.infer<typeof A2aTaskSchema>;
+export type A2aJsonRpcRequest = z.infer<typeof JsonRpcRequestSchema>;
+export type A2aJsonRpcResponse = z.infer<typeof JsonRpcResponseSchema>;
+export type A2aResponse = z.infer<typeof A2aResponseSchema>;

--- a/packages/a2a/tsconfig.json
+++ b/packages/a2a/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "tsBuildInfoFile": "tsconfig.tsbuildinfo"
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -18,7 +18,8 @@
     "drizzle-orm": "^0.45.1",
     "hono": "^4.11.9",
     "posthog-node": "^5.29.2",
-    "zod": "^4.3.6"
+    "zod": "^4.3.6",
+    "@relaycast/a2a": "1.1.3"
   },
   "repository": {
     "type": "git",

--- a/packages/server/src/engine/a2a.ts
+++ b/packages/server/src/engine/a2a.ts
@@ -1,5 +1,23 @@
 import crypto from 'node:crypto';
 import { and, eq, sql } from 'drizzle-orm';
+import {
+  A2aAgentCardSchema,
+  A2aMessageSchema,
+  A2aPartSchema,
+  A2aResponseSchema,
+  A2aTaskSchema,
+  A2aTaskStateSchema,
+  JsonRpcRequestSchema,
+  JsonRpcResponseSchema,
+  type A2aAgentCard,
+  type A2aJsonRpcRequest,
+  type A2aJsonRpcResponse,
+  type A2aMessage,
+  type A2aPart,
+  type A2aResponse,
+  type A2aTask,
+  type A2aTaskState,
+} from '@relaycast/a2a';
 import { z } from 'zod';
 import type { FileAttachment } from '@relaycast/types';
 import type { getDb } from '../db/index.js';
@@ -11,26 +29,6 @@ type Db = ReturnType<typeof getDb>;
 
 const RETRY_DELAYS_MS = [250, 750] as const;
 const DEFAULT_WEBHOOK_BASE_PATH = '/a2a/webhook';
-
-const A2aSkillSchema = z.object({
-  id: z.string().min(1).optional(),
-  name: z.string().min(1),
-  description: z.string().optional(),
-  tags: z.array(z.string()).optional(),
-});
-
-export const A2aAgentCardSchema = z.object({
-  name: z.string().min(1),
-  description: z.string().optional(),
-  url: z.string().url(),
-  version: z.string().min(1),
-  skills: z.array(A2aSkillSchema).min(1),
-  provider: z.record(z.string(), z.unknown()).optional(),
-  capabilities: z.record(z.string(), z.unknown()).optional(),
-  default_input_modes: z.array(z.string()).optional(),
-  default_output_modes: z.array(z.string()).optional(),
-  documentation_url: z.string().url().optional(),
-});
 
 const RelayFileAttachmentSchema = z.object({
   file_id: z.string(),
@@ -49,106 +47,28 @@ const RelayDMSchema = z.object({
   attachments: z.array(RelayFileAttachmentSchema).optional(),
 });
 
-const A2aFilePartSchema = z.object({
-  kind: z.literal('file'),
-  file: z.object({
-    name: z.string().min(1),
-    mime_type: z.string().min(1).optional(),
-    uri: z.string().min(1).optional(),
-    bytes: z.number().int().nonnegative().optional(),
-  }),
-});
+export {
+  A2aAgentCardSchema,
+  A2aMessageSchema,
+  A2aPartSchema,
+  A2aResponseSchema,
+  A2aTaskSchema,
+  A2aTaskStateSchema,
+  JsonRpcRequestSchema,
+  JsonRpcResponseSchema,
+};
 
-const A2aDataPartSchema = z.object({
-  kind: z.literal('data'),
-  data: z.record(z.string(), z.unknown()),
-});
+export type {
+  A2aAgentCard,
+  A2aJsonRpcRequest,
+  A2aJsonRpcResponse,
+  A2aMessage,
+  A2aPart,
+  A2aResponse,
+  A2aTask,
+  A2aTaskState,
+};
 
-const A2aTextPartSchema = z.object({
-  kind: z.literal('text'),
-  text: z.string(),
-});
-
-export const A2aPartSchema = z.discriminatedUnion('kind', [
-  A2aTextPartSchema,
-  A2aFilePartSchema,
-  A2aDataPartSchema,
-]);
-
-export const A2aMessageSchema = z.object({
-  message_id: z.string(),
-  role: z.enum(['user', 'agent', 'system']).default('user'),
-  context_id: z.string().optional(),
-  parts: z.array(A2aPartSchema).min(1),
-});
-
-const A2aArtifactSchema = z.object({
-  name: z.string(),
-  description: z.string().optional(),
-  parts: z.array(A2aPartSchema).min(1),
-});
-
-export const A2aTaskStateSchema = z.enum([
-  'submitted',
-  'working',
-  'input-required',
-  'completed',
-  'failed',
-  'canceled',
-  'unknown',
-]);
-
-export const A2aTaskSchema = z.object({
-  id: z.string(),
-  context_id: z.string().optional(),
-  status: z.object({
-    state: A2aTaskStateSchema,
-    message: z.string().optional(),
-  }),
-  artifacts: z.array(A2aArtifactSchema).optional(),
-  history: z.array(A2aMessageSchema).optional(),
-  metadata: z.record(z.string(), z.unknown()).optional(),
-});
-
-export const JsonRpcRequestSchema = z.object({
-  jsonrpc: z.literal('2.0'),
-  id: z.union([z.string(), z.number()]).optional(),
-  method: z.string().min(1),
-  params: z.object({
-    message: A2aMessageSchema.optional(),
-  }).passthrough().optional(),
-});
-
-const JsonRpcErrorSchema = z.object({
-  code: z.number(),
-  message: z.string(),
-  data: z.unknown().optional(),
-});
-
-export const JsonRpcResponseSchema = z.object({
-  jsonrpc: z.literal('2.0'),
-  id: z.union([z.string(), z.number()]).optional(),
-  result: z.object({
-    task: A2aTaskSchema.optional(),
-    message: A2aMessageSchema.optional(),
-  }).passthrough().optional(),
-  error: JsonRpcErrorSchema.optional(),
-});
-
-const _A2aResponseSchema = z.object({
-  task: A2aTaskSchema.optional(),
-  message: A2aMessageSchema.optional(),
-  response: JsonRpcResponseSchema.optional(),
-});
-
-export type A2aAgentCard = z.infer<typeof A2aAgentCardSchema>;
-export type A2aMessage = z.infer<typeof A2aMessageSchema>;
-export type A2aPart = z.infer<typeof A2aPartSchema>;
-export type A2aTask = z.infer<typeof A2aTaskSchema>;
-export type A2aTaskState = z.infer<typeof A2aTaskStateSchema>;
-export type A2aJsonRpcRequest = z.infer<typeof JsonRpcRequestSchema>;
-export type A2aJsonRpcResponse = z.infer<typeof JsonRpcResponseSchema>;
-export type A2aResponse = z.infer<typeof _A2aResponseSchema>;
 export type RelayDM = z.infer<typeof RelayDMSchema>;
 
 export interface RegisterA2aAgentInput {


### PR DESCRIPTION
## Summary
- add a new published `@relaycast/a2a` package for shared A2A schemas and types
- switch the server A2A engine to import those schemas/types from the new package
- keep compatibility re-exports in `packages/server/src/engine/a2a.ts` so existing internal server imports keep working

## Why
Sage and Cloud are currently vendoring `a2a-schemas.ts` from relaycast. That is the wrong long-term shape. Relaycast already owns the A2A schema truth, so it should publish a package both repos can depend on instead of copying schema files.

## What this unlocks
- Sage can depend on `@relaycast/a2a` instead of vendoring schemas
- Cloud specialist-worker can depend on the same package
- Relaycast remains the canonical source of truth for A2A wire schemas

## Validation
- `npm run build --workspace @relaycast/a2a`

Additional server workspace validation in this clean worktree was noisy due to broader existing workspace/environment typing issues (for example Worker globals / package resolution), so this PR keeps the scope bounded and preserves server compatibility via re-exports in `engine/a2a.ts`.
