### PR TITLE
fix(a2a): export package entrypoint

### DIFF
--- a/packages/a2a/package.json
+++ b/packages/a2a/package.json
@@ -4,6 +4,13 @@
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
+    }
+  },
   "scripts": {
     "build": "rm -rf dist tsconfig.tsbuildinfo && tsc",
     "test": "vitest run --passWithNoTests",


### PR DESCRIPTION
## Summary
- add an explicit `exports` map to `@relaycast/a2a`

## Why
The initial `@relaycast/a2a` publish shipped `main` and `types`, but no `exports` field. That works in some Node resolution paths, but Vite consumers like Sage fail to resolve the package entry cleanly.

This follow-up makes the package consumable by stricter ESM tooling.

## Validation
- `npm install`
- `npm run build --workspace @relaycast/a2a`
- `npm run test --workspace @relaycast/a2a`
- `npm run lint --workspace @relaycast/a2a`
