### PR TITLE
Add Cursor Cloud specific instructions to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,6 +36,28 @@ Relaycast is headless Slack for agents: channels, threads, DMs, reactions, files
 
 
 
+## Cursor Cloud specific instructions
+
+### Services overview
+
+| Service | Command | Port | Notes |
+|---------|---------|------|-------|
+| API Server (`@relaycast/server`) | `npx wrangler dev --port 8787` | 8787 | Core REST + WebSocket server. Uses D1 (local SQLite) via wrangler. |
+| Observer Dashboard | `RELAY_SERVER_URL=http://localhost:7528 npm run -w @relaycast/observer-dashboard dev` | 3100 | Optional Next.js dashboard. |
+
+### Running the dev server
+
+1. Apply D1 migrations before first run: `npx wrangler d1 migrations apply relaycast --local`
+2. Start with `npx wrangler dev --port 8787` or `npm run dev` (starts server + dashboard via turbo).
+3. Health check: `curl http://localhost:8787/health` should return `{"ok":true,...}`.
+
+### Gotchas
+
+- The `wrangler.toml` at repo root has placeholder IDs for production resources. Local dev uses `--local` mode which creates an in-process D1 SQLite database — no external Postgres/Redis needed.
+- The `.env.example` references PostgreSQL and Redis from an earlier architecture; these are **not required** for local development via wrangler.
+- D1 local mode has eventual consistency quirks: deleting then immediately re-creating a resource (e.g., an A2A agent) may fail with "already exists." Add a small delay or use `--continue-on-failure` in E2E tests.
+- `npm run e2e -- http://localhost:8787 --ci` runs the full E2E smoke test in non-interactive mode. Use `--continue-on-failure` to see all results despite D1 consistency issues.
+- Standard commands for build/test/lint are in the **Core Commands** section above and in root `package.json` scripts.
 
 <!-- prpm:snippet:start @agent-workforce/trail-snippet@1.1.2 -->
 # Trail


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds a `## Cursor Cloud specific instructions` section to `AGENTS.md` with durable development context for future Cloud Agents:

- **Services overview table** — API server (`wrangler dev` on port 8787) and optional Observer Dashboard (port 3100)
- **Dev server startup steps** — D1 migration command, `wrangler dev`, and health check verification
- **Gotchas** — `.env.example` references to Postgres/Redis are not needed locally; D1 eventual consistency quirks for E2E testing; `--continue-on-failure` flag for E2E

### Environment verification

All commands were verified against the local wrangler dev server:

| Check | Result |
|-------|--------|
| `npm install` | 721 packages installed |
| `npx turbo build` | 9/9 packages built |
| `npx turbo lint` | 0 errors, 64 warnings |
| `npx turbo test` | 436/436 tests passed (46 test files) |
| `npx wrangler dev` | Server running on port 8787 |
| `npm run e2e -- http://localhost:8787 --ci --continue-on-failure` | 101/102 passed (1 D1 consistency flake) |

E2E smoke test output:
[e2e_smoke_test_results.log](https://cursor.com/agents/bc-22967b5a-e88e-4f05-b902-80d1f276d720/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fe2e_smoke_test_results.log)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-22967b5a-e88e-4f05-b902-80d1f276d720"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-22967b5a-e88e-4f05-b902-80d1f276d720"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

