### PR TITLE
fix(sdk-rust): tolerate public agent payloads

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -105,6 +105,30 @@ components:
         created_at:
           type: string
           format: date-time
+          description: Agent creation timestamp when available.
+        last_seen:
+          type: string
+          format: date-time
+          description: Last presence update timestamp.
+        channels:
+          type: array
+          description: Channels this agent belongs to. Present on agent detail responses.
+          items:
+            $ref: '#/components/schemas/AgentChannelMembership'
+
+    AgentChannelMembership:
+      type: object
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+        role:
+          type: string
+          enum: [owner, member]
+        joined_at:
+          type: string
+          format: date-time
 
     Channel:
       type: object

--- a/packages/sdk-rust/src/lib.rs
+++ b/packages/sdk-rust/src/lib.rs
@@ -90,6 +90,7 @@ pub use ws::{EventReceiver, LifecycleReceiver, WsClient, WsClientOptions, WsLife
 pub use types::{
     // Agents
     Agent,
+    AgentChannelMembership,
     // Commands
     AgentCommand,
     AgentListQuery,

--- a/packages/sdk-rust/src/relay.rs
+++ b/packages/sdk-rust/src/relay.rs
@@ -539,15 +539,18 @@ impl RelayCast {
     ) -> Result<CreateAgentResponse> {
         match self.register_agent(request.clone()).await {
             Ok(response) => Ok(response),
-            Err(RelayError::Api { code, .. }) if code == "agent_already_exists" => {
+            Err(RelayError::Api { code, status, .. })
+                if code == "agent_already_exists" || status == 409 =>
+            {
                 let agent = self.get_agent(&request.name).await?;
                 let token_response = self.rotate_agent_token(&agent.name).await?;
+                let created_at = agent.created_at.or(agent.last_seen).unwrap_or_default();
                 Ok(CreateAgentResponse {
                     id: agent.id,
                     name: agent.name,
                     token: token_response.token,
                     status: agent.status,
-                    created_at: agent.created_at,
+                    created_at,
                 })
             }
             Err(e) => Err(e),

--- a/packages/sdk-rust/src/types.rs
+++ b/packages/sdk-rust/src/types.rs
@@ -147,16 +147,27 @@ pub struct TokenRotateResponse {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Agent {
     pub id: String,
-    pub workspace_id: String,
     pub name: String,
     #[serde(rename = "type")]
     pub agent_type: String,
-    pub token_hash: String,
     pub status: String,
     pub persona: Option<String>,
+    #[serde(default)]
     pub metadata: serde_json::Map<String, serde_json::Value>,
-    pub created_at: String,
-    pub last_seen: String,
+    #[serde(default)]
+    pub created_at: Option<String>,
+    #[serde(default)]
+    pub last_seen: Option<String>,
+    #[serde(default)]
+    pub channels: Vec<AgentChannelMembership>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AgentChannelMembership {
+    pub id: String,
+    pub name: String,
+    pub role: String,
+    pub joined_at: String,
 }
 
 #[derive(Debug, Clone, Serialize)]

--- a/packages/sdk-rust/tests/parity.rs
+++ b/packages/sdk-rust/tests/parity.rs
@@ -1,6 +1,6 @@
 use relaycast::{
-    AgentClient, DmConversationSummary, MessageInjectionMode, MessageListQuery, RelayCast,
-    RelayCastOptions, ReleaseAgentRequest, SpawnAgentRequest, WsEvent,
+    AgentClient, CreateAgentRequest, DmConversationSummary, MessageInjectionMode, MessageListQuery,
+    RelayCast, RelayCastOptions, ReleaseAgentRequest, SpawnAgentRequest, WsEvent,
 };
 use serde_json::json;
 use wiremock::matchers::{body_json, header, method, path, query_param};
@@ -16,6 +16,82 @@ fn local_options_builder_sets_expected_defaults() {
 
 fn ok(data: serde_json::Value) -> ResponseTemplate {
     ResponseTemplate::new(200).set_body_json(json!({ "ok": true, "data": data }))
+}
+
+fn api_error(status: u16, code: &str, message: &str) -> ResponseTemplate {
+    ResponseTemplate::new(status).set_body_json(json!({
+        "ok": false,
+        "error": {
+            "code": code,
+            "message": message
+        }
+    }))
+}
+
+#[tokio::test]
+async fn register_or_get_agent_reclaims_public_agent_payload() {
+    let server = MockServer::start().await;
+    let relay = RelayCast::new(RelayCastOptions::new("rk_live_test").with_base_url(server.uri()))
+        .expect("failed to create relay client");
+
+    Mock::given(method("POST"))
+        .and(path("/v1/agents"))
+        .and(body_json(json!({
+            "name": "Lead",
+            "type": "agent"
+        })))
+        .respond_with(api_error(409, "agent_already_exists", "name_taken"))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path("/v1/agents/Lead"))
+        .respond_with(ok(json!({
+            "id": "a_existing",
+            "name": "Lead",
+            "type": "agent",
+            "status": "offline",
+            "persona": null,
+            "last_seen": "2026-01-01T00:00:00.000Z",
+            "channels": [
+                {
+                    "id": "ch_1",
+                    "name": "general",
+                    "role": "member",
+                    "joined_at": "2026-01-01T00:00:00.000Z"
+                }
+            ]
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    Mock::given(method("POST"))
+        .and(path("/v1/agents/Lead/rotate-token"))
+        .respond_with(ok(json!({
+            "name": "Lead",
+            "token": "at_live_rotated"
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let reclaimed = relay
+        .register_or_get_agent(CreateAgentRequest {
+            name: "Lead".to_string(),
+            agent_type: Some("agent".to_string()),
+            persona: None,
+            metadata: None,
+        })
+        .await
+        .expect("register_or_get_agent should tolerate public get-agent payload");
+
+    assert_eq!(reclaimed.id, "a_existing");
+    assert_eq!(reclaimed.name, "Lead");
+    assert_eq!(reclaimed.token, "at_live_rotated");
+    assert_eq!(reclaimed.status, "offline");
+    assert_eq!(reclaimed.created_at, "2026-01-01T00:00:00.000Z");
 }
 
 #[tokio::test]
@@ -216,7 +292,10 @@ async fn send_defaults_mode_wait() {
         .send("#general", "Hello", None, None, None)
         .await
         .expect("send failed");
-    assert!(matches!(sent.injection_mode, Some(MessageInjectionMode::Wait)));
+    assert!(matches!(
+        sent.injection_mode,
+        Some(MessageInjectionMode::Wait)
+    ));
 }
 
 #[tokio::test]
@@ -258,7 +337,10 @@ async fn send_with_mode_forwards_steer() {
         )
         .await
         .expect("send_with_mode failed");
-    assert!(matches!(sent.injection_mode, Some(MessageInjectionMode::Steer)));
+    assert!(matches!(
+        sent.injection_mode,
+        Some(MessageInjectionMode::Steer)
+    ));
 }
 
 #[tokio::test]
@@ -323,7 +405,10 @@ fn ws_message_created_deserializes_optional_agent_id() {
         WsEvent::MessageCreated(msg) => {
             assert_eq!(msg.message.agent_id.as_deref(), Some("a_123"));
             assert_eq!(msg.message.agent_name, "alice");
-            assert!(matches!(msg.message.injection_mode, Some(MessageInjectionMode::Steer)));
+            assert!(matches!(
+                msg.message.injection_mode,
+                Some(MessageInjectionMode::Steer)
+            ));
         }
         other => panic!("unexpected event variant: {other:?}"),
     }

--- a/packages/server/src/engine/agent.ts
+++ b/packages/server/src/engine/agent.ts
@@ -114,6 +114,7 @@ export async function listAgents(db: Db, workspaceId: string, status?: string) {
     type: a.type,
     status: a.status,
     persona: a.persona,
+    created_at: a.createdAt.toISOString(),
     last_seen: a.lastSeen.toISOString(),
     metadata: a.metadata,
   }));
@@ -145,6 +146,7 @@ export async function getAgentByName(db: Db, workspaceId: string, name: string) 
     type: agent.type,
     status: agent.status,
     persona: agent.persona,
+    created_at: agent.createdAt.toISOString(),
     last_seen: agent.lastSeen.toISOString(),
     metadata: agent.metadata,
     channels: memberships.map((m) => ({
@@ -194,6 +196,7 @@ export async function updateAgent(
     type: updated.type,
     status: updated.status,
     persona: updated.persona,
+    created_at: updated.createdAt.toISOString(),
     last_seen: updated.lastSeen.toISOString(),
     metadata: updated.metadata,
   };

--- a/packages/types/src/__tests__/types.test.ts
+++ b/packages/types/src/__tests__/types.test.ts
@@ -95,13 +95,14 @@ describe('Type definitions', () => {
   // ============================================
   it('Agent has required fields', () => {
     expectTypeOf<Agent>().toHaveProperty('id');
-    expectTypeOf<Agent>().toHaveProperty('workspace_id');
     expectTypeOf<Agent>().toHaveProperty('name');
     expectTypeOf<Agent>().toHaveProperty('type');
-    expectTypeOf<Agent>().toHaveProperty('token_hash');
     expectTypeOf<Agent>().toHaveProperty('status');
     expectTypeOf<Agent>().toHaveProperty('persona');
+    expectTypeOf<Agent>().toHaveProperty('metadata');
     expectTypeOf<Agent>().toHaveProperty('last_seen');
+    expectTypeOf<Agent>().toHaveProperty('created_at');
+    expectTypeOf<Agent>().toHaveProperty('channels');
   });
 
   it('AgentType union', () => {


### PR DESCRIPTION
## Summary

Fix the upstream Relaycast SDK/API mismatch that forced AgentWorkforce/relay#830 to work around `RelayCast::register_or_get_agent()` with raw JSON.

The Rust SDK `Agent` type previously modeled internal database fields (`workspace_id`, `token_hash`, required `created_at`) that are not part of the public `GET /v1/agents/{name}` response. When registration hit a 409 and `register_or_get_agent()` tried to reclaim the existing agent, `get_agent()` failed to deserialize the public payload before token rotation could complete.

This PR updates the Rust SDK to model the public agent payload, makes optional response fields tolerant during deserialization, and keeps the server/OpenAPI/shared type contract aligned by returning/documenting `created_at`, `last_seen`, and detail-response channel memberships.

## Changes

- Remove internal-only `workspace_id` and `token_hash` requirements from the Rust SDK `Agent` type.
- Make Rust SDK agent `metadata`, `created_at`, `last_seen`, and `channels` tolerant of public/deployed payload variance.
- Add `AgentChannelMembership` and export it from the Rust SDK.
- Make `register_or_get_agent()` reclaim on either `agent_already_exists` or HTTP 409.
- Make reclaimed `CreateAgentResponse.created_at` fall back to `last_seen` when the server payload omits `created_at`.
- Add a regression test for the 409 reclaim path using the public `GET /v1/agents/{name}` payload shape.
- Include `created_at` in public server agent list/get/update responses.
- Update `openapi.yaml` for agent `last_seen`, detail-response `channels`, and channel membership role values.
- Update shared type tests so `@relaycast/types` asserts the public agent shape instead of internal fields.

## Validation

- [x] `cargo test`
- [x] `cargo clippy --all-targets`
- [x] `npm test -w @relaycast/types`
- [x] `npm run build -w @relaycast/types`
- [x] `npm test -w @relaycast/sdk -- src/__tests__/relay.test.ts src/__tests__/strict-identity.test.ts`
- [x] `npm run build -w @relaycast/server`
- [x] `npm test -w @relaycast/server -- src/routes/__tests__/agent.test.ts`
- [x] `npm run lint -w @relaycast/server` (passes with existing warnings)
- [x] `git diff --check`

Note: `cargo fmt --check` still reports pre-existing formatting drift in `packages/sdk-rust/src/agent.rs`, which this PR intentionally leaves untouched.
