### PR TITLE
feat(sdk): multiplexed subscribe, @self DM routing, stable event ids

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ await alice.channels.create({ name: 'general', topic: 'Team chat' });
 await bob.channels.join('general');
 await carol.channels.join('general');
 
-// 6) Realtime listeners (on.messageCreated is the onMessage-style hook)
+// 6) Realtime listeners on one multiplexed websocket per agent
 const agents = [
   { name: 'Alice', client: alice },
   { name: 'Bob', client: bob },
@@ -49,17 +49,14 @@ await Promise.all(
   agents.map(
     ({ name, client }) =>
       new Promise<void>((resolve) => {
-        client.connect();
+        client.subscribe(['general', '@self'], (event) => {
+          console.log(`[${name} stream] ${event.message.agentName}: ${event.message.text}`);
+        });
 
         const stopConnected = client.on.connected(() => {
-          client.subscribe(['general']);
           console.log(`${name} websocket connected`);
           stopConnected();
           resolve();
-        });
-
-        client.on.messageCreated((event) => {
-          console.log(`[${name} stream] ${event.message.agentName}: ${event.message.text}`);
         });
       }),
   ),
@@ -75,7 +72,6 @@ await new Promise((resolve) => setTimeout(resolve, 1500));
 
 // 8) Cleanup
 for (const { client } of agents) {
-  client.unsubscribe(['general']);
   await client.disconnect();
 }
 ```
@@ -140,8 +136,7 @@ const { token } = await relay.agents.register({ name: 'Reviewer', type: 'agent' 
 const me = relay.as(token);
 
 me.connect();
-me.on.connected(() => me.subscribe(['general']));
-me.on.messageCreated((event) => {
+me.subscribe(['general', '@self'], (event) => {
   console.log(`${event.message.agentName}: ${event.message.text}`);
 });
 
@@ -172,19 +167,12 @@ const relay = new RelayCast({ apiKey, baseUrl: localBaseUrl });
 Realtime example:
 
 ```typescript
-me.connect();
-const stopConnected = me.on.connected(() => {
-  me.subscribe(['general']);
-  stopConnected();
-});
-
-const unsub = me.on.messageCreated((event) => {
+const sub = me.subscribe(['general', '@self'], (event) => {
   console.log(`${event.message.agentName}: ${event.message.text}`);
 });
 
 // later
-unsub();
-me.unsubscribe(['general']);
+sub.unsubscribe();
 await me.disconnect();
 ```
 

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1545,7 +1545,12 @@ paths:
   /dm:
     post:
       summary: Send DM
-      description: Send a direct message to another agent
+      description: |
+        Send a direct message to another agent.
+
+        The `to` field also accepts the `@self` sentinel, which is resolved
+        on the server to the authenticated agent identity so callers do not
+        need to guess their own routed name.
       tags:
         - Direct Messages
       security:
@@ -1567,7 +1572,7 @@ paths:
               properties:
                 to:
                   type: string
-                  description: Recipient agent name
+                  description: Recipient agent name or `@self`
                 text:
                   type: string
                 attachments:

--- a/packages/sdk-typescript/src/__tests__/agent-messaging.test.ts
+++ b/packages/sdk-typescript/src/__tests__/agent-messaging.test.ts
@@ -104,6 +104,20 @@ describe('AgentClient', () => {
     });
   });
 
+  describe('post()', () => {
+    it('aliases send() for channel messages', async () => {
+      mockFetch.mockImplementation(() => mockResponse({ id: 'm_1' }));
+
+      await me.post('#general', 'hello');
+
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+      const [url, init] = mockFetch.mock.calls[0]!;
+      expect(url).toBe('https://api.relaycast.dev/v1/channels/general/messages');
+      expect(init.method).toBe('POST');
+      expect(init.body).toBe(JSON.stringify({ text: 'hello', mode: 'wait' }));
+    });
+  });
+
   describe('messages()', () => {
     it('gets from /v1/channels/:name/messages', async () => {
       mockFetch.mockImplementation(() => mockResponse([{ id: 'm_1' }]));

--- a/packages/sdk-typescript/src/__tests__/agent-ws.test.ts
+++ b/packages/sdk-typescript/src/__tests__/agent-ws.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { AgentClient, type AgentClientOptions } from '../agent.js';
+import { stableRelaycastEventId } from '../event-id.js';
 import { HttpClient } from '../client.js';
 
 class MockWebSocket {
@@ -248,6 +249,8 @@ describe('AgentClient WebSocket integration', () => {
     agent.connect();
     const ws = MockWebSocket.instances[0]!;
     ws.simulateOpen();
+    agent.subscribe(['dev']);
+    ws.send.mockClear();
 
     agent.unsubscribe(['dev']);
 
@@ -266,6 +269,69 @@ describe('AgentClient WebSocket integration', () => {
     const agent = createAgent();
     // Should not throw
     agent.unsubscribe(['general']);
+  });
+
+  it('subscribe(channels, handler) multiplexes channel and self DM events on one socket', async () => {
+    const agent = createAgent();
+    const handler = vi.fn();
+
+    const subscription = agent.subscribe(['#general', '@self'], handler);
+
+    expect(MockWebSocket.instances).toHaveLength(1);
+    const ws = MockWebSocket.instances[0]!;
+    ws.simulateOpen();
+
+    expect(ws.send).toHaveBeenCalledWith(
+      JSON.stringify({ type: 'subscribe', channels: ['general'] }),
+    );
+
+    ws.simulateMessage({
+      id: stableRelaycastEventId('m_1'),
+      type: 'message.created',
+      channel: 'general',
+      message: { id: 'm_1', agent_name: 'Bot', text: 'hi', attachments: [] },
+    });
+    ws.simulateMessage({
+      id: stableRelaycastEventId('dm_1'),
+      type: 'dm.received',
+      conversation_id: 'conv_1',
+      message: { id: 'dm_1', agent_name: 'Alice', text: 'hello' },
+    });
+    ws.simulateMessage({
+      id: stableRelaycastEventId('m_2'),
+      type: 'message.created',
+      channel: 'random',
+      message: { id: 'm_2', agent_name: 'Bot', text: 'skip', attachments: [] },
+    });
+    await Promise.resolve();
+
+    expect(handler).toHaveBeenCalledTimes(2);
+    expect(handler.mock.calls[0]![0]).toMatchObject({ id: stableRelaycastEventId('m_1'), type: 'message.created' });
+    expect(handler.mock.calls[1]![0]).toMatchObject({ id: stableRelaycastEventId('dm_1'), type: 'dm.received' });
+
+    subscription.unsubscribe();
+    expect(ws.send).toHaveBeenCalledWith(
+      JSON.stringify({ type: 'unsubscribe', channels: ['general'] }),
+    );
+  });
+
+  it('resubscribes managed channels after reconnect', () => {
+    const agent = createAgent();
+    const subscription = agent.subscribe(['general'], vi.fn());
+
+    const ws1 = MockWebSocket.instances[0]!;
+    ws1.simulateOpen();
+    ws1.simulateClose();
+
+    vi.advanceTimersByTime(1000);
+
+    const ws2 = MockWebSocket.instances[1]!;
+    ws2.simulateOpen();
+    expect(ws2.send).toHaveBeenCalledWith(
+      JSON.stringify({ type: 'subscribe', channels: ['general'] }),
+    );
+
+    subscription.unsubscribe();
   });
 
   // --- lifecycle events ---

--- a/packages/sdk-typescript/src/__tests__/agent-ws.test.ts
+++ b/packages/sdk-typescript/src/__tests__/agent-ws.test.ts
@@ -143,6 +143,30 @@ describe('AgentClient WebSocket integration', () => {
     expect(MockWebSocket.instances).toHaveLength(2);
   });
 
+  it('disconnect() clears manual and managed subscriptions before future reconnect', async () => {
+    const agent = createAgent();
+    agent.connect();
+    const ws1 = MockWebSocket.instances[0]!;
+    ws1.simulateOpen();
+    agent.subscribe(['general']);
+    agent.subscribe(['dev'], vi.fn());
+
+    const p = agent.disconnect();
+    await vi.advanceTimersByTimeAsync(200);
+    await p;
+
+    agent.subscribe(['random'], vi.fn());
+    const ws2 = MockWebSocket.instances[1]!;
+    ws2.simulateOpen();
+
+    const subscribePayloads = ws2.send.mock.calls
+      .map(([payload]) => JSON.parse(String(payload)))
+      .filter((payload) => payload.type === 'subscribe');
+    expect(subscribePayloads).toEqual([
+      { type: 'subscribe', channels: ['random'] },
+    ]);
+  });
+
   // --- typed on.* handlers ---
 
   it('on.messageCreated fires with message.created event', () => {
@@ -313,6 +337,30 @@ describe('AgentClient WebSocket integration', () => {
     expect(ws.send).toHaveBeenCalledWith(
       JSON.stringify({ type: 'unsubscribe', channels: ['general'] }),
     );
+  });
+
+  it('subscribe(channels, handler) logs rejected handler promises', async () => {
+    const agent = createAgent();
+    const err = new Error('handler failed');
+    const handler = vi.fn().mockRejectedValue(err);
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+
+    agent.subscribe(['general'], handler);
+    const ws = MockWebSocket.instances[0]!;
+    ws.simulateOpen();
+    ws.simulateMessage({
+      type: 'message.created',
+      channel: 'general',
+      message: { id: 'm_1', agent_name: 'Bot', text: 'hi', attachments: [] },
+    });
+
+    for (let i = 0; i < 5; i += 1) {
+      await Promise.resolve();
+    }
+
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(errorSpy).toHaveBeenCalledWith('[relaycast] Subscription handler failed', err);
+    errorSpy.mockRestore();
   });
 
   it('resubscribes managed channels after reconnect', () => {

--- a/packages/sdk-typescript/src/__tests__/errors.test.ts
+++ b/packages/sdk-typescript/src/__tests__/errors.test.ts
@@ -64,6 +64,14 @@ describe('normalizeRelayErrorCode', () => {
     expect(normalizeRelayErrorCode('agent_not_found')).toBe('not_found');
   });
 
+  it('maps rate_limit_exceeded to rate_limited', () => {
+    expect(normalizeRelayErrorCode('rate_limit_exceeded')).toBe('rate_limited');
+  });
+
+  it('maps backpressure to backpressure', () => {
+    expect(normalizeRelayErrorCode('backpressure')).toBe('backpressure');
+  });
+
   it('maps not_found to not_found', () => {
     expect(normalizeRelayErrorCode('not_found')).toBe('not_found');
   });
@@ -90,6 +98,10 @@ describe('normalizeRelayErrorCode', () => {
 
   it('falls back to statusCode-based mapping for 404', () => {
     expect(normalizeRelayErrorCode('unknown_code', 404)).toBe('not_found');
+  });
+
+  it('falls back to statusCode-based mapping for 429', () => {
+    expect(normalizeRelayErrorCode('unknown_code', 429)).toBe('rate_limited');
   });
 
   it('falls back to statusCode-based mapping for 409', () => {
@@ -124,6 +136,14 @@ describe('relayErrorRetryable', () => {
 
   it('returns false for unauthorized', () => {
     expect(relayErrorRetryable('unauthorized', 401)).toBe(false);
+  });
+
+  it('returns true for rate_limited', () => {
+    expect(relayErrorRetryable('rate_limited', 429)).toBe(true);
+  });
+
+  it('returns true for backpressure', () => {
+    expect(relayErrorRetryable('backpressure', 429)).toBe(true);
   });
 
   it('returns false for workspace_mismatch', () => {
@@ -165,6 +185,12 @@ describe('relayErrorFromApi', () => {
   it('normalizes unknown codes based on statusCode', () => {
     const err = relayErrorFromApi('custom_error', 'not found', 404);
     expect(err.code).toBe('not_found');
+  });
+
+  it('maps 429 api errors to rate_limited', () => {
+    const err = relayErrorFromApi('rate_limit_exceeded', 'slow down', 429);
+    expect(err.code).toBe('rate_limited');
+    expect(err.retryable).toBe(true);
   });
 
   it('defaults to transport_error for completely unknown', () => {

--- a/packages/sdk-typescript/src/__tests__/errors.test.ts
+++ b/packages/sdk-typescript/src/__tests__/errors.test.ts
@@ -72,6 +72,14 @@ describe('normalizeRelayErrorCode', () => {
     expect(normalizeRelayErrorCode('backpressure')).toBe('backpressure');
   });
 
+  it('maps queue_overloaded to backpressure', () => {
+    expect(normalizeRelayErrorCode('queue_overloaded')).toBe('backpressure');
+  });
+
+  it('maps workspace_stream_backpressure to backpressure', () => {
+    expect(normalizeRelayErrorCode('workspace_stream_backpressure')).toBe('backpressure');
+  });
+
   it('maps not_found to not_found', () => {
     expect(normalizeRelayErrorCode('not_found')).toBe('not_found');
   });

--- a/packages/sdk-typescript/src/__tests__/event-id.test.ts
+++ b/packages/sdk-typescript/src/__tests__/event-id.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from 'vitest';
+import { stableRelaycastEventId } from '../event-id.js';
+
+describe('stableRelaycastEventId', () => {
+  it('preserves part boundaries when hashing', () => {
+    expect(stableRelaycastEventId('a', 'b:c')).not.toBe(stableRelaycastEventId('a:b', 'c'));
+  });
+
+  it('uses the stable empty-event fallback for blank input', () => {
+    expect(stableRelaycastEventId()).toBe(stableRelaycastEventId('empty-event'));
+    expect(stableRelaycastEventId('  ', undefined, null)).toBe(stableRelaycastEventId('empty-event'));
+  });
+});

--- a/packages/sdk-typescript/src/agent.ts
+++ b/packages/sdk-typescript/src/agent.ts
@@ -230,6 +230,13 @@ export class AgentClient {
       await this.pendingHeartbeat;
       this.pendingHeartbeat = null;
     }
+    for (const subscription of this.managedSubscriptions.values()) {
+      for (const stop of subscription.stops) {
+        stop();
+      }
+    }
+    this.managedSubscriptions.clear();
+    this.manualSubscriptions.clear();
     if (this.ws) {
       this.ws.disconnect();
       this.ws = null;
@@ -266,7 +273,11 @@ export class AgentClient {
       if (!this.matchesSubscription(channelSet, event)) {
         return;
       }
-      void onMessage(ensureRelaycastMessageEventId(event));
+      void Promise.resolve()
+        .then(() => onMessage(ensureRelaycastMessageEventId(event)))
+        .catch((err) => {
+          console.error('[relaycast] Subscription handler failed', err);
+        });
     };
 
     const stops = [
@@ -284,7 +295,7 @@ export class AgentClient {
     this.syncDesiredSubscriptions();
 
     return {
-      channels: normalized,
+      channels: Object.freeze([...normalized]),
       unsubscribe: () => {
         const current = this.managedSubscriptions.get(key);
         if (!current) return;

--- a/packages/sdk-typescript/src/agent.ts
+++ b/packages/sdk-typescript/src/agent.ts
@@ -40,6 +40,7 @@ import type {
   ReactionRemovedEvent,
   DmReceivedEvent,
   GroupDmReceivedEvent,
+  RelaycastMessageEvent,
   AgentOnlineEvent,
   AgentOfflineEvent,
   ChannelCreatedEvent,
@@ -57,6 +58,8 @@ import type {
 } from './types.js';
 import { HttpClient, type RequestOptions } from './client.js';
 import { WsClient, type WsClientOptions, withInternalWsOrigin } from './ws.js';
+import type { Subscription } from './subscription.js';
+import { stableRelaycastEventId } from './event-id.js';
 
 function stripHash(channel: string): string {
   return channel.startsWith('#') ? channel.slice(1) : channel;
@@ -106,6 +109,29 @@ export interface AgentClientOptions {
   ws?: Omit<WsClientOptions, 'token' | 'baseUrl'>;
 }
 
+type RelaycastMessageHandler = (event: RelaycastMessageEvent) => void | Promise<void>;
+type ManagedSubscription = {
+  channels: Set<string>;
+  handler: RelaycastMessageHandler;
+  stops: Array<() => void>;
+};
+
+function normalizeSubscriptionChannel(channel: string): string {
+  const trimmed = channel.trim();
+  if (trimmed === '@self') return trimmed;
+  return stripHash(trimmed);
+}
+
+function ensureRelaycastMessageEventId(event: RelaycastMessageEvent): RelaycastMessageEvent {
+  if (typeof event.id === 'string' && event.id.length > 0) {
+    return event;
+  }
+  return {
+    ...event,
+    id: stableRelaycastEventId(event.message.id),
+  } as RelaycastMessageEvent;
+}
+
 export class AgentClient {
   public readonly client: HttpClient;
   private ws: WsClient | null = null;
@@ -113,6 +139,9 @@ export class AgentClient {
   private autoHeartbeatTimer: ReturnType<typeof setInterval> | null = null;
   private pendingHeartbeat: Promise<void> | null = null;
   private wsOptions: Omit<WsClientOptions, 'token' | 'baseUrl'>;
+  private manualSubscriptions = new Set<string>();
+  private managedSubscriptions = new Map<symbol, ManagedSubscription>();
+  private activeWsChannels = new Set<string>();
 
   constructor(client: HttpClient, options: AgentClientOptions = {}) {
     this.client = client;
@@ -175,12 +204,15 @@ export class AgentClient {
     this.ws.on('open', () => {
       void this.presence.markOnline().catch(() => {});
       this.startAutoHeartbeat();
+      this.syncDesiredSubscriptions({ resetRemoteState: true });
     });
     this.ws.on('close', () => {
       this.stopAutoHeartbeat();
+      this.activeWsChannels.clear();
     });
     this.ws.on('permanently_disconnected', () => {
       this.stopAutoHeartbeat();
+      this.activeWsChannels.clear();
     });
     this.ws.connect();
   }
@@ -202,17 +234,75 @@ export class AgentClient {
       this.ws.disconnect();
       this.ws = null;
     }
+    this.activeWsChannels.clear();
     // Always send the HTTP disconnect — it works even without a WS and
     // serves as the authoritative presence update.
     await this.client.post('/v1/agents/disconnect', {}).catch(() => {});
   }
 
-  subscribe(channels: string[]): void {
-    this.ws?.subscribe(channels);
+  subscribe(channels: string[]): void;
+  subscribe(channels: string[], onMessage: RelaycastMessageHandler): Subscription;
+  subscribe(channels: string[], onMessage?: RelaycastMessageHandler): void | Subscription {
+    const normalized = [...new Set(channels.map(normalizeSubscriptionChannel).filter(Boolean))];
+    if (normalized.length === 0) {
+      if (onMessage) {
+        return { channels: [], unsubscribe() {} };
+      }
+      return;
+    }
+
+    if (!onMessage) {
+      for (const channel of normalized) {
+        this.manualSubscriptions.add(channel);
+      }
+      this.syncDesiredSubscriptions();
+      return;
+    }
+
+    this.connect();
+    const key = Symbol('relaycast.subscription');
+    const channelSet = new Set(normalized);
+    const invoke = (event: RelaycastMessageEvent): void => {
+      if (!this.matchesSubscription(channelSet, event)) {
+        return;
+      }
+      void onMessage(ensureRelaycastMessageEventId(event));
+    };
+
+    const stops = [
+      this.on.messageCreated((event) => invoke(event)),
+      this.on.threadReply((event) => invoke(event)),
+      this.on.dmReceived((event) => invoke(event)),
+      this.on.groupDmReceived((event) => invoke(event)),
+    ];
+
+    this.managedSubscriptions.set(key, {
+      channels: channelSet,
+      handler: onMessage,
+      stops,
+    });
+    this.syncDesiredSubscriptions();
+
+    return {
+      channels: normalized,
+      unsubscribe: () => {
+        const current = this.managedSubscriptions.get(key);
+        if (!current) return;
+        this.managedSubscriptions.delete(key);
+        for (const stop of current.stops) {
+          stop();
+        }
+        this.syncDesiredSubscriptions();
+      },
+    };
   }
 
   unsubscribe(channels: string[]): void {
-    this.ws?.unsubscribe(channels);
+    const normalized = [...new Set(channels.map(normalizeSubscriptionChannel).filter(Boolean))];
+    for (const channel of normalized) {
+      this.manualSubscriptions.delete(channel);
+    }
+    this.syncDesiredSubscriptions();
   }
 
   private onEvent<T extends WsClientEvent>(eventType: string, handler: (e: T) => void): () => void {
@@ -293,6 +383,19 @@ export class AgentClient {
       body,
       idempotencyHeaders(opts),
     );
+  }
+
+  post(
+    channel: string,
+    text: string,
+    opts?: {
+      attachments?: string[];
+      blocks?: MessageBlock[];
+      mode?: 'wait' | 'steer';
+      idempotencyKey?: string;
+    },
+  ): Promise<MessageWithMeta> {
+    return this.send(channel, text, opts);
   }
 
   async messages(
@@ -416,6 +519,66 @@ export class AgentClient {
         `/v1/dm/${encodeURIComponent(conversationId)}/participants/${encodeURIComponent(agent)}`,
       ),
   };
+
+  private matchesSubscription(channels: Set<string>, event: RelaycastMessageEvent): boolean {
+    switch (event.type) {
+      case 'dm.received':
+      case 'group_dm.received':
+        return channels.has('@self');
+      case 'message.created':
+      case 'thread.reply':
+        return channels.has(stripHash(event.channel));
+      default:
+        return false;
+    }
+  }
+
+  private desiredWsChannels(): Set<string> {
+    const desired = new Set<string>();
+    for (const channel of this.manualSubscriptions) {
+      if (channel !== '@self') {
+        desired.add(channel);
+      }
+    }
+    for (const subscription of this.managedSubscriptions.values()) {
+      for (const channel of subscription.channels) {
+        if (channel !== '@self') {
+          desired.add(channel);
+        }
+      }
+    }
+    return desired;
+  }
+
+  private syncDesiredSubscriptions(options: { resetRemoteState?: boolean } = {}): void {
+    if (!this.ws) {
+      return;
+    }
+
+    const desired = this.desiredWsChannels();
+    if (!this.ws.connected) {
+      if (options.resetRemoteState) {
+        this.activeWsChannels.clear();
+      }
+      return;
+    }
+
+    if (options.resetRemoteState) {
+      this.activeWsChannels.clear();
+    }
+
+    const toSubscribe = [...desired].filter((channel) => !this.activeWsChannels.has(channel));
+    const toUnsubscribe = [...this.activeWsChannels].filter((channel) => !desired.has(channel));
+
+    if (toSubscribe.length > 0) {
+      this.ws.subscribe(toSubscribe);
+    }
+    if (toUnsubscribe.length > 0) {
+      this.ws.unsubscribe(toUnsubscribe);
+    }
+
+    this.activeWsChannels = desired;
+  }
 
   // === Channels ===
 

--- a/packages/sdk-typescript/src/errors.ts
+++ b/packages/sdk-typescript/src/errors.ts
@@ -1,6 +1,8 @@
 export type RelayErrorCode =
   | 'name_conflict'
   | 'not_found'
+  | 'rate_limited'
+  | 'backpressure'
   | 'unauthorized'
   | 'workspace_mismatch'
   | 'transport_error';
@@ -17,6 +19,10 @@ const RAW_CODE_MAP: Record<string, RelayErrorCode> = {
   agent_already_exists: 'name_conflict',
   not_found: 'not_found',
   agent_not_found: 'not_found',
+  rate_limit_exceeded: 'rate_limited',
+  backpressure: 'backpressure',
+  queue_overloaded: 'backpressure',
+  workspace_stream_backpressure: 'backpressure',
   unauthorized: 'unauthorized',
   workspace_mismatch: 'workspace_mismatch',
   workspace_not_found: 'workspace_mismatch',
@@ -36,6 +42,10 @@ export function normalizeRelayErrorCode(rawCode: string | undefined, statusCode?
     return 'not_found';
   }
 
+  if (statusCode === 429) {
+    return 'rate_limited';
+  }
+
   if (statusCode === 409) {
     return 'name_conflict';
   }
@@ -44,6 +54,10 @@ export function normalizeRelayErrorCode(rawCode: string | undefined, statusCode?
 }
 
 export function relayErrorRetryable(code: RelayErrorCode, statusCode?: number): boolean {
+  if (code === 'rate_limited' || code === 'backpressure') {
+    return true;
+  }
+
   if (code !== 'transport_error') {
     return false;
   }

--- a/packages/sdk-typescript/src/event-id.ts
+++ b/packages/sdk-typescript/src/event-id.ts
@@ -1,0 +1,55 @@
+function hashStringParts(parts: string[]): [number, number, number, number] {
+  const input = parts.join(':');
+  let h1 = 0xdeadbeef;
+  let h2 = 0x41c6ce57;
+  let h3 = 0xc0decafe;
+  let h4 = 0x9e3779b9;
+
+  for (let i = 0; i < input.length; i += 1) {
+    const code = input.charCodeAt(i);
+    h1 = Math.imul(h1 ^ code, 2654435761);
+    h2 = Math.imul(h2 ^ code, 1597334677);
+    h3 = Math.imul(h3 ^ code, 2246822507);
+    h4 = Math.imul(h4 ^ code, 3266489909);
+  }
+
+  h1 = Math.imul(h1 ^ (h1 >>> 16), 2246822507) ^ Math.imul(h2 ^ (h2 >>> 13), 3266489909);
+  h2 = Math.imul(h2 ^ (h2 >>> 16), 2246822507) ^ Math.imul(h3 ^ (h3 >>> 13), 3266489909);
+  h3 = Math.imul(h3 ^ (h3 >>> 16), 2246822507) ^ Math.imul(h4 ^ (h4 >>> 13), 3266489909);
+  h4 = Math.imul(h4 ^ (h4 >>> 16), 2246822507) ^ Math.imul(h1 ^ (h1 >>> 13), 3266489909);
+
+  return [h1 >>> 0, h2 >>> 0, h3 >>> 0, h4 >>> 0];
+}
+
+function formatUuidFromWords(words: [number, number, number, number]): string {
+  const bytes = new Uint8Array(16);
+
+  for (let i = 0; i < words.length; i += 1) {
+    const word = words[i];
+    const offset = i * 4;
+    bytes[offset] = (word >>> 24) & 0xff;
+    bytes[offset + 1] = (word >>> 16) & 0xff;
+    bytes[offset + 2] = (word >>> 8) & 0xff;
+    bytes[offset + 3] = word & 0xff;
+  }
+
+  bytes[6] = (bytes[6] & 0x0f) | 0x50;
+  bytes[8] = (bytes[8] & 0x3f) | 0x80;
+
+  const hex = [...bytes].map((byte) => byte.toString(16).padStart(2, '0')).join('');
+  return [
+    hex.slice(0, 8),
+    hex.slice(8, 12),
+    hex.slice(12, 16),
+    hex.slice(16, 20),
+    hex.slice(20, 32),
+  ].join('-');
+}
+
+export function stableRelaycastEventId(...parts: Array<string | null | undefined>): string {
+  const normalized = parts
+    .map((part) => part?.trim())
+    .filter((part): part is string => typeof part === 'string' && part.length > 0);
+
+  return formatUuidFromWords(hashStringParts(['relaycast', ...normalized]));
+}

--- a/packages/sdk-typescript/src/event-id.ts
+++ b/packages/sdk-typescript/src/event-id.ts
@@ -1,5 +1,5 @@
 function hashStringParts(parts: string[]): [number, number, number, number] {
-  const input = parts.join(':');
+  const input = JSON.stringify(parts);
   let h1 = 0xdeadbeef;
   let h2 = 0x41c6ce57;
   let h3 = 0xc0decafe;
@@ -50,6 +50,10 @@ export function stableRelaycastEventId(...parts: Array<string | null | undefined
   const normalized = parts
     .map((part) => part?.trim())
     .filter((part): part is string => typeof part === 'string' && part.length > 0);
+
+  if (normalized.length === 0) {
+    return formatUuidFromWords(hashStringParts(['relaycast', 'empty-event']));
+  }
 
   return formatUuidFromWords(hashStringParts(['relaycast', ...normalized]));
 }

--- a/packages/sdk-typescript/src/index.ts
+++ b/packages/sdk-typescript/src/index.ts
@@ -41,4 +41,5 @@ export {
 export type { RegisterAgentInput, RegisterOrRotateInput, ResolvedIdentity } from './identity.js';
 export { WsClient } from './ws.js';
 export type { WsClientOptions, EventHandler } from './ws.js';
+export type { Subscription } from './subscription.js';
 export type * from './types.js';

--- a/packages/sdk-typescript/src/subscription.ts
+++ b/packages/sdk-typescript/src/subscription.ts
@@ -1,0 +1,4 @@
+export interface Subscription {
+  readonly channels: string[];
+  unsubscribe(): void;
+}

--- a/packages/sdk-typescript/src/subscription.ts
+++ b/packages/sdk-typescript/src/subscription.ts
@@ -1,4 +1,4 @@
 export interface Subscription {
-  readonly channels: string[];
+  readonly channels: readonly string[];
   unsubscribe(): void;
 }

--- a/packages/sdk-typescript/src/types.ts
+++ b/packages/sdk-typescript/src/types.ts
@@ -226,6 +226,7 @@ export type ReactionGroup = Camelize<Raw.ReactionGroup>;
 export type ReactionRemovedEvent = Camelize<Raw.ReactionRemovedEvent>;
 export type ReadReceipt = Camelize<Raw.ReadReceipt>;
 export type ReaderInfo = Camelize<Raw.ReaderInfo>;
+export type RelaycastMessageEvent = Camelize<Raw.RelaycastMessageEvent>;
 export type ReleaseAgentRequest = Camelize<Raw.ReleaseAgentRequest>;
 export type ReleaseAgentResponse = Camelize<Raw.ReleaseAgentResponse>;
 export type SendDmRequest = Camelize<Raw.SendDmRequest>;

--- a/packages/sdk-typescript/src/ws.ts
+++ b/packages/sdk-typescript/src/ws.ts
@@ -264,6 +264,10 @@ export class WsClient {
     this.handlers.get(event)?.delete(handler);
   }
 
+  get connected(): boolean {
+    return this.isOpen;
+  }
+
   private emit(event: string, data: WsClientEvent): void {
     this.handlers.get(event)?.forEach((h) => h(data));
     this.handlers.get('*')?.forEach((h) => h(data));

--- a/packages/server/src/engine/__tests__/wsTransform.test.ts
+++ b/packages/server/src/engine/__tests__/wsTransform.test.ts
@@ -1,3 +1,4 @@
+import { stableRelaycastEventId } from '../event-id.js';
 import { describe, it, expect } from 'vitest';
 import { transformForClient, type WsEvent } from '../wsTransform.js';
 
@@ -23,6 +24,7 @@ describe('transformForClient', () => {
     }, 'ch_1');
 
     expect(transformForClient(event)).toEqual({
+      id: stableRelaycastEventId('msg_1'),
       type: 'message.created',
       channel: 'general',
       message: {
@@ -67,6 +69,7 @@ describe('transformForClient', () => {
     }, 'ch_1');
 
     expect(transformForClient(event)).toEqual({
+      id: stableRelaycastEventId('msg_3'),
       type: 'thread.reply',
       channel: 'general',
       parent_id: 'msg_root',
@@ -119,6 +122,7 @@ describe('transformForClient', () => {
     });
 
     expect(transformForClient(event)).toEqual({
+      id: stableRelaycastEventId('msg_6'),
       type: 'dm.received',
       conversation_id: 'dm_1',
       message: {
@@ -146,6 +150,7 @@ describe('transformForClient', () => {
     });
 
     expect(transformForClient(event)).toEqual({
+      id: stableRelaycastEventId('msg_6b'),
       type: 'dm.received',
       conversation_id: 'dm_1',
       message: {
@@ -171,6 +176,7 @@ describe('transformForClient', () => {
     });
 
     expect(transformForClient(event)).toEqual({
+      id: stableRelaycastEventId('msg_7'),
       type: 'group_dm.received',
       conversation_id: 'gdm_1',
       message: {
@@ -197,6 +203,7 @@ describe('transformForClient', () => {
     });
 
     expect(transformForClient(event)).toEqual({
+      id: stableRelaycastEventId('msg_7b'),
       type: 'group_dm.received',
       conversation_id: 'gdm_1',
       message: {

--- a/packages/server/src/engine/dm.ts
+++ b/packages/server/src/engine/dm.ts
@@ -220,11 +220,15 @@ export async function sendDm(
   options: SendDmOptions = {},
 ) {
   const startedAtMs = Date.now();
-  // Resolve the target agent by name
-  const [toAgent] = await db
-    .select()
-    .from(agents)
-    .where(and(eq(agents.workspaceId, workspaceId), eq(agents.name, data.to)));
+  const [toAgent] = data.to === '@self'
+    ? await db
+      .select()
+      .from(agents)
+      .where(and(eq(agents.workspaceId, workspaceId), eq(agents.id, fromAgentId)))
+    : await db
+      .select()
+      .from(agents)
+      .where(and(eq(agents.workspaceId, workspaceId), eq(agents.name, data.to)));
 
   if (!toAgent) {
     const err = new Error(`Agent "${data.to}" not found`);

--- a/packages/server/src/engine/event-id.ts
+++ b/packages/server/src/engine/event-id.ts
@@ -1,0 +1,55 @@
+function hashStringParts(parts: string[]): [number, number, number, number] {
+  const input = parts.join(':');
+  let h1 = 0xdeadbeef;
+  let h2 = 0x41c6ce57;
+  let h3 = 0xc0decafe;
+  let h4 = 0x9e3779b9;
+
+  for (let i = 0; i < input.length; i += 1) {
+    const code = input.charCodeAt(i);
+    h1 = Math.imul(h1 ^ code, 2654435761);
+    h2 = Math.imul(h2 ^ code, 1597334677);
+    h3 = Math.imul(h3 ^ code, 2246822507);
+    h4 = Math.imul(h4 ^ code, 3266489909);
+  }
+
+  h1 = Math.imul(h1 ^ (h1 >>> 16), 2246822507) ^ Math.imul(h2 ^ (h2 >>> 13), 3266489909);
+  h2 = Math.imul(h2 ^ (h2 >>> 16), 2246822507) ^ Math.imul(h3 ^ (h3 >>> 13), 3266489909);
+  h3 = Math.imul(h3 ^ (h3 >>> 16), 2246822507) ^ Math.imul(h4 ^ (h4 >>> 13), 3266489909);
+  h4 = Math.imul(h4 ^ (h4 >>> 16), 2246822507) ^ Math.imul(h1 ^ (h1 >>> 13), 3266489909);
+
+  return [h1 >>> 0, h2 >>> 0, h3 >>> 0, h4 >>> 0];
+}
+
+function formatUuidFromWords(words: [number, number, number, number]): string {
+  const bytes = new Uint8Array(16);
+
+  for (let i = 0; i < words.length; i += 1) {
+    const word = words[i];
+    const offset = i * 4;
+    bytes[offset] = (word >>> 24) & 0xff;
+    bytes[offset + 1] = (word >>> 16) & 0xff;
+    bytes[offset + 2] = (word >>> 8) & 0xff;
+    bytes[offset + 3] = word & 0xff;
+  }
+
+  bytes[6] = (bytes[6] & 0x0f) | 0x50;
+  bytes[8] = (bytes[8] & 0x3f) | 0x80;
+
+  const hex = [...bytes].map((byte) => byte.toString(16).padStart(2, '0')).join('');
+  return [
+    hex.slice(0, 8),
+    hex.slice(8, 12),
+    hex.slice(12, 16),
+    hex.slice(16, 20),
+    hex.slice(20, 32),
+  ].join('-');
+}
+
+export function stableRelaycastEventId(...parts: Array<string | null | undefined>): string {
+  const normalized = parts
+    .map((part) => part?.trim())
+    .filter((part): part is string => typeof part === 'string' && part.length > 0);
+
+  return formatUuidFromWords(hashStringParts(['relaycast', ...normalized]));
+}

--- a/packages/server/src/engine/event-id.ts
+++ b/packages/server/src/engine/event-id.ts
@@ -1,5 +1,5 @@
 function hashStringParts(parts: string[]): [number, number, number, number] {
-  const input = parts.join(':');
+  const input = JSON.stringify(parts);
   let h1 = 0xdeadbeef;
   let h2 = 0x41c6ce57;
   let h3 = 0xc0decafe;
@@ -50,6 +50,10 @@ export function stableRelaycastEventId(...parts: Array<string | null | undefined
   const normalized = parts
     .map((part) => part?.trim())
     .filter((part): part is string => typeof part === 'string' && part.length > 0);
+
+  if (normalized.length === 0) {
+    return formatUuidFromWords(hashStringParts(['relaycast', 'empty-event']));
+  }
 
   return formatUuidFromWords(hashStringParts(['relaycast', ...normalized]));
 }

--- a/packages/server/src/engine/wsTransform.ts
+++ b/packages/server/src/engine/wsTransform.ts
@@ -1,3 +1,5 @@
+import { stableRelaycastEventId } from './event-id.js';
+
 export type WsEvent = {
   type: string;
   workspace_id: string;
@@ -17,6 +19,7 @@ export function transformForClient(event: WsEvent): Record<string, unknown> {
   switch (event.type) {
     case 'message.created':
       return {
+        id: stableRelaycastEventId(d.id as string),
         type: 'message.created',
         channel: d.channel_name as string,
         message: {
@@ -43,6 +46,7 @@ export function transformForClient(event: WsEvent): Record<string, unknown> {
 
     case 'thread.reply':
       return {
+        id: stableRelaycastEventId(d.id as string),
         type: 'thread.reply',
         channel: d.channel_name as string,
         parent_id: d.thread_id as string,
@@ -75,6 +79,7 @@ export function transformForClient(event: WsEvent): Record<string, unknown> {
       const injectionMode = (msg.injection_mode ?? d.injection_mode) as 'wait' | 'steer' | undefined;
       const attachments = (msg.attachments ?? d.attachments ?? []) as unknown[];
       return {
+        id: stableRelaycastEventId((msg.id ?? d.id) as string),
         type: 'dm.received',
         conversation_id: d.conversation_id as string,
         message: {
@@ -93,6 +98,7 @@ export function transformForClient(event: WsEvent): Record<string, unknown> {
       const injectionMode = (msg.injection_mode ?? d.injection_mode) as 'wait' | 'steer' | undefined;
       const attachments = (msg.attachments ?? d.attachments ?? []) as unknown[];
       return {
+        id: stableRelaycastEventId((msg.id ?? d.id) as string),
         type: 'group_dm.received',
         conversation_id: d.conversation_id as string,
         message: {

--- a/packages/server/src/routes/__tests__/dm.test.ts
+++ b/packages/server/src/routes/__tests__/dm.test.ts
@@ -117,6 +117,32 @@ describe('POST /v1/dm', () => {
     }));
   });
 
+  it('passes @self through to the DM engine for server-side resolution', async () => {
+    vi.mocked(dmEngine.sendDm).mockResolvedValue({
+      id: 'msg_003',
+      conversation_id: 'conv_self',
+      from_agent_id: 'agent_123',
+      to: '@self',
+      text: 'note to self',
+      created_at: '2025-01-01T00:00:00.000Z',
+      injection_mode: 'wait',
+    });
+
+    const res = await app.request('/v1/dm', {
+      method: 'POST',
+      headers: agentAuthHeaders(),
+      body: JSON.stringify({ to: '@self', text: 'note to self' }),
+    }, bindings);
+
+    expect(res.status).toBe(201);
+    expect(vi.mocked(dmEngine.sendDm)).toHaveBeenCalledWith(
+      expect.anything(),
+      FAKE_WORKSPACE.id,
+      'agent_123',
+      expect.objectContaining({ to: '@self', text: 'note to self' }),
+    );
+  });
+
   it('returns 400 when text is missing', async () => {
     const res = await app.request('/v1/dm', {
       method: 'POST',

--- a/packages/server/src/routes/__tests__/fanout.test.ts
+++ b/packages/server/src/routes/__tests__/fanout.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import type { Context } from 'hono';
 import type { AppEnv } from '../../env.js';
+import { stableRelaycastEventId } from '../../engine/event-id.js';
 import {
   fanoutToChannel,
   fanoutToAgents,
@@ -56,6 +57,7 @@ describe('fanout helpers', () => {
     const body = await req.json();
     expect(body.workspaceId).toBe(FAKE_WORKSPACE.id);
     expect(body.event).toEqual({
+      id: stableRelaycastEventId('msg_1'),
       type: 'message.created',
       channel: 'general',
       message: {

--- a/packages/types/src/__tests__/event-id.test.ts
+++ b/packages/types/src/__tests__/event-id.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from 'vitest';
+import { stableRelaycastEventId } from '../event-id.js';
+
+describe('stableRelaycastEventId', () => {
+  it('preserves part boundaries when hashing', () => {
+    expect(stableRelaycastEventId('a', 'b:c')).not.toBe(stableRelaycastEventId('a:b', 'c'));
+  });
+
+  it('uses the stable empty-event fallback for blank input', () => {
+    expect(stableRelaycastEventId()).toBe(stableRelaycastEventId('empty-event'));
+    expect(stableRelaycastEventId('  ', undefined, null)).toBe(stableRelaycastEventId('empty-event'));
+  });
+});

--- a/packages/types/src/event-id.ts
+++ b/packages/types/src/event-id.ts
@@ -1,5 +1,5 @@
 function hashStringParts(parts: string[]): [number, number, number, number] {
-  const input = parts.join(':');
+  const input = JSON.stringify(parts);
   let h1 = 0xdeadbeef;
   let h2 = 0x41c6ce57;
   let h3 = 0xc0decafe;

--- a/packages/types/src/event-id.ts
+++ b/packages/types/src/event-id.ts
@@ -1,0 +1,59 @@
+function hashStringParts(parts: string[]): [number, number, number, number] {
+  const input = parts.join(':');
+  let h1 = 0xdeadbeef;
+  let h2 = 0x41c6ce57;
+  let h3 = 0xc0decafe;
+  let h4 = 0x9e3779b9;
+
+  for (let i = 0; i < input.length; i += 1) {
+    const code = input.charCodeAt(i);
+    h1 = Math.imul(h1 ^ code, 2654435761);
+    h2 = Math.imul(h2 ^ code, 1597334677);
+    h3 = Math.imul(h3 ^ code, 2246822507);
+    h4 = Math.imul(h4 ^ code, 3266489909);
+  }
+
+  h1 = Math.imul(h1 ^ (h1 >>> 16), 2246822507) ^ Math.imul(h2 ^ (h2 >>> 13), 3266489909);
+  h2 = Math.imul(h2 ^ (h2 >>> 16), 2246822507) ^ Math.imul(h3 ^ (h3 >>> 13), 3266489909);
+  h3 = Math.imul(h3 ^ (h3 >>> 16), 2246822507) ^ Math.imul(h4 ^ (h4 >>> 13), 3266489909);
+  h4 = Math.imul(h4 ^ (h4 >>> 16), 2246822507) ^ Math.imul(h1 ^ (h1 >>> 13), 3266489909);
+
+  return [h1 >>> 0, h2 >>> 0, h3 >>> 0, h4 >>> 0];
+}
+
+function formatUuidFromWords(words: [number, number, number, number]): string {
+  const bytes = new Uint8Array(16);
+
+  for (let i = 0; i < words.length; i += 1) {
+    const word = words[i];
+    const offset = i * 4;
+    bytes[offset] = (word >>> 24) & 0xff;
+    bytes[offset + 1] = (word >>> 16) & 0xff;
+    bytes[offset + 2] = (word >>> 8) & 0xff;
+    bytes[offset + 3] = word & 0xff;
+  }
+
+  bytes[6] = (bytes[6] & 0x0f) | 0x50;
+  bytes[8] = (bytes[8] & 0x3f) | 0x80;
+
+  const hex = [...bytes].map((byte) => byte.toString(16).padStart(2, '0')).join('');
+  return [
+    hex.slice(0, 8),
+    hex.slice(8, 12),
+    hex.slice(12, 16),
+    hex.slice(16, 20),
+    hex.slice(20, 32),
+  ].join('-');
+}
+
+export function stableRelaycastEventId(...parts: Array<string | null | undefined>): string {
+  const normalized = parts
+    .map((part) => part?.trim())
+    .filter((part): part is string => typeof part === 'string' && part.length > 0);
+
+  if (normalized.length === 0) {
+    return formatUuidFromWords(hashStringParts(['relaycast', 'empty-event']));
+  }
+
+  return formatUuidFromWords(hashStringParts(['relaycast', ...normalized]));
+}

--- a/packages/types/src/events.ts
+++ b/packages/types/src/events.ts
@@ -34,6 +34,7 @@ export const ChannelMessagePayloadSchema = CoreMessagePayloadSchema.extend({
 export type ChannelMessagePayload = z.infer<typeof ChannelMessagePayloadSchema>;
 
 export const MessageCreatedEventSchema = z.object({
+  id: z.string().uuid(),
   type: z.literal('message.created'),
   channel: z.string(),
   message: ChannelMessagePayloadSchema,
@@ -48,6 +49,7 @@ export const MessageUpdatedEventSchema = z.object({
 export type MessageUpdatedEvent = z.infer<typeof MessageUpdatedEventSchema>;
 
 export const ThreadReplyEventSchema = z.object({
+  id: z.string().uuid(),
   type: z.literal('thread.reply'),
   channel: z.string(),
   parent_id: z.string(),
@@ -72,6 +74,7 @@ export const ReactionRemovedEventSchema = z.object({
 export type ReactionRemovedEvent = z.infer<typeof ReactionRemovedEventSchema>;
 
 export const DmReceivedEventSchema = z.object({
+  id: z.string().uuid(),
   type: z.literal('dm.received'),
   conversation_id: z.string(),
   message: CoreMessagePayloadSchema,
@@ -79,6 +82,7 @@ export const DmReceivedEventSchema = z.object({
 export type DmReceivedEvent = z.infer<typeof DmReceivedEventSchema>;
 
 export const GroupDmReceivedEventSchema = z.object({
+  id: z.string().uuid(),
   type: z.literal('group_dm.received'),
   conversation_id: z.string(),
   message: CoreMessagePayloadSchema,
@@ -258,6 +262,13 @@ export const ServerEventSchema = z.discriminatedUnion('type', [
 export type ServerEvent = z.infer<typeof ServerEventSchema>;
 export type ServerEventType = ServerEvent['type'];
 export type ClientEventType = ClientEvent['type'];
+export const RelaycastMessageEventSchema = z.discriminatedUnion('type', [
+  MessageCreatedEventSchema,
+  ThreadReplyEventSchema,
+  DmReceivedEventSchema,
+  GroupDmReceivedEventSchema,
+]);
+export type RelaycastMessageEvent = z.infer<typeof RelaycastMessageEventSchema>;
 
 // Union of all events that WsClient can emit (includes server events + client-only events)
 export const WsClientEventSchema = z.discriminatedUnion('type', [

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -13,3 +13,4 @@ export * from './subscription.js';
 export * from './command.js';
 export * from './telemetry.js';
 export * from './emoji.js';
+export * from './event-id.js';


### PR DESCRIPTION
## Summary
- `AgentClient.subscribe(channels, onMessage): Subscription` multiplexes one websocket per agent, auto-resubscribes on reconnect, and treats `@self` as a DM-only filter in the high-level SDK.
- Server resolves `to: "@self"` on DM send from the authenticated `agentId` (no client-side substitution).
- WebSocket message events now carry a deterministic top-level UUID `id` derived from the message id, so clients can dedupe across reconnects.
- `RelayError` distinguishes `rate_limited` and `backpressure` from generic transport failures.

## Origin
Implemented as **Track A of the proactive-runtime M3 swarm workflow** on 2026-05-12. The worker (`impl-relaycast-work-b37a7cf5`) reported `OWNER_DECISION: COMPLETE` to the WorkflowRunner with all three workspace test suites green, then self-terminated without committing or opening a PR. The changes have been sitting uncommitted on a local rust-SDK branch since then. This PR commits that work against current `main` after re-verifying it locally.

## Test plan
- [x] `npm test --workspace @relaycast/types` — 38 tests
- [x] `npm test --workspace @relaycast/sdk` — 294 tests
- [x] `npm test --workspace @relaycast/server` — 437 tests
- [ ] Manual smoke: subscribe to `['general', '@self']` with two agents, verify cross-agent DMs land on `@self` only and channel posts land on the named channel
- [ ] Verify `event.id` is stable across a reconnect+replay sequence
- [ ] Verify `RelayError.code === 'rate_limited' | 'backpressure'` is surfaced when the server emits the corresponding close frames

## Downstream
Tracks B–G of M3 (in `cloud-runtime-run` and `relayfile-adapters`) consume this SDK surface and likely have the same uncommitted-but-COMPLETE status — their PRs should follow this one, with a fresh `@relaycast/sdk` release bumped after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)