### PR TITLE
chore(telemetry): remove hardcoded PostHog key default

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -173,14 +173,19 @@ jobs:
       - name: Inject PostHog API key into marketing site
         shell: bash
         env:
-          RELAYCAST_POSTHOG_API_KEY: ${{ secrets.RELAYCAST_POSTHOG_API_KEY }}
+          # POSTHOG_PROJECT_KEY is a GitHub Actions repo *variable* (not a secret).
+          # PostHog `phc_*` project keys are ingestion-only and public by design —
+          # same category as a Sentry DSN or Stripe publishable key. We still gate
+          # on its presence so forks (which inherit neither vars nor secrets in
+          # fork PRs) and local previews silently ship without telemetry.
+          RELAYCAST_POSTHOG_API_KEY: ${{ vars.POSTHOG_PROJECT_KEY }}
         run: |
           # The committed site/index.html contains a __RELAYCAST_POSTHOG_API_KEY__
           # placeholder so that forks and local previews never accidentally send
           # telemetry to our production PostHog project. Substitute the real key
-          # here when (and only when) the GitHub Actions secret is present.
+          # here when (and only when) the GitHub Actions variable is present.
           if [ -z "${RELAYCAST_POSTHOG_API_KEY:-}" ]; then
-            echo "RELAYCAST_POSTHOG_API_KEY secret is not set; marketing site will ship without telemetry."
+            echo "POSTHOG_PROJECT_KEY variable is not set; marketing site will ship without telemetry."
           else
             # Use a Node script to do a literal replacement (avoids shell escaping
             # surprises and works even if the key ever contains regex-special chars).

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -170,6 +170,33 @@ jobs:
       deployments: write
     steps:
       - uses: actions/checkout@v4
+      - name: Inject PostHog API key into marketing site
+        shell: bash
+        env:
+          RELAYCAST_POSTHOG_API_KEY: ${{ secrets.RELAYCAST_POSTHOG_API_KEY }}
+        run: |
+          # The committed site/index.html contains a __RELAYCAST_POSTHOG_API_KEY__
+          # placeholder so that forks and local previews never accidentally send
+          # telemetry to our production PostHog project. Substitute the real key
+          # here when (and only when) the GitHub Actions secret is present.
+          if [ -z "${RELAYCAST_POSTHOG_API_KEY:-}" ]; then
+            echo "RELAYCAST_POSTHOG_API_KEY secret is not set; marketing site will ship without telemetry."
+          else
+            # Use a Node script to do a literal replacement (avoids shell escaping
+            # surprises and works even if the key ever contains regex-special chars).
+            node -e "
+              const fs = require('fs');
+              const path = 'site/index.html';
+              const key = process.env.RELAYCAST_POSTHOG_API_KEY;
+              const src = fs.readFileSync(path, 'utf8');
+              if (!src.includes('__RELAYCAST_POSTHOG_API_KEY__')) {
+                console.error('Placeholder __RELAYCAST_POSTHOG_API_KEY__ not found in ' + path);
+                process.exit(1);
+              }
+              fs.writeFileSync(path, src.split('__RELAYCAST_POSTHOG_API_KEY__').join(key));
+              console.log('Substituted PostHog key into ' + path);
+            "
+          fi
       - uses: cloudflare/wrangler-action@v3
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -7150,6 +7150,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -7171,6 +7172,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -7192,6 +7194,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -7213,6 +7216,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -7234,6 +7238,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -7255,6 +7260,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -7276,6 +7282,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -7297,6 +7304,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -7318,6 +7326,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -7339,6 +7348,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -7360,6 +7370,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },

--- a/packages/mcp/src/__tests__/telemetry.test.ts
+++ b/packages/mcp/src/__tests__/telemetry.test.ts
@@ -158,6 +158,28 @@ describe('createMcpTelemetry', () => {
     }
   });
 
+  it('uses options.posthogApiKey when process.env is unset (Cloudflare Worker path)', async () => {
+    // Regression: in CF Workers, wrangler secrets only flow through the env
+    // bindings, not process.env. McpSessionDO threads them into createMcpTelemetry
+    // via the options object. Verify that path actually captures events.
+    vi.mocked(fs.readFileSync).mockReturnValue(JSON.stringify({ anonymousId: 'anon-cf' }));
+
+    expect(process.env.RELAYCAST_POSTHOG_API_KEY).toBeUndefined();
+    expect(process.env.POSTHOG_API_KEY).toBeUndefined();
+
+    const telemetry = createMcpTelemetry('1.0.0', {
+      posthogHost: 'https://cf-host.example/',
+      posthogApiKey: 'phc_cf_worker',
+    });
+
+    telemetry.capture('relaycast_mcp_server_started', { transport: 'http' });
+    await telemetry.flush();
+
+    expect(nodeRequestMock).toHaveBeenCalledTimes(1);
+    const body = JSON.parse(capturedBodies[0] ?? '{}') as { api_key: string };
+    expect(body.api_key).toBe('phc_cf_worker');
+  });
+
   it('silently no-ops when no PostHog API key is configured', async () => {
     vi.mocked(fs.readFileSync).mockReturnValue(JSON.stringify({ anonymousId: 'anon-123' }));
 

--- a/packages/mcp/src/__tests__/telemetry.test.ts
+++ b/packages/mcp/src/__tests__/telemetry.test.ts
@@ -139,7 +139,10 @@ describe('createMcpTelemetry', () => {
       vi.mocked(fs.mkdirSync).mockImplementation(() => undefined);
       vi.mocked(fs.writeFileSync).mockImplementation(() => undefined);
 
-      const telemetry = createMcpTelemetry('1.0.0', { posthogHost: 'https://api.example.com' });
+      const telemetry = createMcpTelemetry('1.0.0', {
+        posthogHost: 'https://api.example.com',
+        posthogApiKey: 'phc_example',
+      });
       telemetry.capture('relaycast_mcp_server_started', {});
       await telemetry.flush();
 
@@ -153,6 +156,20 @@ describe('createMcpTelemetry', () => {
         (globalThis as { WebSocketPair?: unknown }).WebSocketPair = originalWebSocketPair;
       }
     }
+  });
+
+  it('silently no-ops when no PostHog API key is configured', async () => {
+    vi.mocked(fs.readFileSync).mockReturnValue(JSON.stringify({ anonymousId: 'anon-123' }));
+
+    // No env vars, no options.posthogApiKey — should not make any HTTP calls.
+    const telemetry = createMcpTelemetry('1.0.0', {
+      posthogHost: 'https://app.posthog.example/',
+    });
+
+    telemetry.capture('relaycast_mcp_server_started', { transport: 'stdio' });
+    await telemetry.flush();
+
+    expect(nodeRequestMock).not.toHaveBeenCalled();
   });
 
   it('flush resolves when no events are pending', async () => {

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -46,6 +46,8 @@ export interface McpServerOptions {
   strictAgentName?: boolean;
   telemetryTransport?: 'stdio' | 'http';
   telemetry?: McpTelemetry;
+  /** PostHog API key for MCP telemetry. Used in runtimes where process.env is unavailable (e.g. Cloudflare Workers). */
+  posthogApiKey?: string;
   /** Multi-workspace configs parsed from RELAY_WORKSPACES_JSON. */
   workspaces?: McpWorkspaceConfig[];
   /** Default workspace ID or alias to use as the active workspace. */
@@ -84,6 +86,7 @@ export function createRelayMcpServer(options: McpServerOptions): McpServer {
     originSurface: mcpOrigin.surface,
     originClient: mcpOrigin.client,
     originVersion: mcpOrigin.version,
+    posthogApiKey: options.posthogApiKey,
   });
 
   const mcpServer = new McpServer(

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -48,6 +48,8 @@ export interface McpServerOptions {
   telemetry?: McpTelemetry;
   /** PostHog API key for MCP telemetry. Used in runtimes where process.env is unavailable (e.g. Cloudflare Workers). */
   posthogApiKey?: string;
+  /** PostHog host for MCP telemetry. Used in runtimes where process.env is unavailable (e.g. Cloudflare Workers). */
+  posthogHost?: string;
   /** Multi-workspace configs parsed from RELAY_WORKSPACES_JSON. */
   workspaces?: McpWorkspaceConfig[];
   /** Default workspace ID or alias to use as the active workspace. */
@@ -87,6 +89,7 @@ export function createRelayMcpServer(options: McpServerOptions): McpServer {
     originClient: mcpOrigin.client,
     originVersion: mcpOrigin.version,
     posthogApiKey: options.posthogApiKey,
+    posthogHost: options.posthogHost,
   });
 
   const mcpServer = new McpServer(

--- a/packages/mcp/src/telemetry.ts
+++ b/packages/mcp/src/telemetry.ts
@@ -30,7 +30,6 @@ export interface McpTelemetry {
 
 const TELEMETRY_PATH = path.join(os.homedir(), '.relay', 'telemetry.json');
 const DEFAULT_POSTHOG_HOST = 'https://us.i.posthog.com';
-const DEFAULT_POSTHOG_PUBLIC_KEY = 'phc_OAqBdey9pESZCcwaen9Fpyz6Ez8QKiMmLOnvFknXzg4';
 
 function isTruthy(value: string | undefined): boolean {
   if (!value) return false;
@@ -38,11 +37,14 @@ function isTruthy(value: string | undefined): boolean {
   return normalized === '1' || normalized === 'true' || normalized === 'yes' || normalized === 'on';
 }
 
-function telemetryEnabled(state: TelemetryState): boolean {
+function telemetryEnabled(state: TelemetryState, apiKey: string): boolean {
   if (isTruthy(process.env.DO_NOT_TRACK) || isTruthy(process.env.RELAYCAST_TELEMETRY_DISABLED)) {
     return false;
   }
   if (state.telemetryDisabled === true) return false;
+  // No API key configured -> silently no-op. This is the default for forks
+  // and local development; production builds inject the key via env.
+  if (!apiKey) return false;
   return true;
 }
 
@@ -65,7 +67,7 @@ function getPosthogApiKey(options: McpTelemetryOptions): string {
     process.env.RELAYCAST_POSTHOG_API_KEY
     ?? process.env.POSTHOG_API_KEY
     ?? options.posthogApiKey
-    ?? DEFAULT_POSTHOG_PUBLIC_KEY
+    ?? ''
   );
 }
 
@@ -211,7 +213,7 @@ export function createMcpTelemetry(version = 'unknown', options: McpTelemetryOpt
   const originVersion = options.originVersion ?? version;
 
   const capture = (event: ClientTelemetryEventName, properties: Record<string, unknown> = {}) => {
-    if (!telemetryEnabled(state)) return;
+    if (!telemetryEnabled(state, posthogApiKey)) return;
 
     const parsed = parseTelemetryIngestionEvent({
       event,

--- a/packages/server/src/durable-objects/mcpSession.ts
+++ b/packages/server/src/durable-objects/mcpSession.ts
@@ -54,6 +54,7 @@ export class McpSessionDO implements DurableObject {
         ? 'https://api.relaycast.dev'
         : undefined,
       telemetryTransport: 'http',
+      posthogApiKey: this.env.POSTHOG_API_KEY,
     });
 
     this.transport.onclose = () => {

--- a/packages/server/src/durable-objects/mcpSession.ts
+++ b/packages/server/src/durable-objects/mcpSession.ts
@@ -54,7 +54,11 @@ export class McpSessionDO implements DurableObject {
         ? 'https://api.relaycast.dev'
         : undefined,
       telemetryTransport: 'http',
+      // Cloudflare Workers expose `wrangler secret put` values through the
+      // env bindings, not process.env, so forward them explicitly. Both are
+      // optional; when unset the MCP telemetry layer silently no-ops.
       posthogApiKey: this.env.POSTHOG_API_KEY,
+      posthogHost: this.env.POSTHOG_HOST,
     });
 
     this.transport.onclose = () => {

--- a/site/index.html
+++ b/site/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Relaycast — Headless Slack for AI Agents</title>
   <meta name="description" content="Give your AI agents channels, threads, DMs, and real-time events. Framework-agnostic messaging that works across any CLI, any language, any model.">
-  <meta name="relaycast-posthog-key" content="phc_OAqBdey9pESZCcwaen9Fpyz6Ez8QKiMmLOnvFknXzg4">
+  <meta name="relaycast-posthog-key" content="__RELAYCAST_POSTHOG_API_KEY__">
   <meta name="relaycast-posthog-host" content="https://us.i.posthog.com">
   <meta name="theme-color" content="#F9FAFB">
   <link rel="preconnect" href="https://fonts.googleapis.com">

--- a/site/script.js
+++ b/site/script.js
@@ -1,5 +1,4 @@
 const POSTHOG_DEFAULT_HOST = 'https://us.i.posthog.com';
-const POSTHOG_PUBLIC_KEY = 'phc_OAqBdey9pESZCcwaen9Fpyz6Ez8QKiMmLOnvFknXzg4';
 const POSTHOG_DISTINCT_ID_KEY = 'relaycast_posthog_distinct_id';
 const POSTHOG_SESSION_ID = window.crypto?.randomUUID?.() ?? String(Date.now());
 
@@ -33,11 +32,24 @@ const telemetry = (() => {
     };
   }
 
-  const posthogKey =
+  const metaKey = getMetaContent('relaycast-posthog-key');
+  // The meta tag ships with a `__RELAYCAST_POSTHOG_API_KEY__` placeholder that
+  // CI substitutes at deploy time. Treat the unsubstituted placeholder (and any
+  // other non-phc value) as "no key configured" so forks / local previews
+  // silently no-op instead of POSTing to an unknown PostHog project.
+  const candidateKey =
     window.POSTHOG_API_KEY ||
     window.RELAYCAST_POSTHOG_KEY ||
-    getMetaContent('relaycast-posthog-key') ||
-    POSTHOG_PUBLIC_KEY;
+    metaKey ||
+    '';
+  const posthogKey = candidateKey.startsWith('phc_') ? candidateKey : '';
+
+  if (!posthogKey) {
+    return {
+      enabled: false,
+      capture: () => {},
+    };
+  }
 
   const rawHost =
     window.POSTHOG_HOST || window.RELAYCAST_POSTHOG_HOST || getMetaContent('relaycast-posthog-host');


### PR DESCRIPTION
## Summary

Relaycast half of [AgentWorkforce/relay#881](https://github.com/AgentWorkforce/relay/issues/881) (P0.5). A parallel PR in the `relay` repo handles the relay-side changes.

Drops the baked-in `phc_OAqBdey9...` PostHog write key from this repo so that:

1. Forks running tests / dev no longer pollute our production PostHog project.
2. Telemetry silently no-ops when no key is configured (no scary warnings, no HTTP calls, no event buffer).
3. Production builds get the key injected from a GitHub Actions repo variable at deploy / install time.

**Why a variable, not a secret:** PostHog `phc_*` project keys are ingestion-only and public by design — same category as a Sentry DSN or Stripe publishable key. The structural problem is fork pollution, and that's already solved by (a) the new no-op-when-missing behavior and (b) the fact that GitHub gates both `vars` and `secrets` from fork PRs. Calling it a secret was misleading.

## What changed

### `packages/mcp/src/telemetry.ts`
- Removed the `DEFAULT_POSTHOG_PUBLIC_KEY` constant.
- `getPosthogApiKey()` now falls back to `''` (empty string) when no env / option is provided.
- `telemetryEnabled()` now takes the resolved API key and returns `false` when it's empty — same code path as the existing `DO_NOT_TRACK` / `RELAYCAST_TELEMETRY_DISABLED` opt-outs, so `capture()` silently no-ops with no HTTP calls.
- Env precedence is unchanged: `RELAYCAST_POSTHOG_API_KEY` > `POSTHOG_API_KEY` > `options.posthogApiKey`.

### `packages/mcp/src/__tests__/telemetry.test.ts`
- Existing "prefers fetch transport" test now passes an explicit `posthogApiKey: 'phc_example'` (previously relied on the hardcoded default).
- New test: `silently no-ops when no PostHog API key is configured`.

### `site/index.html`
- Replaced the hardcoded `phc_OAqBdey9...` meta value with a `__RELAYCAST_POSTHOG_API_KEY__` placeholder that CI substitutes at deploy time.

### `site/script.js`
- Removed the `POSTHOG_PUBLIC_KEY` constant fallback.
- Added a `startsWith('phc_')` guard so the unsubstituted `__RELAYCAST_POSTHOG_API_KEY__` placeholder (or any other non-phc value) is treated as "no key configured" and the analytics layer returns a no-op `capture`. Forks deploying their own copy of the static site, and local previews via `file://`, both get no-op behavior.

### `.github/workflows/deploy.yml`
- New `Inject PostHog API key into marketing site` step before `pages deploy site/`. Uses a small Node script to do a literal `__RELAYCAST_POSTHOG_API_KEY__` -> value substitution in `site/index.html`. The source is `vars.POSTHOG_PROJECT_KEY` (a repository **variable**, not a secret — see "why" above). If the variable is unset, logs a warning and ships the site with telemetry disabled (no failure).
- The existing `deploy-production` job already pipes `secrets.POSTHOG_API_KEY` from a GitHub secret into the Cloudflare Worker via `wrangler secret put` — left as-is. The Cloudflare-side is still a runtime secret (that's a Cloudflare concept), and the GitHub source for that step is a separate value managed independently from this PR.

### Workflows intentionally NOT modified
- `publish-npm.yml` — the MCP package reads `RELAYCAST_POSTHOG_API_KEY` from the user's runtime env at install time; nothing is baked into the npm artifact.
- `publish-rust.yml`, `local-binary-release.yml` — no PostHog integration in those artifacts.
- `ci.yml` and the `ci` job in `deploy.yml` — left without the key so test events from CI don't pollute the prod project. `DO_NOT_TRACK=1` was already set on test runs there.

## Action required after merge

Add **`POSTHOG_PROJECT_KEY`** as a repository **Variable** (Settings → Secrets and variables → Actions → **Variables** tab, NOT Secrets) before the next release. The `deploy-pages` job injects this value into the marketing site at deploy time. Without it, the site ships cleanly but with telemetry disabled.

The Cloudflare Worker still receives its PostHog value as a runtime *secret* via `wrangler secret put POSTHOG_API_KEY` (that's a Cloudflare-side concept, not a GitHub-side one). The existing `secrets.POSTHOG_API_KEY` GitHub Actions secret feeding that step is unchanged by this PR.

Users running the MCP locally won't have a key set by default and will silently no-op. If we want to opt them in via documentation, that's a follow-up.

## Notes / judgment calls

- I made `site/script.js` reject any meta value that doesn't start with `phc_`. This handles the `__RELAYCAST_POSTHOG_API_KEY__` placeholder cleanly and also defensively rejects garbage values. Felt cleaner than a `value === '__RELAYCAST_POSTHOG_API_KEY__'` string compare.
- The substitution step in the workflow uses a Node script (rather than `sed -i`) to avoid GNU vs. BSD `sed` differences and any regex-special-char surprises in the key. It also validates the placeholder is present and exits non-zero if it isn't.
- No `docs/` or marketing-copy mentions of the key needed updating (verified by `grep -r phc_OAqBdey9 .`).

## Test plan

- [x] `npm run build` — succeeds (turbo, 9 tasks).
- [x] `DO_NOT_TRACK=1 npm test` — 223/223 MCP tests pass; 437/437 server tests pass; full suite green.
- [x] `npm run lint` — 0 errors (64 pre-existing warnings unrelated to this change).
- [x] `grep -r 'phc_OAqBdey9'` returns 0 hits across the repo.
- [ ] After merge + variable config: trigger a deploy, confirm `<meta name="relaycast-posthog-key">` contains the real key in the deployed `site/index.html`.
- [ ] After merge: run `npx @relaycast/mcp` locally with no env, confirm no PostHog requests in network logs.