### PR TITLE
Add reusable Rust SDK relay helpers

### DIFF
--- a/packages/sdk-rust/CHANGELOG.md
+++ b/packages/sdk-rust/CHANGELOG.md
@@ -6,6 +6,18 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
 
 ## [Unreleased]
 
+### Added
+- Added raw WebSocket event subscriptions with `WsClient::subscribe_raw_events()` and `RawEventReceiver`.
+- Added SDK-owned raw event normalization helpers:
+  - `normalize_inbound_event(...)`
+  - `normalize_command_invocation(...)`
+  - `normalize_sender_identity(...)`
+  - `NormalizedInboundEvent`, `NormalizedCommandInvocation`, `NormalizedEventKind`, `SenderKind`, and `RelayPriority`
+- Added identity helpers `agent_name_eq(...)` and `is_self_name(...)`.
+- Added `AgentRegistrationClient::registered_agent_client(...)` for cached/spawned token registration followed by agent-client construction.
+- Added idempotent channel startup helpers `AgentClient::ensure_joined_channel(...)` and `AgentClient::ensure_joined_channels(...)`.
+- Added `DmParticipantsCache` for bounded workspace DM participant lookup caching.
+
 ### Changed
 - Made `agent.spawn_requested` websocket parsing tolerant of missing or `null` `task`, `channel`, and `already_existed` fields.
 - Kept `AgentSpawnRequestedPayload.task` as a `String` for API compatibility by deserializing missing or `null` values to an empty string.

--- a/packages/sdk-rust/README.md
+++ b/packages/sdk-rust/README.md
@@ -83,9 +83,17 @@ agent.dm("other-agent", "Private message", None).await?;
 agent.create_channel(CreateChannelRequest {
     name: "my-channel".to_string(),
     topic: Some("Channel topic".to_string()),
+    metadata: None,
 }).await?;
 
 agent.join_channel("my-channel").await?;
+
+// Idempotent startup helper: create if needed, then join if needed
+agent.ensure_joined_channel(CreateChannelRequest {
+    name: "general".to_string(),
+    topic: Some("General discussion".to_string()),
+    metadata: None,
+}).await?;
 ```
 
 ### Real-time Events
@@ -119,6 +127,36 @@ while let Ok(event) = events.recv().await {
         _ => {}
     }
 }
+```
+
+For consumers that need to handle evolving event shapes before converting to typed SDK events, subscribe to raw JSON events and normalize them:
+
+```rust
+use relaycast::{normalize_inbound_event, WsClient, WsClientOptions};
+
+let mut ws = WsClient::new(WsClientOptions::new("at_live_xxx"));
+let mut raw_events = ws.subscribe_raw_events();
+ws.connect().await?;
+
+while let Ok(raw) = raw_events.recv().await {
+    if let Some(event) = normalize_inbound_event(&raw) {
+        println!("{} -> {}: {}", event.from, event.target, event.text);
+    }
+}
+```
+
+### Registration Helpers
+
+```rust
+use relaycast::{AgentRegistrationClient, RelayCast, RelayCastOptions};
+
+let relay = RelayCast::new(RelayCastOptions::new("rk_live_xxx"))?;
+let registration = AgentRegistrationClient::new(relay, "codex");
+
+let agent = registration
+    .registered_agent_client("worker-a", Some("codex"))
+    .await?;
+agent.send("#general", "ready", None, None, None).await?;
 ```
 
 ### Files

--- a/packages/sdk-rust/src/agent.rs
+++ b/packages/sdk-rust/src/agent.rs
@@ -1,7 +1,7 @@
 //! Agent client for message and channel operations.
 
 use crate::client::{ClientOptions, HttpClient, RequestOptions};
-use crate::error::Result;
+use crate::error::{RelayError, Result};
 use crate::types::*;
 use crate::ws::{EventReceiver, LifecycleReceiver, WsClient, WsClientOptions};
 
@@ -32,6 +32,17 @@ impl Default for DmOptions {
             idempotency_key: None,
         }
     }
+}
+
+/// Result of ensuring a channel exists and is joined.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EnsureChannelOutcome {
+    /// Channel name that was ensured.
+    pub name: String,
+    /// Whether the channel was created by this call.
+    pub created: bool,
+    /// Whether the agent joined the channel during this call.
+    pub joined: bool,
 }
 
 impl AgentClient {
@@ -314,7 +325,12 @@ impl AgentClient {
     // === DMs ===
 
     /// Send a direct message to another agent.
-    pub async fn dm(&self, agent: &str, text: &str, opts: Option<DmOptions>) -> Result<serde_json::Value> {
+    pub async fn dm(
+        &self,
+        agent: &str,
+        text: &str,
+        opts: Option<DmOptions>,
+    ) -> Result<serde_json::Value> {
         let opts = opts.unwrap_or_default();
         let body = SendDmRequest {
             to: agent.to_string(),
@@ -322,12 +338,19 @@ impl AgentClient {
             attachments: opts.attachments,
             mode: Some(opts.mode),
         };
-        let options = opts.idempotency_key.map(RequestOptions::with_idempotency_key);
+        let options = opts
+            .idempotency_key
+            .map(RequestOptions::with_idempotency_key);
         self.client.post("/v1/dm", Some(body), options).await
     }
 
     /// Send a direct message to another agent (typed response).
-    pub async fn dm_typed(&self, agent: &str, text: &str, opts: Option<DmOptions>) -> Result<DmSendResponse> {
+    pub async fn dm_typed(
+        &self,
+        agent: &str,
+        text: &str,
+        opts: Option<DmOptions>,
+    ) -> Result<DmSendResponse> {
         let opts = opts.unwrap_or_default();
         let body = SendDmRequest {
             to: agent.to_string(),
@@ -335,7 +358,9 @@ impl AgentClient {
             attachments: opts.attachments,
             mode: Some(opts.mode),
         };
-        let options = opts.idempotency_key.map(RequestOptions::with_idempotency_key);
+        let options = opts
+            .idempotency_key
+            .map(RequestOptions::with_idempotency_key);
         self.client.post("/v1/dm", Some(body), options).await
     }
 
@@ -434,7 +459,10 @@ impl AgentClient {
     ) -> Result<serde_json::Value> {
         let opts = opts.unwrap_or_default();
         let mut body = serde_json::Map::new();
-        body.insert("text".to_string(), serde_json::Value::String(text.to_string()));
+        body.insert(
+            "text".to_string(),
+            serde_json::Value::String(text.to_string()),
+        );
         body.insert(
             "mode".to_string(),
             serde_json::Value::String(match opts.mode {
@@ -443,9 +471,14 @@ impl AgentClient {
             }),
         );
         if let Some(attachments) = opts.attachments {
-            body.insert("attachments".to_string(), serde_json::to_value(attachments)?);
+            body.insert(
+                "attachments".to_string(),
+                serde_json::to_value(attachments)?,
+            );
         }
-        let options = opts.idempotency_key.map(RequestOptions::with_idempotency_key);
+        let options = opts
+            .idempotency_key
+            .map(RequestOptions::with_idempotency_key);
         self.client
             .post(
                 &format!("/v1/dm/{}/messages", urlencoding::encode(conversation_id)),
@@ -464,7 +497,10 @@ impl AgentClient {
     ) -> Result<GroupDmMessageResponse> {
         let opts = opts.unwrap_or_default();
         let mut body = serde_json::Map::new();
-        body.insert("text".to_string(), serde_json::Value::String(text.to_string()));
+        body.insert(
+            "text".to_string(),
+            serde_json::Value::String(text.to_string()),
+        );
         body.insert(
             "mode".to_string(),
             serde_json::Value::String(match opts.mode {
@@ -473,9 +509,14 @@ impl AgentClient {
             }),
         );
         if let Some(attachments) = opts.attachments {
-            body.insert("attachments".to_string(), serde_json::to_value(attachments)?);
+            body.insert(
+                "attachments".to_string(),
+                serde_json::to_value(attachments)?,
+            );
         }
-        let options = opts.idempotency_key.map(RequestOptions::with_idempotency_key);
+        let options = opts
+            .idempotency_key
+            .map(RequestOptions::with_idempotency_key);
         self.client
             .post(
                 &format!("/v1/dm/{}/messages", urlencoding::encode(conversation_id)),
@@ -542,6 +583,46 @@ impl AgentClient {
     /// Create a new channel.
     pub async fn create_channel(&self, request: CreateChannelRequest) -> Result<Channel> {
         self.client.post("/v1/channels", Some(request), None).await
+    }
+
+    /// Ensure a channel exists and this agent is a member.
+    ///
+    /// `409 Conflict` from either create or join is treated as success, which
+    /// makes this safe to call during startup.
+    pub async fn ensure_joined_channel(
+        &self,
+        request: CreateChannelRequest,
+    ) -> Result<EnsureChannelOutcome> {
+        let name = request.name.clone();
+        let created = match self.create_channel(request).await {
+            Ok(_) => true,
+            Err(RelayError::Api { status: 409, .. }) => false,
+            Err(error) => return Err(error),
+        };
+
+        let joined = match self.join_channel(&name).await {
+            Ok(_) => true,
+            Err(RelayError::Api { status: 409, .. }) => false,
+            Err(error) => return Err(error),
+        };
+
+        Ok(EnsureChannelOutcome {
+            name,
+            created,
+            joined,
+        })
+    }
+
+    /// Ensure several channels exist and this agent is a member of each.
+    pub async fn ensure_joined_channels<I>(&self, requests: I) -> Result<Vec<EnsureChannelOutcome>>
+    where
+        I: IntoIterator<Item = CreateChannelRequest>,
+    {
+        let mut outcomes = Vec::new();
+        for request in requests {
+            outcomes.push(self.ensure_joined_channel(request).await?);
+        }
+        Ok(outcomes)
     }
 
     /// List channels.

--- a/packages/sdk-rust/src/dm_participants.rs
+++ b/packages/sdk-rust/src/dm_participants.rs
@@ -1,0 +1,237 @@
+//! Cached resolution for workspace DM conversation participants.
+
+use std::collections::HashMap;
+use std::time::{Duration, Instant};
+
+use crate::{RelayCast, Result};
+
+/// Default successful participant lookup TTL.
+pub const DM_PARTICIPANT_CACHE_TTL: Duration = Duration::from_secs(30);
+/// Default failed participant lookup TTL.
+pub const DM_PARTICIPANT_FAILURE_TTL: Duration = Duration::from_secs(5);
+const DEFAULT_MAX_DM_CACHE_ENTRIES: usize = 8192;
+
+/// A cached DM participant lookup entry.
+#[derive(Debug, Clone)]
+pub enum DmParticipantsCacheEntry {
+    Success {
+        fetched_at: Instant,
+        participants: Vec<String>,
+    },
+    Failure {
+        failed_at: Instant,
+    },
+}
+
+impl DmParticipantsCacheEntry {
+    fn timestamp(&self) -> Instant {
+        match self {
+            Self::Success { fetched_at, .. } => *fetched_at,
+            Self::Failure { failed_at } => *failed_at,
+        }
+    }
+}
+
+/// Small bounded cache for resolving workspace DM conversation participants.
+#[derive(Debug, Clone)]
+pub struct DmParticipantsCache {
+    entries: HashMap<String, DmParticipantsCacheEntry>,
+    success_ttl: Duration,
+    failure_ttl: Duration,
+    max_entries: usize,
+}
+
+impl Default for DmParticipantsCache {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl DmParticipantsCache {
+    /// Create a cache with the default TTLs and entry limit.
+    pub fn new() -> Self {
+        Self::with_options(
+            DM_PARTICIPANT_CACHE_TTL,
+            DM_PARTICIPANT_FAILURE_TTL,
+            DEFAULT_MAX_DM_CACHE_ENTRIES,
+        )
+    }
+
+    /// Create a cache with explicit TTLs and entry limit.
+    pub fn with_options(success_ttl: Duration, failure_ttl: Duration, max_entries: usize) -> Self {
+        Self {
+            entries: HashMap::new(),
+            success_ttl,
+            failure_ttl,
+            max_entries,
+        }
+    }
+
+    /// Number of cached entries.
+    pub fn len(&self) -> usize {
+        self.entries.len()
+    }
+
+    /// Whether the cache is empty.
+    pub fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+
+    /// Clear all cached entries.
+    pub fn clear(&mut self) {
+        self.entries.clear();
+    }
+
+    /// Resolve participants, returning cached successes and suppressing only
+    /// recently cached failures.
+    pub async fn resolve(
+        &mut self,
+        relay: &RelayCast,
+        workspace_id: &str,
+        conversation_id: &str,
+    ) -> Result<Vec<String>> {
+        let workspace_id = workspace_id.trim();
+        let conversation_id = conversation_id.trim();
+        if conversation_id.is_empty() {
+            return Ok(vec![]);
+        }
+
+        let cache_key = format!("{workspace_id}:{conversation_id}");
+        if let Some(entry) = self.entries.get(&cache_key) {
+            match entry {
+                DmParticipantsCacheEntry::Success {
+                    fetched_at,
+                    participants,
+                } if fetched_at.elapsed() < self.success_ttl => {
+                    return Ok(participants.clone());
+                }
+                DmParticipantsCacheEntry::Failure { failed_at }
+                    if failed_at.elapsed() < self.failure_ttl =>
+                {
+                    return Ok(vec![]);
+                }
+                _ => {}
+            }
+        }
+
+        match relay.dm_conversation_participants(conversation_id).await {
+            Ok(participants) => {
+                self.insert(
+                    cache_key,
+                    DmParticipantsCacheEntry::Success {
+                        fetched_at: Instant::now(),
+                        participants: participants.clone(),
+                    },
+                );
+                Ok(participants)
+            }
+            Err(error) => {
+                self.insert(
+                    cache_key,
+                    DmParticipantsCacheEntry::Failure {
+                        failed_at: Instant::now(),
+                    },
+                );
+                Err(error)
+            }
+        }
+    }
+
+    /// Resolve participants and convert lookup errors into an empty list.
+    pub async fn resolve_or_empty(
+        &mut self,
+        relay: &RelayCast,
+        workspace_id: &str,
+        conversation_id: &str,
+    ) -> Vec<String> {
+        match self.resolve(relay, workspace_id, conversation_id).await {
+            Ok(participants) => participants,
+            Err(error) => {
+                tracing::warn!(
+                    workspace_id = %workspace_id,
+                    conversation_id = %conversation_id,
+                    error = %error,
+                    "failed resolving DM participants"
+                );
+                vec![]
+            }
+        }
+    }
+
+    fn insert(&mut self, cache_key: String, entry: DmParticipantsCacheEntry) {
+        if self.max_entries == 0 {
+            return;
+        }
+
+        if !self.entries.contains_key(&cache_key) && self.entries.len() >= self.max_entries {
+            if let Some(oldest_key) = self
+                .entries
+                .iter()
+                .min_by_key(|(_, entry)| entry.timestamp())
+                .map(|(key, _)| key.clone())
+            {
+                self.entries.remove(&oldest_key);
+            }
+        }
+
+        self.entries.insert(cache_key, entry);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{DmParticipantsCache, DmParticipantsCacheEntry};
+    use std::time::{Duration, Instant};
+
+    #[test]
+    fn cache_entry_timestamp_tracks_entry_kind() {
+        let now = Instant::now();
+        let success = DmParticipantsCacheEntry::Success {
+            fetched_at: now,
+            participants: vec!["alice".to_string()],
+        };
+        let failure = DmParticipantsCacheEntry::Failure { failed_at: now };
+
+        assert_eq!(success.timestamp(), now);
+        assert_eq!(failure.timestamp(), now);
+    }
+
+    #[test]
+    fn cache_zero_capacity_drops_entries() {
+        let mut cache =
+            DmParticipantsCache::with_options(Duration::from_secs(1), Duration::from_secs(1), 0);
+
+        cache.insert(
+            "workspace:dm_1".to_string(),
+            DmParticipantsCacheEntry::Failure {
+                failed_at: Instant::now(),
+            },
+        );
+
+        assert!(cache.is_empty());
+    }
+
+    #[test]
+    fn cache_evicts_oldest_entry_at_capacity() {
+        let mut cache =
+            DmParticipantsCache::with_options(Duration::from_secs(1), Duration::from_secs(1), 1);
+
+        cache.insert(
+            "workspace:dm_1".to_string(),
+            DmParticipantsCacheEntry::Success {
+                fetched_at: Instant::now() - Duration::from_secs(2),
+                participants: vec!["alice".to_string()],
+            },
+        );
+        cache.insert(
+            "workspace:dm_2".to_string(),
+            DmParticipantsCacheEntry::Success {
+                fetched_at: Instant::now(),
+                participants: vec!["bob".to_string()],
+            },
+        );
+
+        assert_eq!(cache.len(), 1);
+        assert!(cache.entries.contains_key("workspace:dm_2"));
+    }
+}

--- a/packages/sdk-rust/src/events.rs
+++ b/packages/sdk-rust/src/events.rs
@@ -1,0 +1,867 @@
+//! Helpers for consuming raw RelayCast WebSocket events.
+
+use std::{
+    collections::hash_map::DefaultHasher,
+    hash::{Hash, Hasher},
+};
+
+use serde::{Deserialize, Serialize};
+use serde_json::{Map, Value};
+
+/// Normalized inbound event kind for message-like WebSocket events.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum NormalizedEventKind {
+    MessageCreated,
+    DmReceived,
+    ThreadReply,
+    GroupDmReceived,
+    Presence,
+    ReactionReceived,
+}
+
+/// Normalized sender kind extracted from event metadata.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SenderKind {
+    Human,
+    Agent,
+    Unknown,
+}
+
+/// Suggested delivery priority for a normalized inbound event.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "UPPERCASE")]
+pub enum RelayPriority {
+    P2,
+    P3,
+    P4,
+}
+
+/// A stable, SDK-owned shape for inbound WebSocket events that need routing.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct NormalizedInboundEvent {
+    pub event_id: String,
+    pub kind: NormalizedEventKind,
+    pub from: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub sender_agent_id: Option<String>,
+    pub sender_kind: SenderKind,
+    pub target: String,
+    pub text: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub thread_id: Option<String>,
+    pub priority: RelayPriority,
+}
+
+/// A normalized command invocation event.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct NormalizedCommandInvocation {
+    pub command: String,
+    pub channel: String,
+    pub invoked_by: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub handler_agent_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub args: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub parameters: Option<Map<String, Value>>,
+}
+
+/// Normalize a raw WebSocket event value into a routeable message-like event.
+///
+/// The parser accepts current top-level event fields and payload-wrapped event
+/// shapes. It intentionally returns `None` for command events; use
+/// [`normalize_command_invocation`] for `command.invoked`.
+pub fn normalize_inbound_event(value: &Value) -> Option<NormalizedInboundEvent> {
+    let accessor = EventAccessor::new(value);
+    let event_type = accessor
+        .field(EventNesting::Top, "type")
+        .and_then(Value::as_str)?;
+    let mut kind = parse_inbound_kind(event_type)?;
+
+    if matches!(kind, NormalizedEventKind::MessageCreated)
+        && extract_channel(accessor).is_none()
+        && has_conversation_context(accessor)
+    {
+        kind = NormalizedEventKind::DmReceived;
+    }
+
+    if matches!(
+        kind,
+        NormalizedEventKind::MessageCreated
+            | NormalizedEventKind::DmReceived
+            | NormalizedEventKind::ThreadReply
+            | NormalizedEventKind::GroupDmReceived
+    ) {
+        let has_message = accessor
+            .nested(EventNesting::Message)
+            .is_some_and(Value::is_object)
+            || accessor
+                .nested(EventNesting::PayloadMessage)
+                .is_some_and(Value::is_object);
+        if !has_message && extract_text(accessor).is_none() {
+            return None;
+        }
+    }
+
+    if matches!(kind, NormalizedEventKind::Presence) {
+        let from = extract_presence_sender(accessor).unwrap_or_else(|| "unknown".to_string());
+        return Some(NormalizedInboundEvent {
+            event_id: format!("presence-{event_type}-{from}"),
+            kind,
+            from,
+            sender_agent_id: None,
+            sender_kind: SenderKind::Agent,
+            target: String::new(),
+            text: String::new(),
+            thread_id: None,
+            priority: RelayPriority::P4,
+        });
+    }
+
+    if matches!(kind, NormalizedEventKind::ReactionReceived) {
+        return normalize_reaction(accessor, event_type, kind);
+    }
+
+    let from = extract_sender(accessor).unwrap_or_else(|| "unknown".to_string());
+    let sender_agent_id = extract_sender_agent_id(accessor);
+    let sender_kind = parse_sender_kind(accessor);
+    let target = extract_target(accessor, kind).unwrap_or_else(|| "unknown".to_string());
+    let text = extract_text(accessor).unwrap_or_default();
+    let thread_id = extract_thread_id(accessor);
+    let event_id = extract_event_id(accessor)
+        .unwrap_or_else(|| synth_event_id(event_type, &from, &target, &text, thread_id.as_deref()));
+    let priority = match kind {
+        NormalizedEventKind::DmReceived => RelayPriority::P2,
+        NormalizedEventKind::MessageCreated
+        | NormalizedEventKind::ThreadReply
+        | NormalizedEventKind::GroupDmReceived => RelayPriority::P3,
+        NormalizedEventKind::Presence | NormalizedEventKind::ReactionReceived => RelayPriority::P4,
+    };
+
+    Some(NormalizedInboundEvent {
+        event_id,
+        kind,
+        from,
+        sender_agent_id,
+        sender_kind,
+        target,
+        text,
+        thread_id,
+        priority,
+    })
+}
+
+/// Normalize a raw `command.invoked` WebSocket event.
+pub fn normalize_command_invocation(value: &Value) -> Option<NormalizedCommandInvocation> {
+    let event_type = value.get("type")?.as_str()?;
+    if event_type != "command.invoked" {
+        return None;
+    }
+
+    Some(NormalizedCommandInvocation {
+        command: value.get("command")?.as_str()?.to_string(),
+        channel: value
+            .get("channel")
+            .and_then(scalar_to_string)
+            .unwrap_or_default(),
+        invoked_by: value
+            .get("invoked_by")
+            .and_then(scalar_to_string)
+            .unwrap_or_else(|| "unknown".to_string()),
+        handler_agent_id: value
+            .get("handler_agent_id")
+            .and_then(scalar_to_string)
+            .or_else(|| {
+                value
+                    .get("handler")
+                    .and_then(|handler| handler.get("id"))
+                    .and_then(scalar_to_string)
+            }),
+        args: value.get("args").and_then(scalar_to_string),
+        parameters: value.get("parameters").and_then(Value::as_object).cloned(),
+    })
+}
+
+fn normalize_reaction(
+    accessor: EventAccessor<'_>,
+    _event_type: &str,
+    kind: NormalizedEventKind,
+) -> Option<NormalizedInboundEvent> {
+    let from = accessor
+        .field(EventNesting::Top, "agent_name")
+        .and_then(scalar_to_string)
+        .unwrap_or_else(|| "unknown".to_string());
+    let emoji = accessor
+        .field(EventNesting::Top, "emoji")
+        .and_then(scalar_to_string)
+        .unwrap_or_else(|| "?".to_string());
+    let message_id = accessor
+        .field(EventNesting::Top, "message_id")
+        .and_then(scalar_to_string)
+        .unwrap_or_default();
+    let channel_name = accessor
+        .field(EventNesting::Top, "channel_name")
+        .and_then(scalar_to_string);
+    let target = match channel_name {
+        Some(channel) if channel.starts_with('#') => channel,
+        Some(channel) if !channel.is_empty() => format!("#{channel}"),
+        _ => return None,
+    };
+
+    Some(NormalizedInboundEvent {
+        event_id: format!("reaction-{message_id}-{from}-{emoji}"),
+        kind,
+        from: from.clone(),
+        sender_agent_id: None,
+        sender_kind: SenderKind::Agent,
+        target,
+        text: format!(
+            ":{emoji}: reaction from {from} on message {message_id} (informational; no response required)"
+        ),
+        thread_id: None,
+        priority: RelayPriority::P4,
+    })
+}
+
+#[derive(Clone, Copy)]
+enum EventNesting {
+    Top,
+    Message,
+    Payload,
+    PayloadMessage,
+}
+
+#[derive(Clone, Copy)]
+struct EventAccessor<'a> {
+    top: &'a Value,
+    message: Option<&'a Value>,
+    payload: Option<&'a Value>,
+    payload_message: Option<&'a Value>,
+}
+
+impl<'a> EventAccessor<'a> {
+    fn new(top: &'a Value) -> Self {
+        let payload = top.get("payload");
+        let message = top.get("message");
+        let payload_message = payload.and_then(|nested| nested.get("message"));
+
+        Self {
+            top,
+            message,
+            payload,
+            payload_message,
+        }
+    }
+
+    fn nested(self, nesting: EventNesting) -> Option<&'a Value> {
+        match nesting {
+            EventNesting::Top => Some(self.top),
+            EventNesting::Message => self.message,
+            EventNesting::Payload => self.payload,
+            EventNesting::PayloadMessage => self.payload_message,
+        }
+    }
+
+    fn field(self, nesting: EventNesting, key: &str) -> Option<&'a Value> {
+        self.nested(nesting)?.get(key)
+    }
+
+    fn agent_name(self, nesting: EventNesting) -> Option<&'a Value> {
+        self.field(nesting, "agent")
+            .and_then(|agent| agent.get("name"))
+    }
+
+    fn first_string<F>(
+        self,
+        candidates: &[(EventNesting, &str)],
+        mut convert: F,
+        require_non_empty: bool,
+    ) -> Option<String>
+    where
+        F: FnMut(&Value) -> Option<String>,
+    {
+        for (nesting, key) in candidates {
+            if let Some(value) = self.field(*nesting, key).and_then(&mut convert) {
+                if !require_non_empty || !value.is_empty() {
+                    return Some(value);
+                }
+            }
+        }
+        None
+    }
+
+    fn first_agent_name(self, nestings: &[EventNesting]) -> Option<String> {
+        for nesting in nestings {
+            if let Some(name) = self.agent_name(*nesting).and_then(scalar_to_string) {
+                if !name.is_empty() {
+                    return Some(name);
+                }
+            }
+        }
+        None
+    }
+
+    fn has_trimmed_non_empty_scalar(self, candidates: &[(EventNesting, &str)]) -> bool {
+        candidates.iter().any(|(nesting, key)| {
+            self.field(*nesting, key)
+                .and_then(Value::as_str)
+                .is_some_and(|value| !value.trim().is_empty())
+        })
+    }
+}
+
+fn parse_inbound_kind(event_type: &str) -> Option<NormalizedEventKind> {
+    match event_type {
+        "message.created" | "message.received" | "message.new" | "message.sent"
+        | "message.delivered" => Some(NormalizedEventKind::MessageCreated),
+        "dm.received"
+        | "dm.created"
+        | "dm.new"
+        | "dm.sent"
+        | "dm.message.created"
+        | "direct_message.received"
+        | "direct_message.created"
+        | "direct_message.new"
+        | "direct_message.sent" => Some(NormalizedEventKind::DmReceived),
+        "thread.reply" | "thread.message.created" | "thread.message.sent" => {
+            Some(NormalizedEventKind::ThreadReply)
+        }
+        "group_dm.received"
+        | "group_dm.created"
+        | "group_dm.new"
+        | "group_dm.sent"
+        | "group_dm.message.created" => Some(NormalizedEventKind::GroupDmReceived),
+        "agent.online" | "agent.offline" | "user.online" | "user.offline" => {
+            Some(NormalizedEventKind::Presence)
+        }
+        "reaction.added" | "reaction.removed" => Some(NormalizedEventKind::ReactionReceived),
+        _ => None,
+    }
+}
+
+fn extract_presence_sender(accessor: EventAccessor<'_>) -> Option<String> {
+    const AGENT_NAME_NESTINGS: [EventNesting; 2] = [EventNesting::Top, EventNesting::Payload];
+    const AGENT_NAME_FIELDS: [(EventNesting, &str); 2] = [
+        (EventNesting::Top, "agent_name"),
+        (EventNesting::Payload, "agent_name"),
+    ];
+    const FROM_FIELDS: [(EventNesting, &str); 2] =
+        [(EventNesting::Top, "from"), (EventNesting::Payload, "from")];
+
+    accessor
+        .first_agent_name(&AGENT_NAME_NESTINGS)
+        .or_else(|| accessor.first_string(&AGENT_NAME_FIELDS, scalar_to_string, true))
+        .or_else(|| accessor.first_string(&FROM_FIELDS, scalar_to_string, true))
+}
+
+fn extract_event_id(accessor: EventAccessor<'_>) -> Option<String> {
+    const EVENT_ID_FIELDS: [(EventNesting, &str); 12] = [
+        (EventNesting::Top, "event_id"),
+        (EventNesting::Top, "message_id"),
+        (EventNesting::Top, "id"),
+        (EventNesting::Message, "event_id"),
+        (EventNesting::Message, "message_id"),
+        (EventNesting::Message, "id"),
+        (EventNesting::Payload, "event_id"),
+        (EventNesting::Payload, "message_id"),
+        (EventNesting::Payload, "id"),
+        (EventNesting::PayloadMessage, "event_id"),
+        (EventNesting::PayloadMessage, "message_id"),
+        (EventNesting::PayloadMessage, "id"),
+    ];
+
+    accessor.first_string(&EVENT_ID_FIELDS, scalar_to_string, true)
+}
+
+fn extract_sender_agent_id(accessor: EventAccessor<'_>) -> Option<String> {
+    const FIELDS: [(EventNesting, &str); 4] = [
+        (EventNesting::Message, "agent_id"),
+        (EventNesting::PayloadMessage, "agent_id"),
+        (EventNesting::Top, "agent_id"),
+        (EventNesting::Payload, "agent_id"),
+    ];
+
+    accessor.first_string(&FIELDS, scalar_to_string, true)
+}
+
+fn extract_sender(accessor: EventAccessor<'_>) -> Option<String> {
+    const TOP_AGENT_NESTINGS: [EventNesting; 1] = [EventNesting::Top];
+    const TOP_FIELDS: [(EventNesting, &str); 6] = [
+        (EventNesting::Top, "from"),
+        (EventNesting::Top, "sender"),
+        (EventNesting::Top, "author"),
+        (EventNesting::Top, "from_agent"),
+        (EventNesting::Top, "agent"),
+        (EventNesting::Top, "agent_name"),
+    ];
+    const MESSAGE_FIELDS: [(EventNesting, &str); 6] = [
+        (EventNesting::Message, "from"),
+        (EventNesting::Message, "sender"),
+        (EventNesting::Message, "author"),
+        (EventNesting::Message, "from_agent"),
+        (EventNesting::Message, "agent"),
+        (EventNesting::Message, "agent_name"),
+    ];
+    const PAYLOAD_AGENT_NESTINGS: [EventNesting; 1] = [EventNesting::Payload];
+    const PAYLOAD_FIELDS: [(EventNesting, &str); 6] = [
+        (EventNesting::Payload, "from"),
+        (EventNesting::Payload, "sender"),
+        (EventNesting::Payload, "author"),
+        (EventNesting::Payload, "from_agent"),
+        (EventNesting::Payload, "agent"),
+        (EventNesting::Payload, "agent_name"),
+    ];
+    const PAYLOAD_MESSAGE_FIELDS: [(EventNesting, &str); 6] = [
+        (EventNesting::PayloadMessage, "from"),
+        (EventNesting::PayloadMessage, "sender"),
+        (EventNesting::PayloadMessage, "author"),
+        (EventNesting::PayloadMessage, "from_agent"),
+        (EventNesting::PayloadMessage, "agent"),
+        (EventNesting::PayloadMessage, "agent_name"),
+    ];
+
+    let raw = accessor
+        .first_agent_name(&TOP_AGENT_NESTINGS)
+        .or_else(|| accessor.first_string(&TOP_FIELDS, sender_value_to_string, true))
+        .or_else(|| accessor.first_string(&MESSAGE_FIELDS, sender_value_to_string, true))
+        .or_else(|| accessor.first_agent_name(&PAYLOAD_AGENT_NESTINGS))
+        .or_else(|| accessor.first_string(&PAYLOAD_FIELDS, sender_value_to_string, true))
+        .or_else(|| accessor.first_string(&PAYLOAD_MESSAGE_FIELDS, sender_value_to_string, true))?;
+
+    Some(normalize_sender_identity(&raw))
+}
+
+/// Normalize relay infrastructure sender identities to a stable display name.
+pub fn normalize_sender_identity(raw: &str) -> String {
+    if raw == "broker" || raw.starts_with("broker-") || raw.starts_with("human:") {
+        return "Dashboard".to_string();
+    }
+    raw.to_string()
+}
+
+fn extract_target(accessor: EventAccessor<'_>, kind: NormalizedEventKind) -> Option<String> {
+    const EXPLICIT_TARGET_FIELDS: [(EventNesting, &str); 20] = [
+        (EventNesting::Top, "target"),
+        (EventNesting::Top, "to"),
+        (EventNesting::Top, "recipient"),
+        (EventNesting::Top, "to_agent"),
+        (EventNesting::Top, "recipient_agent"),
+        (EventNesting::Message, "target"),
+        (EventNesting::Message, "to"),
+        (EventNesting::Message, "recipient"),
+        (EventNesting::Message, "to_agent"),
+        (EventNesting::Message, "recipient_agent"),
+        (EventNesting::Payload, "target"),
+        (EventNesting::Payload, "to"),
+        (EventNesting::Payload, "recipient"),
+        (EventNesting::Payload, "to_agent"),
+        (EventNesting::Payload, "recipient_agent"),
+        (EventNesting::PayloadMessage, "target"),
+        (EventNesting::PayloadMessage, "to"),
+        (EventNesting::PayloadMessage, "recipient"),
+        (EventNesting::PayloadMessage, "to_agent"),
+        (EventNesting::PayloadMessage, "recipient_agent"),
+    ];
+    const CONVERSATION_DM_FIELDS: [(EventNesting, &str); 2] = [
+        (EventNesting::Top, "conversation_id"),
+        (EventNesting::Payload, "conversation_id"),
+    ];
+    const CONVERSATION_FIELDS: [(EventNesting, &str); 4] = [
+        (EventNesting::Top, "conversation_id"),
+        (EventNesting::Message, "conversation_id"),
+        (EventNesting::Payload, "conversation_id"),
+        (EventNesting::PayloadMessage, "conversation_id"),
+    ];
+
+    if matches!(
+        kind,
+        NormalizedEventKind::DmReceived | NormalizedEventKind::GroupDmReceived
+    ) {
+        if let Some(target) =
+            accessor.first_string(&EXPLICIT_TARGET_FIELDS, sender_value_to_string, true)
+        {
+            return Some(target);
+        }
+        if let Some(target) = accessor.first_string(&CONVERSATION_DM_FIELDS, scalar_to_string, true)
+        {
+            return Some(target);
+        }
+    }
+
+    if let Some(channel) = extract_channel(accessor) {
+        return Some(channel);
+    }
+
+    if let Some(target) =
+        accessor.first_string(&EXPLICIT_TARGET_FIELDS, sender_value_to_string, true)
+    {
+        return Some(target);
+    }
+
+    if let Some(target) = accessor.first_string(&CONVERSATION_FIELDS, scalar_to_string, true) {
+        return Some(target);
+    }
+
+    if matches!(kind, NormalizedEventKind::ThreadReply) {
+        return Some("thread".to_string());
+    }
+
+    None
+}
+
+fn has_conversation_context(accessor: EventAccessor<'_>) -> bool {
+    const CONVERSATION_FIELDS: [(EventNesting, &str); 4] = [
+        (EventNesting::Top, "conversation_id"),
+        (EventNesting::Message, "conversation_id"),
+        (EventNesting::Payload, "conversation_id"),
+        (EventNesting::PayloadMessage, "conversation_id"),
+    ];
+
+    accessor.has_trimmed_non_empty_scalar(&CONVERSATION_FIELDS)
+}
+
+fn synth_event_id(
+    event_type: &str,
+    from: &str,
+    target: &str,
+    text: &str,
+    thread_id: Option<&str>,
+) -> String {
+    let mut hasher = DefaultHasher::new();
+    event_type.hash(&mut hasher);
+    from.hash(&mut hasher);
+    target.hash(&mut hasher);
+    text.hash(&mut hasher);
+    thread_id.unwrap_or_default().hash(&mut hasher);
+    format!("synthetic-{event_type}-{:016x}", hasher.finish())
+}
+
+fn extract_channel(accessor: EventAccessor<'_>) -> Option<String> {
+    const CHANNEL_FIELDS: [(EventNesting, &str); 4] = [
+        (EventNesting::Top, "channel"),
+        (EventNesting::Message, "channel"),
+        (EventNesting::Payload, "channel"),
+        (EventNesting::PayloadMessage, "channel"),
+    ];
+
+    for (nesting, key) in CHANNEL_FIELDS {
+        if let Some(raw) = accessor.field(nesting, key).and_then(scalar_to_string) {
+            if raw.is_empty() {
+                continue;
+            }
+            if raw.starts_with('#') {
+                return Some(raw);
+            }
+            return Some(format!("#{raw}"));
+        }
+    }
+    None
+}
+
+fn extract_text(accessor: EventAccessor<'_>) -> Option<String> {
+    const TEXT_FIELDS: [(EventNesting, &str); 12] = [
+        (EventNesting::Top, "text"),
+        (EventNesting::Top, "body"),
+        (EventNesting::Top, "content"),
+        (EventNesting::Message, "text"),
+        (EventNesting::Message, "body"),
+        (EventNesting::Message, "content"),
+        (EventNesting::Payload, "text"),
+        (EventNesting::Payload, "body"),
+        (EventNesting::Payload, "content"),
+        (EventNesting::PayloadMessage, "text"),
+        (EventNesting::PayloadMessage, "body"),
+        (EventNesting::PayloadMessage, "content"),
+    ];
+
+    if let Some(text) = accessor.first_string(&TEXT_FIELDS, scalar_to_string, false) {
+        return Some(text);
+    }
+
+    if let Some(raw_message) = accessor
+        .field(EventNesting::Top, "message")
+        .and_then(Value::as_str)
+    {
+        return Some(raw_message.to_string());
+    }
+    if let Some(raw_message) = accessor
+        .field(EventNesting::Payload, "message")
+        .and_then(Value::as_str)
+    {
+        return Some(raw_message.to_string());
+    }
+
+    None
+}
+
+fn extract_thread_id(accessor: EventAccessor<'_>) -> Option<String> {
+    const THREAD_FIELDS: [(EventNesting, &str); 6] = [
+        (EventNesting::Top, "parent_id"),
+        (EventNesting::Top, "thread_id"),
+        (EventNesting::Message, "thread_id"),
+        (EventNesting::Payload, "parent_id"),
+        (EventNesting::Payload, "thread_id"),
+        (EventNesting::PayloadMessage, "thread_id"),
+    ];
+
+    accessor.first_string(&THREAD_FIELDS, scalar_to_string, true)
+}
+
+fn sender_value_to_string(value: &Value) -> Option<String> {
+    if let Some(s) = scalar_to_string(value) {
+        return Some(s);
+    }
+
+    let obj = value.as_object()?;
+    for key in ["name", "display_name", "username", "handle", "id"] {
+        if let Some(v) = obj.get(key) {
+            if let Some(s) = scalar_to_string(v) {
+                if !s.is_empty() {
+                    return Some(s);
+                }
+            }
+        }
+    }
+    None
+}
+
+fn scalar_to_string(value: &Value) -> Option<String> {
+    match value {
+        Value::String(s) => Some(s.clone()),
+        Value::Number(n) => Some(n.to_string()),
+        _ => None,
+    }
+}
+
+fn parse_sender_kind(accessor: EventAccessor<'_>) -> SenderKind {
+    const KIND_FIELDS: [(EventNesting, &str); 24] = [
+        (EventNesting::Top, "from_type"),
+        (EventNesting::Top, "sender_type"),
+        (EventNesting::Top, "actor_type"),
+        (EventNesting::Top, "source_type"),
+        (EventNesting::Top, "origin_type"),
+        (EventNesting::Top, "sender_kind"),
+        (EventNesting::Message, "from_type"),
+        (EventNesting::Message, "sender_type"),
+        (EventNesting::Message, "actor_type"),
+        (EventNesting::Message, "source_type"),
+        (EventNesting::Message, "origin_type"),
+        (EventNesting::Message, "sender_kind"),
+        (EventNesting::Payload, "from_type"),
+        (EventNesting::Payload, "sender_type"),
+        (EventNesting::Payload, "actor_type"),
+        (EventNesting::Payload, "source_type"),
+        (EventNesting::Payload, "origin_type"),
+        (EventNesting::Payload, "sender_kind"),
+        (EventNesting::PayloadMessage, "from_type"),
+        (EventNesting::PayloadMessage, "sender_type"),
+        (EventNesting::PayloadMessage, "actor_type"),
+        (EventNesting::PayloadMessage, "source_type"),
+        (EventNesting::PayloadMessage, "origin_type"),
+        (EventNesting::PayloadMessage, "sender_kind"),
+    ];
+    const CONTAINER_NESTINGS: [EventNesting; 4] = [
+        EventNesting::Top,
+        EventNesting::Message,
+        EventNesting::Payload,
+        EventNesting::PayloadMessage,
+    ];
+
+    for (nesting, key) in KIND_FIELDS {
+        if let Some(kind) = accessor
+            .field(nesting, key)
+            .and_then(Value::as_str)
+            .and_then(parse_sender_kind_label)
+        {
+            return kind;
+        }
+    }
+
+    for nesting in CONTAINER_NESTINGS {
+        if let Some(kind) = accessor
+            .nested(nesting)
+            .and_then(Value::as_object)
+            .and_then(parse_sender_kind_from_containers)
+        {
+            return kind;
+        }
+    }
+
+    SenderKind::Unknown
+}
+
+fn parse_sender_kind_label(raw: &str) -> Option<SenderKind> {
+    match raw.trim().to_ascii_lowercase().as_str() {
+        "human" | "user" => Some(SenderKind::Human),
+        "agent" | "bot" | "assistant" => Some(SenderKind::Agent),
+        _ => None,
+    }
+}
+
+fn parse_sender_kind_from_containers(payload: &Map<String, Value>) -> Option<SenderKind> {
+    for container in ["from", "sender", "author"] {
+        if let Some(kind) = payload
+            .get(container)
+            .and_then(Value::as_object)
+            .and_then(|obj| {
+                obj.get("type")
+                    .or_else(|| obj.get("kind"))
+                    .or_else(|| obj.get("role"))
+            })
+            .and_then(Value::as_str)
+            .and_then(parse_sender_kind_label)
+        {
+            return Some(kind);
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::{
+        normalize_command_invocation, normalize_inbound_event, normalize_sender_identity,
+        NormalizedEventKind, RelayPriority, SenderKind,
+    };
+
+    #[test]
+    fn normalizes_message_created_top_level() {
+        let event = normalize_inbound_event(&json!({
+            "type": "message.created",
+            "channel": "general",
+            "message": {
+                "id": "msg_1",
+                "agent_id": "agent_1",
+                "agent_name": "alice",
+                "text": "hello"
+            }
+        }))
+        .expect("message event should normalize");
+
+        assert_eq!(event.kind, NormalizedEventKind::MessageCreated);
+        assert_eq!(event.event_id, "msg_1");
+        assert_eq!(event.from, "alice");
+        assert_eq!(event.sender_agent_id.as_deref(), Some("agent_1"));
+        assert_eq!(event.target, "#general");
+        assert_eq!(event.text, "hello");
+        assert_eq!(event.priority, RelayPriority::P3);
+    }
+
+    #[test]
+    fn normalizes_payload_wrapped_dm() {
+        let event = normalize_inbound_event(&json!({
+            "type": "dm.received",
+            "payload": {
+                "conversation_id": "dm_1",
+                "message": {
+                    "id": "msg_2",
+                    "agent_name": "broker",
+                    "text": "ping"
+                }
+            }
+        }))
+        .expect("payload-wrapped dm should normalize");
+
+        assert_eq!(event.kind, NormalizedEventKind::DmReceived);
+        assert_eq!(event.from, "Dashboard");
+        assert_eq!(event.target, "dm_1");
+        assert_eq!(event.text, "ping");
+        assert_eq!(event.priority, RelayPriority::P2);
+    }
+
+    #[test]
+    fn treats_message_created_with_conversation_as_dm() {
+        let event = normalize_inbound_event(&json!({
+            "type": "message.created",
+            "conversation_id": "dm_2",
+            "message": {
+                "id": "msg_3",
+                "agent_name": "lead",
+                "text": "direct"
+            }
+        }))
+        .expect("conversation message should normalize");
+
+        assert_eq!(event.kind, NormalizedEventKind::DmReceived);
+        assert_eq!(event.target, "dm_2");
+    }
+
+    #[test]
+    fn normalizes_reaction_with_channel_context() {
+        let event = normalize_inbound_event(&json!({
+            "type": "reaction.added",
+            "message_id": "msg_4",
+            "agent_name": "alice",
+            "emoji": "eyes",
+            "channel_name": "general"
+        }))
+        .expect("reaction should normalize");
+
+        assert_eq!(event.kind, NormalizedEventKind::ReactionReceived);
+        assert_eq!(event.target, "#general");
+        assert_eq!(event.priority, RelayPriority::P4);
+    }
+
+    #[test]
+    fn normalizes_command_invocation() {
+        let command = normalize_command_invocation(&json!({
+            "type": "command.invoked",
+            "command": "/spawn",
+            "channel": "general",
+            "invoked_by": "lead",
+            "handler": { "id": "agent_handler" },
+            "args": "worker-1",
+            "parameters": { "name": "worker-1", "cli": "codex" }
+        }))
+        .expect("command should normalize");
+
+        assert_eq!(command.command, "/spawn");
+        assert_eq!(command.handler_agent_id.as_deref(), Some("agent_handler"));
+        assert_eq!(
+            command
+                .parameters
+                .as_ref()
+                .and_then(|params| params.get("cli"))
+                .and_then(|value| value.as_str()),
+            Some("codex")
+        );
+    }
+
+    #[test]
+    fn extracts_sender_kind_from_nested_object() {
+        let event = normalize_inbound_event(&json!({
+            "type": "dm.received",
+            "conversation_id": "dm_3",
+            "message": {
+                "id": "msg_5",
+                "from": { "name": "Will", "type": "human" },
+                "text": "hello"
+            }
+        }))
+        .expect("nested sender should normalize");
+
+        assert_eq!(event.from, "Will");
+        assert_eq!(event.sender_kind, SenderKind::Human);
+    }
+
+    #[test]
+    fn rejects_malformed_message_events() {
+        assert!(normalize_inbound_event(&json!({
+            "type": "message.created",
+            "channel": "general"
+        }))
+        .is_none());
+    }
+
+    #[test]
+    fn normalizes_infrastructure_sender_identity() {
+        assert_eq!(normalize_sender_identity("broker"), "Dashboard");
+        assert_eq!(normalize_sender_identity("broker-abc123"), "Dashboard");
+        assert_eq!(normalize_sender_identity("human:orchestrator"), "Dashboard");
+        assert_eq!(normalize_sender_identity("alice"), "alice");
+    }
+}

--- a/packages/sdk-rust/src/identity.rs
+++ b/packages/sdk-rust/src/identity.rs
@@ -1,0 +1,42 @@
+//! Identity helpers shared by RelayCast clients.
+
+/// Case-insensitive comparison for agent names.
+///
+/// Agent names can arrive from registration responses, WebSocket events, and
+/// API responses with inconsistent casing. Centralizing the comparison keeps
+/// routing code from rolling its own matching rules.
+pub fn agent_name_eq(a: &str, b: &str) -> bool {
+    a.eq_ignore_ascii_case(b)
+}
+
+/// Check whether any known local/self names match `name`.
+pub fn is_self_name<'a, I, S>(self_names: I, name: &str) -> bool
+where
+    I: IntoIterator<Item = &'a S>,
+    S: AsRef<str> + 'a,
+{
+    self_names
+        .into_iter()
+        .any(|candidate| agent_name_eq(candidate.as_ref(), name))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{agent_name_eq, is_self_name};
+
+    #[test]
+    fn agent_name_eq_is_case_insensitive() {
+        assert!(agent_name_eq("Alice", "alice"));
+        assert!(agent_name_eq("worker-1", "WORKER-1"));
+        assert!(!agent_name_eq("Alice", "Bob"));
+    }
+
+    #[test]
+    fn is_self_name_checks_all_candidates() {
+        let names = vec!["Lead".to_string(), "worker-a".to_string()];
+
+        assert!(is_self_name(&names, "lead"));
+        assert!(is_self_name(&names, "WORKER-A"));
+        assert!(!is_self_name(&names, "reviewer"));
+    }
+}

--- a/packages/sdk-rust/src/lib.rs
+++ b/packages/sdk-rust/src/lib.rs
@@ -68,23 +68,38 @@
 pub mod agent;
 pub mod client;
 pub mod credentials;
+pub mod dm_participants;
 pub mod error;
+pub mod events;
+pub mod identity;
 pub mod registration;
 pub mod relay;
 pub mod types;
 pub mod ws;
 
 // Re-export main types
-pub use agent::AgentClient;
+pub use agent::{AgentClient, DmOptions, EnsureChannelOutcome};
 pub use client::{ClientOptions, HttpClient, RequestOptions};
+pub use dm_participants::{
+    DmParticipantsCache, DmParticipantsCacheEntry, DM_PARTICIPANT_CACHE_TTL,
+    DM_PARTICIPANT_FAILURE_TTL,
+};
 pub use error::{RelayError, Result};
+pub use events::{
+    normalize_command_invocation, normalize_inbound_event, normalize_sender_identity,
+    NormalizedCommandInvocation, NormalizedEventKind, NormalizedInboundEvent, RelayPriority,
+    SenderKind,
+};
+pub use identity::{agent_name_eq, is_self_name};
 pub use registration::{
     format_registration_error, registration_is_retryable, registration_retry_after_secs,
     retry_agent_registration, AgentRegistrationClient, AgentRegistrationError,
     AgentRegistrationRetryOutcome,
 };
 pub use relay::{RelayCast, RelayCastOptions};
-pub use ws::{EventReceiver, LifecycleReceiver, WsClient, WsClientOptions, WsLifecycleEvent};
+pub use ws::{
+    EventReceiver, LifecycleReceiver, RawEventReceiver, WsClient, WsClientOptions, WsLifecycleEvent,
+};
 
 // Re-export commonly used types
 pub use types::{

--- a/packages/sdk-rust/src/lib.rs
+++ b/packages/sdk-rust/src/lib.rs
@@ -64,6 +64,53 @@
 //!     Ok(())
 //! }
 //! ```
+//!
+//! ## Raw Events and Normalization
+//!
+//! ```rust,no_run
+//! use relaycast::{normalize_inbound_event, WsClient, WsClientOptions};
+//!
+//! #[tokio::main]
+//! async fn main() -> Result<(), Box<dyn std::error::Error>> {
+//!     let mut ws = WsClient::new(WsClientOptions::new("at_live_agent_token"));
+//!     let mut raw_events = ws.subscribe_raw_events();
+//!     ws.connect().await?;
+//!
+//!     while let Ok(raw) = raw_events.recv().await {
+//!         if let Some(event) = normalize_inbound_event(&raw) {
+//!             println!("{} -> {}: {}", event.from, event.target, event.text);
+//!         }
+//!     }
+//!
+//!     Ok(())
+//! }
+//! ```
+//!
+//! ## Registration and Channel Startup
+//!
+//! ```rust,no_run
+//! use relaycast::{
+//!     AgentRegistrationClient, CreateChannelRequest, RelayCast, RelayCastOptions,
+//! };
+//!
+//! #[tokio::main]
+//! async fn main() -> Result<(), Box<dyn std::error::Error>> {
+//!     let relay = RelayCast::new(RelayCastOptions::new("rk_live_your_api_key"))?;
+//!     let registration = AgentRegistrationClient::new(relay, "codex");
+//!     let agent = registration
+//!         .registered_agent_client("worker-a", Some("codex"))
+//!         .await?;
+//!
+//!     agent.ensure_joined_channel(CreateChannelRequest {
+//!         name: "general".to_string(),
+//!         topic: Some("General discussion".to_string()),
+//!         metadata: None,
+//!     }).await?;
+//!     agent.send("#general", "ready", None, None, None).await?;
+//!
+//!     Ok(())
+//! }
+//! ```
 
 pub mod agent;
 pub mod client;

--- a/packages/sdk-rust/src/registration.rs
+++ b/packages/sdk-rust/src/registration.rs
@@ -8,7 +8,7 @@ use std::time::{Duration, Instant};
 use thiserror::Error;
 
 use crate::error::RelayError;
-use crate::{RelayCast, SpawnAgentRequest};
+use crate::{AgentClient, RelayCast, SpawnAgentRequest};
 
 const DEFAULT_REGISTRATION_COOLDOWN_SECS: u64 = 60;
 
@@ -233,6 +233,22 @@ impl AgentRegistrationClient {
             }),
         }
     }
+
+    /// Register an agent token if needed and return an [`AgentClient`] using it.
+    pub async fn registered_agent_client(
+        &self,
+        agent_name: &str,
+        cli_hint: Option<&str>,
+    ) -> std::result::Result<AgentClient, AgentRegistrationError> {
+        let trimmed_name = agent_name.trim();
+        let token = self.register_agent_token(trimmed_name, cli_hint).await?;
+        self.relay
+            .as_agent(token)
+            .map_err(|error| AgentRegistrationError::Transport {
+                agent_name: trimmed_name.to_string(),
+                detail: error.to_string(),
+            })
+    }
 }
 
 /// Return retry delay seconds for rate-limited registration errors.
@@ -340,6 +356,24 @@ mod tests {
             .await
             .expect("cache hit should succeed");
         assert_eq!(token, "at_live_cached");
+    }
+
+    #[tokio::test]
+    async fn registered_agent_client_uses_cached_token() {
+        let server = MockServer::start().await;
+        let relay =
+            RelayCast::new(RelayCastOptions::new("rk_live_test").with_base_url(server.uri()))
+                .expect("relay init");
+        let client = AgentRegistrationClient::new(relay, "claude");
+        client.seed_agent_token("worker-a", "at_live_cached");
+
+        let agent = client
+            .registered_agent_client("worker-a", Some("codex"))
+            .await
+            .expect("registered agent client should use cached token");
+
+        assert_eq!(agent.http_client().api_key(), "at_live_cached");
+        assert_eq!(agent.http_client().base_url(), server.uri());
     }
 
     #[tokio::test]

--- a/packages/sdk-rust/src/ws.rs
+++ b/packages/sdk-rust/src/ws.rs
@@ -344,14 +344,14 @@ impl WsClient {
                                                 }
                                                 Err(err) => {
                                                     if debug {
-                                                        warn!("[relaycast] Dropped typed WebSocket event: {}: {}", err, &text[..text.len().min(200)]);
+                                                        warn!("[relaycast] Dropped typed WebSocket event: {}: {}", err, truncate_str(&text, 200));
                                                     }
                                                 }
                                             }
                                         }
                                         Err(err) => {
                                             if debug {
-                                                warn!("[relaycast] Dropped non-JSON WebSocket message: {}: {}", err, &text[..text.len().min(200)]);
+                                                warn!("[relaycast] Dropped non-JSON WebSocket message: {}: {}", err, truncate_str(&text, 200));
                                             }
                                         }
                                     }
@@ -505,4 +505,30 @@ fn reconnect_delay_ms(attempt: u32, max_delay_ms: u64) -> u64 {
     let exp = attempt.saturating_sub(1);
     let delay = 1_000u64.saturating_mul(2u64.saturating_pow(exp));
     delay.min(max_delay_ms.max(1_000))
+}
+
+fn truncate_str(s: &str, max_chars: usize) -> &str {
+    match s.char_indices().nth(max_chars) {
+        Some((idx, _)) => &s[..idx],
+        None => s,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::truncate_str;
+
+    #[test]
+    fn truncate_str_respects_utf8_boundaries() {
+        let text = "😀".repeat(201);
+        let truncated = truncate_str(&text, 200);
+
+        assert_eq!(truncated.chars().count(), 200);
+        assert!(truncated.is_char_boundary(truncated.len()));
+    }
+
+    #[test]
+    fn truncate_str_returns_short_strings_unchanged() {
+        assert_eq!(truncate_str("hello", 200), "hello");
+    }
 }

--- a/packages/sdk-rust/src/ws.rs
+++ b/packages/sdk-rust/src/ws.rs
@@ -96,6 +96,8 @@ impl WsClientOptions {
 
 /// A handle for subscribing to WebSocket events.
 pub type EventReceiver = broadcast::Receiver<WsEvent>;
+/// A handle for subscribing to raw WebSocket JSON events.
+pub type RawEventReceiver = broadcast::Receiver<serde_json::Value>;
 /// A handle for subscribing to WebSocket lifecycle events.
 pub type LifecycleReceiver = broadcast::Receiver<WsLifecycleEvent>;
 
@@ -119,6 +121,7 @@ pub struct WsClient {
     max_reconnect_attempts: u32,
     max_reconnect_delay_ms: u64,
     event_tx: broadcast::Sender<WsEvent>,
+    raw_event_tx: broadcast::Sender<serde_json::Value>,
     lifecycle_tx: broadcast::Sender<WsLifecycleEvent>,
     command_tx: Option<mpsc::Sender<WsCommand>>,
     is_connected: Arc<Mutex<bool>>,
@@ -140,6 +143,7 @@ impl WsClient {
             .replace("http://", "ws://");
 
         let (event_tx, _) = broadcast::channel(1024);
+        let (raw_event_tx, _) = broadcast::channel(1024);
         let (lifecycle_tx, _) = broadcast::channel(128);
 
         Self {
@@ -162,6 +166,7 @@ impl WsClient {
                 .max_reconnect_delay_ms
                 .unwrap_or(DEFAULT_MAX_RECONNECT_DELAY_MS),
             event_tx,
+            raw_event_tx,
             lifecycle_tx,
             command_tx: None,
             is_connected: Arc::new(Mutex::new(false)),
@@ -176,6 +181,11 @@ impl WsClient {
     /// Subscribe to receive events.
     pub fn subscribe_events(&self) -> EventReceiver {
         self.event_tx.subscribe()
+    }
+
+    /// Subscribe to receive raw WebSocket JSON events.
+    pub fn subscribe_raw_events(&self) -> RawEventReceiver {
+        self.raw_event_tx.subscribe()
     }
 
     /// Subscribe to lifecycle events.
@@ -211,6 +221,7 @@ impl WsClient {
 
         let token = self.token.clone();
         let event_tx = self.event_tx.clone();
+        let raw_event_tx = self.raw_event_tx.clone();
         let lifecycle_tx = self.lifecycle_tx.clone();
         let is_connected = self.is_connected.clone();
         let debug = self.debug;
@@ -324,13 +335,23 @@ impl WsClient {
                         msg = read.next() => {
                             match msg {
                                 Some(Ok(Message::Text(text))) => {
-                                    match serde_json::from_str::<WsEvent>(&text) {
-                                        Ok(event) => {
-                                            let _ = event_tx.send(event);
+                                    match serde_json::from_str::<serde_json::Value>(&text) {
+                                        Ok(value) => {
+                                            let _ = raw_event_tx.send(value.clone());
+                                            match serde_json::from_value::<WsEvent>(value) {
+                                                Ok(event) => {
+                                                    let _ = event_tx.send(event);
+                                                }
+                                                Err(err) => {
+                                                    if debug {
+                                                        warn!("[relaycast] Dropped typed WebSocket event: {}: {}", err, &text[..text.len().min(200)]);
+                                                    }
+                                                }
+                                            }
                                         }
                                         Err(err) => {
                                             if debug {
-                                                warn!("[relaycast] Dropped WebSocket message: {}: {}", err, &text[..text.len().min(200)]);
+                                                warn!("[relaycast] Dropped non-JSON WebSocket message: {}: {}", err, &text[..text.len().min(200)]);
                                             }
                                         }
                                     }

--- a/packages/sdk-rust/tests/parity.rs
+++ b/packages/sdk-rust/tests/parity.rs
@@ -74,6 +74,44 @@ async fn create_channel_accepts_public_channel_payload() {
 }
 
 #[tokio::test]
+async fn ensure_joined_channel_treats_conflicts_as_success() {
+    let server = MockServer::start().await;
+    let agent = AgentClient::new("at_live_test", Some(server.uri()))
+        .expect("failed to create agent client");
+
+    Mock::given(method("POST"))
+        .and(path("/v1/channels"))
+        .and(body_json(json!({
+            "name": "general",
+            "topic": "General discussion"
+        })))
+        .respond_with(api_error(409, "channel_already_exists", "Channel exists"))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    Mock::given(method("POST"))
+        .and(path("/v1/channels/general/join"))
+        .respond_with(api_error(409, "already_member", "Already joined"))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let outcome = agent
+        .ensure_joined_channel(CreateChannelRequest {
+            name: "general".to_string(),
+            topic: Some("General discussion".to_string()),
+            metadata: None,
+        })
+        .await
+        .expect("ensure_joined_channel should treat 409 as success");
+
+    assert_eq!(outcome.name, "general");
+    assert!(!outcome.created);
+    assert!(!outcome.joined);
+}
+
+#[tokio::test]
 async fn register_or_get_agent_reclaims_public_agent_payload() {
     let server = MockServer::start().await;
     let relay = RelayCast::new(RelayCastOptions::new("rk_live_test").with_base_url(server.uri()))


### PR DESCRIPTION
## Summary
- add raw websocket event subscriptions and SDK-owned event normalization helpers
- add reusable agent registration, identity, channel ensure/join, and DM participant cache helpers
- document the new Rust SDK surface without bumping the crate version

## Tests
- cargo test