### PR TITLE
engine: migrate platform-neutral crypto to Web Crypto

### DIFF
--- a/.trajectories/completed/2026-05/traj_gk8yfvbi52hm.json
+++ b/.trajectories/completed/2026-05/traj_gk8yfvbi52hm.json
@@ -1,0 +1,69 @@
+{
+  "id": "traj_gk8yfvbi52hm",
+  "version": 1,
+  "task": {
+    "title": "Fix issue 143",
+    "source": {
+      "system": "plain",
+      "id": "#143"
+    }
+  },
+  "status": "completed",
+  "startedAt": "2026-05-31T07:03:06.043Z",
+  "agents": [
+    {
+      "name": "default",
+      "role": "lead",
+      "joinedAt": "2026-05-31T07:04:33.345Z"
+    }
+  ],
+  "chapters": [
+    {
+      "id": "chap_gztqcsfuguve",
+      "title": "Work",
+      "agentName": "default",
+      "startedAt": "2026-05-31T07:04:33.345Z",
+      "events": [
+        {
+          "ts": 1780211073346,
+          "type": "decision",
+          "content": "Use shared Web Crypto helpers for hashing, HMAC, random hex, and UUID: Use shared Web Crypto helpers for hashing, HMAC, random hex, and UUID",
+          "raw": {
+            "question": "Use shared Web Crypto helpers for hashing, HMAC, random hex, and UUID",
+            "chosen": "Use shared Web Crypto helpers for hashing, HMAC, random hex, and UUID",
+            "alternatives": [],
+            "reasoning": "This removes node:crypto from platform-neutral request paths while keeping Node adapters free to use Node builtins."
+          },
+          "significance": "high"
+        },
+        {
+          "ts": 1780211395780,
+          "type": "decision",
+          "content": "Constrain issue 143 implementation to @relaycast/engine only: Constrain issue 143 implementation to @relaycast/engine only",
+          "raw": {
+            "question": "Constrain issue 143 implementation to @relaycast/engine only",
+            "chosen": "Constrain issue 143 implementation to @relaycast/engine only",
+            "alternatives": [],
+            "reasoning": "The user clarified @relaycast/server is deprecated and frozen, so server changes were reverted and validation will target the engine package."
+          },
+          "significance": "high"
+        }
+      ],
+      "endedAt": "2026-05-31T07:12:06.624Z"
+    }
+  ],
+  "commits": [],
+  "filesChanged": [],
+  "projectId": "/Users/will/Projects/AgentWorkforce/relaycast",
+  "tags": [],
+  "_trace": {
+    "startRef": "d25826849c0c40b7e78046d06cb8ee44069405fe",
+    "endRef": "d25826849c0c40b7e78046d06cb8ee44069405fe"
+  },
+  "completedAt": "2026-05-31T07:12:06.624Z",
+  "retrospective": {
+    "summary": "Migrated @relaycast/engine platform-neutral crypto usage from node:crypto to Web Crypto helpers, keeping Node-only adapters unchanged and adding helper coverage.",
+    "approach": "Standard approach",
+    "confidence": 0.88
+  }
+}

--- a/.trajectories/completed/2026-05/traj_gk8yfvbi52hm.md
+++ b/.trajectories/completed/2026-05/traj_gk8yfvbi52hm.md
@@ -1,0 +1,37 @@
+# Trajectory: Fix issue 143
+
+> **Status:** ✅ Completed
+> **Task:** #143
+> **Confidence:** 88%
+> **Started:** May 31, 2026 at 03:03 AM
+> **Completed:** May 31, 2026 at 03:12 AM
+
+---
+
+## Summary
+
+Migrated @relaycast/engine platform-neutral crypto usage from node:crypto to Web Crypto helpers, keeping Node-only adapters unchanged and adding helper coverage.
+
+**Approach:** Standard approach
+
+---
+
+## Key Decisions
+
+### Use shared Web Crypto helpers for hashing, HMAC, random hex, and UUID
+- **Chose:** Use shared Web Crypto helpers for hashing, HMAC, random hex, and UUID
+- **Reasoning:** This removes node:crypto from platform-neutral request paths while keeping Node adapters free to use Node builtins.
+
+### Constrain issue 143 implementation to @relaycast/engine only
+- **Chose:** Constrain issue 143 implementation to @relaycast/engine only
+- **Reasoning:** The user clarified @relaycast/server is deprecated and frozen, so server changes were reverted and validation will target the engine package.
+
+---
+
+## Chapters
+
+### 1. Work
+*Agent: default*
+
+- Use shared Web Crypto helpers for hashing, HMAC, random hex, and UUID: Use shared Web Crypto helpers for hashing, HMAC, random hex, and UUID
+- Constrain issue 143 implementation to @relaycast/engine only: Constrain issue 143 implementation to @relaycast/engine only

--- a/.trajectories/index.json
+++ b/.trajectories/index.json
@@ -1,5 +1,13 @@
 {
   "version": 1,
-  "lastUpdated": "2026-05-29T15:00:49.465Z",
-  "trajectories": {}
+  "lastUpdated": "2026-05-31T07:12:06.785Z",
+  "trajectories": {
+    "traj_gk8yfvbi52hm": {
+      "title": "Fix issue 143",
+      "status": "completed",
+      "startedAt": "2026-05-31T07:03:06.043Z",
+      "completedAt": "2026-05-31T07:12:06.624Z",
+      "path": "/Users/will/Projects/AgentWorkforce/relaycast/.trajectories/completed/2026-05/traj_gk8yfvbi52hm.json"
+    }
+  }
 }

--- a/packages/engine/src/auth/index.ts
+++ b/packages/engine/src/auth/index.ts
@@ -1,12 +1,12 @@
-import crypto from 'node:crypto';
 import { eq } from 'drizzle-orm';
 import { workspaces, agents } from '../db/schema.js';
+import { sha256Hex } from '../lib/crypto.js';
 import type { AuthProvider, AuthResult, AuthRequire } from '../ports/auth.js';
 import type { EngineDb } from '../ports/database.js';
 
 /** SHA-256 hash of a raw token to its stored form. */
-export function hashToken(token: string): string {
-  return crypto.createHash('sha256').update(token).digest('hex');
+export function hashToken(token: string): Promise<string> {
+  return sha256Hex(token);
 }
 
 function unauthorized(message: string, code = 'unauthorized'): AuthResult {
@@ -22,13 +22,13 @@ function unauthorized(message: string, code = 'unauthorized'): AuthResult {
  * provider backed by its own accounts/billing system.
  */
 export class SqliteApiKeyAuthProvider implements AuthProvider {
-  hashToken(token: string): string {
+  hashToken(token: string): Promise<string> {
     return hashToken(token);
   }
 
   async authenticate(args: { token: string; require: AuthRequire; db: EngineDb }): Promise<AuthResult> {
     const { token, require, db } = args;
-    const hash = hashToken(token);
+    const hash = await hashToken(token);
 
     if (token.startsWith('rk_live_')) {
       if (require === 'agent') {

--- a/packages/engine/src/engine.ts
+++ b/packages/engine/src/engine.ts
@@ -169,7 +169,7 @@ export function createEngine(deps: EngineDeps): Hono<AppEnv> {
 
     const { auth, connections, kv, config } = c.get('engine');
     const db = c.get('db');
-    const hash = auth.hashToken(token);
+    const hash = await auth.hashToken(token);
     const originInfo = requiredOriginInfo(c.req.raw);
     const origin = {
       surface: originInfo.origin_surface,

--- a/packages/engine/src/engine/a2a.ts
+++ b/packages/engine/src/engine/a2a.ts
@@ -1,4 +1,3 @@
-import crypto from 'node:crypto';
 import { and, eq, sql } from 'drizzle-orm';
 import {
   A2aAgentCardSchema,
@@ -26,6 +25,7 @@ import { registerAgent, getAgentByName, updateAgent } from './agent.js';
 import { rotateAgentToken } from './tokenRotate.js';
 import { createAndRunCertification } from './certify.js';
 import { isSafeExternalUrl } from '../lib/ssrf.js';
+import { randomUuid, sha256Hex } from '../lib/crypto.js';
 
 type Db = ReturnType<typeof getDb>;
 
@@ -127,13 +127,13 @@ function wellKnownAgentCardUrl(agentUrl: string): string {
   return `${base.origin}/.well-known/agent-card.json`;
 }
 
-function deriveRelayName(card: A2aAgentCard): string {
+async function deriveRelayName(card: A2aAgentCard): Promise<string> {
   const slug = card.name
     .toLowerCase()
     .replace(/[^a-z0-9]+/g, '-')
     .replace(/^-+|-+$/g, '')
     .slice(0, 40) || 'agent';
-  const suffix = crypto.createHash('sha256').update(card.url).digest('hex').slice(0, 8);
+  const suffix = (await sha256Hex(card.url)).slice(0, 8);
   return `ext-${slug}-${suffix}`;
 }
 
@@ -184,7 +184,7 @@ function extractAttachmentsFromParts(parts: A2aPart[]): FileAttachment[] {
   for (const part of parts) {
     if (part.kind === 'file') {
       attachments.push({
-        file_id: part.file.uri ?? crypto.randomUUID(),
+        file_id: part.file.uri ?? randomUuid(),
         filename: part.file.name,
         content_type: part.file.mime_type ?? 'application/octet-stream',
         size_bytes: part.file.bytes ?? 0,
@@ -276,7 +276,7 @@ export async function registerA2aAgent(
     ?? await fetchAgentCard(ensureString(input.agentCardUrl, 'agent_card_url is required when agent_card is not provided'));
   const agentCard = A2aAgentCardSchema.parse(resolvedCard);
   const externalUrl = normalizeBaseUrl(agentCard.url);
-  const relayName = deriveRelayName(agentCard);
+  const relayName = await deriveRelayName(agentCard);
 
   const [existing] = await db
     .select({ id: a2aAgents.id })
@@ -334,7 +334,7 @@ export async function registerA2aAgent(
   let certification: 'level_0' | 'level_1' = healthOk ? 'level_1' : 'level_0';
 
   await db.insert(a2aAgents).values({
-    id: `a2a_${crypto.randomUUID()}`,
+    id: `a2a_${randomUuid()}`,
     workspaceId,
     relayAgentId,
     agentCard,
@@ -503,7 +503,7 @@ export function translateA2aToRelay(jsonRpc: A2aJsonRpcRequest | A2aJsonRpcRespo
   const parts = responseMessage?.parts ?? task?.artifacts?.flatMap((artifact) => artifact.parts) ?? [];
 
   return {
-    id: String(parsedResponse.id ?? task?.id ?? crypto.randomUUID()),
+    id: String(parsedResponse.id ?? task?.id ?? randomUuid()),
     agent_id: task?.id ?? 'external',
     agent_name: 'external',
     text: parts.length > 0 ? extractTextFromParts(parts) : task?.status.message ?? '',

--- a/packages/engine/src/engine/agent.ts
+++ b/packages/engine/src/engine/agent.ts
@@ -1,7 +1,7 @@
-import crypto from 'node:crypto';
-import { eq, and, lt, or, sql, inArray } from 'drizzle-orm';
+import { eq, and, lt, inArray } from 'drizzle-orm';
 import type { getDb } from '../db/index.js';
 import { agents, channels, channelMembers, actions, deliveries } from '../db/schema.js';
+import { randomHex, sha256Hex } from '../lib/crypto.js';
 import { generateId } from './snowflake.js';
 
 type Db = ReturnType<typeof getDb>;
@@ -36,8 +36,8 @@ export async function registerAgent(
   },
 ) {
   const agentId = generateId();
-  const token = `at_live_${crypto.randomBytes(16).toString('hex')}`;
-  const tokenHash = crypto.createHash('sha256').update(token).digest('hex');
+  const token = `at_live_${randomHex(16)}`;
+  const tokenHash = await sha256Hex(token);
 
   // Use INSERT directly and let the unique index (workspace_id, name) enforce
   // uniqueness. Avoids TOCTOU race between SELECT check and INSERT that causes
@@ -342,8 +342,8 @@ export async function spawnAgent(
     // Agent exists - rotate token and update metadata
     alreadyExisted = true;
     agentId = existing.id;
-    token = `at_live_${crypto.randomBytes(16).toString('hex')}`;
-    const tokenHash = crypto.createHash('sha256').update(token).digest('hex');
+    token = `at_live_${randomHex(16)}`;
+    const tokenHash = await sha256Hex(token);
 
     // Update agent with new token, set online, store spawn metadata
     const spawnMetadata = {
@@ -372,8 +372,8 @@ export async function spawnAgent(
   } else {
     // Create new agent
     agentId = generateId();
-    token = `at_live_${crypto.randomBytes(16).toString('hex')}`;
-    const tokenHash = crypto.createHash('sha256').update(token).digest('hex');
+    token = `at_live_${randomHex(16)}`;
+    const tokenHash = await sha256Hex(token);
 
     const spawnMetadata = {
       ...(data.metadata || {}),

--- a/packages/engine/src/engine/certify.ts
+++ b/packages/engine/src/engine/certify.ts
@@ -1,8 +1,8 @@
-import crypto from 'node:crypto';
 import { and, eq } from 'drizzle-orm';
 import { z } from 'zod';
 import type { getDb } from '../db/index.js';
 import { certifications } from '../db/schema.js';
+import { randomUuid } from '../lib/crypto.js';
 
 type Db = ReturnType<typeof getDb>;
 
@@ -92,7 +92,7 @@ async function rpcCall(agentUrl: string, method: string, params: Record<string, 
       },
       body: JSON.stringify({
         jsonrpc: '2.0',
-        id: crypto.randomUUID(),
+        id: randomUuid(),
         method,
         params,
       }),
@@ -188,11 +188,11 @@ async function runTest(
 }
 
 function buildMessageParams() {
-  const taskId = `task_${crypto.randomUUID()}`;
-  const contextId = `ctx_${crypto.randomUUID()}`;
+  const taskId = `task_${randomUuid()}`;
+  const contextId = `ctx_${randomUuid()}`;
   return {
     message: {
-      message_id: `msg_${crypto.randomUUID()}`,
+      message_id: `msg_${randomUuid()}`,
       role: 'user',
       context_id: contextId,
       parts: [{ kind: 'text', text: 'Certification probe message' }],
@@ -377,7 +377,7 @@ async function levelThreeTests(agentUrl: string): Promise<CertificationTestResul
       };
     }),
     await runTest('cancellation_latency', 'Cancellation completes quickly', async () => {
-      const taskId = `task_${crypto.randomUUID()}`;
+      const taskId = `task_${randomUuid()}`;
       await rpcCall(agentUrl, 'message/send', {
         ...buildMessageParams(),
         task_id: taskId,
@@ -422,7 +422,7 @@ export async function createCertificationRun(
   workspaceId: string,
   input: PersistCertificationInput,
 ) {
-  const id = `cert_${crypto.randomUUID()}`;
+  const id = `cert_${randomUuid()}`;
   const now = new Date();
 
   await db.insert(certifications).values({

--- a/packages/engine/src/engine/dm.ts
+++ b/packages/engine/src/engine/dm.ts
@@ -1,4 +1,3 @@
-import crypto from 'node:crypto';
 import { eq, and, sql, lt, gt, isNull, inArray, asc } from 'drizzle-orm';
 import type { DmMessage } from '@relaycast/types';
 import type { getDb } from '../db/index.js';
@@ -12,6 +11,7 @@ import {
   files,
   deliveries,
 } from '../db/schema.js';
+import { sha256Hex } from '../lib/crypto.js';
 import { generateId } from './snowflake.js';
 import * as a2aEngine from './a2a.js';
 import { logMessage } from './console.js';
@@ -54,13 +54,9 @@ async function fetchAttachmentsBatch(db: Db, workspaceId: string, msgIds: string
   return map;
 }
 
-function getDmPairKey(workspaceId: string, agentA: string, agentB: string): string {
+async function getDmPairKey(workspaceId: string, agentA: string, agentB: string): Promise<string> {
   const [first, second] = [agentA, agentB].sort();
-  return crypto
-    .createHash('sha256')
-    .update(`${workspaceId}:${first}:${second}`)
-    .digest('hex')
-    .slice(0, 24);
+  return (await sha256Hex(`${workspaceId}:${first}:${second}`)).slice(0, 24);
 }
 
 async function resolveConversation(
@@ -88,7 +84,7 @@ async function resolveConversation(
   let conversationId = existing[0]?.id;
 
   if (!conversationId) {
-    const pairKey = getDmPairKey(workspaceId, fromAgentId, toAgentId);
+    const pairKey = await getDmPairKey(workspaceId, fromAgentId, toAgentId);
     const deterministicConversationId = `dm_${pairKey}`;
     const deterministicChannelId = `dmch_${pairKey}`;
 

--- a/packages/engine/src/engine/eventDelivery.ts
+++ b/packages/engine/src/engine/eventDelivery.ts
@@ -1,11 +1,11 @@
-import { createHmac } from 'node:crypto';
 import type { getDb } from '../db/index.js';
+import { hmacSha256Hex } from '../lib/crypto.js';
 import { getActiveSubscriptions } from './eventSubscription.js';
 
 type Db = ReturnType<typeof getDb>;
 
-export function signPayload(payload: string, secret: string): string {
-  return createHmac('sha256', secret).update(payload).digest('hex');
+export function signPayload(payload: string, secret: string): Promise<string> {
+  return hmacSha256Hex(payload, secret);
 }
 
 interface DeliveryTarget {
@@ -130,7 +130,7 @@ export async function deliverEvent(
       };
 
       if (sub.secret) {
-        headers['X-Relay-Signature'] = `sha256=${signPayload(body, sub.secret)}`;
+        headers['X-Relay-Signature'] = `sha256=${await signPayload(body, sub.secret)}`;
       }
 
       return attemptDelivery(sub.url, body, headers);

--- a/packages/engine/src/engine/inboundWebhook.ts
+++ b/packages/engine/src/engine/inboundWebhook.ts
@@ -1,7 +1,7 @@
-import crypto from 'node:crypto';
 import { eq, and } from 'drizzle-orm';
 import type { getDb } from '../db/index.js';
 import { webhooks, channels, messages, agents } from '../db/schema.js';
+import { randomHex, sha256Hex } from '../lib/crypto.js';
 import { generateId } from './snowflake.js';
 
 type Db = ReturnType<typeof getDb>;
@@ -15,8 +15,8 @@ async function ensureWebhookAgent(db: Db, workspaceId: string): Promise<string> 
 
   if (existing) return existing.id;
 
-  const token = `at_live_${crypto.randomBytes(16).toString('hex')}`;
-  const tokenHash = crypto.createHash('sha256').update(token).digest('hex');
+  const token = `at_live_${randomHex(16)}`;
+  const tokenHash = await sha256Hex(token);
   const agentId = generateId();
 
   await db

--- a/packages/engine/src/engine/tokenRotate.ts
+++ b/packages/engine/src/engine/tokenRotate.ts
@@ -1,7 +1,7 @@
-import crypto from 'node:crypto';
 import { eq, and } from 'drizzle-orm';
 import type { getDb } from '../db/index.js';
 import { agents } from '../db/schema.js';
+import { randomHex, sha256Hex } from '../lib/crypto.js';
 
 type Db = ReturnType<typeof getDb>;
 
@@ -17,8 +17,8 @@ export async function rotateAgentToken(db: Db, workspaceId: string, agentName: s
     throw err;
   }
 
-  const newToken = `at_live_${crypto.randomBytes(16).toString('hex')}`;
-  const newTokenHash = crypto.createHash('sha256').update(newToken).digest('hex');
+  const newToken = `at_live_${randomHex(16)}`;
+  const newTokenHash = await sha256Hex(newToken);
 
   await db
     .update(agents)

--- a/packages/engine/src/engine/workspace.ts
+++ b/packages/engine/src/engine/workspace.ts
@@ -1,7 +1,7 @@
-import crypto from 'node:crypto';
 import { and, eq } from 'drizzle-orm';
 import type { getDb } from '../db/index.js';
 import { workspaces, channels } from '../db/schema.js';
+import { randomHex, sha256Hex } from '../lib/crypto.js';
 import { generateId } from './snowflake.js';
 
 type Db = ReturnType<typeof getDb>;
@@ -13,8 +13,8 @@ type CreateWorkspaceOptions =
       ownerApiKeyHash?: string;
     };
 
-function hashApiKey(apiKey: string) {
-  return crypto.createHash('sha256').update(apiKey).digest('hex');
+function hashApiKey(apiKey: string): Promise<string> {
+  return sha256Hex(apiKey);
 }
 
 function buildWorkspaceResponse(
@@ -35,7 +35,7 @@ export async function createWorkspace(
 ) {
   const providedOwnerApiKeyHash = typeof options === 'string' ? undefined : options?.ownerApiKeyHash;
   const providedOwnerApiKey = typeof options === 'string' ? options : options?.ownerApiKey;
-  const derivedOwnerApiKeyHash = providedOwnerApiKey ? hashApiKey(providedOwnerApiKey) : undefined;
+  const derivedOwnerApiKeyHash = providedOwnerApiKey ? await hashApiKey(providedOwnerApiKey) : undefined;
 
   if (providedOwnerApiKeyHash && derivedOwnerApiKeyHash && providedOwnerApiKeyHash !== derivedOwnerApiKeyHash) {
     const err = new Error('ownerApiKeyHash must match the provided ownerApiKey');
@@ -62,8 +62,8 @@ export async function createWorkspace(
   }
 
   const workspaceId = generateId();
-  const apiKey = `rk_live_${crypto.randomBytes(16).toString('hex')}`;
-  const apiKeyHash = hashApiKey(apiKey);
+  const apiKey = `rk_live_${randomHex(16)}`;
+  const apiKeyHash = await hashApiKey(apiKey);
 
   const [createdWorkspace] = await db
     .insert(workspaces)

--- a/packages/engine/src/lib/__tests__/crypto.test.ts
+++ b/packages/engine/src/lib/__tests__/crypto.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest';
+import { hmacSha256Hex, randomHex, randomUuid, sha256Hex } from '../crypto.js';
+
+describe('crypto helpers', () => {
+  it('returns SHA-256 hex digests', async () => {
+    await expect(sha256Hex('test-token')).resolves.toBe(
+      '4c5dc9b7708905f77f5e5d16316b5dfb425e68cb326dcd55a860e90a7707031e',
+    );
+  });
+
+  it('returns HMAC-SHA-256 hex signatures', async () => {
+    await expect(hmacSha256Hex('payload', 'secret')).resolves.toBe(
+      'b82fcb791acec57859b989b430a826488ce2e479fdf92326bd0a2e8375a42ba4',
+    );
+  });
+
+  it('generates random hex and UUID values', () => {
+    expect(randomHex(16)).toMatch(/^[a-f0-9]{32}$/);
+    expect(randomUuid()).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/);
+  });
+});

--- a/packages/engine/src/lib/crypto.ts
+++ b/packages/engine/src/lib/crypto.ts
@@ -1,0 +1,32 @@
+const textEncoder = new TextEncoder();
+
+function bytesToHex(bytes: Uint8Array): string {
+  return Array.from(bytes, (byte) => byte.toString(16).padStart(2, '0')).join('');
+}
+
+export async function sha256Hex(value: string): Promise<string> {
+  const digest = await globalThis.crypto.subtle.digest('SHA-256', textEncoder.encode(value));
+  return bytesToHex(new Uint8Array(digest));
+}
+
+export async function hmacSha256Hex(payload: string, secret: string): Promise<string> {
+  const key = await globalThis.crypto.subtle.importKey(
+    'raw',
+    textEncoder.encode(secret),
+    { name: 'HMAC', hash: 'SHA-256' },
+    false,
+    ['sign'],
+  );
+  const signature = await globalThis.crypto.subtle.sign('HMAC', key, textEncoder.encode(payload));
+  return bytesToHex(new Uint8Array(signature));
+}
+
+export function randomHex(byteLength: number): string {
+  const bytes = new Uint8Array(byteLength);
+  globalThis.crypto.getRandomValues(bytes);
+  return bytesToHex(bytes);
+}
+
+export function randomUuid(): string {
+  return globalThis.crypto.randomUUID();
+}

--- a/packages/engine/src/middleware/idempotency.ts
+++ b/packages/engine/src/middleware/idempotency.ts
@@ -1,5 +1,5 @@
-import { createHash } from 'node:crypto';
 import type { KeyValueStore } from '../ports/kv.js';
+import { sha256Hex } from '../lib/crypto.js';
 
 const IDEMPOTENCY_TTL_SECONDS = 24 * 60 * 60;
 const IDEMPOTENCY_LOCK_TTL_SECONDS = 30;
@@ -29,10 +29,12 @@ interface RunIdempotentOptions<T> {
   operation: () => Promise<T>;
 }
 
-function buildKey(workspaceId: string, actorId: string, scope: string, key: string): string {
-  const digest = createHash('sha256').update(key).digest('hex');
-  const scopeDigest = createHash('sha256').update(scope).digest('hex').slice(0, 16);
-  return `idem:v1:${workspaceId}:${actorId}:${scopeDigest}:${digest}`;
+async function buildKey(workspaceId: string, actorId: string, scope: string, key: string): Promise<string> {
+  const [digest, scopeDigest] = await Promise.all([
+    sha256Hex(key),
+    sha256Hex(scope),
+  ]);
+  return `idem:v1:${workspaceId}:${actorId}:${scopeDigest.slice(0, 16)}:${digest}`;
 }
 
 export function parseIdempotencyKey(headerValue: string | undefined): { key?: string; error?: string } {
@@ -87,7 +89,7 @@ export async function runIdempotent<T>(
   let lockAcquired = false;
 
   if (kvStore) {
-    kvKey = buildKey(workspaceId, actorId, scope, key);
+    kvKey = await buildKey(workspaceId, actorId, scope, key);
     lockKey = `${kvKey}:lock`;
 
     try {

--- a/packages/engine/src/middleware/logger.ts
+++ b/packages/engine/src/middleware/logger.ts
@@ -1,6 +1,6 @@
-import crypto from 'node:crypto';
 import type { MiddlewareHandler } from 'hono';
 import type { AppEnv } from '../env.js';
+import { randomUuid, sha256Hex } from '../lib/crypto.js';
 import { createRequestLogger } from '../lib/logger.js';
 import { deriveClientName, extractHarness, extractOriginInfo } from '../lib/origin.js';
 
@@ -42,8 +42,8 @@ function tokenType(token: string): 'agent' | 'workspace' | 'unknown' {
   return 'unknown';
 }
 
-function hashIdentifier(value: string): string {
-  return crypto.createHash('sha256').update(value).digest('hex').slice(0, 16);
+async function hashIdentifier(value: string): Promise<string> {
+  return (await sha256Hex(value)).slice(0, 16);
 }
 
 function routeGroupForPath(path: string): string {
@@ -105,7 +105,7 @@ function statusClass(statusCode: number): string {
 }
 
 export const loggerMiddleware: MiddlewareHandler<AppEnv> = async (c, next) => {
-  const requestId = crypto.randomUUID();
+  const requestId = randomUuid();
   c.set('requestId', requestId);
   const requestHeaders = c.req.raw.headers;
   const clientName = deriveClientName(requestHeaders);
@@ -136,6 +136,11 @@ export const loggerMiddleware: MiddlewareHandler<AppEnv> = async (c, next) => {
   const connectingIp = requestHeaders.get('cf-connecting-ip');
   const userAgent = requestHeaders.get('user-agent');
   const errorInfo = statusCode >= 400 ? await extractErrorInfo(c.res) : {};
+  const [actorFingerprint, ipHash, uaHash] = await Promise.all([
+    presentedToken ? hashIdentifier(presentedToken) : undefined,
+    connectingIp ? hashIdentifier(connectingIp) : undefined,
+    userAgent ? hashIdentifier(userAgent) : undefined,
+  ]);
 
   const metadata: Record<string, unknown> = {
     status_code: statusCode,
@@ -146,9 +151,9 @@ export const loggerMiddleware: MiddlewareHandler<AppEnv> = async (c, next) => {
     ...(contentType ? { content_type: contentType } : {}),
     ...(accept ? { accept } : {}),
     ...(clientName ? { client_name: clientName } : {}),
-    ...(presentedToken ? { actor_fingerprint: hashIdentifier(presentedToken) } : {}),
-    ...(connectingIp ? { ip_hash: hashIdentifier(connectingIp) } : {}),
-    ...(userAgent ? { ua_hash: hashIdentifier(userAgent) } : {}),
+    ...(actorFingerprint ? { actor_fingerprint: actorFingerprint } : {}),
+    ...(ipHash ? { ip_hash: ipHash } : {}),
+    ...(uaHash ? { ua_hash: uaHash } : {}),
     ...originInfo,
     harness,
     ...errorInfo,

--- a/packages/engine/src/ports/auth.ts
+++ b/packages/engine/src/ports/auth.ts
@@ -34,5 +34,5 @@ export interface AuthProvider {
    * key handling, which look tokens up directly. Providers that don't use hashed
    * keys may return the token unchanged.
    */
-  hashToken(token: string): string;
+  hashToken(token: string): Promise<string>;
 }

--- a/packages/engine/src/routes/a2a.ts
+++ b/packages/engine/src/routes/a2a.ts
@@ -214,7 +214,7 @@ async function resolveWorkspaceFromAuth(c: Context<AppEnv>): Promise<{ id: strin
   if (!authHeader?.startsWith('Bearer ')) return null;
 
   const token = authHeader.slice(7);
-  const hash = hashToken(token);
+  const hash = await hashToken(token);
   const db = c.get('db');
 
   if (token.startsWith('rk_live_')) {
@@ -344,7 +344,8 @@ a2aRoutes.post('/a2a/webhook/:workspace_id/:agent_name', async (c) => {
     const token = c.req.header('Authorization')?.startsWith('Bearer ')
       ? c.req.header('Authorization')!.slice(7)
       : null;
-    if (!token || hashToken(token) !== relayAgent.tokenHash) {
+    const tokenHash = token ? await hashToken(token) : null;
+    if (!tokenHash || tokenHash !== relayAgent.tokenHash) {
       return c.json({
         ok: false,
         error: { code: 'unauthorized', message: 'Missing or invalid bearer token' },


### PR DESCRIPTION
## Summary
- add Web Crypto helpers for SHA-256, HMAC-SHA-256, random hex, and UUID generation
- update @relaycast/engine auth, middleware, and engine modules to stop importing node:crypto outside Node adapters
- make token hashing async through the AuthProvider surface and await direct lookup call sites
- add engine crypto helper tests

## Validation
- npm run build -- --filter=@relaycast/engine
- npm run test -- --filter=@relaycast/engine
- npm run lint -- --filter=@relaycast/engine (0 errors; existing warnings remain)
- rg node:crypto/createHash/randomBytes/createHmac in packages/engine/src excluding adapters/node returned no matches

Closes #143