### PR TITLE
fix(ci): write real newline in version.ts during publish version sync

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -145,11 +145,11 @@ jobs:
 
             // Sync package version constants
             const sdkVersionPath = path.join(packagesDir, 'sdk-typescript', 'src', 'version.ts');
-            fs.writeFileSync(sdkVersionPath, 'export const SDK_VERSION = ' + JSON.stringify(version) + ' as const;\\n');
+            fs.writeFileSync(sdkVersionPath, 'export const SDK_VERSION = ' + JSON.stringify(version) + ' as const;\n');
             console.log('SDK_VERSION -> ' + version);
             const cliVersionPath = path.join(packagesDir, 'cli', 'src', 'version.ts');
             if (fs.existsSync(cliVersionPath)) {
-              fs.writeFileSync(cliVersionPath, 'export const CLI_VERSION = ' + JSON.stringify(version) + ' as const;\\n');
+              fs.writeFileSync(cliVersionPath, 'export const CLI_VERSION = ' + JSON.stringify(version) + ' as const;\n');
               console.log('CLI_VERSION -> ' + version);
             }
           NODE


### PR DESCRIPTION
## Problem

The **Publish NPM Packages → Build & Version** job fails at the "Build all packages" step with `@relaycast/sdk#build` erroring on TS1127 **"Invalid character"** (exit code 2).

[Failing run](https://github.com/AgentWorkforce/relaycast/actions/runs/26771806805/job/78912966669)

## Root cause

The version-sync step runs a Node script inside a **single-quoted heredoc** (`<<'NODE'`), so the shell passes the body to `node` verbatim — no escape processing. The `writeFileSync` calls used `\\n`:

```js
fs.writeFileSync(sdkVersionPath, '...as const;\\n');
```

Node received `\\n`, and in a JS string literal `'\\n'` is an *escaped backslash followed by `n`* — so the generated `version.ts` ended with a literal `\n` (backslash + letter n) instead of a newline:

```
export const SDK_VERSION = "2.0.1" as const;\n   ← literal backslash-n
```

`tsc` then hit the stray `\` and threw "Invalid character", failing the build.

## Fix

Changed `\\n` → `\n` for both the SDK and CLI version files. Inside the quoted heredoc, `\n` reaches Node as `\n`, which the JS string evaluates to a real newline.

## Verification

- Reproduced the bug by simulating the exact heredoc write (literal `\n` before, clean trailing newline after the fix).
- `npx turbo build` passes all 9 packages.

https://claude.ai/code/session_011oXzPZxMiyb1FHahGRG3LR

---
_Generated by [Claude Code](https://claude.ai/code/session_011oXzPZxMiyb1FHahGRG3LR)_