### PR TITLE
feat(telemetry): end-to-end harness attribution (UA-style)

### DIFF
--- a/.agentworkforce/trajectories/completed/2026-06/traj_1774522548467_9eeddc03/summary.md
+++ b/.agentworkforce/trajectories/completed/2026-06/traj_1774522548467_9eeddc03/summary.md
@@ -1,0 +1,69 @@
+# Trajectory: cloud-iac-sst-workflow
+
+> **Status:** ✅ Completed
+> **Task:** ad7d3d56d99b1e5cf6efefe0
+> **Confidence:** 90%
+> **Started:** March 26, 2026 at 10:55 AM
+> **Completed:** June 3, 2026 at 05:33 AM
+
+---
+
+## Summary
+
+Reviewed PR 160 harness telemetry changes, fixed SDK public export gap for sanitizeHarness/HARNESS_HEADER, aligned changelog, and verified affected SDK/engine builds, tests, and lint.
+
+**Approach:** Standard approach
+
+---
+
+## Key Decisions
+
+### Expose sanitizeHarness from the SDK root export
+- **Chose:** Expose sanitizeHarness from the SDK root export
+- **Reasoning:** The PR changelog documents sanitizeHarness as exported, but package.json does not export the origin subpath; re-exporting the helper and header from index.ts makes the new public helper reachable without adding a new subpath contract.
+
+---
+
+## Chapters
+
+### 1. Planning
+*Agent: orchestrator*
+
+### 2. Execution: read-cloud-package-json, read-relayfile-wrangler, read-relayfile-package-json, read-relayfile-worker, read-relayfile-src-listing, read-relayauth-spec, read-relayauth-server-listing, read-relayauth-worker, verify-scaffold
+*Agent: orchestrator*
+
+### 3. Convergence: read-cloud-package-json + read-relayfile-wrangler + read-relayfile-package-json + read-relayfile-worker + read-relayfile-src-listing + read-relayauth-spec + read-relayauth-server-listing + read-relayauth-worker + verify-scaffold
+*Agent: orchestrator*
+
+- read-cloud-package-json + read-relayfile-wrangler + read-relayfile-package-json + read-relayfile-worker + read-relayfile-src-listing + read-relayauth-spec + read-relayauth-server-listing + read-relayauth-worker + verify-scaffold resolved. 9/9 steps completed. All steps completed on first attempt. Unblocking: move-workers, read-index-ts, implement-relayfile, implement-relayauth.
+
+### 4. Execution: move-workers, read-index-ts
+*Agent: orchestrator*
+
+### 5. Execution: move-workers
+*Agent: mover*
+
+### 6. Convergence: move-workers + read-index-ts
+*Agent: orchestrator*
+
+- move-workers + read-index-ts resolved. 2/2 steps completed. All steps completed on first attempt. Unblocking: verify-move, implement-relayfile, implement-relayauth.
+
+### 7. Execution: verify-move, implement-relayfile, implement-relayauth
+*Agent: orchestrator*
+
+### 8. Execution: implement-relayauth
+*Agent: relayauth-dev*
+
+### 9. Execution: implement-relayfile
+*Agent: relayfile-dev*
+
+### 10. Convergence: verify-move + implement-relayfile + implement-relayauth
+*Agent: orchestrator*
+
+- verify-move + implement-relayfile + implement-relayauth resolved. 3/3 steps completed. All steps completed on first attempt. Unblocking: verify-all-files.
+
+### 11. Execution: integrate
+*Agent: integrator*
+
+- Expose sanitizeHarness from the SDK root export: Expose sanitizeHarness from the SDK root export
+- Reviewed harness telemetry PR; implementation behavior is sound, found and fixed public export packaging gap; tests now passing after building local workspace deps.

--- a/.agentworkforce/trajectories/completed/2026-06/traj_1774522548467_9eeddc03/trajectory.json
+++ b/.agentworkforce/trajectories/completed/2026-06/traj_1774522548467_9eeddc03/trajectory.json
@@ -8,8 +8,9 @@
       "id": "ad7d3d56d99b1e5cf6efefe0"
     }
   },
-  "status": "active",
+  "status": "completed",
   "startedAt": "2026-03-26T10:55:48.467Z",
+  "completedAt": "2026-06-03T05:33:48.707Z",
   "agents": [
     {
       "name": "orchestrator",
@@ -43,6 +44,7 @@
       "title": "Planning",
       "agentName": "orchestrator",
       "startedAt": "2026-03-26T10:55:48.467Z",
+      "endedAt": "2026-03-26T10:55:52.656Z",
       "events": [
         {
           "ts": 1774522548467,
@@ -54,28 +56,27 @@
           "type": "note",
           "content": "Approach: 25-step dag workflow — Parsed 25 steps, 12 parallel tracks, 13 dependent steps, DAG validated, no cycles"
         }
-      ],
-      "endedAt": "2026-03-26T10:55:52.656Z"
+      ]
     },
     {
       "id": "ch_5d39f379",
       "title": "Execution: read-cloud-package-json, read-relayfile-wrangler, read-relayfile-package-json, read-relayfile-worker, read-relayfile-src-listing, read-relayauth-spec, read-relayauth-server-listing, read-relayauth-worker, verify-scaffold",
       "agentName": "orchestrator",
       "startedAt": "2026-03-26T10:55:52.656Z",
-      "events": [],
-      "endedAt": "2026-03-26T10:56:08.733Z"
+      "endedAt": "2026-03-26T10:56:08.733Z",
+      "events": []
     },
     {
       "id": "ch_be70b4fd",
       "title": "Convergence: read-cloud-package-json + read-relayfile-wrangler + read-relayfile-package-json + read-relayfile-worker + read-relayfile-src-listing + read-relayauth-spec + read-relayauth-server-listing + read-relayauth-worker + verify-scaffold",
       "agentName": "orchestrator",
       "startedAt": "2026-03-26T10:56:08.733Z",
+      "endedAt": "2026-03-26T10:56:08.737Z",
       "events": [
         {
           "ts": 1774522568736,
           "type": "reflection",
           "content": "read-cloud-package-json + read-relayfile-wrangler + read-relayfile-package-json + read-relayfile-worker + read-relayfile-src-listing + read-relayauth-spec + read-relayauth-server-listing + read-relayauth-worker + verify-scaffold resolved. 9/9 steps completed. All steps completed on first attempt. Unblocking: move-workers, read-index-ts, implement-relayfile, implement-relayauth.",
-          "significance": "high",
           "raw": {
             "confidence": 0.75,
             "focalPoints": [
@@ -89,24 +90,25 @@
               "read-relayauth-worker: completed",
               "verify-scaffold: completed"
             ]
-          }
+          },
+          "significance": "high"
         }
-      ],
-      "endedAt": "2026-03-26T10:56:08.737Z"
+      ]
     },
     {
       "id": "ch_ba7d3d3f",
       "title": "Execution: move-workers, read-index-ts",
       "agentName": "orchestrator",
       "startedAt": "2026-03-26T10:56:08.737Z",
-      "events": [],
-      "endedAt": "2026-03-26T10:56:08.768Z"
+      "endedAt": "2026-03-26T10:56:08.768Z",
+      "events": []
     },
     {
       "id": "ch_d31be8f0",
       "title": "Execution: move-workers",
       "agentName": "mover",
       "startedAt": "2026-03-26T10:56:08.768Z",
+      "endedAt": "2026-03-26T10:59:25.608Z",
       "events": [
         {
           "ts": 1774522568769,
@@ -120,7 +122,6 @@
           "ts": 1774522765606,
           "type": "completion-evidence",
           "content": "\"move-workers\" verification-based completion — Verification passed (5 signal(s), 1 relevant channel post(s), 3 file change(s), exit=0; signals=0, **Completed**, OpenAI Codex v0.116.0 (research preview), Verification passed, **[move-workers] Output:**; channel=**[move-workers] Output:**\n```\nes/relayfile`](/Users/khaliqgant/Projects/AgentWorkforce/cloud/packages/relayfile)\n- [`/Users/khaliqgant/Projects/AgentWorkforce/; files=modified:site/hero-animation.js, modified:site/index.html, modified:site/styles.css; exit=0)",
-          "significance": "medium",
           "raw": {
             "stepName": "move-workers",
             "completionMode": "verification",
@@ -144,7 +145,8 @@
               ],
               "exitCode": 0
             }
-          }
+          },
+          "significance": "medium"
         },
         {
           "ts": 1774522765606,
@@ -152,44 +154,44 @@
           "content": "\"move-workers\" completed → **Completed**\n\nCopied the requested worker package contents into:\n\n- [`/Users/khaliqgant/Projects/AgentWorkforce/cloud/p",
           "significance": "medium"
         }
-      ],
-      "endedAt": "2026-03-26T10:59:25.608Z"
+      ]
     },
     {
       "id": "ch_babac6e7",
       "title": "Convergence: move-workers + read-index-ts",
       "agentName": "orchestrator",
       "startedAt": "2026-03-26T10:59:25.608Z",
+      "endedAt": "2026-03-26T10:59:25.609Z",
       "events": [
         {
           "ts": 1774522765609,
           "type": "reflection",
           "content": "move-workers + read-index-ts resolved. 2/2 steps completed. All steps completed on first attempt. Unblocking: verify-move, implement-relayfile, implement-relayauth.",
-          "significance": "high",
           "raw": {
             "confidence": 0.875,
             "focalPoints": [
               "move-workers: completed",
               "read-index-ts: completed"
             ]
-          }
+          },
+          "significance": "high"
         }
-      ],
-      "endedAt": "2026-03-26T10:59:25.609Z"
+      ]
     },
     {
       "id": "ch_30f892ce",
       "title": "Execution: verify-move, implement-relayfile, implement-relayauth",
       "agentName": "orchestrator",
       "startedAt": "2026-03-26T10:59:25.609Z",
-      "events": [],
-      "endedAt": "2026-03-26T10:59:25.631Z"
+      "endedAt": "2026-03-26T10:59:25.631Z",
+      "events": []
     },
     {
       "id": "ch_c691d45c",
       "title": "Execution: implement-relayauth",
       "agentName": "relayauth-dev",
       "startedAt": "2026-03-26T10:59:25.631Z",
+      "endedAt": "2026-03-26T10:59:25.631Z",
       "events": [
         {
           "ts": 1774522765631,
@@ -199,14 +201,14 @@
             "agent": "relayauth-dev"
           }
         }
-      ],
-      "endedAt": "2026-03-26T10:59:25.631Z"
+      ]
     },
     {
       "id": "ch_a4d94c98",
       "title": "Execution: implement-relayfile",
       "agentName": "relayfile-dev",
       "startedAt": "2026-03-26T10:59:25.631Z",
+      "endedAt": "2026-03-26T11:01:53.935Z",
       "events": [
         {
           "ts": 1774522765631,
@@ -220,7 +222,6 @@
           "ts": 1774522911066,
           "type": "completion-evidence",
           "content": "\"implement-relayfile\" verification-based completion — Verification passed (3 signal(s), 1 file change(s), exit=0; signals=0, OpenAI Codex v0.116.0 (research preview), Verification passed; files=modified:.github/workflows/publish-npm.yml; exit=0)",
-          "significance": "medium",
           "raw": {
             "stepName": "implement-relayfile",
             "completionMode": "verification",
@@ -237,7 +238,8 @@
               ],
               "exitCode": 0
             }
-          }
+          },
+          "significance": "medium"
         },
         {
           "ts": 1774522911066,
@@ -249,7 +251,6 @@
           "ts": 1774522913932,
           "type": "completion-evidence",
           "content": "\"implement-relayauth\" verification-based completion — Verification passed (5 signal(s), 1 relevant channel post(s), 1 file change(s), exit=0; signals=0, Implemented `/Users/khaliqgant/Projects/AgentWorkforce/cloud/infra/cloudflare/relayauth.ts`., OpenAI Codex v0.116.0 (research preview), Verification passed, **[implement-relayauth] Output:**; channel=**[implement-relayauth] Output:**\n```\nImplemented `/Users/khaliqgant/Projects/AgentWorkforce/cloud/infra/cloudflare/relayauth.ts`.\nWhat was added:\n- `relayauthI; files=modified:.github/workflows/publish-npm.yml; exit=0)",
-          "significance": "medium",
           "raw": {
             "stepName": "implement-relayauth",
             "completionMode": "verification",
@@ -271,7 +272,8 @@
               ],
               "exitCode": 0
             }
-          }
+          },
+          "significance": "medium"
         },
         {
           "ts": 1774522913932,
@@ -279,20 +281,19 @@
           "content": "\"implement-relayauth\" completed → - Included stage-aware D1, KV, and DNS resources plus exported output fields",
           "significance": "medium"
         }
-      ],
-      "endedAt": "2026-03-26T11:01:53.935Z"
+      ]
     },
     {
       "id": "ch_144c2eee",
       "title": "Convergence: verify-move + implement-relayfile + implement-relayauth",
       "agentName": "orchestrator",
       "startedAt": "2026-03-26T11:01:53.935Z",
+      "endedAt": "2026-03-26T11:01:54.107Z",
       "events": [
         {
           "ts": 1774522913937,
           "type": "reflection",
           "content": "verify-move + implement-relayfile + implement-relayauth resolved. 3/3 steps completed. All steps completed on first attempt. Unblocking: verify-all-files.",
-          "significance": "high",
           "raw": {
             "confidence": 0.9166666666666666,
             "focalPoints": [
@@ -300,16 +301,17 @@
               "implement-relayfile: completed",
               "implement-relayauth: completed"
             ]
-          }
+          },
+          "significance": "high"
         }
-      ],
-      "endedAt": "2026-03-26T11:01:54.107Z"
+      ]
     },
     {
       "id": "ch_48dbadfe",
       "title": "Execution: integrate",
       "agentName": "integrator",
       "startedAt": "2026-03-26T11:01:54.107Z",
+      "endedAt": "2026-06-03T05:33:48.707Z",
       "events": [
         {
           "ts": 1774522914107,
@@ -318,8 +320,48 @@
           "raw": {
             "agent": "integrator"
           }
+        },
+        {
+          "ts": 1780464732756,
+          "type": "decision",
+          "content": "Expose sanitizeHarness from the SDK root export: Expose sanitizeHarness from the SDK root export",
+          "raw": {
+            "question": "Expose sanitizeHarness from the SDK root export",
+            "chosen": "Expose sanitizeHarness from the SDK root export",
+            "alternatives": [],
+            "reasoning": "The PR changelog documents sanitizeHarness as exported, but package.json does not export the origin subpath; re-exporting the helper and header from index.ts makes the new public helper reachable without adding a new subpath contract."
+          },
+          "significance": "high"
+        },
+        {
+          "ts": 1780464813582,
+          "type": "reflection",
+          "content": "Reviewed harness telemetry PR; implementation behavior is sound, found and fixed public export packaging gap; tests now passing after building local workspace deps.",
+          "raw": {
+            "focalPoints": [
+              "api-surface",
+              "packaging",
+              "verification"
+            ],
+            "confidence": 0.85
+          },
+          "significance": "high",
+          "tags": [
+            "focal:api-surface",
+            "focal:packaging",
+            "focal:verification",
+            "confidence:0.85"
+          ]
         }
       ]
     }
-  ]
+  ],
+  "retrospective": {
+    "summary": "Reviewed PR 160 harness telemetry changes, fixed SDK public export gap for sanitizeHarness/HARNESS_HEADER, aligned changelog, and verified affected SDK/engine builds, tests, and lint.",
+    "approach": "Standard approach",
+    "confidence": 0.9
+  },
+  "commits": [],
+  "filesChanged": [],
+  "tags": []
 }

--- a/.agentworkforce/trajectories/completed/2026-06/traj_bcy2wuz2urpu/summary.md
+++ b/.agentworkforce/trajectories/completed/2026-06/traj_bcy2wuz2urpu/summary.md
@@ -1,0 +1,32 @@
+# Trajectory: Review and fix PR #160 harness telemetry
+
+> **Status:** ✅ Completed
+> **Confidence:** 90%
+> **Started:** June 3, 2026 at 05:40 AM
+> **Completed:** June 3, 2026 at 05:43 AM
+
+---
+
+## Summary
+
+Reviewed PR 160 harness telemetry, fixed docs coverage for the new harness attribution contract, restored unrelated package-lock peer metadata, and verified affected and root CI commands.
+
+**Approach:** Standard approach
+
+---
+
+## Key Decisions
+
+### Document harness telemetry in README and OpenAPI
+- **Chose:** Document harness telemetry in README and OpenAPI
+- **Reasoning:** The engine now accepts a public attribution header/query parameter, and repo docs require README and openapi.yaml to move together when API behavior changes.
+
+---
+
+## Chapters
+
+### 1. Work
+*Agent: default*
+
+- Document harness telemetry in README and OpenAPI: Document harness telemetry in README and OpenAPI
+- Reviewed PR 160 harness telemetry, added missing README/OpenAPI coverage, restored unrelated package-lock peer metadata, and verified affected packages plus root build/test/lint.

--- a/.agentworkforce/trajectories/completed/2026-06/traj_bcy2wuz2urpu/trajectory.json
+++ b/.agentworkforce/trajectories/completed/2026-06/traj_bcy2wuz2urpu/trajectory.json
@@ -1,0 +1,73 @@
+{
+  "id": "traj_bcy2wuz2urpu",
+  "version": 1,
+  "task": {
+    "title": "Review and fix PR #160 harness telemetry"
+  },
+  "status": "completed",
+  "startedAt": "2026-06-03T05:40:15.505Z",
+  "completedAt": "2026-06-03T05:43:26.533Z",
+  "agents": [
+    {
+      "name": "default",
+      "role": "lead",
+      "joinedAt": "2026-06-03T05:40:56.058Z"
+    }
+  ],
+  "chapters": [
+    {
+      "id": "chap_2z6rg02v9zjb",
+      "title": "Work",
+      "agentName": "default",
+      "startedAt": "2026-06-03T05:40:56.058Z",
+      "endedAt": "2026-06-03T05:43:26.533Z",
+      "events": [
+        {
+          "ts": 1780465256059,
+          "type": "decision",
+          "content": "Document harness telemetry in README and OpenAPI: Document harness telemetry in README and OpenAPI",
+          "raw": {
+            "question": "Document harness telemetry in README and OpenAPI",
+            "chosen": "Document harness telemetry in README and OpenAPI",
+            "alternatives": [],
+            "reasoning": "The engine now accepts a public attribution header/query parameter, and repo docs require README and openapi.yaml to move together when API behavior changes."
+          },
+          "significance": "high"
+        },
+        {
+          "ts": 1780465400030,
+          "type": "reflection",
+          "content": "Reviewed PR 160 harness telemetry, added missing README/OpenAPI coverage, restored unrelated package-lock peer metadata, and verified affected packages plus root build/test/lint.",
+          "raw": {
+            "focalPoints": [
+              "docs",
+              "lockfile",
+              "verification"
+            ],
+            "confidence": 0.9
+          },
+          "significance": "high",
+          "tags": [
+            "focal:docs",
+            "focal:lockfile",
+            "focal:verification",
+            "confidence:0.9"
+          ]
+        }
+      ]
+    }
+  ],
+  "retrospective": {
+    "summary": "Reviewed PR 160 harness telemetry, fixed docs coverage for the new harness attribution contract, restored unrelated package-lock peer metadata, and verified affected and root CI commands.",
+    "approach": "Standard approach",
+    "confidence": 0.9
+  },
+  "commits": [],
+  "filesChanged": [],
+  "projectId": "AgentWorkforce/relaycast",
+  "tags": [],
+  "_trace": {
+    "startRef": "8be3f1a0dc2e6ed1daff4796ca8ef282563b63b4",
+    "endRef": "8be3f1a0dc2e6ed1daff4796ca8ef282563b63b4"
+  }
+}

--- a/README.md
+++ b/README.md
@@ -121,6 +121,14 @@ Relaycast is the messaging backbone:
 
 API errors use `{ ok: false, error: { code, message } }`. Invalid or expired agent tokens return `agent_token_invalid` with HTTP 401; clients should recover by re-registering or rotating the agent identity, then retrying the failed operation.
 
+## Telemetry Attribution
+
+SDK and wrapper clients may set a `harness` option, such as `codex` or
+`claude-code/2.3 (model=opus-4.8)`, to attribute traffic in server telemetry.
+The TypeScript SDK sends this as `X-Relaycast-Harness` for HTTP requests and as
+the `harness` query parameter for WebSocket connections. Invalid values are
+omitted.
+
 ## Core Concepts
 
 - Workspace: isolated environment for one project/team

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -10,6 +10,10 @@ info:
     Response format:
     - Success: `{ ok: true, data: ... }`
     - Error: `{ ok: false, error: { code, message } }`
+
+    Clients may include `X-Relaycast-Harness` on HTTP requests to attribute
+    traffic in server telemetry. WebSocket clients that cannot send custom
+    headers may use the `harness` query parameter instead.
   version: 1.0.0
   contact:
     name: Relaycast

--- a/package-lock.json
+++ b/package-lock.json
@@ -5653,7 +5653,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -5675,7 +5674,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -5697,7 +5695,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -5719,7 +5716,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -5741,7 +5737,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -5763,7 +5758,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -5785,7 +5779,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -5807,7 +5800,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -5829,7 +5821,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -5851,7 +5842,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -5873,7 +5863,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -5653,6 +5653,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -5674,6 +5675,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -5695,6 +5697,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -5716,6 +5719,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -5737,6 +5741,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -5758,6 +5763,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -5779,6 +5785,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -5800,6 +5807,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -5821,6 +5829,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -5842,6 +5851,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -5863,6 +5873,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },

--- a/packages/engine/src/lib/__tests__/origin.test.ts
+++ b/packages/engine/src/lib/__tests__/origin.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest';
+import { extractHarness, UNKNOWN_HARNESS } from '../origin.js';
+
+function req(init: { header?: string; query?: string } = {}): Request {
+  const url = new URL('https://gateway.relaycast.dev/v1/activity');
+  if (init.query !== undefined) url.searchParams.set('harness', init.query);
+  const headers = new Headers();
+  if (init.header !== undefined) headers.set('X-Relaycast-Harness', init.header);
+  return new Request(url, { headers });
+}
+
+describe('extractHarness', () => {
+  it('reads the X-Relaycast-Harness header, lowercased', () => {
+    expect(extractHarness(req({ header: 'Claude-Code' }))).toBe('claude-code');
+  });
+
+  it('accepts a UA-style token', () => {
+    expect(extractHarness(req({ header: 'claude-code/2.3 (model=opus-4.8; fast)' })))
+      .toBe('claude-code/2.3 (model=opus-4.8; fast)');
+  });
+
+  it('falls back to the `harness` query param (browser WS path)', () => {
+    expect(extractHarness(req({ query: 'codex' }))).toBe('codex');
+  });
+
+  it('prefers the header over the query param', () => {
+    expect(extractHarness(req({ header: 'claude-code', query: 'codex' }))).toBe('claude-code');
+  });
+
+  it('returns unknown when neither is present', () => {
+    expect(extractHarness(req())).toBe(UNKNOWN_HARNESS);
+  });
+
+  it('rejects disallowed characters in the header', () => {
+    expect(extractHarness(req({ header: 'claude<script>' }))).toBe(UNKNOWN_HARNESS);
+  });
+
+  it('rejects CRLF smuggled through the query param', () => {
+    // The runtime Headers object already blocks CRLF header values, so the only
+    // way control characters reach us is the query string — drop them there too.
+    expect(extractHarness(req({ query: 'evil\r\nX-Inject: bad' }))).toBe(UNKNOWN_HARNESS);
+  });
+
+  it('rejects empty / whitespace-only values', () => {
+    expect(extractHarness(req({ header: '   ' }))).toBe(UNKNOWN_HARNESS);
+  });
+
+  it('truncates to 120 characters', () => {
+    expect(extractHarness(req({ header: 'a'.repeat(200) }))).toBe('a'.repeat(120));
+  });
+});

--- a/packages/engine/src/lib/origin.ts
+++ b/packages/engine/src/lib/origin.ts
@@ -8,36 +8,43 @@ export type OriginInfo = Partial<TelemetryOrigin>;
  */
 export const HARNESS_HEADER = 'X-Relaycast-Harness';
 
-/** Fallback value when the header is missing or invalid. */
+/** Fallback value when the harness is missing or invalid. */
 export const UNKNOWN_HARNESS = 'unknown';
 
-/** Sanity-cap on the header value — long enough for any reasonable identifier. */
-const HARNESS_MAX_LENGTH = 40;
+/** Upper bound on the harness value — generous enough for a UA-style token. */
+const HARNESS_MAX_LENGTH = 120;
 
 /**
- * Read and sanitize the `X-Relaycast-Harness` header from a request.
- *
- * Returns a lowercase identifier (kebab-case by convention, e.g. `claude-code`,
- * `cursor`, `codex`). We intentionally do NOT enforce an enum here — accepting
- * any well-formed value lets us discover new harnesses without shipping a
- * relaycast release first. Segmentation/normalization happens downstream in
- * the analytics layer.
- *
- * Drops empty, oversized, or non-ASCII values to `'unknown'`.
+ * Characters permitted in a harness identifier. Deliberately broad enough for a
+ * User-Agent-style token (`name/version (model=...; setting)`) while excluding
+ * CR/LF and other control characters — rejecting those is what keeps a buggy
+ * upstream caller from smuggling a header injection past the relaycast WAF.
  */
-export function extractHarness(headers: Headers): string {
-  const raw = headers.get(HARNESS_HEADER);
+const HARNESS_ALLOWED = /^[a-z0-9 ._\-/():=;,+]+$/i;
+
+/**
+ * Read and sanitize the harness identifier from a request.
+ *
+ * Read from the `X-Relaycast-Harness` header, falling back to the `harness`
+ * query param (WebSocket upgrades from browsers can't set custom headers, so
+ * the SDK forwards it on the query string — mirrors how origin fields work).
+ *
+ * Returns a lowercase, UA-style identifier (e.g. `claude-code`, `codex`,
+ * `claude-code/2.3 (model=opus-4.8; fast)`). We intentionally do NOT enforce an
+ * enum here — accepting any well-formed value lets us discover new harnesses
+ * without shipping a relaycast release first; segmentation happens downstream
+ * in the analytics layer. Drops empty or malformed values to `'unknown'`.
+ */
+export function extractHarness(request: Request): string {
+  const raw = request.headers.get(HARNESS_HEADER)
+    ?? new URL(request.url).searchParams.get('harness');
   if (!raw) return UNKNOWN_HARNESS;
 
   const trimmed = raw.trim();
   if (!trimmed) return UNKNOWN_HARNESS;
-  if (trimmed.length > HARNESS_MAX_LENGTH) return UNKNOWN_HARNESS;
-  // Restrict to printable ASCII to keep PostHog property values clean. Allow
-  // letters, digits, and the small set of separators harness names tend to
-  // use. Anything else falls back to `unknown`.
-  if (!/^[a-zA-Z0-9._-]+$/.test(trimmed)) return UNKNOWN_HARNESS;
+  if (!HARNESS_ALLOWED.test(trimmed)) return UNKNOWN_HARNESS;
 
-  return trimmed.toLowerCase();
+  return trimmed.slice(0, HARNESS_MAX_LENGTH).toLowerCase();
 }
 
 function sanitizeOriginPart(value: string | null | undefined, maxLen: number): string | undefined {

--- a/packages/engine/src/lib/serverTelemetry.ts
+++ b/packages/engine/src/lib/serverTelemetry.ts
@@ -36,7 +36,7 @@ export function emitServerEvent(
   // Prefer the value stashed by the logger middleware. Fall back to reading the
   // header directly so emitters that bypass middleware still get a sane value.
   const harness = c.get('harness')
-    ?? extractHarness(c.req.raw.headers)
+    ?? extractHarness(c.req.raw)
     ?? UNKNOWN_HARNESS;
 
   const origin = requiredOriginInfo(c.req.raw);

--- a/packages/engine/src/middleware/logger.ts
+++ b/packages/engine/src/middleware/logger.ts
@@ -109,7 +109,7 @@ export const loggerMiddleware: MiddlewareHandler<AppEnv> = async (c, next) => {
   const requestHeaders = c.req.raw.headers;
   const clientName = deriveClientName(requestHeaders);
   const originInfo = extractOriginInfo(c.req.raw, clientName);
-  const harness = extractHarness(requestHeaders);
+  const harness = extractHarness(c.req.raw);
   c.set('harness', harness);
 
   const logger = createRequestLogger(c, 'request', {

--- a/packages/sdk-typescript/CHANGELOG.md
+++ b/packages/sdk-typescript/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+### Added
+- Optional `harness` field on `RelayCastOptions`/`ClientOptions` and `WsClientOptions` (plus the internal `InternalOrigin` plumbing). A User-Agent-style identifier for the harness driving requests (e.g. `'claude-code/2.3 (model=opus-4.8)'`, `'codex'`, `'human'`); stamped as the `X-Relaycast-Harness` HTTP header and forwarded as the `harness` WS query param so server-side telemetry can attribute traffic. When a wrapping host supplies one via the internal origin it takes precedence over the public option. Invalid values (empty, control characters) are dropped rather than sent; the header is omitted entirely when no harness is set, so existing consumers are unchanged on the wire.
+- `sanitizeHarness` exported from `./origin.js` — lowercases, restricts to a UA-safe character set, caps at 120 chars.
+
 ### Breaking
 - Removed snake_case input aliases from the SDK surface; camelCase is now the only supported input style.
 

--- a/packages/sdk-typescript/CHANGELOG.md
+++ b/packages/sdk-typescript/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ### Added
 - Optional `harness` field on `RelayCastOptions`/`ClientOptions` and `WsClientOptions` (plus the internal `InternalOrigin` plumbing). A User-Agent-style identifier for the harness driving requests (e.g. `'claude-code/2.3 (model=opus-4.8)'`, `'codex'`, `'human'`); stamped as the `X-Relaycast-Harness` HTTP header and forwarded as the `harness` WS query param so server-side telemetry can attribute traffic. When a wrapping host supplies one via the internal origin it takes precedence over the public option. Invalid values (empty, control characters) are dropped rather than sent; the header is omitted entirely when no harness is set, so existing consumers are unchanged on the wire.
-- `sanitizeHarness` exported from `./origin.js` — lowercases, restricts to a UA-safe character set, caps at 120 chars.
+- `sanitizeHarness` and `HARNESS_HEADER` exported from the SDK root — lowercases, restricts to a UA-safe character set, caps at 120 chars.
 
 ### Breaking
 - Removed snake_case input aliases from the SDK surface; camelCase is now the only supported input style.

--- a/packages/sdk-typescript/src/__tests__/harness.test.ts
+++ b/packages/sdk-typescript/src/__tests__/harness.test.ts
@@ -1,0 +1,191 @@
+/**
+ * Tests for the harness identifier sent to the relaycast server.
+ *
+ * A caller-supplied harness (public `harness` option or internal origin):
+ *   - lands as the `X-Relaycast-Harness` HTTP header
+ *   - lands as the `harness` WS query param
+ *   - is sanitised (lowercased, length-capped) and accepts UA-style tokens
+ *   - is omitted entirely when absent / invalid
+ *   - survives `withApiKey()` rotations
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { sanitizeHarness } from '../origin.js';
+
+const mockFetch = vi.fn();
+vi.stubGlobal('fetch', mockFetch);
+
+function jsonOk(data: unknown) {
+  return Promise.resolve({
+    ok: true,
+    status: 200,
+    json: () => Promise.resolve({ ok: true, data }),
+  });
+}
+
+function harnessHeaderFromLastCall(): string | undefined {
+  const [, init] = mockFetch.mock.calls.at(-1)!;
+  return (init.headers as Record<string, string>)['X-Relaycast-Harness'];
+}
+
+describe('sanitizeHarness', () => {
+  it('keeps a UA-style token, lowercased', () => {
+    expect(sanitizeHarness('Claude-Code/2.3 (model=Opus-4.8; fast)')).toBe(
+      'claude-code/2.3 (model=opus-4.8; fast)',
+    );
+  });
+
+  it('trims surrounding whitespace', () => {
+    expect(sanitizeHarness('  codex  ')).toBe('codex');
+  });
+
+  it('drops empty / whitespace-only input', () => {
+    expect(sanitizeHarness('')).toBeUndefined();
+    expect(sanitizeHarness('   ')).toBeUndefined();
+    expect(sanitizeHarness(undefined)).toBeUndefined();
+  });
+
+  it('drops CRLF / control characters rather than sending garbage', () => {
+    expect(sanitizeHarness('evil\r\nX-Inject: bad')).toBeUndefined();
+    expect(sanitizeHarness('a\tb')).toBeUndefined();
+  });
+
+  it('caps at 120 characters', () => {
+    expect(sanitizeHarness('a'.repeat(200))).toBe('a'.repeat(120));
+  });
+});
+
+describe('harness — HTTP', () => {
+  beforeEach(() => {
+    mockFetch.mockReset();
+  });
+
+  it('stamps X-Relaycast-Harness from the public constructor option', async () => {
+    const { RelayCast } = await import('../relay.js');
+    const relay = new RelayCast({ apiKey: 'rk_live_test', harness: 'human' });
+
+    mockFetch.mockImplementation(() => jsonOk([]));
+    await relay.activity();
+
+    expect(harnessHeaderFromLastCall()).toBe('human');
+  });
+
+  it('stamps a UA-style harness from the internal origin', async () => {
+    const { createInternalRelayCast } = await import('../internal.js');
+    const relay = createInternalRelayCast(
+      { apiKey: 'rk_live_test' },
+      {
+        surface: 'mcp',
+        client: '@agent-relay/relaycast-mcp',
+        version: '6.0.0',
+        harness: 'claude-code/2.3 (model=opus-4.8)',
+      },
+    );
+
+    mockFetch.mockImplementation(() => jsonOk([]));
+    await relay.activity();
+
+    expect(harnessHeaderFromLastCall()).toBe('claude-code/2.3 (model=opus-4.8)');
+  });
+
+  it('omits the header entirely when no harness is supplied', async () => {
+    const { RelayCast } = await import('../relay.js');
+    const relay = new RelayCast({ apiKey: 'rk_live_test' });
+
+    mockFetch.mockImplementation(() => jsonOk([]));
+    await relay.activity();
+
+    const [, init] = mockFetch.mock.calls.at(-1)!;
+    expect('X-Relaycast-Harness' in (init.headers as Record<string, string>)).toBe(false);
+  });
+
+  it('drops an invalid harness (header omitted) rather than sending garbage', async () => {
+    const { RelayCast } = await import('../relay.js');
+    const relay = new RelayCast({ apiKey: 'rk_live_test', harness: 'evil\r\nX-Inject: bad' });
+
+    mockFetch.mockImplementation(() => jsonOk([]));
+    await relay.activity();
+
+    const [, init] = mockFetch.mock.calls.at(-1)!;
+    expect('X-Relaycast-Harness' in (init.headers as Record<string, string>)).toBe(false);
+  });
+
+  it('preserves the harness across withApiKey()', async () => {
+    const { HttpClient } = await import('../client.js');
+    const client = new HttpClient({ apiKey: 'rk_live_test', harness: 'cursor' });
+    const rotated = client.withApiKey('rk_live_other');
+
+    expect(rotated.apiKey).toBe('rk_live_other');
+    expect(rotated.originHarness).toBe('cursor');
+
+    mockFetch.mockImplementation(() => jsonOk([]));
+    await rotated.get('/v1/activity');
+    expect(harnessHeaderFromLastCall()).toBe('cursor');
+  });
+
+  it('lets the internal origin override the public option', async () => {
+    const { createInternalRelayCast } = await import('../internal.js');
+    const relay = createInternalRelayCast(
+      { apiKey: 'rk_live_test', harness: 'human' },
+      { surface: 'mcp', client: '@agent-relay/relaycast-mcp', version: '6.0.0', harness: 'claude-code' },
+    );
+
+    mockFetch.mockImplementation(() => jsonOk([]));
+    await relay.activity();
+
+    expect(harnessHeaderFromLastCall()).toBe('claude-code');
+  });
+});
+
+describe('harness — WS', () => {
+  it('forwards the harness as a `harness` query param on connect', async () => {
+    const constructed: string[] = [];
+    class MockWs {
+      static readonly OPEN = 1;
+      onopen: (() => void) | null = null;
+      onclose: (() => void) | null = null;
+      onmessage: ((event: { data: string }) => void) | null = null;
+      onerror: (() => void) | null = null;
+      send = vi.fn();
+      close = vi.fn();
+      constructor(url: string) {
+        constructed.push(url);
+      }
+    }
+    vi.stubGlobal('WebSocket', MockWs);
+
+    const { WsClient } = await import('../ws.js');
+    const ws = new WsClient({ token: 'at_live_test', harness: 'claude-code/2.3' });
+    ws.connect();
+    ws.disconnect();
+
+    expect(constructed).toHaveLength(1);
+    const url = new URL(constructed[0]!);
+    expect(url.searchParams.get('harness')).toBe('claude-code/2.3');
+  });
+
+  it('omits the harness query param when none is supplied', async () => {
+    const constructed: string[] = [];
+    class MockWs {
+      static readonly OPEN = 1;
+      onopen: (() => void) | null = null;
+      onclose: (() => void) | null = null;
+      onmessage: ((event: { data: string }) => void) | null = null;
+      onerror: (() => void) | null = null;
+      send = vi.fn();
+      close = vi.fn();
+      constructor(url: string) {
+        constructed.push(url);
+      }
+    }
+    vi.stubGlobal('WebSocket', MockWs);
+
+    const { WsClient } = await import('../ws.js');
+    const ws = new WsClient({ token: 'at_live_test' });
+    ws.connect();
+    ws.disconnect();
+
+    const url = new URL(constructed[0]!);
+    expect(url.searchParams.has('harness')).toBe(false);
+  });
+});

--- a/packages/sdk-typescript/src/__tests__/harness.test.ts
+++ b/packages/sdk-typescript/src/__tests__/harness.test.ts
@@ -29,6 +29,13 @@ function harnessHeaderFromLastCall(): string | undefined {
 }
 
 describe('sanitizeHarness', () => {
+  it('is available from the package root', async () => {
+    const sdk = await import('../index.js');
+
+    expect(sdk.HARNESS_HEADER).toBe('X-Relaycast-Harness');
+    expect(sdk.sanitizeHarness('Codex')).toBe('codex');
+  });
+
   it('keeps a UA-style token, lowercased', () => {
     expect(sanitizeHarness('Claude-Code/2.3 (model=Opus-4.8; fast)')).toBe(
       'claude-code/2.3 (model=opus-4.8; fast)',

--- a/packages/sdk-typescript/src/agent.ts
+++ b/packages/sdk-typescript/src/agent.ts
@@ -213,6 +213,7 @@ export class AgentClient {
         surface: this.client.originSurface,
         client: this.client.originClient,
         version: this.client.originVersion,
+        ...(this.client.originHarness ? { harness: this.client.originHarness } : {}),
       },
     ));
     this.ws.on('open', () => {

--- a/packages/sdk-typescript/src/client.ts
+++ b/packages/sdk-typescript/src/client.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
 import { ApiErrorSchema } from '@relaycast/types';
 import { SDK_VERSION } from './version.js';
-import { SDK_ORIGIN, type InternalOrigin } from './origin.js';
+import { SDK_ORIGIN, HARNESS_HEADER, sanitizeHarness, type InternalOrigin } from './origin.js';
 import { camelizeKeys, decamelizeKey, decamelizeKeys, type Camelize } from './casing.js';
 import { RelayError, relayErrorFromApi } from './errors.js';
 
@@ -9,6 +9,13 @@ export interface ClientOptions {
   apiKey: string;
   baseUrl?: string;
   retryPolicy?: RetryPolicyInput;
+  /**
+   * Optional User-Agent-style identifier for the harness driving requests
+   * (e.g. `'claude-code/2.3 (model=opus-4.8)'`, `'codex'`, `'human'`). Sent as
+   * the `X-Relaycast-Harness` header; invalid values are dropped. See
+   * {@link sanitizeHarness}.
+   */
+  harness?: string;
 }
 
 export interface RequestOptions {
@@ -125,6 +132,7 @@ export class HttpClient {
   private _originSurface: string;
   private _originClient: string;
   private _originVersion: string;
+  private _originHarness?: string;
   private _retryPolicy: RetryPolicy;
 
   constructor(options: ClientOptions) {
@@ -134,6 +142,9 @@ export class HttpClient {
     this._originSurface = origin.surface;
     this._originClient = origin.client;
     this._originVersion = origin.version;
+    // A wrapping host's internal origin is authoritative about the harness;
+    // fall back to the public `harness` option for plain consumers.
+    this._originHarness = sanitizeHarness(origin.harness ?? options.harness);
     this._retryPolicy = normalizeRetryPolicy(options.retryPolicy);
   }
 
@@ -157,6 +168,11 @@ export class HttpClient {
     return this._originVersion;
   }
 
+  /** Sanitized harness identifier, or `undefined` when none was supplied. */
+  get originHarness(): string | undefined {
+    return this._originHarness;
+  }
+
   get retryPolicy(): RetryPolicy {
     return this._retryPolicy;
   }
@@ -168,6 +184,7 @@ export class HttpClient {
         surface: this._originSurface,
         client: this._originClient,
         version: this._originVersion,
+        ...(this._originHarness ? { harness: this._originHarness } : {}),
       },
     ));
   }
@@ -192,6 +209,7 @@ export class HttpClient {
       'X-Relaycast-Origin-Surface': this._originSurface,
       'X-Relaycast-Origin-Client': this._originClient,
       'X-Relaycast-Origin-Version': this._originVersion,
+      ...(this._originHarness ? { [HARNESS_HEADER]: this._originHarness } : {}),
       ...(options?.headers || {}),
     };
 

--- a/packages/sdk-typescript/src/index.ts
+++ b/packages/sdk-typescript/src/index.ts
@@ -29,6 +29,7 @@ export { AgentClient } from './agent.js';
 export type { AgentClientOptions } from './agent.js';
 export { HttpClient, RelayError } from './client.js';
 export type { ClientOptions } from './client.js';
+export { HARNESS_HEADER, sanitizeHarness } from './origin.js';
 export {
   relayErrorFromApi,
   normalizeRelayErrorCode,

--- a/packages/sdk-typescript/src/origin.ts
+++ b/packages/sdk-typescript/src/origin.ts
@@ -4,6 +4,13 @@ export interface InternalOrigin {
   surface: string;
   client: string;
   version: string;
+  /**
+   * Optional User-Agent-style identifier for the harness driving the process
+   * (e.g. `claude-code/2.3 (model=opus-4.8; fast)`, `codex`, `human`). Wrapping
+   * hosts set this so server-side telemetry can attribute requests to a harness.
+   * See {@link sanitizeHarness} for the accepted shape.
+   */
+  harness?: string;
 }
 
 export const SDK_ORIGIN: InternalOrigin = Object.freeze({
@@ -11,3 +18,36 @@ export const SDK_ORIGIN: InternalOrigin = Object.freeze({
   client: '@relaycast/sdk',
   version: SDK_VERSION,
 });
+
+/**
+ * HTTP header (and WS query param) used to tell the relaycast server which
+ * harness is driving the request. Mirrors the server-side contract in
+ * `@relaycast/engine`'s `extractHarness`.
+ */
+export const HARNESS_HEADER = 'X-Relaycast-Harness';
+
+/** Upper bound on the harness identifier — generous enough for a UA-style token. */
+const HARNESS_MAX_LENGTH = 120;
+
+/**
+ * Characters permitted in a harness identifier. Deliberately broad enough for a
+ * User-Agent-style token (`name/version (model=...; setting)`) while excluding
+ * CR/LF and other control characters — dropping those is what keeps a malformed
+ * upstream value from smuggling a header injection past the relaycast WAF.
+ */
+const HARNESS_ALLOWED = /^[a-z0-9 ._\-/():=;,+]+$/i;
+
+/**
+ * Normalize a caller-supplied harness identifier to the wire contract.
+ *
+ * Returns a lowercased, length-capped token, or `undefined` when the input is
+ * empty or contains disallowed characters — in which case callers omit the
+ * header entirely rather than sending garbage the server would reject anyway.
+ */
+export function sanitizeHarness(raw: string | undefined): string | undefined {
+  if (!raw) return undefined;
+  const trimmed = raw.trim();
+  if (!trimmed) return undefined;
+  if (!HARNESS_ALLOWED.test(trimmed)) return undefined;
+  return trimmed.slice(0, HARNESS_MAX_LENGTH).toLowerCase();
+}

--- a/packages/sdk-typescript/src/relay.ts
+++ b/packages/sdk-typescript/src/relay.ts
@@ -89,6 +89,13 @@ export interface RelayCastOptions {
   apiKey: string;
   baseUrl?: string;
   retryPolicy?: RetryPolicyInput;
+  /**
+   * Optional User-Agent-style identifier for the harness driving requests
+   * (e.g. `'claude-code/2.3 (model=opus-4.8)'`, `'codex'`, `'human'`). Sent as
+   * the `X-Relaycast-Harness` header on every request so server-side telemetry
+   * can attribute traffic to a harness.
+   */
+  harness?: string;
 }
 
 export interface WorkspaceStreamConfig {

--- a/packages/sdk-typescript/src/ws.ts
+++ b/packages/sdk-typescript/src/ws.ts
@@ -7,7 +7,7 @@ import type {
   WsCloseEvent,
 } from './types.js';
 import { ServerEventSchema } from '@relaycast/types';
-import { SDK_ORIGIN, type InternalOrigin } from './origin.js';
+import { SDK_ORIGIN, sanitizeHarness, type InternalOrigin } from './origin.js';
 import { camelizeKeys, decamelizeKey } from './casing.js';
 
 export type EventHandler<T = WsClientEvent> = (event: T) => void;
@@ -22,6 +22,11 @@ export interface WsClientOptions {
   circuitBreakerMaxAttempts?: number;
   /** Log warnings for dropped/malformed WebSocket messages via console.warn. */
   debug?: boolean;
+  /**
+   * Optional User-Agent-style harness identifier, forwarded as the `harness`
+   * query param (browsers can't set custom WS headers). See {@link sanitizeHarness}.
+   */
+  harness?: string;
 }
 
 const INTERNAL_WS_ORIGIN = Symbol('relaycast.internal.ws-origin');
@@ -70,6 +75,7 @@ export class WsClient {
   private originSurface: string;
   private originClient: string;
   private originVersion: string;
+  private originHarness?: string;
 
   constructor(options: WsClientOptions) {
     const origin = readInternalWsOrigin(options) ?? SDK_ORIGIN;
@@ -93,6 +99,7 @@ export class WsClient {
     this.originSurface = origin.surface;
     this.originClient = origin.client;
     this.originVersion = origin.version;
+    this.originHarness = sanitizeHarness(origin.harness ?? options.harness);
   }
 
   connect(): void {
@@ -105,6 +112,9 @@ export class WsClient {
     wsUrl.searchParams.set(decamelizeKey('originSurface'), this.originSurface);
     wsUrl.searchParams.set(decamelizeKey('originClient'), this.originClient);
     wsUrl.searchParams.set(decamelizeKey('originVersion'), this.originVersion);
+    if (this.originHarness) {
+      wsUrl.searchParams.set('harness', this.originHarness);
+    }
 
     const ws = new WebSocket(wsUrl.toString());
     this.ws = ws;


### PR DESCRIPTION
## **User description**
Supersedes the stale #133 / #132 — solves the same spirit (telemetry should record **which harness is driving each request**) with the design decisions made fresh: a **User-Agent-style** value, settable by **any requestor** (public option) **and** wrapping hosts (internal origin).

## Why

The engine already reads `X-Relaycast-Harness` and stamps `harness` on every server telemetry event and request log. But **nothing ever sent the header**, so every event records `harness: "unknown"`. The gap is a client-side sender — plus widening the contract so the value can carry model/settings UA-style.

## What

**SDK (`@relaycast/sdk`)**
- Public `harness` option on `RelayCastOptions` / `ClientOptions` and `WsClientOptions`, plus the internal `InternalOrigin` plumbing. Any requestor can self-identify (`'human'`, `'codex'`, `'claude-code/2.3 (model=opus-4.8)'`); wrapping hosts (relaycast-mcp) set it via the internal origin, which **takes precedence** over the public option.
- Stamped as the `X-Relaycast-Harness` header on every HTTP request, and forwarded as the `harness` WS query param (browser `WebSocket` can't set custom headers).
- `sanitizeHarness()` drops empty / malformed values (defence-in-depth against CRLF smuggling) and survives `withApiKey()` rotations. Header omitted entirely when unset — **existing consumers unchanged on the wire**.

**Engine (`@relaycast/engine`)**
- `extractHarness` now accepts a UA-style token (cap 40 → 120; charset widened to a UA-safe set that still rejects CR/LF and control chars) and reads the **header OR the `harness` query param** — fixing the WebSocket path, which previously always resolved `'unknown'` because the logger middleware only read the header.

## Wire contract

| | value |
|---|---|
| HTTP header | `X-Relaycast-Harness: claude-code/2.3 (model=opus-4.8; fast)` |
| WS query param | `?harness=claude-code/2.3` |
| Normalisation | trimmed, lowercased, `[a-z0-9 ._-/():=;,+]`, ≤120 chars; invalid → dropped (HTTP) / `unknown` (server) |

## Tests

- **SDK** — 13 tests: `sanitizeHarness` unit, HTTP header presence/absence/sanitisation/truncation/CRLF-rejection, `withApiKey()` survival, origin-over-option precedence, WS query-param presence/absence.
- **Engine** — 9 tests: header read, UA token, query-param fallback, header-over-query precedence, CRLF/disallowed-char rejection, truncation.
- Full monorepo `turbo build test lint` green (25 tasks).

## Scope notes

- No `openapi.yaml` / `README.md` change: the `X-Relaycast-Origin-*` telemetry headers are intentionally undocumented internal plumbing; `X-Relaycast-Harness` follows that precedent.
- Static bootstrap helpers (`RelayCast.createWorkspace`, `RelaycastSetup`) still use `SDK_ORIGIN` (pre-harness context) — left for a follow-up.
- No `@relaycast/types` schema change: `harness` rides as a telemetry *property*, not part of `TelemetryOrigin`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Attribute requests to the harness that sent them**

### What Changed
- Requests now carry a harness identifier from the SDK to the server, so telemetry can show which tool or host drove each request.
- WebSocket connections now send the same harness value in the connection URL, fixing cases where browser-based connections were recorded as `unknown`.
- Harness values are accepted in a User-Agent-style format, kept lowercase, capped at 120 characters, and dropped if they contain empty or unsafe characters.
- Wrapping hosts can set a harness once and keep it through API key changes; their value takes precedence over a public harness setting.

### Impact
`✅ Clearer telemetry attribution`
`✅ Fewer unknown harness events`
`✅ Safer harness reporting`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
