### PR TITLE
feat(sdk-rust): harness identifier for telemetry attribution

### DIFF
--- a/.agentworkforce/trajectories/completed/2026-06/traj_phcp4f04b31o/summary.md
+++ b/.agentworkforce/trajectories/completed/2026-06/traj_phcp4f04b31o/summary.md
@@ -1,0 +1,31 @@
+# Trajectory: Review and fix PR #161
+
+> **Status:** ✅ Completed
+> **Confidence:** 90%
+> **Started:** June 3, 2026 at 09:07 AM
+> **Completed:** June 3, 2026 at 09:07 AM
+
+---
+
+## Summary
+
+Reviewed PR #161, added missing Rust harness parity tests, verified Rust and filtered JS checks locally.
+
+**Approach:** Standard approach
+
+---
+
+## Key Decisions
+
+### Added focused Rust harness regression coverage
+- **Chose:** Added focused Rust harness regression coverage
+- **Reasoning:** The PR claimed harness propagation through HTTP API-key rotation and WebSocket query params; tests now cover both paths.
+
+---
+
+## Chapters
+
+### 1. Work
+*Agent: default*
+
+- Added focused Rust harness regression coverage: Added focused Rust harness regression coverage

--- a/.agentworkforce/trajectories/completed/2026-06/traj_phcp4f04b31o/trajectory.json
+++ b/.agentworkforce/trajectories/completed/2026-06/traj_phcp4f04b31o/trajectory.json
@@ -1,0 +1,53 @@
+{
+  "id": "traj_phcp4f04b31o",
+  "version": 1,
+  "task": {
+    "title": "Review and fix PR #161"
+  },
+  "status": "completed",
+  "startedAt": "2026-06-03T09:07:51.466Z",
+  "completedAt": "2026-06-03T09:07:52.216Z",
+  "agents": [
+    {
+      "name": "default",
+      "role": "lead",
+      "joinedAt": "2026-06-03T09:07:51.817Z"
+    }
+  ],
+  "chapters": [
+    {
+      "id": "chap_rshmdk2c4n6t",
+      "title": "Work",
+      "agentName": "default",
+      "startedAt": "2026-06-03T09:07:51.817Z",
+      "endedAt": "2026-06-03T09:07:52.216Z",
+      "events": [
+        {
+          "ts": 1780477671818,
+          "type": "decision",
+          "content": "Added focused Rust harness regression coverage: Added focused Rust harness regression coverage",
+          "raw": {
+            "question": "Added focused Rust harness regression coverage",
+            "chosen": "Added focused Rust harness regression coverage",
+            "alternatives": [],
+            "reasoning": "The PR claimed harness propagation through HTTP API-key rotation and WebSocket query params; tests now cover both paths."
+          },
+          "significance": "high"
+        }
+      ]
+    }
+  ],
+  "retrospective": {
+    "summary": "Reviewed PR #161, added missing Rust harness parity tests, verified Rust and filtered JS checks locally.",
+    "approach": "Standard approach",
+    "confidence": 0.9
+  },
+  "commits": [],
+  "filesChanged": [],
+  "projectId": "AgentWorkforce/relaycast",
+  "tags": [],
+  "_trace": {
+    "startRef": "d69212d242da769dc9cf7d3f434178de6abc1182",
+    "endRef": "d69212d242da769dc9cf7d3f434178de6abc1182"
+  }
+}

--- a/.trajectories/active/traj_qs5trmxsz90l/trajectory.json
+++ b/.trajectories/active/traj_qs5trmxsz90l/trajectory.json
@@ -6,8 +6,35 @@
   },
   "status": "active",
   "startedAt": "2026-06-03T03:22:36.933Z",
-  "agents": [],
-  "chapters": [],
+  "agents": [
+    {
+      "name": "default",
+      "role": "lead",
+      "joinedAt": "2026-06-03T09:01:33.714Z"
+    }
+  ],
+  "chapters": [
+    {
+      "id": "chap_qolb24dyiy0e",
+      "title": "Work",
+      "agentName": "default",
+      "startedAt": "2026-06-03T09:01:33.714Z",
+      "events": [
+        {
+          "ts": 1780477293714,
+          "type": "decision",
+          "content": "Added focused Rust SDK harness parity tests: Added focused Rust SDK harness parity tests",
+          "raw": {
+            "question": "Added focused Rust SDK harness parity tests",
+            "chosen": "Added focused Rust SDK harness parity tests",
+            "alternatives": [],
+            "reasoning": "PR adds Rust harness support but only covered HTTP constructor stamping; API-key rotation and WebSocket query propagation are explicit contract claims and needed local regression coverage."
+          },
+          "significance": "high"
+        }
+      ]
+    }
+  ],
   "commits": [],
   "filesChanged": [],
   "projectId": "relaycast",

--- a/package-lock.json
+++ b/package-lock.json
@@ -5653,7 +5653,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -5675,7 +5674,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -5697,7 +5695,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -5719,7 +5716,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -5741,7 +5737,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -5763,7 +5758,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -5785,7 +5779,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -5807,7 +5800,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -5829,7 +5821,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -5851,7 +5842,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -5873,7 +5863,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },

--- a/packages/sdk-rust/CHANGELOG.md
+++ b/packages/sdk-rust/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
 ## [Unreleased]
 
 ### Added
+- Added optional `harness` identifier on `RelayCastOptions`/`ClientOptions` and `WsClientOptions` via `with_harness(...)`, plus `sanitize_harness(...)` and the `HARNESS_HEADER` constant. A User-Agent-style identifier for the harness driving requests (e.g. `"claude-code/2.3 (model=opus-4.8)"`, `"codex"`, `"human"`); sent as the `X-Relaycast-Harness` HTTP header and forwarded as the `harness` WS query param so server-side telemetry can attribute traffic. Invalid values (empty, control characters) are dropped; the header/param is omitted entirely when unset, and the value survives `HttpClient::with_api_key(...)`. Brings the Rust SDK to parity with `@relaycast/sdk`.
 - Added raw WebSocket event subscriptions with `WsClient::subscribe_raw_events()` and `RawEventReceiver`.
 - Added SDK-owned raw event normalization helpers:
   - `normalize_inbound_event(...)`

--- a/packages/sdk-rust/README.md
+++ b/packages/sdk-rust/README.md
@@ -306,6 +306,15 @@ let options = RelayCastOptions::new("rk_live_xxx")
 let relay = RelayCast::new(options)?;
 ```
 
+```rust
+// Identify the harness driving requests for server-side telemetry.
+// Sent as the `X-Relaycast-Harness` header; a User-Agent-style string is fine.
+let options = RelayCastOptions::new("rk_live_xxx")
+    .with_harness("claude-code/2.3 (model=opus-4.8)");
+
+let relay = RelayCast::new(options)?;
+```
+
 Self-hosting:
 
 By default, the Rust SDK talks to the hosted engine at `https://gateway.relaycast.dev`.

--- a/packages/sdk-rust/src/agent.rs
+++ b/packages/sdk-rust/src/agent.rs
@@ -89,13 +89,16 @@ impl AgentClient {
             return Ok(());
         }
 
-        let options = WsClientOptions::new(self.client.api_key())
+        let mut options = WsClientOptions::new(self.client.api_key())
             .with_base_url(self.client.base_url())
             .with_origin(
                 self.client.origin_surface(),
                 self.client.origin_client(),
                 self.client.origin_version(),
             );
+        if let Some(harness) = self.client.harness() {
+            options = options.with_harness(harness);
+        }
         let mut ws = WsClient::new(options);
         ws.connect().await?;
         self.ws = Some(ws);

--- a/packages/sdk-rust/src/client.rs
+++ b/packages/sdk-rust/src/client.rs
@@ -5,6 +5,7 @@ use serde::{de::DeserializeOwned, Serialize};
 use std::time::Duration;
 
 use crate::error::{RelayError, Result};
+use crate::harness::{sanitize_harness, HARNESS_HEADER};
 use crate::types::ApiResponse;
 
 const SDK_VERSION: &str = env!("CARGO_PKG_VERSION");
@@ -26,6 +27,10 @@ pub struct ClientOptions {
     pub origin_client: Option<String>,
     /// SDK origin version metadata.
     pub origin_version: Option<String>,
+    /// User-Agent-style identifier for the harness driving requests
+    /// (e.g. `"claude-code/2.3 (model=opus-4.8)"`, `"codex"`, `"human"`). Sent as
+    /// the `X-Relaycast-Harness` header; invalid values are dropped.
+    pub harness: Option<String>,
 }
 
 impl ClientOptions {
@@ -37,6 +42,7 @@ impl ClientOptions {
             origin_surface: None,
             origin_client: None,
             origin_version: None,
+            harness: None,
         }
     }
 
@@ -56,6 +62,12 @@ impl ClientOptions {
         self.origin_surface = Some(origin_surface.into());
         self.origin_client = Some(origin_client.into());
         self.origin_version = Some(origin_version.into());
+        self
+    }
+
+    /// Set the harness identifier sent as the `X-Relaycast-Harness` header.
+    pub fn with_harness(mut self, harness: impl Into<String>) -> Self {
+        self.harness = Some(harness.into());
         self
     }
 }
@@ -88,6 +100,7 @@ pub struct HttpClient {
     origin_surface: String,
     origin_client: String,
     origin_version: String,
+    harness: Option<String>,
 }
 
 impl HttpClient {
@@ -110,6 +123,7 @@ impl HttpClient {
             origin_version: options
                 .origin_version
                 .unwrap_or_else(|| SDK_VERSION.to_string()),
+            harness: sanitize_harness(options.harness),
         })
     }
 
@@ -138,17 +152,24 @@ impl HttpClient {
         &self.origin_version
     }
 
+    /// Get the sanitized harness identifier, if one was supplied.
+    pub fn harness(&self) -> Option<&str> {
+        self.harness.as_deref()
+    }
+
     /// Return a cloned client with a different API key while preserving base URL and origin metadata.
     pub fn with_api_key(&self, api_key: impl Into<String>) -> Result<Self> {
-        HttpClient::new(
-            ClientOptions::new(api_key)
-                .with_base_url(self.base_url.clone())
-                .with_origin(
-                    self.origin_surface.clone(),
-                    self.origin_client.clone(),
-                    self.origin_version.clone(),
-                ),
-        )
+        let mut options = ClientOptions::new(api_key)
+            .with_base_url(self.base_url.clone())
+            .with_origin(
+                self.origin_surface.clone(),
+                self.origin_client.clone(),
+                self.origin_version.clone(),
+            );
+        if let Some(harness) = &self.harness {
+            options = options.with_harness(harness.clone());
+        }
+        HttpClient::new(options)
     }
 
     /// Make a request to the API.
@@ -220,6 +241,10 @@ impl HttpClient {
             .header("X-Relaycast-Origin-Surface", &self.origin_surface)
             .header("X-Relaycast-Origin-Client", &self.origin_client)
             .header("X-Relaycast-Origin-Version", &self.origin_version);
+
+        if let Some(ref harness) = self.harness {
+            request = request.header(HARNESS_HEADER, harness);
+        }
 
         if let Some(ref key) = options.idempotency_key {
             request = request.header("Idempotency-Key", key);

--- a/packages/sdk-rust/src/harness.rs
+++ b/packages/sdk-rust/src/harness.rs
@@ -1,0 +1,87 @@
+//! Harness identifier handling.
+//!
+//! A harness is a User-Agent-style identifier for the process driving requests
+//! (e.g. `claude-code/2.3 (model=opus-4.8; fast)`, `codex`, `human`). When set,
+//! it is sent as the `X-Relaycast-Harness` HTTP header and the `harness` WS query
+//! param so server-side telemetry can attribute traffic. Mirrors the contract in
+//! `@relaycast/sdk` and `@relaycast/engine`.
+
+/// HTTP header used to tell the relaycast server which harness drives a request.
+pub const HARNESS_HEADER: &str = "X-Relaycast-Harness";
+
+/// Upper bound on the harness value — generous enough for a UA-style token.
+const HARNESS_MAX_LENGTH: usize = 120;
+
+/// Characters permitted in a harness identifier. Deliberately broad enough for a
+/// User-Agent-style token (`name/version (model=...; setting)`) while excluding
+/// CR/LF and other control characters.
+fn is_allowed(c: char) -> bool {
+    c.is_ascii_alphanumeric()
+        || matches!(
+            c,
+            ' ' | '.' | '_' | '-' | '/' | '(' | ')' | ':' | '=' | ';' | ',' | '+'
+        )
+}
+
+/// Normalize a caller-supplied harness identifier to the wire contract.
+///
+/// Returns a trimmed, lowercased, length-capped token, or `None` when the input
+/// is empty or contains disallowed characters — in which case callers omit the
+/// header/param entirely rather than sending garbage the server would reject.
+pub fn sanitize_harness(raw: Option<impl AsRef<str>>) -> Option<String> {
+    let raw = raw?;
+    let trimmed = raw.as_ref().trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+    if !trimmed.chars().all(is_allowed) {
+        return None;
+    }
+    Some(
+        trimmed
+            .chars()
+            .take(HARNESS_MAX_LENGTH)
+            .collect::<String>()
+            .to_lowercase(),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn keeps_a_ua_style_token_lowercased() {
+        assert_eq!(
+            sanitize_harness(Some("Claude-Code/2.3 (model=Opus-4.8; fast)")),
+            Some("claude-code/2.3 (model=opus-4.8; fast)".to_string())
+        );
+    }
+
+    #[test]
+    fn trims_surrounding_whitespace() {
+        assert_eq!(
+            sanitize_harness(Some("  codex  ")),
+            Some("codex".to_string())
+        );
+    }
+
+    #[test]
+    fn drops_empty_and_none() {
+        assert_eq!(sanitize_harness(Some("")), None);
+        assert_eq!(sanitize_harness(Some("   ")), None);
+        assert_eq!(sanitize_harness(None::<&str>), None);
+    }
+
+    #[test]
+    fn drops_crlf_and_control_characters() {
+        assert_eq!(sanitize_harness(Some("evil\r\nX-Inject: bad")), None);
+        assert_eq!(sanitize_harness(Some("a\tb")), None);
+    }
+
+    #[test]
+    fn caps_at_120_characters() {
+        let long = "a".repeat(200);
+        assert_eq!(sanitize_harness(Some(&long)), Some("a".repeat(120)));
+    }
+}

--- a/packages/sdk-rust/src/lib.rs
+++ b/packages/sdk-rust/src/lib.rs
@@ -118,6 +118,7 @@ pub mod credentials;
 pub mod dm_participants;
 pub mod error;
 pub mod events;
+pub mod harness;
 pub mod identity;
 pub mod registration;
 pub mod relay;
@@ -137,6 +138,7 @@ pub use events::{
     NormalizedCommandInvocation, NormalizedEventKind, NormalizedInboundEvent, RelayPriority,
     SenderKind,
 };
+pub use harness::{sanitize_harness, HARNESS_HEADER};
 pub use identity::{agent_name_eq, is_self_name};
 pub use registration::{
     format_registration_error, registration_is_retryable, registration_retry_after_secs,

--- a/packages/sdk-rust/src/lib.rs
+++ b/packages/sdk-rust/src/lib.rs
@@ -154,8 +154,8 @@ pub use ws::{
 pub use types::{
     // Actions & session events
     ActionCompletedEvent,
-    ActionDeniedEvent,
     ActionDefinition,
+    ActionDeniedEvent,
     ActionFailedEvent,
     ActionInvocation,
     ActionInvocationStatus,

--- a/packages/sdk-rust/src/relay.rs
+++ b/packages/sdk-rust/src/relay.rs
@@ -24,6 +24,11 @@ pub struct RelayCastOptions {
     /// To self-host, run the engine (`relaycast-engine`, default port 8787) and
     /// set this to e.g. `http://localhost:8787`.
     pub base_url: Option<String>,
+    /// User-Agent-style identifier for the harness driving requests
+    /// (e.g. `"claude-code/2.3 (model=opus-4.8)"`, `"codex"`, `"human"`). Sent as
+    /// the `X-Relaycast-Harness` header so server-side telemetry can attribute
+    /// traffic. Invalid values are dropped.
+    pub harness: Option<String>,
 }
 
 impl RelayCastOptions {
@@ -32,12 +37,19 @@ impl RelayCastOptions {
         Self {
             api_key: api_key.into(),
             base_url: None,
+            harness: None,
         }
     }
 
     /// Set a custom base URL.
     pub fn with_base_url(mut self, base_url: impl Into<String>) -> Self {
         self.base_url = Some(base_url.into());
+        self
+    }
+
+    /// Set the harness identifier sent as the `X-Relaycast-Harness` header.
+    pub fn with_harness(mut self, harness: impl Into<String>) -> Self {
+        self.harness = Some(harness.into());
         self
     }
 }
@@ -63,6 +75,9 @@ impl RelayCast {
 
         let mut client_options = ClientOptions::new(options.api_key);
         client_options = client_options.with_base_url(base_url);
+        if let Some(harness) = options.harness {
+            client_options = client_options.with_harness(harness);
+        }
         let client = HttpClient::new(client_options)?;
         Ok(Self { client })
     }

--- a/packages/sdk-rust/src/ws.rs
+++ b/packages/sdk-rust/src/ws.rs
@@ -10,6 +10,7 @@ use tracing::{debug, warn};
 use url::Url;
 
 use crate::error::{RelayError, Result};
+use crate::harness::sanitize_harness;
 use crate::types::WsEvent;
 
 const DEFAULT_BASE_URL: &str = "https://gateway.relaycast.dev";
@@ -35,6 +36,9 @@ pub struct WsClientOptions {
     pub origin_client: Option<String>,
     /// SDK origin version metadata.
     pub origin_version: Option<String>,
+    /// User-Agent-style harness identifier, forwarded as the `harness` query
+    /// param (browsers can't set custom WS headers). Invalid values are dropped.
+    pub harness: Option<String>,
     /// Maximum reconnect attempts before giving up (default: 10).
     pub max_reconnect_attempts: Option<u32>,
     /// Maximum reconnect delay in milliseconds (default: 30000).
@@ -51,6 +55,7 @@ impl WsClientOptions {
             origin_surface: None,
             origin_client: None,
             origin_version: None,
+            harness: None,
             max_reconnect_attempts: None,
             max_reconnect_delay_ms: None,
         }
@@ -78,6 +83,12 @@ impl WsClientOptions {
         self.origin_surface = Some(origin_surface.into());
         self.origin_client = Some(origin_client.into());
         self.origin_version = Some(origin_version.into());
+        self
+    }
+
+    /// Set the harness identifier forwarded as the `harness` query param.
+    pub fn with_harness(mut self, harness: impl Into<String>) -> Self {
+        self.harness = Some(harness.into());
         self
     }
 
@@ -118,6 +129,7 @@ pub struct WsClient {
     origin_surface: String,
     origin_client: String,
     origin_version: String,
+    harness: Option<String>,
     max_reconnect_attempts: u32,
     max_reconnect_delay_ms: u64,
     event_tx: broadcast::Sender<WsEvent>,
@@ -159,6 +171,7 @@ impl WsClient {
             origin_version: options
                 .origin_version
                 .unwrap_or_else(|| SDK_VERSION.to_string()),
+            harness: sanitize_harness(options.harness),
             max_reconnect_attempts: options
                 .max_reconnect_attempts
                 .unwrap_or(DEFAULT_MAX_RECONNECT_ATTEMPTS),
@@ -212,6 +225,9 @@ impl WsClient {
             query.append_pair("origin_surface", &self.origin_surface);
             query.append_pair("origin_client", &self.origin_client);
             query.append_pair("origin_version", &self.origin_version);
+            if let Some(ref harness) = self.harness {
+                query.append_pair("harness", harness);
+            }
         }
 
         let (ws_stream, _) = connect_async(url.as_str()).await?;
@@ -229,6 +245,7 @@ impl WsClient {
         let origin_surface = self.origin_surface.clone();
         let origin_client = self.origin_client.clone();
         let origin_version = self.origin_version.clone();
+        let harness = self.harness.clone();
         let max_reconnect_attempts = self.max_reconnect_attempts;
         let max_reconnect_delay_ms = self.max_reconnect_delay_ms;
 
@@ -260,6 +277,9 @@ impl WsClient {
                         query.append_pair("origin_surface", &origin_surface);
                         query.append_pair("origin_client", &origin_client);
                         query.append_pair("origin_version", &origin_version);
+                        if let Some(ref harness) = harness {
+                            query.append_pair("harness", harness);
+                        }
                     }
 
                     match connect_async(reconnect_url.as_str()).await {

--- a/packages/sdk-rust/tests/parity.rs
+++ b/packages/sdk-rust/tests/parity.rs
@@ -515,6 +515,35 @@ async fn create_workspace_sends_origin_headers() {
 }
 
 #[tokio::test]
+async fn client_sends_sanitized_harness_header() {
+    let server = MockServer::start().await;
+
+    // The harness is supplied mixed-case; it should arrive lowercased.
+    Mock::given(method("GET"))
+        .and(path("/v1/channels"))
+        .and(header(
+            "x-relaycast-harness",
+            "claude-code/2.3 (model=opus-4.8)",
+        ))
+        .respond_with(ok(json!([])))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let relay = RelayCast::new(
+        RelayCastOptions::new("rk_live_test")
+            .with_base_url(server.uri())
+            .with_harness("Claude-Code/2.3 (model=Opus-4.8)"),
+    )
+    .expect("failed to create RelayCast client");
+
+    relay
+        .list_channels(false)
+        .await
+        .expect("list_channels failed");
+}
+
+#[tokio::test]
 async fn agent_heartbeat_uses_presence_endpoint() {
     let server = MockServer::start().await;
 

--- a/packages/sdk-rust/tests/parity.rs
+++ b/packages/sdk-rust/tests/parity.rs
@@ -1,12 +1,17 @@
 use relaycast::{
-    ActionInvocationStatus, AgentClient, CompleteInvocationRequest, CreateAgentRequest,
-    CreateChannelRequest, CreateSubscriptionRequest, CreateWebhookRequest, DeferDeliveryRequest,
-    DeliveryStatus, DmConversationSummary, EmitSessionEventRequest, FailDeliveryRequest,
-    ListDeliveriesOptions, ListSessionEventsQuery, MessageInjectionMode, MessageListQuery,
-    RegisterActionRequest, RelayCast, RelayCastOptions, ReleaseAgentRequest, SpawnAgentRequest,
-    WebhookTriggerRequest, WsEvent,
+    ActionInvocationStatus, AgentClient, ClientOptions, CompleteInvocationRequest,
+    CreateAgentRequest, CreateChannelRequest, CreateSubscriptionRequest, CreateWebhookRequest,
+    DeferDeliveryRequest, DeliveryStatus, DmConversationSummary, EmitSessionEventRequest,
+    FailDeliveryRequest, HttpClient, ListDeliveriesOptions, ListSessionEventsQuery,
+    MessageInjectionMode, MessageListQuery, RegisterActionRequest, RelayCast, RelayCastOptions,
+    ReleaseAgentRequest, SpawnAgentRequest, WebhookTriggerRequest, WsClient, WsClientOptions,
+    WsEvent,
 };
 use serde_json::json;
+use std::net::TcpListener;
+use std::sync::mpsc;
+use std::time::Duration;
+use tokio_tungstenite::tungstenite::handshake::server::{Request, Response};
 use wiremock::matchers::{body_json, header, method, path, query_param, query_param_is_missing};
 use wiremock::{Mock, MockServer, ResponseTemplate};
 
@@ -541,6 +546,82 @@ async fn client_sends_sanitized_harness_header() {
         .list_channels(false)
         .await
         .expect("list_channels failed");
+}
+
+#[tokio::test]
+async fn client_preserves_harness_across_api_key_rotation() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/v1/channels"))
+        .and(header("authorization", "Bearer at_live_rotated"))
+        .and(header("x-relaycast-harness", "cursor"))
+        .respond_with(ok(json!([])))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let client = HttpClient::new(
+        ClientOptions::new("rk_live_test")
+            .with_base_url(server.uri())
+            .with_harness("Cursor"),
+    )
+    .expect("failed to create HTTP client");
+    let rotated = client
+        .with_api_key("at_live_rotated")
+        .expect("failed to rotate API key");
+
+    rotated
+        .get::<Vec<serde_json::Value>>("/v1/channels", None, None)
+        .await
+        .expect("list channels failed");
+}
+
+#[tokio::test]
+async fn ws_client_forwards_sanitized_harness_query_param() {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("failed to bind test WS server");
+    let addr = listener.local_addr().expect("failed to read listener addr");
+    let (uri_tx, uri_rx) = mpsc::channel();
+
+    let server = std::thread::spawn(move || {
+        let (stream, _) = listener.accept().expect("failed to accept WS connection");
+        let callback = |request: &Request, response: Response| {
+            uri_tx
+                .send(request.uri().to_string())
+                .expect("failed to send captured request URI");
+            Ok(response)
+        };
+        let _websocket = tokio_tungstenite::tungstenite::accept_hdr(stream, callback)
+            .expect("failed to accept WS handshake");
+    });
+
+    let mut ws = WsClient::new(
+        WsClientOptions::new("at_live_test")
+            .with_base_url(format!("http://{addr}"))
+            .with_harness("Claude-Code/2.3"),
+    );
+    ws.connect().await.expect("WS connect failed");
+
+    let uri = uri_rx
+        .recv_timeout(Duration::from_secs(2))
+        .expect("test WS server did not capture a request URI");
+    let url = url::Url::parse(&format!("http://localhost{uri}")).expect("invalid captured URI");
+    assert_eq!(url.path(), "/v1/ws");
+    assert_eq!(
+        url.query_pairs()
+            .find(|(key, _)| key == "token")
+            .map(|(_, value)| value.into_owned()),
+        Some("at_live_test".to_string())
+    );
+    assert_eq!(
+        url.query_pairs()
+            .find(|(key, _)| key == "harness")
+            .map(|(_, value)| value.into_owned()),
+        Some("claude-code/2.3".to_string())
+    );
+
+    ws.disconnect().await;
+    server.join().expect("test WS server panicked");
 }
 
 #[tokio::test]


### PR DESCRIPTION
## **User description**
Brings the **Rust SDK** to parity with the TypeScript SDK's harness support (companion to #160). The relaycast engine already reads `X-Relaycast-Harness` and stamps `harness` on every telemetry event — but the Rust SDK had no way to send it, so its traffic always recorded `harness: "unknown"`.

## What

- **Public `harness`** on `RelayCastOptions` / `ClientOptions` and `WsClientOptions` via `with_harness(...)`. A User-Agent-style identifier (`"human"`, `"codex"`, `"claude-code/2.3 (model=opus-4.8)"`):
  - stamped as the `X-Relaycast-Harness` header on every HTTP request,
  - forwarded as the `harness` WS query param on **both** the initial connect and reconnects (browser `WebSocket` can't set custom headers).
- New `harness` module: `sanitize_harness()` + `HARNESS_HEADER`, mirroring the TS/engine contract — trim, lowercase, UA-safe charset, cap 120, drop on empty/invalid/CRLF.
- Survives `HttpClient::with_api_key(...)`; `AgentClient::connect()` propagates it to the underlying `WsClient`.
- Header/param **omitted entirely when unset** — existing consumers are unchanged on the wire.

## Wire contract (matches `@relaycast/sdk` + engine)

| | value |
|---|---|
| HTTP header | `X-Relaycast-Harness: claude-code/2.3 (model=opus-4.8)` |
| WS query param | `?harness=claude-code/2.3` |
| Normalisation | trimmed, lowercased, `[a-z0-9 ._-/():=;,+]`, ≤120; invalid → dropped |

## Tests

- 5 `sanitize_harness` unit tests (UA token lowercased, trim, empty/None dropped, CRLF/control dropped, 120-char cap).
- A wiremock parity test asserting a mixed-case UA harness arrives lowercased in the `X-Relaycast-Harness` header end-to-end.
- `cargo test` (34 lib + 30 parity + 5 doctests), `cargo clippy --all-targets`, and `cargo fmt --check` (on changed files) all green.

## Notes

- Static `RelayCast::create_workspace` still uses default origin (pre-harness bootstrap context), mirroring the TS decision in #160.
- Two pre-existing `cargo fmt` violations remain in `examples/basic.rs` and the `lib.rs` types re-export block — untouched here to avoid unrelated churn.
- Follow-up filed for the **Python SDK**, which has the same gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
Add a harness identifier for request and telemetry attribution

### What Changed
- Requests can now include a user-facing harness name such as `codex`, `human`, or `claude-code/2.3 (model=opus-4.8)` for telemetry attribution
- The harness is sent on HTTP requests as `X-Relaycast-Harness` and on WebSocket connections as the `harness` query param, including reconnects
- Empty, invalid, or control-character values are dropped, and the harness is omitted entirely when not set
- The harness value is preserved when reusing a client with a new API key

### Impact
`✅ Clearer telemetry attribution`
`✅ Fewer unknown-client events`
`✅ Consistent harness tracking across HTTP and WebSocket requests`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
