### PR TITLE
SDK: expose workspace realtime stream

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,19 @@ me.subscribe(['general', '@self'], (event) => {
 
 await me.send('#general', 'Hello from Relaycast');
 
+// Workspace-key clients can observe the workspace stream directly.
+await relay.workspace.stream.set(true);
+relay.connect();
+relay.on.messageCreated((event) => {
+  console.log(`[workspace] ${event.channel}: ${event.message.text}`);
+});
+relay.on.actionCompleted((event) => {
+  console.log(`[workspace] ${event.actionName} ${event.status}`);
+});
+relay.on.any((event) => {
+  console.log(`[workspace] ${event.type}`);
+});
+
 // Convenience identity helpers
 const { token: systemToken } = await relay.system({ name: 'System' });
 ```

--- a/packages/sdk-typescript/CHANGELOG.md
+++ b/packages/sdk-typescript/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 ### Added
 - Optional `harness` field on `RelayCastOptions`/`ClientOptions` and `WsClientOptions` (plus the internal `InternalOrigin` plumbing). A User-Agent-style identifier for the harness driving requests (e.g. `'claude-code/2.3 (model=opus-4.8)'`, `'codex'`, `'human'`); stamped as the `X-Relaycast-Harness` HTTP header and forwarded as the `harness` WS query param so server-side telemetry can attribute traffic. When a wrapping host supplies one via the internal origin it takes precedence over the public option. Invalid values (empty, control characters) are dropped rather than sent; the header is omitted entirely when no harness is set, so existing consumers are unchanged on the wire.
 - `sanitizeHarness` and `HARNESS_HEADER` exported from the SDK root — lowercases, restricts to a UA-safe character set, caps at 120 chars.
+- Workspace-key realtime on `RelayCast`: `connect()`, `disconnect()`, and typed `on.*` handlers now open `/v1/ws` with the workspace key and expose workspace stream events.
 
 ### Breaking
 - Removed snake_case input aliases from the SDK surface; camelCase is now the only supported input style.

--- a/packages/sdk-typescript/src/__tests__/relay.test.ts
+++ b/packages/sdk-typescript/src/__tests__/relay.test.ts
@@ -73,6 +73,10 @@ describe('RelayCast', () => {
       const relay = new RelayCast({
         apiKey: 'rk_live_test123',
         baseUrl: 'http://localhost:8080',
+        ws: {
+          token: 'rk_live_wrong',
+          baseUrl: 'https://wrong.example',
+        } as any,
       });
 
       relay.connect();
@@ -90,9 +94,11 @@ describe('RelayCast', () => {
       relay.disconnect();
     });
 
-    it('connect() is idempotent and disconnect() allows a fresh workspace socket', async () => {
+    it('connect() is idempotent and disconnect() allows a fresh workspace socket with existing handlers', async () => {
       const { RelayCast } = await import('../relay.js');
       const relay = new RelayCast({ apiKey: 'rk_live_test123' });
+      const handler = vi.fn();
+      relay.on.messageCreated(handler);
 
       relay.connect();
       relay.connect();
@@ -104,6 +110,14 @@ describe('RelayCast', () => {
 
       relay.connect();
       expect(MockWebSocket.instances).toHaveLength(2);
+      const ws2 = MockWebSocket.instances[1]!;
+      ws2.simulateOpen();
+      ws2.simulateMessage({
+        type: 'message.created',
+        channel: 'general',
+        message: { id: 'm_1', agent_name: 'Bot', text: 'hi', attachments: [] },
+      });
+      expect(handler).toHaveBeenCalledTimes(1);
 
       relay.disconnect();
     });
@@ -112,12 +126,12 @@ describe('RelayCast', () => {
       vi.useFakeTimers();
       const { RelayCast } = await import('../relay.js');
       const relay = new RelayCast({ apiKey: 'rk_live_test123' });
+      const handler = vi.fn();
+      relay.on.messageCreated(handler);
+
       relay.connect();
       const ws = MockWebSocket.instances[0]!;
       ws.simulateOpen();
-
-      const handler = vi.fn();
-      relay.on.messageCreated(handler);
 
       ws.simulateMessage({
         type: 'message.created',
@@ -133,6 +147,29 @@ describe('RelayCast', () => {
           message: expect.objectContaining({ agentName: 'Bot' }),
         }),
       );
+
+      relay.disconnect();
+    });
+
+    it('connect() restarts the workspace stream after permanent disconnection', async () => {
+      vi.useFakeTimers();
+      const { RelayCast } = await import('../relay.js');
+      const relay = new RelayCast({
+        apiKey: 'rk_live_test123',
+        ws: { maxReconnectAttempts: 0, reconnectJitter: false },
+      });
+      const permanentlyDisconnected = vi.fn();
+      relay.on.permanentlyDisconnected(permanentlyDisconnected);
+
+      relay.connect();
+      const ws1 = MockWebSocket.instances[0]!;
+      ws1.simulateOpen();
+      ws1.simulateClose();
+
+      expect(permanentlyDisconnected).toHaveBeenCalledWith(0);
+
+      relay.connect();
+      expect(MockWebSocket.instances).toHaveLength(2);
 
       relay.disconnect();
     });
@@ -210,13 +247,24 @@ describe('RelayCast', () => {
       relay.disconnect();
     });
 
-    it('on.messageCreated throws if called before connect()', async () => {
+    it('allows registering event handlers before connect()', async () => {
       const { RelayCast } = await import('../relay.js');
       const relay = new RelayCast({ apiKey: 'rk_live_test123' });
+      const handler = vi.fn();
 
-      expect(() => relay.on.messageCreated(vi.fn())).toThrow(
-        'WebSocket not connected. Call connect() first.',
-      );
+      expect(() => relay.on.messageCreated(handler)).not.toThrow();
+
+      relay.connect();
+      const ws = MockWebSocket.instances[0]!;
+      ws.simulateOpen();
+      ws.simulateMessage({
+        type: 'message.created',
+        channel: 'general',
+        message: { id: 'm_1', agent_name: 'Bot', text: 'hi', attachments: [] },
+      });
+      expect(handler).toHaveBeenCalledTimes(1);
+
+      relay.disconnect();
     });
   });
 

--- a/packages/sdk-typescript/src/__tests__/relay.test.ts
+++ b/packages/sdk-typescript/src/__tests__/relay.test.ts
@@ -1,8 +1,46 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 // Mock global fetch once for this file.
 const mockFetch = vi.fn();
 vi.stubGlobal('fetch', mockFetch);
+
+class MockWebSocket {
+  static readonly OPEN = 1;
+  static readonly CLOSED = 3;
+  static instances: MockWebSocket[] = [];
+
+  url: string;
+  readyState = MockWebSocket.OPEN;
+  onopen: (() => void) | null = null;
+  onclose: (() => void) | null = null;
+  onmessage: ((event: { data: string }) => void) | null = null;
+  onerror: (() => void) | null = null;
+  send = vi.fn();
+  close = vi.fn(() => {
+    this.readyState = MockWebSocket.CLOSED;
+  });
+
+  constructor(url: string) {
+    this.url = url;
+    MockWebSocket.instances.push(this);
+  }
+
+  simulateOpen(): void {
+    this.readyState = MockWebSocket.OPEN;
+    this.onopen?.();
+  }
+
+  simulateMessage(data: unknown): void {
+    this.onmessage?.({ data: JSON.stringify(data) });
+  }
+
+  simulateClose(): void {
+    this.readyState = MockWebSocket.CLOSED;
+    this.onclose?.();
+  }
+}
+
+vi.stubGlobal('WebSocket', MockWebSocket);
 
 function mockResponse(data: unknown, apiOk = true, status = 200) {
   return Promise.resolve({
@@ -16,12 +54,170 @@ function mockResponse(data: unknown, apiOk = true, status = 200) {
 describe('RelayCast', () => {
   beforeEach(() => {
     mockFetch.mockReset();
+    MockWebSocket.instances = [];
+    vi.useRealTimers();
+  });
+
+  afterEach(() => {
     vi.useRealTimers();
   });
 
   it('requires apiKey', async () => {
     const { RelayCast } = await import('../relay.js');
     expect(() => new RelayCast({} as any)).toThrow('RelayCast apiKey is required');
+  });
+
+  describe('workspace realtime', () => {
+    it('connect() opens /v1/ws with the workspace key and SDK origin metadata', async () => {
+      const { RelayCast } = await import('../relay.js');
+      const relay = new RelayCast({
+        apiKey: 'rk_live_test123',
+        baseUrl: 'http://localhost:8080',
+      });
+
+      relay.connect();
+
+      expect(MockWebSocket.instances).toHaveLength(1);
+      const url = new URL(MockWebSocket.instances[0]!.url);
+      expect(url.origin).toBe('ws://localhost:8080');
+      expect(url.pathname).toBe('/v1/ws');
+      expect(url.searchParams.get('token')).toBe('rk_live_test123');
+      expect(url.searchParams.get('origin_surface')).toBe('sdk');
+      expect(url.searchParams.get('origin_client')).toBe('@relaycast/sdk');
+      expect(url.searchParams.get('origin_version')).toBeDefined();
+      expect(mockFetch).not.toHaveBeenCalled();
+
+      relay.disconnect();
+    });
+
+    it('connect() is idempotent and disconnect() allows a fresh workspace socket', async () => {
+      const { RelayCast } = await import('../relay.js');
+      const relay = new RelayCast({ apiKey: 'rk_live_test123' });
+
+      relay.connect();
+      relay.connect();
+      expect(MockWebSocket.instances).toHaveLength(1);
+
+      const ws1 = MockWebSocket.instances[0]!;
+      relay.disconnect();
+      expect(ws1.close).toHaveBeenCalled();
+
+      relay.connect();
+      expect(MockWebSocket.instances).toHaveLength(2);
+
+      relay.disconnect();
+    });
+
+    it('on.messageCreated fires with camelized workspace stream events', async () => {
+      vi.useFakeTimers();
+      const { RelayCast } = await import('../relay.js');
+      const relay = new RelayCast({ apiKey: 'rk_live_test123' });
+      relay.connect();
+      const ws = MockWebSocket.instances[0]!;
+      ws.simulateOpen();
+
+      const handler = vi.fn();
+      relay.on.messageCreated(handler);
+
+      ws.simulateMessage({
+        type: 'message.created',
+        channel: 'general',
+        message: { id: 'm_1', agent_name: 'Bot', text: 'hi', attachments: [] },
+      });
+
+      expect(handler).toHaveBeenCalledTimes(1);
+      expect(handler).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: 'message.created',
+          channel: 'general',
+          message: expect.objectContaining({ agentName: 'Bot' }),
+        }),
+      );
+
+      relay.disconnect();
+    });
+
+    it('on.actionCompleted fires with camelized action completion events', async () => {
+      vi.useFakeTimers();
+      const { RelayCast } = await import('../relay.js');
+      const relay = new RelayCast({ apiKey: 'rk_live_test123' });
+      relay.connect();
+      const ws = MockWebSocket.instances[0]!;
+      ws.simulateOpen();
+
+      const handler = vi.fn();
+      relay.on.actionCompleted(handler);
+
+      ws.simulateMessage({
+        type: 'action.completed',
+        invocation_id: 'inv_1',
+        action_name: 'deploy',
+        status: 'completed',
+        output: { ok: true },
+        error: null,
+      });
+
+      expect(handler).toHaveBeenCalledTimes(1);
+      expect(handler).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: 'action.completed',
+          invocationId: 'inv_1',
+          actionName: 'deploy',
+        }),
+      );
+
+      relay.disconnect();
+    });
+
+    it('on.any returns an unsubscribe function for workspace events', async () => {
+      vi.useFakeTimers();
+      const { RelayCast } = await import('../relay.js');
+      const relay = new RelayCast({ apiKey: 'rk_live_test123' });
+      relay.connect();
+      const ws = MockWebSocket.instances[0]!;
+      ws.simulateOpen();
+
+      const handler = vi.fn();
+      const unsubscribe = relay.on.any(handler);
+
+      ws.simulateMessage({ type: 'pong' });
+      expect(handler).toHaveBeenCalledTimes(1);
+
+      unsubscribe();
+      ws.simulateMessage({ type: 'pong' });
+      expect(handler).toHaveBeenCalledTimes(1);
+
+      relay.disconnect();
+    });
+
+    it('on.reconnecting exposes the reconnect attempt number', async () => {
+      vi.useFakeTimers();
+      const { RelayCast } = await import('../relay.js');
+      const relay = new RelayCast({
+        apiKey: 'rk_live_test123',
+        ws: { reconnectJitter: false },
+      });
+      relay.connect();
+      const ws = MockWebSocket.instances[0]!;
+      ws.simulateOpen();
+
+      const handler = vi.fn();
+      relay.on.reconnecting(handler);
+
+      ws.simulateClose();
+      expect(handler).toHaveBeenCalledWith(1);
+
+      relay.disconnect();
+    });
+
+    it('on.messageCreated throws if called before connect()', async () => {
+      const { RelayCast } = await import('../relay.js');
+      const relay = new RelayCast({ apiKey: 'rk_live_test123' });
+
+      expect(() => relay.on.messageCreated(vi.fn())).toThrow(
+        'WebSocket not connected. Call connect() first.',
+      );
+    });
   });
 
   describe('workspace', () => {

--- a/packages/sdk-typescript/src/relay.ts
+++ b/packages/sdk-typescript/src/relay.ts
@@ -25,9 +25,14 @@ import type {
   EventSubscription,
   ActivityItem,
   DmMessage,
+  DmReceivedEvent,
   WorkspaceDmConversation,
   TokenRotateResponse,
   MessageListQuery,
+  MessageCreatedEvent,
+  MessageReadEvent,
+  MessageReactedEvent,
+  MessageUpdatedEvent,
   MessageWithMeta,
   ReactionGroup,
   SpawnAgentRequest,
@@ -68,10 +73,36 @@ import type {
   ConsoleAgentStatsQuery,
   ConsoleWindowQuery,
   ConsoleCostStats,
+  ThreadReplyEvent,
+  WsClientEvent,
+  AgentStatusActiveEvent,
+  AgentStatusChangedEvent,
+  AgentStatusOfflineEvent,
+  ChannelCreatedEvent,
+  ChannelUpdatedEvent,
+  ChannelArchivedEvent,
+  MemberJoinedEvent,
+  MemberLeftEvent,
+  ChannelMutedEvent,
+  ChannelUnmutedEvent,
+  FileUploadedEvent,
+  WebhookReceivedEvent,
+  ActionInvokedEvent,
+  ActionCompletedEvent,
+  ActionDeniedEvent,
+  ActionFailedEvent,
+  DeliveryAcceptedEvent,
+  DeliveryDeliveredEvent,
+  DeliveryDeferredEvent,
+  DeliveryFailedEvent,
+  GroupDmReceivedEvent,
+  WsReconnectingEvent,
+  WsPermanentlyDisconnectedEvent,
 } from './types.js';
 import { ApiResponseSchema, CreateWorkspaceResponseSchema, WorkspaceLookupSchema } from '@relaycast/types';
 import { AgentClient, type AgentClientOptions } from './agent.js';
 import { HttpClient, type RetryPolicyInput } from './client.js';
+import { WsClient, type WsClientOptions, withInternalWsOrigin } from './ws.js';
 import { RelayError, relayErrorFromApi } from './errors.js';
 import {
   appendLegacySuffix,
@@ -89,6 +120,7 @@ export interface RelayCastOptions {
   apiKey: string;
   baseUrl?: string;
   retryPolicy?: RetryPolicyInput;
+  ws?: Omit<WsClientOptions, 'token' | 'baseUrl'>;
   /**
    * Optional User-Agent-style identifier for the harness driving requests
    * (e.g. `'claude-code/2.3 (model=opus-4.8)'`, `'codex'`, `'human'`). Sent as
@@ -134,6 +166,8 @@ function resolveWorkspaceBootstrapOptions(
 
 export class RelayCast {
   private client: HttpClient;
+  private ws: WsClient | null = null;
+  private wsOptions: Omit<WsClientOptions, 'token' | 'baseUrl'>;
   private identityHint: { agentId: string; name: string } | null = null;
   private workspaceIdHint: string | null = null;
 
@@ -145,7 +179,91 @@ export class RelayCast {
     // Preserve hidden internal-origin metadata on options when created via
     // createInternalRelayCast() so downstream requests use the correct origin headers.
     this.client = new HttpClient(options);
+    this.wsOptions = options.ws ?? {};
   }
+
+  connect(): void {
+    if (this.ws) return;
+    this.ws = new WsClient(withInternalWsOrigin(
+      {
+        token: this.client.apiKey,
+        baseUrl: this.client.baseUrl,
+        ...this.wsOptions,
+      },
+      {
+        surface: this.client.originSurface,
+        client: this.client.originClient,
+        version: this.client.originVersion,
+        ...(this.client.originHarness ? { harness: this.client.originHarness } : {}),
+      },
+    ));
+    this.ws.connect();
+  }
+
+  disconnect(): void {
+    if (!this.ws) return;
+    this.ws.disconnect();
+    this.ws = null;
+  }
+
+  private onEvent<T extends WsClientEvent>(eventType: string, handler: (e: T) => void): () => void {
+    if (!this.ws) {
+      throw new Error('WebSocket not connected. Call connect() first.');
+    }
+    return this.ws.on(eventType, handler as (e: WsClientEvent) => void);
+  }
+
+  on = {
+    messageCreated:  (handler: (e: MessageCreatedEvent) => void): (() => void)  => this.onEvent('message.created', handler),
+    messageUpdated:  (handler: (e: MessageUpdatedEvent) => void): (() => void)  => this.onEvent('message.updated', handler),
+    threadReply:     (handler: (e: ThreadReplyEvent) => void): (() => void)     => this.onEvent('thread.reply', handler),
+    messageRead:     (handler: (e: MessageReadEvent) => void): (() => void)     => this.onEvent('message.read', handler),
+    messageReacted:  (handler: (e: MessageReactedEvent) => void): (() => void)  => this.onEvent('message.reacted', handler),
+    dmReceived:      (handler: (e: DmReceivedEvent) => void): (() => void)      => this.onEvent('dm.received', handler),
+    groupDmReceived: (handler: (e: GroupDmReceivedEvent) => void): (() => void) => this.onEvent('group_dm.received', handler),
+    agentStatusChanged: (handler: (e: AgentStatusChangedEvent) => void): (() => void) => this.onEvent('agent.status.changed', handler),
+    agentActive:     (handler: (e: AgentStatusActiveEvent) => void): (() => void)  => this.onEvent('agent.status.active', handler),
+    agentOffline:    (handler: (e: AgentStatusOfflineEvent) => void): (() => void) => this.onEvent('agent.status.offline', handler),
+    channelCreated:  (handler: (e: ChannelCreatedEvent) => void): (() => void)  => this.onEvent('channel.created', handler),
+    channelUpdated:  (handler: (e: ChannelUpdatedEvent) => void): (() => void)  => this.onEvent('channel.updated', handler),
+    channelArchived: (handler: (e: ChannelArchivedEvent) => void): (() => void) => this.onEvent('channel.archived', handler),
+    memberJoined:    (handler: (e: MemberJoinedEvent) => void): (() => void)    => this.onEvent('member.joined', handler),
+    memberLeft:      (handler: (e: MemberLeftEvent) => void): (() => void)      => this.onEvent('member.left', handler),
+    channelMuted:    (handler: (e: ChannelMutedEvent) => void): (() => void)    => this.onEvent('member.channel_muted', handler),
+    channelUnmuted:  (handler: (e: ChannelUnmutedEvent) => void): (() => void)  => this.onEvent('member.channel_unmuted', handler),
+    fileUploaded:    (handler: (e: FileUploadedEvent) => void): (() => void)    => this.onEvent('file.uploaded', handler),
+    webhookReceived: (handler: (e: WebhookReceivedEvent) => void): (() => void) => this.onEvent('webhook.received', handler),
+    actionInvoked:   (handler: (e: ActionInvokedEvent) => void): (() => void)   => this.onEvent('action.invoked', handler),
+    actionCompleted: (handler: (e: ActionCompletedEvent) => void): (() => void) => this.onEvent('action.completed', handler),
+    actionFailed:    (handler: (e: ActionFailedEvent) => void): (() => void)    => this.onEvent('action.failed', handler),
+    actionDenied:    (handler: (e: ActionDeniedEvent) => void): (() => void)    => this.onEvent('action.denied', handler),
+    deliveryAccepted:  (handler: (e: DeliveryAcceptedEvent) => void): (() => void)  => this.onEvent('delivery.accepted', handler),
+    deliveryDelivered: (handler: (e: DeliveryDeliveredEvent) => void): (() => void) => this.onEvent('delivery.delivered', handler),
+    deliveryDeferred:  (handler: (e: DeliveryDeferredEvent) => void): (() => void)  => this.onEvent('delivery.deferred', handler),
+    deliveryFailed:    (handler: (e: DeliveryFailedEvent) => void): (() => void)    => this.onEvent('delivery.failed', handler),
+    connected:    (handler: () => void): (() => void) => this.onEvent('open', handler as (e: never) => void),
+    disconnected: (handler: () => void): (() => void) => this.onEvent('close', handler as (e: never) => void),
+    error:        (handler: () => void): (() => void) => this.onEvent('error', handler as (e: never) => void),
+    reconnecting: (handler: (attempt: number) => void): (() => void) => {
+      if (!this.ws) {
+        throw new Error('WebSocket not connected. Call connect() first.');
+      }
+      return this.ws.on('reconnecting', (e: WsClientEvent) => handler((e as WsReconnectingEvent).attempt));
+    },
+    permanentlyDisconnected: (handler: (attempt: number) => void): (() => void) => {
+      if (!this.ws) {
+        throw new Error('WebSocket not connected. Call connect() first.');
+      }
+      return this.ws.on('permanently_disconnected', (e: WsClientEvent) =>
+        handler((e as WsPermanentlyDisconnectedEvent).attempt));
+    },
+    any: (handler: (e: WsClientEvent) => void): (() => void) => {
+      if (!this.ws) {
+        throw new Error('WebSocket not connected. Call connect() first.');
+      }
+      return this.ws.on('*', handler);
+    },
+  };
 
   static async createWorkspace(
     name: string,

--- a/packages/sdk-typescript/src/relay.ts
+++ b/packages/sdk-typescript/src/relay.ts
@@ -166,8 +166,7 @@ function resolveWorkspaceBootstrapOptions(
 
 export class RelayCast {
   private client: HttpClient;
-  private ws: WsClient | null = null;
-  private wsOptions: Omit<WsClientOptions, 'token' | 'baseUrl'>;
+  private ws: WsClient;
   private identityHint: { agentId: string; name: string } | null = null;
   private workspaceIdHint: string | null = null;
 
@@ -179,16 +178,11 @@ export class RelayCast {
     // Preserve hidden internal-origin metadata on options when created via
     // createInternalRelayCast() so downstream requests use the correct origin headers.
     this.client = new HttpClient(options);
-    this.wsOptions = options.ws ?? {};
-  }
-
-  connect(): void {
-    if (this.ws) return;
     this.ws = new WsClient(withInternalWsOrigin(
       {
+        ...(options.ws ?? {}),
         token: this.client.apiKey,
         baseUrl: this.client.baseUrl,
-        ...this.wsOptions,
       },
       {
         surface: this.client.originSurface,
@@ -197,19 +191,17 @@ export class RelayCast {
         ...(this.client.originHarness ? { harness: this.client.originHarness } : {}),
       },
     ));
+  }
+
+  connect(): void {
     this.ws.connect();
   }
 
   disconnect(): void {
-    if (!this.ws) return;
     this.ws.disconnect();
-    this.ws = null;
   }
 
   private onEvent<T extends WsClientEvent>(eventType: string, handler: (e: T) => void): () => void {
-    if (!this.ws) {
-      throw new Error('WebSocket not connected. Call connect() first.');
-    }
     return this.ws.on(eventType, handler as (e: WsClientEvent) => void);
   }
 
@@ -244,25 +236,12 @@ export class RelayCast {
     connected:    (handler: () => void): (() => void) => this.onEvent('open', handler as (e: never) => void),
     disconnected: (handler: () => void): (() => void) => this.onEvent('close', handler as (e: never) => void),
     error:        (handler: () => void): (() => void) => this.onEvent('error', handler as (e: never) => void),
-    reconnecting: (handler: (attempt: number) => void): (() => void) => {
-      if (!this.ws) {
-        throw new Error('WebSocket not connected. Call connect() first.');
-      }
-      return this.ws.on('reconnecting', (e: WsClientEvent) => handler((e as WsReconnectingEvent).attempt));
-    },
-    permanentlyDisconnected: (handler: (attempt: number) => void): (() => void) => {
-      if (!this.ws) {
-        throw new Error('WebSocket not connected. Call connect() first.');
-      }
-      return this.ws.on('permanently_disconnected', (e: WsClientEvent) =>
-        handler((e as WsPermanentlyDisconnectedEvent).attempt));
-    },
-    any: (handler: (e: WsClientEvent) => void): (() => void) => {
-      if (!this.ws) {
-        throw new Error('WebSocket not connected. Call connect() first.');
-      }
-      return this.ws.on('*', handler);
-    },
+    reconnecting: (handler: (attempt: number) => void): (() => void) =>
+      this.ws.on('reconnecting', (e: WsClientEvent) => handler((e as WsReconnectingEvent).attempt)),
+    permanentlyDisconnected: (handler: (attempt: number) => void): (() => void) =>
+      this.ws.on('permanently_disconnected', (e: WsClientEvent) =>
+        handler((e as WsPermanentlyDisconnectedEvent).attempt)),
+    any: (handler: (e: WsClientEvent) => void): (() => void) => this.ws.on('*', handler),
   };
 
   static async createWorkspace(


### PR DESCRIPTION
## **User description**
Closes #163

## Summary
- Add RelayCast.connect()/disconnect() backed by WsClient using the workspace key
- Mirror AgentClient typed on.* realtime handlers on the workspace client
- Document the workspace stream flow and add a changelog entry

## Verification
- npx tsc --noEmit -p packages/sdk-typescript/tsconfig.json
- npx vitest run packages/sdk-typescript/src/__tests__/relay.test.ts packages/sdk-typescript/src/__tests__/agent-ws.test.ts packages/sdk-typescript/src/__tests__/ws.test.ts
- npm run test --workspace @relaycast/sdk
- npm run lint --workspace @relaycast/sdk
- npm run build --workspace @relaycast/sdk
- npm run build


___

## **CodeAnt-AI Description**
**Expose workspace realtime events through the SDK**

### What Changed
- Workspace-key clients can now open and close a realtime connection to the workspace stream directly.
- The SDK now provides typed handlers for workspace events such as new messages, action results, member changes, and connection status updates.
- Event payloads are delivered in a cleaner, camel-cased shape, and event handlers can be removed after subscribing.
- The README and changelog now show how to use the workspace stream.

### Impact
`✅ Live workspace updates in SDK apps`
`✅ Clearer handling of message and action events`
`✅ Easier cleanup of realtime listeners`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
