### PR TITLE
chore(telemetry): no-op without key and accept Agent Relay identity

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -70,6 +70,25 @@ jobs:
       deployments: write
     steps:
       - uses: actions/checkout@v4
+      - name: Inject PostHog API key into marketing site
+        env:
+          POSTHOG_PROJECT_KEY: ${{ vars.POSTHOG_PROJECT_KEY }}
+        run: |
+          node -e '
+            const fs = require("fs");
+            const file = "site/index.html";
+            const placeholder = "__RELAYCAST_POSTHOG_API_KEY__";
+            const key = process.env.POSTHOG_PROJECT_KEY || "";
+            const html = fs.readFileSync(file, "utf8");
+            if (!html.includes(placeholder)) {
+              console.error(`Placeholder ${placeholder} not found in ${file}`);
+              process.exit(1);
+            }
+            if (!key) {
+              console.warn("POSTHOG_PROJECT_KEY is unset — shipping site with telemetry disabled.");
+            }
+            fs.writeFileSync(file, html.split(placeholder).join(key));
+          '
       - uses: cloudflare/wrangler-action@v3
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}

--- a/packages/engine/src/lib/__tests__/origin.test.ts
+++ b/packages/engine/src/lib/__tests__/origin.test.ts
@@ -1,51 +1,94 @@
-import { describe, expect, it } from 'vitest';
-import { extractHarness, UNKNOWN_HARNESS } from '../origin.js';
+import { describe, expect, it } from "vitest";
+import {
+  extractAgentRelayAnonymousId,
+  extractHarness,
+  UNKNOWN_HARNESS,
+} from "../origin.js";
 
-function req(init: { header?: string; query?: string } = {}): Request {
-  const url = new URL('https://gateway.relaycast.dev/v1/activity');
-  if (init.query !== undefined) url.searchParams.set('harness', init.query);
+function req(
+  init: { agentRelayId?: string; header?: string; query?: string } = {},
+): Request {
+  const url = new URL("https://gateway.relaycast.dev/v1/activity");
+  if (init.query !== undefined) url.searchParams.set("harness", init.query);
   const headers = new Headers();
-  if (init.header !== undefined) headers.set('X-Relaycast-Harness', init.header);
+  if (init.header !== undefined)
+    headers.set("X-Relaycast-Harness", init.header);
+  if (init.agentRelayId !== undefined) {
+    headers.set("X-Agent-Relay-Anonymous-Id", init.agentRelayId);
+  }
   return new Request(url, { headers });
 }
 
-describe('extractHarness', () => {
-  it('reads the X-Relaycast-Harness header, lowercased', () => {
-    expect(extractHarness(req({ header: 'Claude-Code' }))).toBe('claude-code');
+describe("extractHarness", () => {
+  it("reads the X-Relaycast-Harness header, lowercased", () => {
+    expect(extractHarness(req({ header: "Claude-Code" }))).toBe("claude-code");
   });
 
-  it('accepts a UA-style token', () => {
-    expect(extractHarness(req({ header: 'claude-code/2.3 (model=opus-4.8; fast)' })))
-      .toBe('claude-code/2.3 (model=opus-4.8; fast)');
+  it("accepts a UA-style token", () => {
+    expect(
+      extractHarness(req({ header: "claude-code/2.3 (model=opus-4.8; fast)" })),
+    ).toBe("claude-code/2.3 (model=opus-4.8; fast)");
   });
 
-  it('falls back to the `harness` query param (browser WS path)', () => {
-    expect(extractHarness(req({ query: 'codex' }))).toBe('codex');
+  it("falls back to the `harness` query param (browser WS path)", () => {
+    expect(extractHarness(req({ query: "codex" }))).toBe("codex");
   });
 
-  it('prefers the header over the query param', () => {
-    expect(extractHarness(req({ header: 'claude-code', query: 'codex' }))).toBe('claude-code');
+  it("prefers the header over the query param", () => {
+    expect(extractHarness(req({ header: "claude-code", query: "codex" }))).toBe(
+      "claude-code",
+    );
   });
 
-  it('returns unknown when neither is present', () => {
+  it("returns unknown when neither is present", () => {
     expect(extractHarness(req())).toBe(UNKNOWN_HARNESS);
   });
 
-  it('rejects disallowed characters in the header', () => {
-    expect(extractHarness(req({ header: 'claude<script>' }))).toBe(UNKNOWN_HARNESS);
+  it("rejects disallowed characters in the header", () => {
+    expect(extractHarness(req({ header: "claude<script>" }))).toBe(
+      UNKNOWN_HARNESS,
+    );
   });
 
-  it('rejects CRLF smuggled through the query param', () => {
+  it("rejects CRLF smuggled through the query param", () => {
     // The runtime Headers object already blocks CRLF header values, so the only
     // way control characters reach us is the query string — drop them there too.
-    expect(extractHarness(req({ query: 'evil\r\nX-Inject: bad' }))).toBe(UNKNOWN_HARNESS);
+    expect(extractHarness(req({ query: "evil\r\nX-Inject: bad" }))).toBe(
+      UNKNOWN_HARNESS,
+    );
   });
 
-  it('rejects empty / whitespace-only values', () => {
-    expect(extractHarness(req({ header: '   ' }))).toBe(UNKNOWN_HARNESS);
+  it("rejects empty / whitespace-only values", () => {
+    expect(extractHarness(req({ header: "   " }))).toBe(UNKNOWN_HARNESS);
   });
 
-  it('truncates to 120 characters', () => {
-    expect(extractHarness(req({ header: 'a'.repeat(200) }))).toBe('a'.repeat(120));
+  it("truncates to 120 characters", () => {
+    expect(extractHarness(req({ header: "a".repeat(200) }))).toBe(
+      "a".repeat(120),
+    );
+  });
+});
+
+describe("extractAgentRelayAnonymousId", () => {
+  it("reads a sanitized Agent Relay anonymous id header", () => {
+    expect(
+      extractAgentRelayAnonymousId(req({ agentRelayId: "abc123def4567890" })),
+    ).toBe("abc123def4567890");
+  });
+
+  it("rejects empty or malformed ids", () => {
+    expect(extractAgentRelayAnonymousId(req())).toBeUndefined();
+    expect(
+      extractAgentRelayAnonymousId(req({ agentRelayId: "   " })),
+    ).toBeUndefined();
+    expect(
+      extractAgentRelayAnonymousId(req({ agentRelayId: "abc<script>" })),
+    ).toBeUndefined();
+  });
+
+  it("truncates long ids", () => {
+    expect(
+      extractAgentRelayAnonymousId(req({ agentRelayId: "a".repeat(200) })),
+    ).toBe("a".repeat(128));
   });
 });

--- a/packages/engine/src/lib/origin.ts
+++ b/packages/engine/src/lib/origin.ts
@@ -1,4 +1,7 @@
-import { normalizeTelemetryOrigin, type TelemetryOrigin } from '@relaycast/types';
+import {
+  normalizeTelemetryOrigin,
+  type TelemetryOrigin,
+} from "@relaycast/types";
 
 export type OriginInfo = Partial<TelemetryOrigin>;
 
@@ -6,10 +9,11 @@ export type OriginInfo = Partial<TelemetryOrigin>;
  * HTTP header used by harnesses (Claude Code, Cursor, etc.) to identify
  * themselves to the relaycast server. See relay#881.
  */
-export const HARNESS_HEADER = 'X-Relaycast-Harness';
+export const HARNESS_HEADER = "X-Relaycast-Harness";
+export const AGENT_RELAY_ANONYMOUS_ID_HEADER = "X-Agent-Relay-Anonymous-Id";
 
 /** Fallback value when the harness is missing or invalid. */
-export const UNKNOWN_HARNESS = 'unknown';
+export const UNKNOWN_HARNESS = "unknown";
 
 /** Upper bound on the harness value — generous enough for a UA-style token. */
 const HARNESS_MAX_LENGTH = 120;
@@ -21,6 +25,7 @@ const HARNESS_MAX_LENGTH = 120;
  * upstream caller from smuggling a header injection past the relaycast WAF.
  */
 const HARNESS_ALLOWED = /^[a-z0-9 ._\-/():=;,+]+$/i;
+const AGENT_RELAY_ANONYMOUS_ID_ALLOWED = /^[a-z0-9._:-]+$/i;
 
 /**
  * Read and sanitize the harness identifier from a request.
@@ -36,8 +41,9 @@ const HARNESS_ALLOWED = /^[a-z0-9 ._\-/():=;,+]+$/i;
  * in the analytics layer. Drops empty or malformed values to `'unknown'`.
  */
 export function extractHarness(request: Request): string {
-  const raw = request.headers.get(HARNESS_HEADER)
-    ?? new URL(request.url).searchParams.get('harness');
+  const raw =
+    request.headers.get(HARNESS_HEADER) ??
+    new URL(request.url).searchParams.get("harness");
   if (!raw) return UNKNOWN_HARNESS;
 
   const trimmed = raw.trim();
@@ -47,7 +53,23 @@ export function extractHarness(request: Request): string {
   return trimmed.slice(0, HARNESS_MAX_LENGTH).toLowerCase();
 }
 
-function sanitizeOriginPart(value: string | null | undefined, maxLen: number): string | undefined {
+export function extractAgentRelayAnonymousId(
+  request: Request,
+): string | undefined {
+  const raw = request.headers.get(AGENT_RELAY_ANONYMOUS_ID_HEADER);
+  if (!raw) return undefined;
+
+  const trimmed = raw.trim();
+  if (!trimmed) return undefined;
+  if (!AGENT_RELAY_ANONYMOUS_ID_ALLOWED.test(trimmed)) return undefined;
+
+  return trimmed.slice(0, 128);
+}
+
+function sanitizeOriginPart(
+  value: string | null | undefined,
+  maxLen: number,
+): string | undefined {
   if (!value) return undefined;
   const normalized = value.trim();
   if (!normalized) return undefined;
@@ -55,39 +77,45 @@ function sanitizeOriginPart(value: string | null | undefined, maxLen: number): s
 }
 
 export function deriveClientName(headers: Headers): string | undefined {
-  const explicit = headers.get('x-client-name') ?? headers.get('x-relaycast-client');
+  const explicit =
+    headers.get("x-client-name") ?? headers.get("x-relaycast-client");
   if (explicit) return explicit.trim().slice(0, 80);
 
-  const ua = headers.get('user-agent');
+  const ua = headers.get("user-agent");
   if (!ua) return undefined;
   const family = ua.split(/[\/\s;]/)[0];
   return family ? family.trim().slice(0, 80) : undefined;
 }
 
-export function extractOriginInfo(request: Request, fallbackClientName?: string): OriginInfo {
+export function extractOriginInfo(
+  request: Request,
+  fallbackClientName?: string,
+): OriginInfo {
   const headers = request.headers;
   const url = new URL(request.url);
 
-  const querySurface = url.searchParams.get('origin_surface');
-  const queryClient = url.searchParams.get('origin_client');
-  const queryVersion = url.searchParams.get('origin_version');
+  const querySurface = url.searchParams.get("origin_surface");
+  const queryClient = url.searchParams.get("origin_client");
+  const queryVersion = url.searchParams.get("origin_version");
 
   const originSurface = sanitizeOriginPart(
-    headers.get('x-relaycast-origin-surface') ?? headers.get('x-origin-surface') ?? querySurface,
+    headers.get("x-relaycast-origin-surface") ??
+      headers.get("x-origin-surface") ??
+      querySurface,
     32,
   );
   const originClient = sanitizeOriginPart(
-    headers.get('x-relaycast-origin-client')
-      ?? headers.get('x-origin-client')
-      ?? queryClient
-      ?? fallbackClientName,
+    headers.get("x-relaycast-origin-client") ??
+      headers.get("x-origin-client") ??
+      queryClient ??
+      fallbackClientName,
     80,
   );
   const originVersion = sanitizeOriginPart(
-    headers.get('x-relaycast-origin-version')
-      ?? headers.get('x-origin-version')
-      ?? queryVersion
-      ?? headers.get('x-sdk-version'),
+    headers.get("x-relaycast-origin-version") ??
+      headers.get("x-origin-version") ??
+      queryVersion ??
+      headers.get("x-sdk-version"),
     48,
   );
 
@@ -98,6 +126,11 @@ export function extractOriginInfo(request: Request, fallbackClientName?: string)
   };
 }
 
-export function requiredOriginInfo(request: Request, fallbackClientName?: string): TelemetryOrigin {
-  return normalizeTelemetryOrigin(extractOriginInfo(request, fallbackClientName));
+export function requiredOriginInfo(
+  request: Request,
+  fallbackClientName?: string,
+): TelemetryOrigin {
+  return normalizeTelemetryOrigin(
+    extractOriginInfo(request, fallbackClientName),
+  );
 }

--- a/packages/engine/src/lib/serverTelemetry.ts
+++ b/packages/engine/src/lib/serverTelemetry.ts
@@ -1,20 +1,34 @@
-import type { Context } from 'hono';
-import type { AppEnv } from '../env.js';
-import { extractHarness, requiredOriginInfo, UNKNOWN_HARNESS } from './origin.js';
+import type { Context } from "hono";
+import type { AppEnv } from "../env.js";
+import {
+  extractAgentRelayAnonymousId,
+  extractHarness,
+  requiredOriginInfo,
+  UNKNOWN_HARNESS,
+} from "./origin.js";
 
 type ServerEvent = `relaycast_server_${string}`;
 
 export function normalizeRoutePathForTelemetry(value: string): string {
   const withoutQuery = value.split(/[?#]/)[0] ?? value;
-  const compact = withoutQuery.replace(/\/+/g, '/').trim();
-  const withLeadingSlash = compact.startsWith('/') ? compact : `/${compact}`;
-  const segments = withLeadingSlash.split('/').filter(Boolean).map((segment) => {
-    if (/^\d{6,}$/.test(segment)) return ':id';
-    if (/^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(segment)) return ':id';
-    if (/^(dm|dmch|cmd|sub|wh)_[a-zA-Z0-9_-]{8,}$/.test(segment)) return ':id';
-    return segment;
-  });
-  return `/${segments.join('/')}`;
+  const compact = withoutQuery.replace(/\/+/g, "/").trim();
+  const withLeadingSlash = compact.startsWith("/") ? compact : `/${compact}`;
+  const segments = withLeadingSlash
+    .split("/")
+    .filter(Boolean)
+    .map((segment) => {
+      if (/^\d{6,}$/.test(segment)) return ":id";
+      if (
+        /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(
+          segment,
+        )
+      )
+        return ":id";
+      if (/^(dm|dmch|cmd|sub|wh)_[a-zA-Z0-9_-]{8,}$/.test(segment))
+        return ":id";
+      return segment;
+    });
+  return `/${segments.join("/")}`;
 }
 
 /**
@@ -29,22 +43,27 @@ export function emitServerEvent(
   properties: Record<string, unknown>,
 ): void {
   const normalizedProperties = { ...properties };
-  if (typeof normalizedProperties.route_path === 'string') {
-    normalizedProperties.route_path = normalizeRoutePathForTelemetry(normalizedProperties.route_path);
+  if (typeof normalizedProperties.route_path === "string") {
+    normalizedProperties.route_path = normalizeRoutePathForTelemetry(
+      normalizedProperties.route_path,
+    );
   }
 
   // Prefer the value stashed by the logger middleware. Fall back to reading the
   // header directly so emitters that bypass middleware still get a sane value.
-  const harness = c.get('harness')
-    ?? extractHarness(c.req.raw)
-    ?? UNKNOWN_HARNESS;
+  const harness =
+    c.get("harness") ?? extractHarness(c.req.raw) ?? UNKNOWN_HARNESS;
 
   const origin = requiredOriginInfo(c.req.raw);
-  c.get('engine').telemetry.capture({
+  const clientAnonymousId = extractAgentRelayAnonymousId(c.req.raw);
+  c.get("engine").telemetry.capture({
     name: event,
-    distinctId: workspaceId,
+    distinctId: clientAnonymousId ?? workspaceId,
     properties: {
+      app: "relaycast-server",
+      surface: "cloud",
       workspace_id: workspaceId,
+      ...(clientAnonymousId ? { client_anonymous_id: clientAnonymousId } : {}),
       harness,
       origin_surface: origin.origin_surface,
       origin_client: origin.origin_client,

--- a/packages/mcp/src/__tests__/telemetry.test.ts
+++ b/packages/mcp/src/__tests__/telemetry.test.ts
@@ -139,7 +139,10 @@ describe('createMcpTelemetry', () => {
       vi.mocked(fs.mkdirSync).mockImplementation(() => undefined);
       vi.mocked(fs.writeFileSync).mockImplementation(() => undefined);
 
-      const telemetry = createMcpTelemetry('1.0.0', { posthogHost: 'https://api.example.com' });
+      const telemetry = createMcpTelemetry('1.0.0', {
+        posthogHost: 'https://api.example.com',
+        posthogApiKey: 'phc_example',
+      });
       telemetry.capture('relaycast_mcp_server_started', {});
       await telemetry.flush();
 
@@ -153,6 +156,18 @@ describe('createMcpTelemetry', () => {
         (globalThis as { WebSocketPair?: unknown }).WebSocketPair = originalWebSocketPair;
       }
     }
+  });
+
+  it('silently no-ops when no PostHog API key is configured', async () => {
+    vi.mocked(fs.readFileSync).mockReturnValue(JSON.stringify({ anonymousId: 'anon-123' }));
+
+    // No env key, no option key → telemetry disabled, no HTTP call.
+    const telemetry = createMcpTelemetry('1.0.0', { posthogHost: 'https://api.example.com' });
+    telemetry.capture('relaycast_mcp_server_started', { transport: 'stdio' });
+    await telemetry.flush();
+
+    expect(nodeRequestMock).not.toHaveBeenCalled();
+    expect(capturedBodies).toHaveLength(0);
   });
 
   it('flush resolves when no events are pending', async () => {

--- a/packages/mcp/src/telemetry.ts
+++ b/packages/mcp/src/telemetry.ts
@@ -40,7 +40,7 @@ function isTruthy(value: string | undefined): boolean {
 function telemetryEnabled(state: TelemetryState, apiKey: string): boolean {
   // No key configured (e.g. forks, local dev, CI) → silently no-op. Same code
   // path as the explicit DO_NOT_TRACK / RELAYCAST_TELEMETRY_DISABLED opt-outs.
-  if (!apiKey) return false;
+  if (!apiKey.trim()) return false;
   if (isTruthy(process.env.DO_NOT_TRACK) || isTruthy(process.env.RELAYCAST_TELEMETRY_DISABLED)) {
     return false;
   }

--- a/packages/mcp/src/telemetry.ts
+++ b/packages/mcp/src/telemetry.ts
@@ -30,7 +30,6 @@ export interface McpTelemetry {
 
 const TELEMETRY_PATH = path.join(os.homedir(), '.relay', 'telemetry.json');
 const DEFAULT_POSTHOG_HOST = 'https://us.i.posthog.com';
-const DEFAULT_POSTHOG_PUBLIC_KEY = 'phc_OAqBdey9pESZCcwaen9Fpyz6Ez8QKiMmLOnvFknXzg4';
 
 function isTruthy(value: string | undefined): boolean {
   if (!value) return false;
@@ -38,7 +37,10 @@ function isTruthy(value: string | undefined): boolean {
   return normalized === '1' || normalized === 'true' || normalized === 'yes' || normalized === 'on';
 }
 
-function telemetryEnabled(state: TelemetryState): boolean {
+function telemetryEnabled(state: TelemetryState, apiKey: string): boolean {
+  // No key configured (e.g. forks, local dev, CI) → silently no-op. Same code
+  // path as the explicit DO_NOT_TRACK / RELAYCAST_TELEMETRY_DISABLED opt-outs.
+  if (!apiKey) return false;
   if (isTruthy(process.env.DO_NOT_TRACK) || isTruthy(process.env.RELAYCAST_TELEMETRY_DISABLED)) {
     return false;
   }
@@ -61,11 +63,13 @@ function getPosthogHost(options: McpTelemetryOptions): string {
 }
 
 function getPosthogApiKey(options: McpTelemetryOptions): string {
+  // No baked-in default: a missing key disables telemetry rather than writing
+  // into the project's production PostHog. Production injects the key via env.
   return (
     process.env.RELAYCAST_POSTHOG_API_KEY
     ?? process.env.POSTHOG_API_KEY
     ?? options.posthogApiKey
-    ?? DEFAULT_POSTHOG_PUBLIC_KEY
+    ?? ''
   );
 }
 
@@ -211,7 +215,7 @@ export function createMcpTelemetry(version = 'unknown', options: McpTelemetryOpt
   const originVersion = options.originVersion ?? version;
 
   const capture = (event: ClientTelemetryEventName, properties: Record<string, unknown> = {}) => {
-    if (!telemetryEnabled(state)) return;
+    if (!telemetryEnabled(state, posthogApiKey)) return;
 
     const parsed = parseTelemetryIngestionEvent({
       event,

--- a/site/index.html
+++ b/site/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Relaycast — Headless Slack for AI Agents</title>
   <meta name="description" content="Give your AI agents channels, threads, DMs, and real-time events. Framework-agnostic messaging that works across any CLI, any language, any model.">
-  <meta name="relaycast-posthog-key" content="phc_OAqBdey9pESZCcwaen9Fpyz6Ez8QKiMmLOnvFknXzg4">
+  <meta name="relaycast-posthog-key" content="__RELAYCAST_POSTHOG_API_KEY__">
   <meta name="relaycast-posthog-host" content="https://us.i.posthog.com">
   <meta name="theme-color" content="#F9FAFB">
   <link rel="preconnect" href="https://fonts.googleapis.com">

--- a/site/script.js
+++ b/site/script.js
@@ -1,5 +1,4 @@
 const POSTHOG_DEFAULT_HOST = 'https://us.i.posthog.com';
-const POSTHOG_PUBLIC_KEY = 'phc_OAqBdey9pESZCcwaen9Fpyz6Ez8QKiMmLOnvFknXzg4';
 const POSTHOG_DISTINCT_ID_KEY = 'relaycast_posthog_distinct_id';
 const POSTHOG_SESSION_ID = window.crypto?.randomUUID?.() ?? String(Date.now());
 
@@ -36,8 +35,17 @@ const telemetry = (() => {
   const posthogKey =
     window.POSTHOG_API_KEY ||
     window.RELAYCAST_POSTHOG_KEY ||
-    getMetaContent('relaycast-posthog-key') ||
-    POSTHOG_PUBLIC_KEY;
+    getMetaContent('relaycast-posthog-key');
+
+  // No real key configured — e.g. the `__RELAYCAST_POSTHOG_API_KEY__` placeholder
+  // was never substituted (forks, local `file://` previews). Treat as opt-out
+  // rather than firing requests with a garbage key.
+  if (!posthogKey || !posthogKey.startsWith('phc_')) {
+    return {
+      enabled: false,
+      capture: () => {},
+    };
+  }
 
   const rawHost =
     window.POSTHOG_HOST || window.RELAYCAST_POSTHOG_HOST || getMetaContent('relaycast-posthog-host');


### PR DESCRIPTION
## Summary
- remove hardcoded PostHog defaults so MCP/site telemetry no-ops when no key is configured
- accept `X-Agent-Relay-Anonymous-Id` in the engine and use it as `distinctId` for server telemetry when present
- preserve workspace attribution as `workspace_id` and add cloud/server app-surface properties
- add origin/header coverage for the new Agent Relay anonymous id path

## Verification
- turbo build test lint --filter=@relaycast/mcp
- npm --prefix packages/engine run test -- src/lib/__tests__/origin.test.ts
- npm --prefix packages/engine run typecheck
