### PR TITLE
ci: add Python SDK publish workflow + wire tests into CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,3 +37,19 @@ jobs:
         run: cargo test --manifest-path packages/sdk-rust/Cargo.toml
       - name: Clippy
         run: cargo clippy --manifest-path packages/sdk-rust/Cargo.toml -- -D warnings
+
+  python-sdk:
+    name: Python SDK
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: packages/sdk-python
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+      - name: Install dependencies
+        run: uv sync --all-extras
+      - name: Test
+        run: uv run python -m pytest

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -70,6 +70,25 @@ jobs:
       deployments: write
     steps:
       - uses: actions/checkout@v4
+      - name: Inject PostHog API key into marketing site
+        env:
+          POSTHOG_PROJECT_KEY: ${{ vars.POSTHOG_PROJECT_KEY }}
+        run: |
+          node -e '
+            const fs = require("fs");
+            const file = "site/index.html";
+            const placeholder = "__RELAYCAST_POSTHOG_API_KEY__";
+            const key = process.env.POSTHOG_PROJECT_KEY || "";
+            const html = fs.readFileSync(file, "utf8");
+            if (!html.includes(placeholder)) {
+              console.error(`Placeholder ${placeholder} not found in ${file}`);
+              process.exit(1);
+            }
+            if (!key) {
+              console.warn("POSTHOG_PROJECT_KEY is unset — shipping site with telemetry disabled.");
+            }
+            fs.writeFileSync(file, html.split(placeholder).join(key));
+          '
       - uses: cloudflare/wrangler-action@v3
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}

--- a/.github/workflows/publish-python.yml
+++ b/.github/workflows/publish-python.yml
@@ -1,0 +1,217 @@
+name: Publish Python SDK
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version bump type"
+        required: true
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+          - prepatch
+          - preminor
+          - premajor
+          - prerelease
+      custom_version:
+        description: "Custom version (optional, overrides version type)"
+        required: false
+        type: string
+      dry_run:
+        description: "Dry run (do not actually publish)"
+        required: false
+        type: boolean
+        default: false
+
+concurrency:
+  group: publish-python-sdk
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+
+jobs:
+  publish:
+    name: Build, Test & Publish sdk-python
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: packages/sdk-python
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          fetch-depth: 0
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+
+      - name: Determine and set version
+        id: bump
+        shell: bash
+        env:
+          # Bind inputs through env so free-form custom_version is never
+          # interpolated into the shell script body.
+          CUSTOM_VERSION: ${{ github.event.inputs.custom_version }}
+          VERSION_TYPE: ${{ github.event.inputs.version }}
+        run: |
+          PYPROJECT="pyproject.toml"
+          CLIENT="src/relay_sdk/client.py"
+
+          CURRENT_VERSION=$(awk -F '"' '/^version = / { print $2; exit }' "$PYPROJECT")
+          if [ -z "$CURRENT_VERSION" ]; then
+            echo "Unable to read current version from $PYPROJECT"
+            exit 1
+          fi
+          echo "Current version: $CURRENT_VERSION"
+
+          bump_semver() {
+            local current="$1"
+            local kind="$2"
+
+            # PEP 440 release with optional beta prerelease: MAJOR.MINOR.PATCH[bN]
+            if [[ ! "$current" =~ ^([0-9]+)\.([0-9]+)\.([0-9]+)(b([0-9]+))?$ ]]; then
+              echo "Invalid version (expected MAJOR.MINOR.PATCH or MAJOR.MINOR.PATCHbN): $current" >&2
+              return 1
+            fi
+
+            local major="${BASH_REMATCH[1]}"
+            local minor="${BASH_REMATCH[2]}"
+            local patch="${BASH_REMATCH[3]}"
+            local pre_num="${BASH_REMATCH[5]}"
+
+            case "$kind" in
+              patch)
+                patch=$((patch + 1)); pre_num="" ;;
+              minor)
+                minor=$((minor + 1)); patch=0; pre_num="" ;;
+              major)
+                major=$((major + 1)); minor=0; patch=0; pre_num="" ;;
+              prepatch)
+                patch=$((patch + 1)); pre_num="0" ;;
+              preminor)
+                minor=$((minor + 1)); patch=0; pre_num="0" ;;
+              premajor)
+                major=$((major + 1)); minor=0; patch=0; pre_num="0" ;;
+              prerelease)
+                if [[ -n "$pre_num" ]]; then
+                  pre_num=$((pre_num + 1))
+                else
+                  patch=$((patch + 1)); pre_num="0"
+                fi
+                ;;
+              *)
+                echo "Unsupported version bump type: $kind" >&2
+                return 1 ;;
+            esac
+
+            # PEP 440 prerelease marker: beta segment is "bN".
+            if [ -n "$pre_num" ]; then
+              echo "${major}.${minor}.${patch}b${pre_num}"
+            else
+              echo "${major}.${minor}.${patch}"
+            fi
+          }
+
+          if [ -n "$CUSTOM_VERSION" ]; then
+            if [[ ! "$CUSTOM_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+([abrc.][0-9A-Za-z.]*)?$ ]]; then
+              echo "Invalid custom_version (must be PEP 440): $CUSTOM_VERSION"
+              exit 1
+            fi
+            NEW_VERSION="$CUSTOM_VERSION"
+            echo "Using custom version: $NEW_VERSION"
+          else
+            NEW_VERSION=$(bump_semver "$CURRENT_VERSION" "$VERSION_TYPE")
+            echo "Bumped version: $VERSION_TYPE -> $NEW_VERSION"
+          fi
+
+          # Update pyproject.toml [project] version (first match only).
+          awk -v v="$NEW_VERSION" '
+            !done && /^version = / { print "version = \"" v "\""; done=1; next }
+            { print }
+            END { if (!done) { print "Failed to update version in pyproject.toml" > "/dev/stderr"; exit 1 } }
+          ' "$PYPROJECT" > "$PYPROJECT.tmp" && mv "$PYPROJECT.tmp" "$PYPROJECT"
+
+          # Keep the SDK_VERSION constant in lockstep with the package version.
+          awk -v v="$NEW_VERSION" '
+            !done && /^SDK_VERSION = / { print "SDK_VERSION = \"" v "\""; done=1; next }
+            { print }
+            END { if (!done) { print "Failed to update SDK_VERSION in client.py" > "/dev/stderr"; exit 1 } }
+          ' "$CLIENT" > "$CLIENT.tmp" && mv "$CLIENT.tmp" "$CLIENT"
+
+          echo "new_version=$NEW_VERSION" >> "$GITHUB_OUTPUT"
+          echo "New version: $NEW_VERSION"
+
+      - name: Install dependencies
+        run: uv sync --all-extras
+
+      - name: Run tests
+        run: uv run python -m pytest
+
+      - name: Build distributions
+        run: uv build
+
+      - name: Check distribution metadata
+        run: uvx twine check dist/*
+
+      - name: Publish to PyPI
+        if: github.event.inputs.dry_run != 'true'
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: packages/sdk-python/dist
+          password: ${{ secrets.PYPI_API_TOKEN }}
+
+      - name: Commit and tag
+        if: github.event.inputs.dry_run != 'true'
+        working-directory: ${{ github.workspace }}
+        run: |
+          NEW_VERSION="${{ steps.bump.outputs.new_version }}"
+
+          git config user.name "GitHub Actions"
+          git config user.email "actions@github.com"
+
+          git add packages/sdk-python/pyproject.toml packages/sdk-python/src/relay_sdk/client.py
+          if ! git diff --staged --quiet; then
+            git commit -m "chore(sdk-python): v${NEW_VERSION}"
+            git push origin HEAD:main
+          fi
+
+          git tag -a "sdk-python-v${NEW_VERSION}" -m "sdk-python v${NEW_VERSION}"
+          git push origin "sdk-python-v${NEW_VERSION}"
+
+      - name: Create GitHub Release
+        if: github.event.inputs.dry_run != 'true'
+        uses: softprops/action-gh-release@v1
+        with:
+          tag_name: sdk-python-v${{ steps.bump.outputs.new_version }}
+          name: sdk-python-v${{ steps.bump.outputs.new_version }}
+          body: |
+            ## Python SDK v${{ steps.bump.outputs.new_version }}
+
+            ### Install
+            ```bash
+            pip install relay-sdk==${{ steps.bump.outputs.new_version }}
+            ```
+          generate_release_notes: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Summary
+        if: always()
+        run: |
+          echo "## Python SDK Publish Summary" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "**Version**: \`${{ steps.bump.outputs.new_version }}\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "**Dry Run**: \`${{ github.event.inputs.dry_run }}\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          if [ "${{ github.event.inputs.dry_run }}" = "true" ]; then
+            echo "Dry run completed. Built and checked dist, but did not publish or tag." >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "Published to PyPI and created tag \`sdk-python-v${{ steps.bump.outputs.new_version }}\`." >> "$GITHUB_STEP_SUMMARY"
+          fi

--- a/.github/workflows/publish-python.yml
+++ b/.github/workflows/publish-python.yml
@@ -52,6 +52,15 @@ jobs:
         with:
           enable-cache: true
 
+      - name: Validate publish ref
+        env:
+          DRY_RUN: ${{ github.event.inputs.dry_run }}
+        run: |
+          if [ "$DRY_RUN" != "true" ] && [ "$GITHUB_REF" != "refs/heads/main" ]; then
+            echo "Publishing is only allowed from main; current ref is $GITHUB_REF"
+            exit 1
+          fi
+
       - name: Determine and set version
         id: bump
         shell: bash
@@ -120,8 +129,8 @@ jobs:
           }
 
           if [ -n "$CUSTOM_VERSION" ]; then
-            if [[ ! "$CUSTOM_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+([abrc.][0-9A-Za-z.]*)?$ ]]; then
-              echo "Invalid custom_version (must be PEP 440): $CUSTOM_VERSION"
+            if [[ ! "$CUSTOM_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+((a|b|rc)[0-9]+)?$ ]]; then
+              echo "Invalid custom_version (expected MAJOR.MINOR.PATCH or MAJOR.MINOR.PATCH{a|b|rc}N): $CUSTOM_VERSION"
               exit 1
             fi
             NEW_VERSION="$CUSTOM_VERSION"

--- a/packages/engine/src/lib/__tests__/origin.test.ts
+++ b/packages/engine/src/lib/__tests__/origin.test.ts
@@ -1,51 +1,94 @@
-import { describe, expect, it } from 'vitest';
-import { extractHarness, UNKNOWN_HARNESS } from '../origin.js';
+import { describe, expect, it } from "vitest";
+import {
+  extractAgentRelayAnonymousId,
+  extractHarness,
+  UNKNOWN_HARNESS,
+} from "../origin.js";
 
-function req(init: { header?: string; query?: string } = {}): Request {
-  const url = new URL('https://gateway.relaycast.dev/v1/activity');
-  if (init.query !== undefined) url.searchParams.set('harness', init.query);
+function req(
+  init: { agentRelayId?: string; header?: string; query?: string } = {},
+): Request {
+  const url = new URL("https://gateway.relaycast.dev/v1/activity");
+  if (init.query !== undefined) url.searchParams.set("harness", init.query);
   const headers = new Headers();
-  if (init.header !== undefined) headers.set('X-Relaycast-Harness', init.header);
+  if (init.header !== undefined)
+    headers.set("X-Relaycast-Harness", init.header);
+  if (init.agentRelayId !== undefined) {
+    headers.set("X-Agent-Relay-Anonymous-Id", init.agentRelayId);
+  }
   return new Request(url, { headers });
 }
 
-describe('extractHarness', () => {
-  it('reads the X-Relaycast-Harness header, lowercased', () => {
-    expect(extractHarness(req({ header: 'Claude-Code' }))).toBe('claude-code');
+describe("extractHarness", () => {
+  it("reads the X-Relaycast-Harness header, lowercased", () => {
+    expect(extractHarness(req({ header: "Claude-Code" }))).toBe("claude-code");
   });
 
-  it('accepts a UA-style token', () => {
-    expect(extractHarness(req({ header: 'claude-code/2.3 (model=opus-4.8; fast)' })))
-      .toBe('claude-code/2.3 (model=opus-4.8; fast)');
+  it("accepts a UA-style token", () => {
+    expect(
+      extractHarness(req({ header: "claude-code/2.3 (model=opus-4.8; fast)" })),
+    ).toBe("claude-code/2.3 (model=opus-4.8; fast)");
   });
 
-  it('falls back to the `harness` query param (browser WS path)', () => {
-    expect(extractHarness(req({ query: 'codex' }))).toBe('codex');
+  it("falls back to the `harness` query param (browser WS path)", () => {
+    expect(extractHarness(req({ query: "codex" }))).toBe("codex");
   });
 
-  it('prefers the header over the query param', () => {
-    expect(extractHarness(req({ header: 'claude-code', query: 'codex' }))).toBe('claude-code');
+  it("prefers the header over the query param", () => {
+    expect(extractHarness(req({ header: "claude-code", query: "codex" }))).toBe(
+      "claude-code",
+    );
   });
 
-  it('returns unknown when neither is present', () => {
+  it("returns unknown when neither is present", () => {
     expect(extractHarness(req())).toBe(UNKNOWN_HARNESS);
   });
 
-  it('rejects disallowed characters in the header', () => {
-    expect(extractHarness(req({ header: 'claude<script>' }))).toBe(UNKNOWN_HARNESS);
+  it("rejects disallowed characters in the header", () => {
+    expect(extractHarness(req({ header: "claude<script>" }))).toBe(
+      UNKNOWN_HARNESS,
+    );
   });
 
-  it('rejects CRLF smuggled through the query param', () => {
+  it("rejects CRLF smuggled through the query param", () => {
     // The runtime Headers object already blocks CRLF header values, so the only
     // way control characters reach us is the query string — drop them there too.
-    expect(extractHarness(req({ query: 'evil\r\nX-Inject: bad' }))).toBe(UNKNOWN_HARNESS);
+    expect(extractHarness(req({ query: "evil\r\nX-Inject: bad" }))).toBe(
+      UNKNOWN_HARNESS,
+    );
   });
 
-  it('rejects empty / whitespace-only values', () => {
-    expect(extractHarness(req({ header: '   ' }))).toBe(UNKNOWN_HARNESS);
+  it("rejects empty / whitespace-only values", () => {
+    expect(extractHarness(req({ header: "   " }))).toBe(UNKNOWN_HARNESS);
   });
 
-  it('truncates to 120 characters', () => {
-    expect(extractHarness(req({ header: 'a'.repeat(200) }))).toBe('a'.repeat(120));
+  it("truncates to 120 characters", () => {
+    expect(extractHarness(req({ header: "a".repeat(200) }))).toBe(
+      "a".repeat(120),
+    );
+  });
+});
+
+describe("extractAgentRelayAnonymousId", () => {
+  it("reads a sanitized Agent Relay anonymous id header", () => {
+    expect(
+      extractAgentRelayAnonymousId(req({ agentRelayId: "abc123def4567890" })),
+    ).toBe("abc123def4567890");
+  });
+
+  it("rejects empty or malformed ids", () => {
+    expect(extractAgentRelayAnonymousId(req())).toBeUndefined();
+    expect(
+      extractAgentRelayAnonymousId(req({ agentRelayId: "   " })),
+    ).toBeUndefined();
+    expect(
+      extractAgentRelayAnonymousId(req({ agentRelayId: "abc<script>" })),
+    ).toBeUndefined();
+  });
+
+  it("truncates long ids", () => {
+    expect(
+      extractAgentRelayAnonymousId(req({ agentRelayId: "a".repeat(200) })),
+    ).toBe("a".repeat(128));
   });
 });

--- a/packages/engine/src/lib/__tests__/serverTelemetry.test.ts
+++ b/packages/engine/src/lib/__tests__/serverTelemetry.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from 'vitest';
+import type { Context } from 'hono';
+import type { AppEnv } from '../../env.js';
+import { emitServerEvent } from '../serverTelemetry.js';
+
+type CapturedEvent = Parameters<AppEnv['Variables']['engine']['telemetry']['capture']>[0];
+
+function contextFor(
+  request: Request,
+  capture: (event: CapturedEvent) => void,
+): Context<AppEnv> {
+  return {
+    req: { raw: request },
+    get(key: keyof AppEnv['Variables']) {
+      if (key === 'engine') {
+        return { telemetry: { capture } };
+      }
+      if (key === 'harness') {
+        return undefined;
+      }
+      return undefined;
+    },
+  } as unknown as Context<AppEnv>;
+}
+
+describe('emitServerEvent', () => {
+  it('uses a valid client anonymous id as the distinct id and preserves workspace id', () => {
+    const captured: CapturedEvent[] = [];
+    const request = new Request('https://gateway.relaycast.dev/v1/messages', {
+      headers: {
+        'X-Agent-Relay-Anonymous-Id': 'anon-123',
+        'X-Relaycast-Origin-Surface': 'sdk',
+        'X-Relaycast-Origin-Client': '@relaycast/sdk',
+        'X-Relaycast-Origin-Version': '2.4.0',
+      },
+    });
+
+    emitServerEvent(
+      contextFor(request, (event) => captured.push(event)),
+      'ws_123',
+      'relaycast_server_message_created',
+      { route_path: '/v1/messages/msg_123456789' },
+    );
+
+    expect(captured).toHaveLength(1);
+    expect(captured[0]).toMatchObject({
+      name: 'relaycast_server_message_created',
+      distinctId: 'anon-123',
+      properties: {
+        app: 'relaycast-server',
+        surface: 'cloud',
+        workspace_id: 'ws_123',
+        client_anonymous_id: 'anon-123',
+        harness: 'unknown',
+        origin_surface: 'sdk',
+        origin_client: '@relaycast/sdk',
+        origin_version: '2.4.0',
+        route_path: '/v1/messages/msg_123456789',
+      },
+    });
+  });
+
+  it('falls back to workspace id when the client anonymous id is malformed', () => {
+    const captured: CapturedEvent[] = [];
+    const request = new Request('https://gateway.relaycast.dev/v1/messages', {
+      headers: {
+        'X-Agent-Relay-Anonymous-Id': 'bad<script>',
+      },
+    });
+
+    emitServerEvent(
+      contextFor(request, (event) => captured.push(event)),
+      'ws_123',
+      'relaycast_server_message_created',
+      {},
+    );
+
+    expect(captured[0]?.distinctId).toBe('ws_123');
+    expect(captured[0]?.properties).not.toHaveProperty('client_anonymous_id');
+  });
+});

--- a/packages/engine/src/lib/logger.ts
+++ b/packages/engine/src/lib/logger.ts
@@ -4,7 +4,9 @@ import type { AppEnv, EngineRuntime } from '../env.js';
 type LogLevel = 'debug' | 'info' | 'warn' | 'error';
 type LogFields = Record<string, unknown>;
 
-const DEFAULT_POSTHOG_HOST = 'https://us.i.posthog.com';
+// Route log export through the first-party reverse proxy; overridable via
+// the engine's logExport.posthogHost config.
+const DEFAULT_POSTHOG_HOST = 'https://i.agentrelay.com';
 const DEFAULT_APP_VERSION = '0.1.0';
 const DEFAULT_SDK_VERSION = 'unknown';
 const SERVICE_NAME = 'relaycast-server';

--- a/packages/engine/src/lib/origin.ts
+++ b/packages/engine/src/lib/origin.ts
@@ -1,4 +1,7 @@
-import { normalizeTelemetryOrigin, type TelemetryOrigin } from '@relaycast/types';
+import {
+  normalizeTelemetryOrigin,
+  type TelemetryOrigin,
+} from "@relaycast/types";
 
 export type OriginInfo = Partial<TelemetryOrigin>;
 
@@ -6,10 +9,11 @@ export type OriginInfo = Partial<TelemetryOrigin>;
  * HTTP header used by harnesses (Claude Code, Cursor, etc.) to identify
  * themselves to the relaycast server. See relay#881.
  */
-export const HARNESS_HEADER = 'X-Relaycast-Harness';
+export const HARNESS_HEADER = "X-Relaycast-Harness";
+export const AGENT_RELAY_ANONYMOUS_ID_HEADER = "X-Agent-Relay-Anonymous-Id";
 
 /** Fallback value when the harness is missing or invalid. */
-export const UNKNOWN_HARNESS = 'unknown';
+export const UNKNOWN_HARNESS = "unknown";
 
 /** Upper bound on the harness value — generous enough for a UA-style token. */
 const HARNESS_MAX_LENGTH = 120;
@@ -21,6 +25,7 @@ const HARNESS_MAX_LENGTH = 120;
  * upstream caller from smuggling a header injection past the relaycast WAF.
  */
 const HARNESS_ALLOWED = /^[a-z0-9 ._\-/():=;,+]+$/i;
+const AGENT_RELAY_ANONYMOUS_ID_ALLOWED = /^[a-z0-9._:-]+$/i;
 
 /**
  * Read and sanitize the harness identifier from a request.
@@ -36,8 +41,9 @@ const HARNESS_ALLOWED = /^[a-z0-9 ._\-/():=;,+]+$/i;
  * in the analytics layer. Drops empty or malformed values to `'unknown'`.
  */
 export function extractHarness(request: Request): string {
-  const raw = request.headers.get(HARNESS_HEADER)
-    ?? new URL(request.url).searchParams.get('harness');
+  const raw =
+    request.headers.get(HARNESS_HEADER) ??
+    new URL(request.url).searchParams.get("harness");
   if (!raw) return UNKNOWN_HARNESS;
 
   const trimmed = raw.trim();
@@ -47,7 +53,23 @@ export function extractHarness(request: Request): string {
   return trimmed.slice(0, HARNESS_MAX_LENGTH).toLowerCase();
 }
 
-function sanitizeOriginPart(value: string | null | undefined, maxLen: number): string | undefined {
+export function extractAgentRelayAnonymousId(
+  request: Request,
+): string | undefined {
+  const raw = request.headers.get(AGENT_RELAY_ANONYMOUS_ID_HEADER);
+  if (!raw) return undefined;
+
+  const trimmed = raw.trim();
+  if (!trimmed) return undefined;
+  if (!AGENT_RELAY_ANONYMOUS_ID_ALLOWED.test(trimmed)) return undefined;
+
+  return trimmed.slice(0, 128);
+}
+
+function sanitizeOriginPart(
+  value: string | null | undefined,
+  maxLen: number,
+): string | undefined {
   if (!value) return undefined;
   const normalized = value.trim();
   if (!normalized) return undefined;
@@ -55,39 +77,45 @@ function sanitizeOriginPart(value: string | null | undefined, maxLen: number): s
 }
 
 export function deriveClientName(headers: Headers): string | undefined {
-  const explicit = headers.get('x-client-name') ?? headers.get('x-relaycast-client');
+  const explicit =
+    headers.get("x-client-name") ?? headers.get("x-relaycast-client");
   if (explicit) return explicit.trim().slice(0, 80);
 
-  const ua = headers.get('user-agent');
+  const ua = headers.get("user-agent");
   if (!ua) return undefined;
   const family = ua.split(/[\/\s;]/)[0];
   return family ? family.trim().slice(0, 80) : undefined;
 }
 
-export function extractOriginInfo(request: Request, fallbackClientName?: string): OriginInfo {
+export function extractOriginInfo(
+  request: Request,
+  fallbackClientName?: string,
+): OriginInfo {
   const headers = request.headers;
   const url = new URL(request.url);
 
-  const querySurface = url.searchParams.get('origin_surface');
-  const queryClient = url.searchParams.get('origin_client');
-  const queryVersion = url.searchParams.get('origin_version');
+  const querySurface = url.searchParams.get("origin_surface");
+  const queryClient = url.searchParams.get("origin_client");
+  const queryVersion = url.searchParams.get("origin_version");
 
   const originSurface = sanitizeOriginPart(
-    headers.get('x-relaycast-origin-surface') ?? headers.get('x-origin-surface') ?? querySurface,
+    headers.get("x-relaycast-origin-surface") ??
+      headers.get("x-origin-surface") ??
+      querySurface,
     32,
   );
   const originClient = sanitizeOriginPart(
-    headers.get('x-relaycast-origin-client')
-      ?? headers.get('x-origin-client')
-      ?? queryClient
-      ?? fallbackClientName,
+    headers.get("x-relaycast-origin-client") ??
+      headers.get("x-origin-client") ??
+      queryClient ??
+      fallbackClientName,
     80,
   );
   const originVersion = sanitizeOriginPart(
-    headers.get('x-relaycast-origin-version')
-      ?? headers.get('x-origin-version')
-      ?? queryVersion
-      ?? headers.get('x-sdk-version'),
+    headers.get("x-relaycast-origin-version") ??
+      headers.get("x-origin-version") ??
+      queryVersion ??
+      headers.get("x-sdk-version"),
     48,
   );
 
@@ -98,6 +126,11 @@ export function extractOriginInfo(request: Request, fallbackClientName?: string)
   };
 }
 
-export function requiredOriginInfo(request: Request, fallbackClientName?: string): TelemetryOrigin {
-  return normalizeTelemetryOrigin(extractOriginInfo(request, fallbackClientName));
+export function requiredOriginInfo(
+  request: Request,
+  fallbackClientName?: string,
+): TelemetryOrigin {
+  return normalizeTelemetryOrigin(
+    extractOriginInfo(request, fallbackClientName),
+  );
 }

--- a/packages/engine/src/lib/serverTelemetry.ts
+++ b/packages/engine/src/lib/serverTelemetry.ts
@@ -1,20 +1,34 @@
-import type { Context } from 'hono';
-import type { AppEnv } from '../env.js';
-import { extractHarness, requiredOriginInfo, UNKNOWN_HARNESS } from './origin.js';
+import type { Context } from "hono";
+import type { AppEnv } from "../env.js";
+import {
+  extractAgentRelayAnonymousId,
+  extractHarness,
+  requiredOriginInfo,
+  UNKNOWN_HARNESS,
+} from "./origin.js";
 
 type ServerEvent = `relaycast_server_${string}`;
 
 export function normalizeRoutePathForTelemetry(value: string): string {
   const withoutQuery = value.split(/[?#]/)[0] ?? value;
-  const compact = withoutQuery.replace(/\/+/g, '/').trim();
-  const withLeadingSlash = compact.startsWith('/') ? compact : `/${compact}`;
-  const segments = withLeadingSlash.split('/').filter(Boolean).map((segment) => {
-    if (/^\d{6,}$/.test(segment)) return ':id';
-    if (/^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(segment)) return ':id';
-    if (/^(dm|dmch|cmd|sub|wh)_[a-zA-Z0-9_-]{8,}$/.test(segment)) return ':id';
-    return segment;
-  });
-  return `/${segments.join('/')}`;
+  const compact = withoutQuery.replace(/\/+/g, "/").trim();
+  const withLeadingSlash = compact.startsWith("/") ? compact : `/${compact}`;
+  const segments = withLeadingSlash
+    .split("/")
+    .filter(Boolean)
+    .map((segment) => {
+      if (/^\d{6,}$/.test(segment)) return ":id";
+      if (
+        /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(
+          segment,
+        )
+      )
+        return ":id";
+      if (/^(dm|dmch|cmd|sub|wh)_[a-zA-Z0-9_-]{8,}$/.test(segment))
+        return ":id";
+      return segment;
+    });
+  return `/${segments.join("/")}`;
 }
 
 /**
@@ -29,22 +43,27 @@ export function emitServerEvent(
   properties: Record<string, unknown>,
 ): void {
   const normalizedProperties = { ...properties };
-  if (typeof normalizedProperties.route_path === 'string') {
-    normalizedProperties.route_path = normalizeRoutePathForTelemetry(normalizedProperties.route_path);
+  if (typeof normalizedProperties.route_path === "string") {
+    normalizedProperties.route_path = normalizeRoutePathForTelemetry(
+      normalizedProperties.route_path,
+    );
   }
 
   // Prefer the value stashed by the logger middleware. Fall back to reading the
   // header directly so emitters that bypass middleware still get a sane value.
-  const harness = c.get('harness')
-    ?? extractHarness(c.req.raw)
-    ?? UNKNOWN_HARNESS;
+  const harness =
+    c.get("harness") ?? extractHarness(c.req.raw) ?? UNKNOWN_HARNESS;
 
   const origin = requiredOriginInfo(c.req.raw);
-  c.get('engine').telemetry.capture({
+  const clientAnonymousId = extractAgentRelayAnonymousId(c.req.raw);
+  c.get("engine").telemetry.capture({
     name: event,
-    distinctId: workspaceId,
+    distinctId: clientAnonymousId ?? workspaceId,
     properties: {
+      app: "relaycast-server",
+      surface: "cloud",
       workspace_id: workspaceId,
+      ...(clientAnonymousId ? { client_anonymous_id: clientAnonymousId } : {}),
       harness,
       origin_surface: origin.origin_surface,
       origin_client: origin.origin_client,

--- a/packages/mcp/src/__tests__/telemetry.test.ts
+++ b/packages/mcp/src/__tests__/telemetry.test.ts
@@ -139,7 +139,10 @@ describe('createMcpTelemetry', () => {
       vi.mocked(fs.mkdirSync).mockImplementation(() => undefined);
       vi.mocked(fs.writeFileSync).mockImplementation(() => undefined);
 
-      const telemetry = createMcpTelemetry('1.0.0', { posthogHost: 'https://api.example.com' });
+      const telemetry = createMcpTelemetry('1.0.0', {
+        posthogHost: 'https://api.example.com',
+        posthogApiKey: 'phc_example',
+      });
       telemetry.capture('relaycast_mcp_server_started', {});
       await telemetry.flush();
 
@@ -153,6 +156,18 @@ describe('createMcpTelemetry', () => {
         (globalThis as { WebSocketPair?: unknown }).WebSocketPair = originalWebSocketPair;
       }
     }
+  });
+
+  it('silently no-ops when no PostHog API key is configured', async () => {
+    vi.mocked(fs.readFileSync).mockReturnValue(JSON.stringify({ anonymousId: 'anon-123' }));
+
+    // No env key, no option key → telemetry disabled, no HTTP call.
+    const telemetry = createMcpTelemetry('1.0.0', { posthogHost: 'https://api.example.com' });
+    telemetry.capture('relaycast_mcp_server_started', { transport: 'stdio' });
+    await telemetry.flush();
+
+    expect(nodeRequestMock).not.toHaveBeenCalled();
+    expect(capturedBodies).toHaveLength(0);
   });
 
   it('flush resolves when no events are pending', async () => {

--- a/packages/mcp/src/__tests__/telemetry.test.ts
+++ b/packages/mcp/src/__tests__/telemetry.test.ts
@@ -158,6 +158,20 @@ describe('createMcpTelemetry', () => {
     }
   });
 
+  it('defaults to the first-party proxy host when none is configured', async () => {
+    vi.mocked(fs.readFileSync).mockReturnValue(JSON.stringify({ anonymousId: 'anon-123' }));
+
+    // Key but no host → falls back to the default proxy, not posthog.com directly.
+    const telemetry = createMcpTelemetry('1.0.0', { posthogApiKey: 'phc_example' });
+    telemetry.capture('relaycast_mcp_server_started', {});
+    await telemetry.flush();
+
+    expect(nodeRequestMock).toHaveBeenCalledTimes(1);
+    const options = nodeRequestMock.mock.calls[0]?.[0] as { hostname: string; path: string };
+    expect(options.hostname).toBe('i.agentrelay.com');
+    expect(options.path).toBe('/capture/');
+  });
+
   it('silently no-ops when no PostHog API key is configured', async () => {
     vi.mocked(fs.readFileSync).mockReturnValue(JSON.stringify({ anonymousId: 'anon-123' }));
 

--- a/packages/mcp/src/telemetry.ts
+++ b/packages/mcp/src/telemetry.ts
@@ -29,7 +29,10 @@ export interface McpTelemetry {
 }
 
 const TELEMETRY_PATH = path.join(os.homedir(), '.relay', 'telemetry.json');
-const DEFAULT_POSTHOG_HOST = 'https://us.i.posthog.com';
+// Route ingestion through the first-party reverse proxy rather than PostHog
+// directly (avoids ad-blockers, keeps traffic first-party). Overridable via
+// RELAYCAST_POSTHOG_HOST / POSTHOG_HOST / options.posthogHost.
+const DEFAULT_POSTHOG_HOST = 'https://i.agentrelay.com';
 
 function isTruthy(value: string | undefined): boolean {
   if (!value) return false;

--- a/packages/mcp/src/telemetry.ts
+++ b/packages/mcp/src/telemetry.ts
@@ -30,7 +30,6 @@ export interface McpTelemetry {
 
 const TELEMETRY_PATH = path.join(os.homedir(), '.relay', 'telemetry.json');
 const DEFAULT_POSTHOG_HOST = 'https://us.i.posthog.com';
-const DEFAULT_POSTHOG_PUBLIC_KEY = 'phc_OAqBdey9pESZCcwaen9Fpyz6Ez8QKiMmLOnvFknXzg4';
 
 function isTruthy(value: string | undefined): boolean {
   if (!value) return false;
@@ -38,7 +37,10 @@ function isTruthy(value: string | undefined): boolean {
   return normalized === '1' || normalized === 'true' || normalized === 'yes' || normalized === 'on';
 }
 
-function telemetryEnabled(state: TelemetryState): boolean {
+function telemetryEnabled(state: TelemetryState, apiKey: string): boolean {
+  // No key configured (e.g. forks, local dev, CI) → silently no-op. Same code
+  // path as the explicit DO_NOT_TRACK / RELAYCAST_TELEMETRY_DISABLED opt-outs.
+  if (!apiKey) return false;
   if (isTruthy(process.env.DO_NOT_TRACK) || isTruthy(process.env.RELAYCAST_TELEMETRY_DISABLED)) {
     return false;
   }
@@ -61,11 +63,13 @@ function getPosthogHost(options: McpTelemetryOptions): string {
 }
 
 function getPosthogApiKey(options: McpTelemetryOptions): string {
+  // No baked-in default: a missing key disables telemetry rather than writing
+  // into the project's production PostHog. Production injects the key via env.
   return (
     process.env.RELAYCAST_POSTHOG_API_KEY
     ?? process.env.POSTHOG_API_KEY
     ?? options.posthogApiKey
-    ?? DEFAULT_POSTHOG_PUBLIC_KEY
+    ?? ''
   );
 }
 
@@ -211,7 +215,7 @@ export function createMcpTelemetry(version = 'unknown', options: McpTelemetryOpt
   const originVersion = options.originVersion ?? version;
 
   const capture = (event: ClientTelemetryEventName, properties: Record<string, unknown> = {}) => {
-    if (!telemetryEnabled(state)) return;
+    if (!telemetryEnabled(state, posthogApiKey)) return;
 
     const parsed = parseTelemetryIngestionEvent({
       event,

--- a/site/index.html
+++ b/site/index.html
@@ -6,7 +6,7 @@
   <title>Relaycast — Headless Slack for AI Agents</title>
   <meta name="description" content="Give your AI agents channels, threads, DMs, and real-time events. Framework-agnostic messaging that works across any CLI, any language, any model.">
   <meta name="relaycast-posthog-key" content="__RELAYCAST_POSTHOG_API_KEY__">
-  <meta name="relaycast-posthog-host" content="https://us.i.posthog.com">
+  <meta name="relaycast-posthog-host" content="https://i.agentrelay.com">
   <meta name="theme-color" content="#F9FAFB">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/site/index.html
+++ b/site/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Relaycast — Headless Slack for AI Agents</title>
   <meta name="description" content="Give your AI agents channels, threads, DMs, and real-time events. Framework-agnostic messaging that works across any CLI, any language, any model.">
-  <meta name="relaycast-posthog-key" content="phc_OAqBdey9pESZCcwaen9Fpyz6Ez8QKiMmLOnvFknXzg4">
+  <meta name="relaycast-posthog-key" content="__RELAYCAST_POSTHOG_API_KEY__">
   <meta name="relaycast-posthog-host" content="https://us.i.posthog.com">
   <meta name="theme-color" content="#F9FAFB">
   <link rel="preconnect" href="https://fonts.googleapis.com">

--- a/site/script.js
+++ b/site/script.js
@@ -1,5 +1,4 @@
 const POSTHOG_DEFAULT_HOST = 'https://us.i.posthog.com';
-const POSTHOG_PUBLIC_KEY = 'phc_OAqBdey9pESZCcwaen9Fpyz6Ez8QKiMmLOnvFknXzg4';
 const POSTHOG_DISTINCT_ID_KEY = 'relaycast_posthog_distinct_id';
 const POSTHOG_SESSION_ID = window.crypto?.randomUUID?.() ?? String(Date.now());
 
@@ -36,8 +35,17 @@ const telemetry = (() => {
   const posthogKey =
     window.POSTHOG_API_KEY ||
     window.RELAYCAST_POSTHOG_KEY ||
-    getMetaContent('relaycast-posthog-key') ||
-    POSTHOG_PUBLIC_KEY;
+    getMetaContent('relaycast-posthog-key');
+
+  // No real key configured — e.g. the `__RELAYCAST_POSTHOG_API_KEY__` placeholder
+  // was never substituted (forks, local `file://` previews). Treat as opt-out
+  // rather than firing requests with a garbage key.
+  if (!posthogKey || !posthogKey.startsWith('phc_')) {
+    return {
+      enabled: false,
+      capture: () => {},
+    };
+  }
 
   const rawHost =
     window.POSTHOG_HOST || window.RELAYCAST_POSTHOG_HOST || getMetaContent('relaycast-posthog-host');

--- a/site/script.js
+++ b/site/script.js
@@ -1,4 +1,4 @@
-const POSTHOG_DEFAULT_HOST = 'https://us.i.posthog.com';
+const POSTHOG_DEFAULT_HOST = 'https://i.agentrelay.com';
 const POSTHOG_DISTINCT_ID_KEY = 'relaycast_posthog_distinct_id';
 const POSTHOG_SESSION_ID = window.crypto?.randomUUID?.() ?? String(Date.now());
 


### PR DESCRIPTION
## **User description**
## What

Brings the Python SDK (`relay-sdk` in `packages/sdk-python`) up to parity with the npm and Rust SDKs, which already have automated publish workflows — the Python package previously had none.

### `publish-python.yml` (new)
Manual `workflow_dispatch`, modeled on `publish-rust.yml`:
- Inputs: `version` bump type (patch/minor/major/pre*), optional `custom_version`, `dry_run`.
- Uses **uv** (matching the package's `uv.lock`).
- Bumps the version and writes it to **both** places that must stay in sync: `pyproject.toml` and the `SDK_VERSION` constant in `src/relay_sdk/client.py`. Prerelease bumps use PEP 440 `bN` markers.
- Build/test: `uv sync --all-extras` → `uv run python -m pytest` → `uv build` → `twine check`.
- Publishes to PyPI via `pypa/gh-action-pypi-publish` using a classic **`PYPI_API_TOKEN`** secret.
- Commits the bump, tags `sdk-python-v<version>`, and creates a GitHub Release. `dry_run` stops after build/check.

### `ci.yml`
- Adds a `python-sdk` job (alongside `rust-sdk`) running the pytest suite on PRs via uv.

## Verification
- Both workflow YAML files parse.
- Test command passes locally: **174 passed**.

## Required before first publish
- Add the **`PYPI_API_TOKEN`** repo secret (Settings → Secrets and variables → Actions). For the very first publish, an account-scoped token is needed since the project doesn't exist on PyPI yet; rotate to a project-scoped token afterward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Route telemetry through the first-party proxy and add Python SDK publishing**

### What Changed
- Server and MCP telemetry now send data through the first-party relaycast host by default instead of PostHog directly
- Telemetry now uses an Agent Relay anonymous ID when present, so events from the same client can be linked more reliably
- The marketing site no longer ships with a baked-in analytics key; telemetry stays off when no real key is injected
- Added a manual Python SDK release workflow that bumps the package version, runs tests, builds the package, publishes to PyPI, and creates a GitHub release
- Python SDK tests now run on pull requests in CI

### Impact
`✅ Fewer broken telemetry events from ad blockers`
`✅ Cleaner analytics across connected client sessions`
`✅ Safer marketing site deployments without accidental tracking`
`✅ Python SDK releases can be published from GitHub`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
