### PR TITLE
feat(sdk): forward Agent Relay distinct identity

### DIFF
--- a/.agentworkforce/trajectories/completed/2026-06/traj_02kwlw0w4ti6/summary.md
+++ b/.agentworkforce/trajectories/completed/2026-06/traj_02kwlw0w4ti6/summary.md
@@ -1,0 +1,32 @@
+# Trajectory: Review PR #167
+
+> **Status:** ✅ Completed
+> **Confidence:** 86%
+> **Started:** June 3, 2026 at 10:48 AM
+> **Completed:** June 3, 2026 at 10:51 AM
+
+---
+
+## Summary
+
+Reviewed PR #167 anonymous Agent Relay id propagation across engine, TypeScript SDK, Python SDK, and Rust SDK. No code changes were needed; focused TypeScript, engine, Python, lint, and build checks passed after dependency workspace setup. Rust was statically reviewed but not executed because cargo/rustc are unavailable.
+
+**Approach:** Standard approach
+
+---
+
+## Key Decisions
+
+### Validated PR #167 focused surfaces
+- **Chose:** Validated PR #167 focused surfaces
+- **Reasoning:** After building dependent TypeScript workspaces, focused engine and TypeScript SDK tests pass; Python SDK focused tests pass after installing package extras. Rust tests remain un-runnable because cargo is unavailable in this environment.
+
+---
+
+## Chapters
+
+### 1. Work
+*Agent: default*
+
+- Validated PR #167 focused surfaces: Validated PR #167 focused surfaces
+- PR #167 review found no code changes required after focused validation; Rust remains statically reviewed only because cargo/rustc are unavailable in the runner.

--- a/.agentworkforce/trajectories/completed/2026-06/traj_02kwlw0w4ti6/trajectory.json
+++ b/.agentworkforce/trajectories/completed/2026-06/traj_02kwlw0w4ti6/trajectory.json
@@ -1,0 +1,65 @@
+{
+  "id": "traj_02kwlw0w4ti6",
+  "version": 1,
+  "task": {
+    "title": "Review PR #167"
+  },
+  "status": "completed",
+  "startedAt": "2026-06-03T10:48:59.949Z",
+  "completedAt": "2026-06-03T10:51:12.847Z",
+  "agents": [
+    {
+      "name": "default",
+      "role": "lead",
+      "joinedAt": "2026-06-03T10:50:00.042Z"
+    }
+  ],
+  "chapters": [
+    {
+      "id": "chap_494eb5s2ccs4",
+      "title": "Work",
+      "agentName": "default",
+      "startedAt": "2026-06-03T10:50:00.042Z",
+      "endedAt": "2026-06-03T10:51:12.847Z",
+      "events": [
+        {
+          "ts": 1780483800043,
+          "type": "decision",
+          "content": "Validated PR #167 focused surfaces: Validated PR #167 focused surfaces",
+          "raw": {
+            "question": "Validated PR #167 focused surfaces",
+            "chosen": "Validated PR #167 focused surfaces",
+            "alternatives": [],
+            "reasoning": "After building dependent TypeScript workspaces, focused engine and TypeScript SDK tests pass; Python SDK focused tests pass after installing package extras. Rust tests remain un-runnable because cargo is unavailable in this environment."
+          },
+          "significance": "high"
+        },
+        {
+          "ts": 1780483860097,
+          "type": "reflection",
+          "content": "PR #167 review found no code changes required after focused validation; Rust remains statically reviewed only because cargo/rustc are unavailable in the runner.",
+          "raw": {
+            "confidence": 0.86
+          },
+          "significance": "high",
+          "tags": [
+            "confidence:0.86"
+          ]
+        }
+      ]
+    }
+  ],
+  "retrospective": {
+    "summary": "Reviewed PR #167 anonymous Agent Relay id propagation across engine, TypeScript SDK, Python SDK, and Rust SDK. No code changes were needed; focused TypeScript, engine, Python, lint, and build checks passed after dependency workspace setup. Rust was statically reviewed but not executed because cargo/rustc are unavailable.",
+    "approach": "Standard approach",
+    "confidence": 0.86
+  },
+  "commits": [],
+  "filesChanged": [],
+  "projectId": "AgentWorkforce/relaycast",
+  "tags": [],
+  "_trace": {
+    "startRef": "6bff4189b194d09462ed069a4da0bec2c7744c7d",
+    "endRef": "6bff4189b194d09462ed069a4da0bec2c7744c7d"
+  }
+}

--- a/.agentworkforce/trajectories/completed/2026-06/traj_kgjircgbl4ix/summary.md
+++ b/.agentworkforce/trajectories/completed/2026-06/traj_kgjircgbl4ix/summary.md
@@ -1,0 +1,14 @@
+# Trajectory: Update SDKs to forward Agent Relay anonymous identity
+
+> **Status:** ✅ Completed
+> **Confidence:** 91%
+> **Started:** June 3, 2026 at 06:28 AM
+> **Completed:** June 3, 2026 at 06:37 AM
+
+---
+
+## Summary
+
+Added sanitized Agent Relay anonymous id propagation across TypeScript, Python, and Rust SDK HTTP/WS surfaces, plus engine WS query extraction and focused tests.
+
+**Approach:** Standard approach

--- a/.agentworkforce/trajectories/completed/2026-06/traj_kgjircgbl4ix/summary.md
+++ b/.agentworkforce/trajectories/completed/2026-06/traj_kgjircgbl4ix/summary.md
@@ -1,4 +1,4 @@
-# Trajectory: Update SDKs to forward Agent Relay anonymous identity
+# Trajectory: Update SDKs to forward Agent Relay distinct identity
 
 > **Status:** ✅ Completed
 > **Confidence:** 91%
@@ -9,6 +9,6 @@
 
 ## Summary
 
-Added sanitized Agent Relay anonymous id propagation across TypeScript, Python, and Rust SDK HTTP/WS surfaces, plus engine WS query extraction and focused tests.
+Added sanitized Agent Relay distinct id propagation across TypeScript, Python, and Rust SDK HTTP/WS surfaces, plus engine WS query extraction and focused tests.
 
 **Approach:** Standard approach

--- a/.agentworkforce/trajectories/completed/2026-06/traj_kgjircgbl4ix/trajectory.json
+++ b/.agentworkforce/trajectories/completed/2026-06/traj_kgjircgbl4ix/trajectory.json
@@ -1,0 +1,25 @@
+{
+  "id": "traj_kgjircgbl4ix",
+  "version": 1,
+  "task": {
+    "title": "Update SDKs to forward Agent Relay anonymous identity"
+  },
+  "status": "completed",
+  "startedAt": "2026-06-03T10:28:43.564Z",
+  "completedAt": "2026-06-03T10:37:19.633Z",
+  "agents": [],
+  "chapters": [],
+  "retrospective": {
+    "summary": "Added sanitized Agent Relay anonymous id propagation across TypeScript, Python, and Rust SDK HTTP/WS surfaces, plus engine WS query extraction and focused tests.",
+    "approach": "Standard approach",
+    "confidence": 0.91
+  },
+  "commits": [],
+  "filesChanged": [],
+  "projectId": "AgentWorkforce/relaycast",
+  "tags": [],
+  "_trace": {
+    "startRef": "dc6cd7097b39da0c62a42b4caf95815f9abef4f9",
+    "endRef": "dc6cd7097b39da0c62a42b4caf95815f9abef4f9"
+  }
+}

--- a/.agentworkforce/trajectories/completed/2026-06/traj_kgjircgbl4ix/trajectory.json
+++ b/.agentworkforce/trajectories/completed/2026-06/traj_kgjircgbl4ix/trajectory.json
@@ -2,7 +2,7 @@
   "id": "traj_kgjircgbl4ix",
   "version": 1,
   "task": {
-    "title": "Update SDKs to forward Agent Relay anonymous identity"
+    "title": "Update SDKs to forward Agent Relay distinct identity"
   },
   "status": "completed",
   "startedAt": "2026-06-03T10:28:43.564Z",
@@ -10,7 +10,7 @@
   "agents": [],
   "chapters": [],
   "retrospective": {
-    "summary": "Added sanitized Agent Relay anonymous id propagation across TypeScript, Python, and Rust SDK HTTP/WS surfaces, plus engine WS query extraction and focused tests.",
+    "summary": "Added sanitized Agent Relay distinct id propagation across TypeScript, Python, and Rust SDK HTTP/WS surfaces, plus engine WS query extraction and focused tests.",
     "approach": "Standard approach",
     "confidence": 0.91
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -206,7 +206,7 @@
     },
     "node_modules/@clack/prompts/node_modules/is-unicode-supported": {
       "version": "1.3.0",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {

--- a/packages/engine/src/lib/__tests__/origin.test.ts
+++ b/packages/engine/src/lib/__tests__/origin.test.ts
@@ -6,10 +6,18 @@ import {
 } from "../origin.js";
 
 function req(
-  init: { agentRelayId?: string; header?: string; query?: string } = {},
+  init: {
+    agentRelayId?: string;
+    agentRelayQuery?: string;
+    header?: string;
+    query?: string;
+  } = {},
 ): Request {
   const url = new URL("https://gateway.relaycast.dev/v1/activity");
   if (init.query !== undefined) url.searchParams.set("harness", init.query);
+  if (init.agentRelayQuery !== undefined) {
+    url.searchParams.set("agent_relay_anonymous_id", init.agentRelayQuery);
+  }
   const headers = new Headers();
   if (init.header !== undefined)
     headers.set("X-Relaycast-Harness", init.header);
@@ -76,6 +84,25 @@ describe("extractAgentRelayAnonymousId", () => {
     ).toBe("abc123def4567890");
   });
 
+  it("falls back to the Agent Relay anonymous id query param", () => {
+    expect(
+      extractAgentRelayAnonymousId(
+        req({ agentRelayQuery: "abc123def4567890" }),
+      ),
+    ).toBe("abc123def4567890");
+  });
+
+  it("prefers the Agent Relay anonymous id header over the query param", () => {
+    expect(
+      extractAgentRelayAnonymousId(
+        req({
+          agentRelayId: "from-header",
+          agentRelayQuery: "from-query",
+        }),
+      ),
+    ).toBe("from-header");
+  });
+
   it("rejects empty or malformed ids", () => {
     expect(extractAgentRelayAnonymousId(req())).toBeUndefined();
     expect(
@@ -83,6 +110,11 @@ describe("extractAgentRelayAnonymousId", () => {
     ).toBeUndefined();
     expect(
       extractAgentRelayAnonymousId(req({ agentRelayId: "abc<script>" })),
+    ).toBeUndefined();
+    expect(
+      extractAgentRelayAnonymousId(
+        req({ agentRelayQuery: "evil\r\nX-Inject: bad" }),
+      ),
     ).toBeUndefined();
   });
 

--- a/packages/engine/src/lib/__tests__/origin.test.ts
+++ b/packages/engine/src/lib/__tests__/origin.test.ts
@@ -1,28 +1,28 @@
 import { describe, expect, it } from "vitest";
 import {
-  extractAgentRelayAnonymousId,
+  extractAgentRelayDistinctId,
   extractHarness,
   UNKNOWN_HARNESS,
 } from "../origin.js";
 
 function req(
   init: {
-    agentRelayId?: string;
-    agentRelayQuery?: string;
+    agentRelayDistinctId?: string;
+    agentRelayDistinctQuery?: string;
     header?: string;
     query?: string;
   } = {},
 ): Request {
   const url = new URL("https://gateway.relaycast.dev/v1/activity");
   if (init.query !== undefined) url.searchParams.set("harness", init.query);
-  if (init.agentRelayQuery !== undefined) {
-    url.searchParams.set("agent_relay_anonymous_id", init.agentRelayQuery);
+  if (init.agentRelayDistinctQuery !== undefined) {
+    url.searchParams.set("agent_relay_distinct_id", init.agentRelayDistinctQuery);
   }
   const headers = new Headers();
   if (init.header !== undefined)
     headers.set("X-Relaycast-Harness", init.header);
-  if (init.agentRelayId !== undefined) {
-    headers.set("X-Agent-Relay-Anonymous-Id", init.agentRelayId);
+  if (init.agentRelayDistinctId !== undefined) {
+    headers.set("X-Agent-Relay-Distinct-Id", init.agentRelayDistinctId);
   }
   return new Request(url, { headers });
 }
@@ -77,50 +77,50 @@ describe("extractHarness", () => {
   });
 });
 
-describe("extractAgentRelayAnonymousId", () => {
-  it("reads a sanitized Agent Relay anonymous id header", () => {
+describe("extractAgentRelayDistinctId", () => {
+  it("reads a sanitized Agent Relay distinct id header", () => {
     expect(
-      extractAgentRelayAnonymousId(req({ agentRelayId: "abc123def4567890" })),
+      extractAgentRelayDistinctId(req({ agentRelayDistinctId: "abc123def4567890" })),
     ).toBe("abc123def4567890");
   });
 
-  it("falls back to the Agent Relay anonymous id query param", () => {
+  it("falls back to the Agent Relay distinct id query param", () => {
     expect(
-      extractAgentRelayAnonymousId(
-        req({ agentRelayQuery: "abc123def4567890" }),
+      extractAgentRelayDistinctId(
+        req({ agentRelayDistinctQuery: "abc123def4567890" }),
       ),
     ).toBe("abc123def4567890");
   });
 
-  it("prefers the Agent Relay anonymous id header over the query param", () => {
+  it("prefers the Agent Relay distinct id header over the query param", () => {
     expect(
-      extractAgentRelayAnonymousId(
+      extractAgentRelayDistinctId(
         req({
-          agentRelayId: "from-header",
-          agentRelayQuery: "from-query",
+          agentRelayDistinctId: "from-header",
+          agentRelayDistinctQuery: "from-query",
         }),
       ),
     ).toBe("from-header");
   });
 
   it("rejects empty or malformed ids", () => {
-    expect(extractAgentRelayAnonymousId(req())).toBeUndefined();
+    expect(extractAgentRelayDistinctId(req())).toBeUndefined();
     expect(
-      extractAgentRelayAnonymousId(req({ agentRelayId: "   " })),
+      extractAgentRelayDistinctId(req({ agentRelayDistinctId: "   " })),
     ).toBeUndefined();
     expect(
-      extractAgentRelayAnonymousId(req({ agentRelayId: "abc<script>" })),
+      extractAgentRelayDistinctId(req({ agentRelayDistinctId: "abc<script>" })),
     ).toBeUndefined();
     expect(
-      extractAgentRelayAnonymousId(
-        req({ agentRelayQuery: "evil\r\nX-Inject: bad" }),
+      extractAgentRelayDistinctId(
+        req({ agentRelayDistinctQuery: "evil\r\nX-Inject: bad" }),
       ),
     ).toBeUndefined();
   });
 
   it("truncates long ids", () => {
     expect(
-      extractAgentRelayAnonymousId(req({ agentRelayId: "a".repeat(200) })),
+      extractAgentRelayDistinctId(req({ agentRelayDistinctId: "a".repeat(200) })),
     ).toBe("a".repeat(128));
   });
 });

--- a/packages/engine/src/lib/origin.ts
+++ b/packages/engine/src/lib/origin.ts
@@ -11,6 +11,7 @@ export type OriginInfo = Partial<TelemetryOrigin>;
  */
 export const HARNESS_HEADER = "X-Relaycast-Harness";
 export const AGENT_RELAY_ANONYMOUS_ID_HEADER = "X-Agent-Relay-Anonymous-Id";
+export const AGENT_RELAY_ANONYMOUS_ID_QUERY = "agent_relay_anonymous_id";
 
 /** Fallback value when the harness is missing or invalid. */
 export const UNKNOWN_HARNESS = "unknown";
@@ -56,7 +57,9 @@ export function extractHarness(request: Request): string {
 export function extractAgentRelayAnonymousId(
   request: Request,
 ): string | undefined {
-  const raw = request.headers.get(AGENT_RELAY_ANONYMOUS_ID_HEADER);
+  const raw =
+    request.headers.get(AGENT_RELAY_ANONYMOUS_ID_HEADER) ??
+    new URL(request.url).searchParams.get(AGENT_RELAY_ANONYMOUS_ID_QUERY);
   if (!raw) return undefined;
 
   const trimmed = raw.trim();

--- a/packages/engine/src/lib/origin.ts
+++ b/packages/engine/src/lib/origin.ts
@@ -10,8 +10,8 @@ export type OriginInfo = Partial<TelemetryOrigin>;
  * themselves to the relaycast server. See relay#881.
  */
 export const HARNESS_HEADER = "X-Relaycast-Harness";
-export const AGENT_RELAY_ANONYMOUS_ID_HEADER = "X-Agent-Relay-Anonymous-Id";
-export const AGENT_RELAY_ANONYMOUS_ID_QUERY = "agent_relay_anonymous_id";
+export const AGENT_RELAY_DISTINCT_ID_HEADER = "X-Agent-Relay-Distinct-Id";
+export const AGENT_RELAY_DISTINCT_ID_QUERY = "agent_relay_distinct_id";
 
 /** Fallback value when the harness is missing or invalid. */
 export const UNKNOWN_HARNESS = "unknown";
@@ -26,7 +26,7 @@ const HARNESS_MAX_LENGTH = 120;
  * upstream caller from smuggling a header injection past the relaycast WAF.
  */
 const HARNESS_ALLOWED = /^[a-z0-9 ._\-/():=;,+]+$/i;
-const AGENT_RELAY_ANONYMOUS_ID_ALLOWED = /^[a-z0-9._:-]+$/i;
+const AGENT_RELAY_DISTINCT_ID_ALLOWED = /^[a-z0-9._:-]+$/i;
 
 /**
  * Read and sanitize the harness identifier from a request.
@@ -54,17 +54,17 @@ export function extractHarness(request: Request): string {
   return trimmed.slice(0, HARNESS_MAX_LENGTH).toLowerCase();
 }
 
-export function extractAgentRelayAnonymousId(
+export function extractAgentRelayDistinctId(
   request: Request,
 ): string | undefined {
   const raw =
-    request.headers.get(AGENT_RELAY_ANONYMOUS_ID_HEADER) ??
-    new URL(request.url).searchParams.get(AGENT_RELAY_ANONYMOUS_ID_QUERY);
+    request.headers.get(AGENT_RELAY_DISTINCT_ID_HEADER) ??
+    new URL(request.url).searchParams.get(AGENT_RELAY_DISTINCT_ID_QUERY);
   if (!raw) return undefined;
 
   const trimmed = raw.trim();
   if (!trimmed) return undefined;
-  if (!AGENT_RELAY_ANONYMOUS_ID_ALLOWED.test(trimmed)) return undefined;
+  if (!AGENT_RELAY_DISTINCT_ID_ALLOWED.test(trimmed)) return undefined;
 
   return trimmed.slice(0, 128);
 }

--- a/packages/engine/src/lib/serverTelemetry.ts
+++ b/packages/engine/src/lib/serverTelemetry.ts
@@ -1,7 +1,7 @@
 import type { Context } from "hono";
 import type { AppEnv } from "../env.js";
 import {
-  extractAgentRelayAnonymousId,
+  extractAgentRelayDistinctId,
   extractHarness,
   requiredOriginInfo,
   UNKNOWN_HARNESS,
@@ -55,15 +55,15 @@ export function emitServerEvent(
     c.get("harness") ?? extractHarness(c.req.raw) ?? UNKNOWN_HARNESS;
 
   const origin = requiredOriginInfo(c.req.raw);
-  const clientAnonymousId = extractAgentRelayAnonymousId(c.req.raw);
+  const clientDistinctId = extractAgentRelayDistinctId(c.req.raw);
   c.get("engine").telemetry.capture({
     name: event,
-    distinctId: clientAnonymousId ?? workspaceId,
+    distinctId: clientDistinctId ?? workspaceId,
     properties: {
       app: "relaycast-server",
       surface: "cloud",
       workspace_id: workspaceId,
-      ...(clientAnonymousId ? { client_anonymous_id: clientAnonymousId } : {}),
+      ...(clientDistinctId ? { client_distinct_id: clientDistinctId } : {}),
       harness,
       origin_surface: origin.origin_surface,
       origin_client: origin.origin_client,

--- a/packages/sdk-python/src/relay_sdk/__init__.py
+++ b/packages/sdk-python/src/relay_sdk/__init__.py
@@ -1,7 +1,14 @@
 """Relay SDK — Python client for Relay Transport."""
 
 from .agent import AgentClient, AsyncAgentClient
-from .client import AsyncHttpClient, HttpClient, SDK_VERSION
+from .client import (
+    AGENT_RELAY_ANONYMOUS_ID_HEADER,
+    AGENT_RELAY_ANONYMOUS_ID_QUERY,
+    AsyncHttpClient,
+    HttpClient,
+    SDK_VERSION,
+    sanitize_agent_relay_anonymous_id,
+)
 from .errors import RelayError
 from .relay import AsyncRelay, Relay
 from .ws import WsClient
@@ -10,6 +17,8 @@ __version__ = SDK_VERSION
 
 __all__ = [
     "AgentClient",
+    "AGENT_RELAY_ANONYMOUS_ID_HEADER",
+    "AGENT_RELAY_ANONYMOUS_ID_QUERY",
     "AsyncAgentClient",
     "AsyncHttpClient",
     "AsyncRelay",
@@ -18,4 +27,5 @@ __all__ = [
     "RelayError",
     "SDK_VERSION",
     "WsClient",
+    "sanitize_agent_relay_anonymous_id",
 ]

--- a/packages/sdk-python/src/relay_sdk/__init__.py
+++ b/packages/sdk-python/src/relay_sdk/__init__.py
@@ -2,12 +2,12 @@
 
 from .agent import AgentClient, AsyncAgentClient
 from .client import (
-    AGENT_RELAY_ANONYMOUS_ID_HEADER,
-    AGENT_RELAY_ANONYMOUS_ID_QUERY,
+    AGENT_RELAY_DISTINCT_ID_HEADER,
+    AGENT_RELAY_DISTINCT_ID_QUERY,
     AsyncHttpClient,
     HttpClient,
     SDK_VERSION,
-    sanitize_agent_relay_anonymous_id,
+    sanitize_agent_relay_distinct_id,
 )
 from .errors import RelayError
 from .relay import AsyncRelay, Relay
@@ -17,8 +17,8 @@ __version__ = SDK_VERSION
 
 __all__ = [
     "AgentClient",
-    "AGENT_RELAY_ANONYMOUS_ID_HEADER",
-    "AGENT_RELAY_ANONYMOUS_ID_QUERY",
+    "AGENT_RELAY_DISTINCT_ID_HEADER",
+    "AGENT_RELAY_DISTINCT_ID_QUERY",
     "AsyncAgentClient",
     "AsyncHttpClient",
     "AsyncRelay",
@@ -27,5 +27,5 @@ __all__ = [
     "RelayError",
     "SDK_VERSION",
     "WsClient",
-    "sanitize_agent_relay_anonymous_id",
+    "sanitize_agent_relay_distinct_id",
 ]

--- a/packages/sdk-python/src/relay_sdk/client.py
+++ b/packages/sdk-python/src/relay_sdk/client.py
@@ -12,24 +12,24 @@ import httpx
 from .errors import RelayError
 
 SDK_VERSION = "0.1.0"
-AGENT_RELAY_ANONYMOUS_ID_HEADER = "X-Agent-Relay-Anonymous-Id"
-AGENT_RELAY_ANONYMOUS_ID_QUERY = "agent_relay_anonymous_id"
+AGENT_RELAY_DISTINCT_ID_HEADER = "X-Agent-Relay-Distinct-Id"
+AGENT_RELAY_DISTINCT_ID_QUERY = "agent_relay_distinct_id"
 
 _DEFAULT_BASE_URL = "https://gateway.relaycast.dev"
 _RETRY_BACKOFFS = [0.2, 0.4, 0.8]
 _DEFAULT_ORIGIN_SURFACE = "sdk"
 _DEFAULT_ORIGIN_CLIENT = "@relaycast/python-sdk"
-_AGENT_RELAY_ANONYMOUS_ID_ALLOWED = re.compile(r"^[a-z0-9._:-]+$", re.IGNORECASE)
+_AGENT_RELAY_DISTINCT_ID_ALLOWED = re.compile(r"^[a-z0-9._:-]+$", re.IGNORECASE)
 
 
-def sanitize_agent_relay_anonymous_id(raw: str | None) -> str | None:
-    """Return a sanitized Agent Relay anonymous id, or None when invalid."""
+def sanitize_agent_relay_distinct_id(raw: str | None) -> str | None:
+    """Return a sanitized Agent Relay distinct id, or None when invalid."""
     if not raw:
         return None
     trimmed = raw.strip()
     if not trimmed:
         return None
-    if not _AGENT_RELAY_ANONYMOUS_ID_ALLOWED.fullmatch(trimmed):
+    if not _AGENT_RELAY_DISTINCT_ID_ALLOWED.fullmatch(trimmed):
         return None
     return trimmed[:128]
 
@@ -45,14 +45,14 @@ class HttpClient:
         origin_surface: str | None = None,
         origin_client: str | None = None,
         origin_version: str | None = None,
-        agent_relay_anonymous_id: str | None = None,
+        agent_relay_distinct_id: str | None = None,
     ) -> None:
         self.api_key = api_key
         self.base_url = (base_url or _DEFAULT_BASE_URL).rstrip("/")
         self.origin_surface = (origin_surface or _DEFAULT_ORIGIN_SURFACE).strip()[:32]
         self.origin_client = (origin_client or _DEFAULT_ORIGIN_CLIENT).strip()[:80]
         self.origin_version = (origin_version or SDK_VERSION).strip()[:48]
-        self.agent_relay_anonymous_id = sanitize_agent_relay_anonymous_id(agent_relay_anonymous_id)
+        self.agent_relay_distinct_id = sanitize_agent_relay_distinct_id(agent_relay_distinct_id)
         self._client = httpx.Client(timeout=30.0)
 
     def _headers(self, with_body: bool = False) -> dict[str, str]:
@@ -63,8 +63,8 @@ class HttpClient:
             "X-Relaycast-Origin-Client": self.origin_client,
             "X-Relaycast-Origin-Version": self.origin_version,
         }
-        if self.agent_relay_anonymous_id:
-            headers[AGENT_RELAY_ANONYMOUS_ID_HEADER] = self.agent_relay_anonymous_id
+        if self.agent_relay_distinct_id:
+            headers[AGENT_RELAY_DISTINCT_ID_HEADER] = self.agent_relay_distinct_id
         if with_body:
             headers["Content-Type"] = "application/json"
         return headers
@@ -147,14 +147,14 @@ class AsyncHttpClient:
         origin_surface: str | None = None,
         origin_client: str | None = None,
         origin_version: str | None = None,
-        agent_relay_anonymous_id: str | None = None,
+        agent_relay_distinct_id: str | None = None,
     ) -> None:
         self.api_key = api_key
         self.base_url = (base_url or _DEFAULT_BASE_URL).rstrip("/")
         self.origin_surface = (origin_surface or _DEFAULT_ORIGIN_SURFACE).strip()[:32]
         self.origin_client = (origin_client or _DEFAULT_ORIGIN_CLIENT).strip()[:80]
         self.origin_version = (origin_version or SDK_VERSION).strip()[:48]
-        self.agent_relay_anonymous_id = sanitize_agent_relay_anonymous_id(agent_relay_anonymous_id)
+        self.agent_relay_distinct_id = sanitize_agent_relay_distinct_id(agent_relay_distinct_id)
         self._client = httpx.AsyncClient(timeout=30.0)
 
     def _headers(self, with_body: bool = False) -> dict[str, str]:
@@ -165,8 +165,8 @@ class AsyncHttpClient:
             "X-Relaycast-Origin-Client": self.origin_client,
             "X-Relaycast-Origin-Version": self.origin_version,
         }
-        if self.agent_relay_anonymous_id:
-            headers[AGENT_RELAY_ANONYMOUS_ID_HEADER] = self.agent_relay_anonymous_id
+        if self.agent_relay_distinct_id:
+            headers[AGENT_RELAY_DISTINCT_ID_HEADER] = self.agent_relay_distinct_id
         if with_body:
             headers["Content-Type"] = "application/json"
         return headers

--- a/packages/sdk-python/src/relay_sdk/client.py
+++ b/packages/sdk-python/src/relay_sdk/client.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import re
 from typing import Any
 from urllib.parse import urlencode
 
@@ -11,11 +12,26 @@ import httpx
 from .errors import RelayError
 
 SDK_VERSION = "0.1.0"
+AGENT_RELAY_ANONYMOUS_ID_HEADER = "X-Agent-Relay-Anonymous-Id"
+AGENT_RELAY_ANONYMOUS_ID_QUERY = "agent_relay_anonymous_id"
 
 _DEFAULT_BASE_URL = "https://gateway.relaycast.dev"
 _RETRY_BACKOFFS = [0.2, 0.4, 0.8]
 _DEFAULT_ORIGIN_SURFACE = "sdk"
 _DEFAULT_ORIGIN_CLIENT = "@relaycast/python-sdk"
+_AGENT_RELAY_ANONYMOUS_ID_ALLOWED = re.compile(r"^[a-z0-9._:-]+$", re.IGNORECASE)
+
+
+def sanitize_agent_relay_anonymous_id(raw: str | None) -> str | None:
+    """Return a sanitized Agent Relay anonymous id, or None when invalid."""
+    if not raw:
+        return None
+    trimmed = raw.strip()
+    if not trimmed:
+        return None
+    if not _AGENT_RELAY_ANONYMOUS_ID_ALLOWED.fullmatch(trimmed):
+        return None
+    return trimmed[:128]
 
 
 class HttpClient:
@@ -29,12 +45,14 @@ class HttpClient:
         origin_surface: str | None = None,
         origin_client: str | None = None,
         origin_version: str | None = None,
+        agent_relay_anonymous_id: str | None = None,
     ) -> None:
         self.api_key = api_key
         self.base_url = (base_url or _DEFAULT_BASE_URL).rstrip("/")
         self.origin_surface = (origin_surface or _DEFAULT_ORIGIN_SURFACE).strip()[:32]
         self.origin_client = (origin_client or _DEFAULT_ORIGIN_CLIENT).strip()[:80]
         self.origin_version = (origin_version or SDK_VERSION).strip()[:48]
+        self.agent_relay_anonymous_id = sanitize_agent_relay_anonymous_id(agent_relay_anonymous_id)
         self._client = httpx.Client(timeout=30.0)
 
     def _headers(self, with_body: bool = False) -> dict[str, str]:
@@ -45,6 +63,8 @@ class HttpClient:
             "X-Relaycast-Origin-Client": self.origin_client,
             "X-Relaycast-Origin-Version": self.origin_version,
         }
+        if self.agent_relay_anonymous_id:
+            headers[AGENT_RELAY_ANONYMOUS_ID_HEADER] = self.agent_relay_anonymous_id
         if with_body:
             headers["Content-Type"] = "application/json"
         return headers
@@ -127,12 +147,14 @@ class AsyncHttpClient:
         origin_surface: str | None = None,
         origin_client: str | None = None,
         origin_version: str | None = None,
+        agent_relay_anonymous_id: str | None = None,
     ) -> None:
         self.api_key = api_key
         self.base_url = (base_url or _DEFAULT_BASE_URL).rstrip("/")
         self.origin_surface = (origin_surface or _DEFAULT_ORIGIN_SURFACE).strip()[:32]
         self.origin_client = (origin_client or _DEFAULT_ORIGIN_CLIENT).strip()[:80]
         self.origin_version = (origin_version or SDK_VERSION).strip()[:48]
+        self.agent_relay_anonymous_id = sanitize_agent_relay_anonymous_id(agent_relay_anonymous_id)
         self._client = httpx.AsyncClient(timeout=30.0)
 
     def _headers(self, with_body: bool = False) -> dict[str, str]:
@@ -143,6 +165,8 @@ class AsyncHttpClient:
             "X-Relaycast-Origin-Client": self.origin_client,
             "X-Relaycast-Origin-Version": self.origin_version,
         }
+        if self.agent_relay_anonymous_id:
+            headers[AGENT_RELAY_ANONYMOUS_ID_HEADER] = self.agent_relay_anonymous_id
         if with_body:
             headers["Content-Type"] = "application/json"
         return headers

--- a/packages/sdk-python/src/relay_sdk/relay.py
+++ b/packages/sdk-python/src/relay_sdk/relay.py
@@ -121,7 +121,7 @@ class Relay:
         origin_surface: str | None = None,
         origin_client: str | None = None,
         origin_version: str | None = None,
-        agent_relay_anonymous_id: str | None = None,
+        agent_relay_distinct_id: str | None = None,
     ) -> None:
         if not api_key or not api_key.strip():
             raise ValueError("Relay api_key is required")
@@ -132,7 +132,7 @@ class Relay:
             origin_surface=origin_surface,
             origin_client=origin_client,
             origin_version=origin_version,
-            agent_relay_anonymous_id=agent_relay_anonymous_id,
+            agent_relay_distinct_id=agent_relay_distinct_id,
         )
         self.workspace = _WorkspaceNamespace(self._client)
         self.agents = _AgentsNamespace(self._client)
@@ -144,7 +144,7 @@ class Relay:
             origin_surface=self._client.origin_surface,
             origin_client=self._client.origin_client,
             origin_version=self._client.origin_version,
-            agent_relay_anonymous_id=self._client.agent_relay_anonymous_id,
+            agent_relay_distinct_id=self._client.agent_relay_distinct_id,
         )
         return AgentClient(agent_client)
 
@@ -266,7 +266,7 @@ class AsyncRelay:
         origin_surface: str | None = None,
         origin_client: str | None = None,
         origin_version: str | None = None,
-        agent_relay_anonymous_id: str | None = None,
+        agent_relay_distinct_id: str | None = None,
     ) -> None:
         if not api_key or not api_key.strip():
             raise ValueError("Relay api_key is required")
@@ -277,7 +277,7 @@ class AsyncRelay:
             origin_surface=origin_surface,
             origin_client=origin_client,
             origin_version=origin_version,
-            agent_relay_anonymous_id=agent_relay_anonymous_id,
+            agent_relay_distinct_id=agent_relay_distinct_id,
         )
         self.workspace = _AsyncWorkspaceNamespace(self._client)
         self.agents = _AsyncAgentsNamespace(self._client)
@@ -289,7 +289,7 @@ class AsyncRelay:
             origin_surface=self._client.origin_surface,
             origin_client=self._client.origin_client,
             origin_version=self._client.origin_version,
-            agent_relay_anonymous_id=self._client.agent_relay_anonymous_id,
+            agent_relay_distinct_id=self._client.agent_relay_distinct_id,
         )
         return AsyncAgentClient(agent_client)
 

--- a/packages/sdk-python/src/relay_sdk/relay.py
+++ b/packages/sdk-python/src/relay_sdk/relay.py
@@ -121,6 +121,7 @@ class Relay:
         origin_surface: str | None = None,
         origin_client: str | None = None,
         origin_version: str | None = None,
+        agent_relay_anonymous_id: str | None = None,
     ) -> None:
         if not api_key or not api_key.strip():
             raise ValueError("Relay api_key is required")
@@ -131,6 +132,7 @@ class Relay:
             origin_surface=origin_surface,
             origin_client=origin_client,
             origin_version=origin_version,
+            agent_relay_anonymous_id=agent_relay_anonymous_id,
         )
         self.workspace = _WorkspaceNamespace(self._client)
         self.agents = _AgentsNamespace(self._client)
@@ -142,6 +144,7 @@ class Relay:
             origin_surface=self._client.origin_surface,
             origin_client=self._client.origin_client,
             origin_version=self._client.origin_version,
+            agent_relay_anonymous_id=self._client.agent_relay_anonymous_id,
         )
         return AgentClient(agent_client)
 
@@ -263,6 +266,7 @@ class AsyncRelay:
         origin_surface: str | None = None,
         origin_client: str | None = None,
         origin_version: str | None = None,
+        agent_relay_anonymous_id: str | None = None,
     ) -> None:
         if not api_key or not api_key.strip():
             raise ValueError("Relay api_key is required")
@@ -273,6 +277,7 @@ class AsyncRelay:
             origin_surface=origin_surface,
             origin_client=origin_client,
             origin_version=origin_version,
+            agent_relay_anonymous_id=agent_relay_anonymous_id,
         )
         self.workspace = _AsyncWorkspaceNamespace(self._client)
         self.agents = _AsyncAgentsNamespace(self._client)
@@ -284,6 +289,7 @@ class AsyncRelay:
             origin_surface=self._client.origin_surface,
             origin_client=self._client.origin_client,
             origin_version=self._client.origin_version,
+            agent_relay_anonymous_id=self._client.agent_relay_anonymous_id,
         )
         return AsyncAgentClient(agent_client)
 

--- a/packages/sdk-python/src/relay_sdk/ws.py
+++ b/packages/sdk-python/src/relay_sdk/ws.py
@@ -11,7 +11,7 @@ from urllib.parse import quote
 import websockets
 from websockets.asyncio.client import ClientConnection
 
-from .client import AGENT_RELAY_ANONYMOUS_ID_QUERY, SDK_VERSION, sanitize_agent_relay_anonymous_id
+from .client import AGENT_RELAY_DISTINCT_ID_QUERY, SDK_VERSION, sanitize_agent_relay_distinct_id
 
 logger = logging.getLogger(__name__)
 
@@ -40,7 +40,7 @@ class WsClient:
         origin_surface: str | None = None,
         origin_client: str | None = None,
         origin_version: str | None = None,
-        agent_relay_anonymous_id: str | None = None,
+        agent_relay_distinct_id: str | None = None,
     ) -> None:
         self._token = token
         base = (base_url or "https://gateway.relaycast.dev").rstrip("/")
@@ -48,7 +48,7 @@ class WsClient:
         self._origin_surface = (origin_surface or "sdk").strip()[:32]
         self._origin_client = (origin_client or "@relaycast/python-sdk").strip()[:80]
         self._origin_version = (origin_version or SDK_VERSION).strip()[:48]
-        self._agent_relay_anonymous_id = sanitize_agent_relay_anonymous_id(agent_relay_anonymous_id)
+        self._agent_relay_distinct_id = sanitize_agent_relay_distinct_id(agent_relay_distinct_id)
         self._ws: ClientConnection | None = None
         self._handlers: dict[str, set[EventHandler]] = {}
         self._reconnect_attempt = 0
@@ -81,10 +81,10 @@ class WsClient:
             f"&origin_client={quote(self._origin_client, safe='')}"
             f"&origin_version={quote(self._origin_version, safe='')}"
         )
-        if self._agent_relay_anonymous_id:
+        if self._agent_relay_distinct_id:
             url += (
-                f"&{AGENT_RELAY_ANONYMOUS_ID_QUERY}="
-                f"{quote(self._agent_relay_anonymous_id, safe='')}"
+                f"&{AGENT_RELAY_DISTINCT_ID_QUERY}="
+                f"{quote(self._agent_relay_distinct_id, safe='')}"
             )
         async with websockets.connect(url) as ws:
             self._ws = ws

--- a/packages/sdk-python/src/relay_sdk/ws.py
+++ b/packages/sdk-python/src/relay_sdk/ws.py
@@ -11,7 +11,7 @@ from urllib.parse import quote
 import websockets
 from websockets.asyncio.client import ClientConnection
 
-from .client import SDK_VERSION
+from .client import AGENT_RELAY_ANONYMOUS_ID_QUERY, SDK_VERSION, sanitize_agent_relay_anonymous_id
 
 logger = logging.getLogger(__name__)
 
@@ -40,6 +40,7 @@ class WsClient:
         origin_surface: str | None = None,
         origin_client: str | None = None,
         origin_version: str | None = None,
+        agent_relay_anonymous_id: str | None = None,
     ) -> None:
         self._token = token
         base = (base_url or "https://gateway.relaycast.dev").rstrip("/")
@@ -47,6 +48,7 @@ class WsClient:
         self._origin_surface = (origin_surface or "sdk").strip()[:32]
         self._origin_client = (origin_client or "@relaycast/python-sdk").strip()[:80]
         self._origin_version = (origin_version or SDK_VERSION).strip()[:48]
+        self._agent_relay_anonymous_id = sanitize_agent_relay_anonymous_id(agent_relay_anonymous_id)
         self._ws: ClientConnection | None = None
         self._handlers: dict[str, set[EventHandler]] = {}
         self._reconnect_attempt = 0
@@ -79,6 +81,11 @@ class WsClient:
             f"&origin_client={quote(self._origin_client, safe='')}"
             f"&origin_version={quote(self._origin_version, safe='')}"
         )
+        if self._agent_relay_anonymous_id:
+            url += (
+                f"&{AGENT_RELAY_ANONYMOUS_ID_QUERY}="
+                f"{quote(self._agent_relay_anonymous_id, safe='')}"
+            )
         async with websockets.connect(url) as ws:
             self._ws = ws
             self._reconnect_attempt = 0

--- a/packages/sdk-python/tests/test_client.py
+++ b/packages/sdk-python/tests/test_client.py
@@ -4,7 +4,13 @@ import httpx
 import pytest
 import respx
 
-from relay_sdk.client import AsyncHttpClient, HttpClient, SDK_VERSION
+from relay_sdk.client import (
+    AGENT_RELAY_ANONYMOUS_ID_HEADER,
+    AsyncHttpClient,
+    HttpClient,
+    SDK_VERSION,
+    sanitize_agent_relay_anonymous_id,
+)
 from relay_sdk.errors import RelayError
 
 from .conftest import API_KEY, BASE_URL, error_response, ok_response
@@ -26,6 +32,16 @@ def test_http_client_constructor_default_base_url_is_set_and_stripped():
     c = HttpClient(api_key=API_KEY)
     assert c.api_key == API_KEY
     assert c.base_url == "https://gateway.relaycast.dev"
+
+
+def test_sanitize_agent_relay_anonymous_id():
+    assert sanitize_agent_relay_anonymous_id("  AgentRelay.abc_123:XYZ-9  ") == "AgentRelay.abc_123:XYZ-9"
+    assert sanitize_agent_relay_anonymous_id("") is None
+    assert sanitize_agent_relay_anonymous_id("   ") is None
+    assert sanitize_agent_relay_anonymous_id(None) is None
+    assert sanitize_agent_relay_anonymous_id("evil\r\nX-Inject: bad") is None
+    assert sanitize_agent_relay_anonymous_id("a/b") is None
+    assert sanitize_agent_relay_anonymous_id("a" * 200) == "a" * 128
 
 
 @respx.mock
@@ -55,6 +71,38 @@ def test_http_client_sends_x_sdk_version_header():
     assert req.headers["X-Relaycast-Origin-Surface"] == "sdk"
     assert req.headers["X-Relaycast-Origin-Client"] == "@relaycast/python-sdk"
     assert req.headers["X-Relaycast-Origin-Version"] == SDK_VERSION
+
+
+@respx.mock
+def test_http_client_sends_agent_relay_anonymous_id_header():
+    route = respx.get(f"{BASE_URL}/v1/version").mock(
+        return_value=httpx.Response(200, json=ok_response({"ok": True}))
+    )
+    c = HttpClient(
+        api_key=API_KEY,
+        base_url=BASE_URL,
+        agent_relay_anonymous_id="abc123def4567890",
+    )
+    c.get("/v1/version")
+
+    req = route.calls[0].request
+    assert req.headers[AGENT_RELAY_ANONYMOUS_ID_HEADER] == "abc123def4567890"
+
+
+@respx.mock
+def test_http_client_omits_invalid_agent_relay_anonymous_id_header():
+    route = respx.get(f"{BASE_URL}/v1/version").mock(
+        return_value=httpx.Response(200, json=ok_response({"ok": True}))
+    )
+    c = HttpClient(
+        api_key=API_KEY,
+        base_url=BASE_URL,
+        agent_relay_anonymous_id="evil\r\nX-Inject: bad",
+    )
+    c.get("/v1/version")
+
+    req = route.calls[0].request
+    assert AGENT_RELAY_ANONYMOUS_ID_HEADER not in req.headers
 
 
 @respx.mock
@@ -265,6 +313,23 @@ async def test_async_http_client_sends_x_sdk_version_header():
     assert req.headers["X-Relaycast-Origin-Surface"] == "sdk"
     assert req.headers["X-Relaycast-Origin-Client"] == "@relaycast/python-sdk"
     assert req.headers["X-Relaycast-Origin-Version"] == SDK_VERSION
+    await c.close()
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_async_http_client_sends_agent_relay_anonymous_id_header():
+    route = respx.get(f"{BASE_URL}/v1/version").mock(
+        return_value=httpx.Response(200, json=ok_response({"ok": True}))
+    )
+    c = AsyncHttpClient(
+        api_key=API_KEY,
+        base_url=BASE_URL,
+        agent_relay_anonymous_id="abc123def4567890",
+    )
+    await c.get("/v1/version")
+    req = route.calls[0].request
+    assert req.headers[AGENT_RELAY_ANONYMOUS_ID_HEADER] == "abc123def4567890"
     await c.close()
 
 

--- a/packages/sdk-python/tests/test_client.py
+++ b/packages/sdk-python/tests/test_client.py
@@ -5,11 +5,11 @@ import pytest
 import respx
 
 from relay_sdk.client import (
-    AGENT_RELAY_ANONYMOUS_ID_HEADER,
+    AGENT_RELAY_DISTINCT_ID_HEADER,
     AsyncHttpClient,
     HttpClient,
     SDK_VERSION,
-    sanitize_agent_relay_anonymous_id,
+    sanitize_agent_relay_distinct_id,
 )
 from relay_sdk.errors import RelayError
 
@@ -34,14 +34,14 @@ def test_http_client_constructor_default_base_url_is_set_and_stripped():
     assert c.base_url == "https://gateway.relaycast.dev"
 
 
-def test_sanitize_agent_relay_anonymous_id():
-    assert sanitize_agent_relay_anonymous_id("  AgentRelay.abc_123:XYZ-9  ") == "AgentRelay.abc_123:XYZ-9"
-    assert sanitize_agent_relay_anonymous_id("") is None
-    assert sanitize_agent_relay_anonymous_id("   ") is None
-    assert sanitize_agent_relay_anonymous_id(None) is None
-    assert sanitize_agent_relay_anonymous_id("evil\r\nX-Inject: bad") is None
-    assert sanitize_agent_relay_anonymous_id("a/b") is None
-    assert sanitize_agent_relay_anonymous_id("a" * 200) == "a" * 128
+def test_sanitize_agent_relay_distinct_id():
+    assert sanitize_agent_relay_distinct_id("  AgentRelay.abc_123:XYZ-9  ") == "AgentRelay.abc_123:XYZ-9"
+    assert sanitize_agent_relay_distinct_id("") is None
+    assert sanitize_agent_relay_distinct_id("   ") is None
+    assert sanitize_agent_relay_distinct_id(None) is None
+    assert sanitize_agent_relay_distinct_id("evil\r\nX-Inject: bad") is None
+    assert sanitize_agent_relay_distinct_id("a/b") is None
+    assert sanitize_agent_relay_distinct_id("a" * 200) == "a" * 128
 
 
 @respx.mock
@@ -74,35 +74,35 @@ def test_http_client_sends_x_sdk_version_header():
 
 
 @respx.mock
-def test_http_client_sends_agent_relay_anonymous_id_header():
+def test_http_client_sends_agent_relay_distinct_id_header():
     route = respx.get(f"{BASE_URL}/v1/version").mock(
         return_value=httpx.Response(200, json=ok_response({"ok": True}))
     )
     c = HttpClient(
         api_key=API_KEY,
         base_url=BASE_URL,
-        agent_relay_anonymous_id="abc123def4567890",
+        agent_relay_distinct_id="abc123def4567890",
     )
     c.get("/v1/version")
 
     req = route.calls[0].request
-    assert req.headers[AGENT_RELAY_ANONYMOUS_ID_HEADER] == "abc123def4567890"
+    assert req.headers[AGENT_RELAY_DISTINCT_ID_HEADER] == "abc123def4567890"
 
 
 @respx.mock
-def test_http_client_omits_invalid_agent_relay_anonymous_id_header():
+def test_http_client_omits_invalid_agent_relay_distinct_id_header():
     route = respx.get(f"{BASE_URL}/v1/version").mock(
         return_value=httpx.Response(200, json=ok_response({"ok": True}))
     )
     c = HttpClient(
         api_key=API_KEY,
         base_url=BASE_URL,
-        agent_relay_anonymous_id="evil\r\nX-Inject: bad",
+        agent_relay_distinct_id="evil\r\nX-Inject: bad",
     )
     c.get("/v1/version")
 
     req = route.calls[0].request
-    assert AGENT_RELAY_ANONYMOUS_ID_HEADER not in req.headers
+    assert AGENT_RELAY_DISTINCT_ID_HEADER not in req.headers
 
 
 @respx.mock
@@ -318,18 +318,18 @@ async def test_async_http_client_sends_x_sdk_version_header():
 
 @pytest.mark.asyncio
 @respx.mock
-async def test_async_http_client_sends_agent_relay_anonymous_id_header():
+async def test_async_http_client_sends_agent_relay_distinct_id_header():
     route = respx.get(f"{BASE_URL}/v1/version").mock(
         return_value=httpx.Response(200, json=ok_response({"ok": True}))
     )
     c = AsyncHttpClient(
         api_key=API_KEY,
         base_url=BASE_URL,
-        agent_relay_anonymous_id="abc123def4567890",
+        agent_relay_distinct_id="abc123def4567890",
     )
     await c.get("/v1/version")
     req = route.calls[0].request
-    assert req.headers[AGENT_RELAY_ANONYMOUS_ID_HEADER] == "abc123def4567890"
+    assert req.headers[AGENT_RELAY_DISTINCT_ID_HEADER] == "abc123def4567890"
     await c.close()
 
 

--- a/packages/sdk-python/tests/test_relay.py
+++ b/packages/sdk-python/tests/test_relay.py
@@ -140,12 +140,12 @@ class TestRelay:
         assert rotate_route.called
 
     def test_as_agent_returns_agent_client(self):
-        r = Relay(KEY, base_url=BASE, agent_relay_anonymous_id="abc123def4567890")
+        r = Relay(KEY, base_url=BASE, agent_relay_distinct_id="abc123def4567890")
         ac = r.as_agent("at_xxx")
         assert isinstance(ac, AgentClient)
         assert ac.client.api_key == "at_xxx"
         assert ac.client.base_url == BASE
-        assert ac.client.agent_relay_anonymous_id == "abc123def4567890"
+        assert ac.client.agent_relay_distinct_id == "abc123def4567890"
 
     def test_as_alias(self):
         r = Relay(KEY, base_url=BASE)
@@ -221,7 +221,7 @@ class TestAsyncRelay:
 
     @pytest.mark.asyncio
     async def test_as_agent_returns_async_client(self):
-        async with AsyncRelay(KEY, base_url=BASE, agent_relay_anonymous_id="abc123def4567890") as r:
+        async with AsyncRelay(KEY, base_url=BASE, agent_relay_distinct_id="abc123def4567890") as r:
             ac = r.as_agent("at_xxx")
             assert isinstance(ac, AsyncAgentClient)
-            assert ac.client.agent_relay_anonymous_id == "abc123def4567890"
+            assert ac.client.agent_relay_distinct_id == "abc123def4567890"

--- a/packages/sdk-python/tests/test_relay.py
+++ b/packages/sdk-python/tests/test_relay.py
@@ -140,11 +140,12 @@ class TestRelay:
         assert rotate_route.called
 
     def test_as_agent_returns_agent_client(self):
-        r = Relay(KEY, base_url=BASE)
+        r = Relay(KEY, base_url=BASE, agent_relay_anonymous_id="abc123def4567890")
         ac = r.as_agent("at_xxx")
         assert isinstance(ac, AgentClient)
         assert ac.client.api_key == "at_xxx"
         assert ac.client.base_url == BASE
+        assert ac.client.agent_relay_anonymous_id == "abc123def4567890"
 
     def test_as_alias(self):
         r = Relay(KEY, base_url=BASE)
@@ -220,6 +221,7 @@ class TestAsyncRelay:
 
     @pytest.mark.asyncio
     async def test_as_agent_returns_async_client(self):
-        async with AsyncRelay(KEY, base_url=BASE) as r:
+        async with AsyncRelay(KEY, base_url=BASE, agent_relay_anonymous_id="abc123def4567890") as r:
             ac = r.as_agent("at_xxx")
             assert isinstance(ac, AsyncAgentClient)
+            assert ac.client.agent_relay_anonymous_id == "abc123def4567890"

--- a/packages/sdk-python/tests/test_ws.py
+++ b/packages/sdk-python/tests/test_ws.py
@@ -155,3 +155,23 @@ class TestWsClientOriginParams:
         assert "origin_surface=sdk" in url
         assert "origin_client=%40relaycast%2Fpython-sdk" in url
         assert "origin_version=0.1.0" in url
+
+    @pytest.mark.asyncio
+    async def test_connect_url_includes_agent_relay_anonymous_id_query_param(self):
+        ws = WsClient(token="at_xxx", agent_relay_anonymous_id="abc123def4567890")
+        with patch("relay_sdk.ws.websockets.connect", side_effect=RuntimeError("stop")) as connect_mock:
+            with pytest.raises(RuntimeError):
+                await ws._connect_once()
+
+        url = connect_mock.call_args.args[0]
+        assert "agent_relay_anonymous_id=abc123def4567890" in url
+
+    @pytest.mark.asyncio
+    async def test_connect_url_omits_invalid_agent_relay_anonymous_id_query_param(self):
+        ws = WsClient(token="at_xxx", agent_relay_anonymous_id="evil\r\nX-Inject: bad")
+        with patch("relay_sdk.ws.websockets.connect", side_effect=RuntimeError("stop")) as connect_mock:
+            with pytest.raises(RuntimeError):
+                await ws._connect_once()
+
+        url = connect_mock.call_args.args[0]
+        assert "agent_relay_anonymous_id=" not in url

--- a/packages/sdk-python/tests/test_ws.py
+++ b/packages/sdk-python/tests/test_ws.py
@@ -157,21 +157,21 @@ class TestWsClientOriginParams:
         assert "origin_version=0.1.0" in url
 
     @pytest.mark.asyncio
-    async def test_connect_url_includes_agent_relay_anonymous_id_query_param(self):
-        ws = WsClient(token="at_xxx", agent_relay_anonymous_id="abc123def4567890")
+    async def test_connect_url_includes_agent_relay_distinct_id_query_param(self):
+        ws = WsClient(token="at_xxx", agent_relay_distinct_id="abc123def4567890")
         with patch("relay_sdk.ws.websockets.connect", side_effect=RuntimeError("stop")) as connect_mock:
             with pytest.raises(RuntimeError):
                 await ws._connect_once()
 
         url = connect_mock.call_args.args[0]
-        assert "agent_relay_anonymous_id=abc123def4567890" in url
+        assert "agent_relay_distinct_id=abc123def4567890" in url
 
     @pytest.mark.asyncio
-    async def test_connect_url_omits_invalid_agent_relay_anonymous_id_query_param(self):
-        ws = WsClient(token="at_xxx", agent_relay_anonymous_id="evil\r\nX-Inject: bad")
+    async def test_connect_url_omits_invalid_agent_relay_distinct_id_query_param(self):
+        ws = WsClient(token="at_xxx", agent_relay_distinct_id="evil\r\nX-Inject: bad")
         with patch("relay_sdk.ws.websockets.connect", side_effect=RuntimeError("stop")) as connect_mock:
             with pytest.raises(RuntimeError):
                 await ws._connect_once()
 
         url = connect_mock.call_args.args[0]
-        assert "agent_relay_anonymous_id=" not in url
+        assert "agent_relay_distinct_id=" not in url

--- a/packages/sdk-rust/src/agent.rs
+++ b/packages/sdk-rust/src/agent.rs
@@ -99,8 +99,8 @@ impl AgentClient {
         if let Some(harness) = self.client.harness() {
             options = options.with_harness(harness);
         }
-        if let Some(id) = self.client.agent_relay_anonymous_id() {
-            options = options.with_agent_relay_anonymous_id(id);
+        if let Some(id) = self.client.agent_relay_distinct_id() {
+            options = options.with_agent_relay_distinct_id(id);
         }
         let mut ws = WsClient::new(options);
         ws.connect().await?;

--- a/packages/sdk-rust/src/agent.rs
+++ b/packages/sdk-rust/src/agent.rs
@@ -99,6 +99,9 @@ impl AgentClient {
         if let Some(harness) = self.client.harness() {
             options = options.with_harness(harness);
         }
+        if let Some(id) = self.client.agent_relay_anonymous_id() {
+            options = options.with_agent_relay_anonymous_id(id);
+        }
         let mut ws = WsClient::new(options);
         ws.connect().await?;
         self.ws = Some(ws);

--- a/packages/sdk-rust/src/client.rs
+++ b/packages/sdk-rust/src/client.rs
@@ -6,7 +6,7 @@ use std::time::Duration;
 
 use crate::error::{RelayError, Result};
 use crate::harness::{
-    sanitize_agent_relay_anonymous_id, sanitize_harness, AGENT_RELAY_ANONYMOUS_ID_HEADER,
+    sanitize_agent_relay_distinct_id, sanitize_harness, AGENT_RELAY_DISTINCT_ID_HEADER,
     HARNESS_HEADER,
 };
 use crate::types::ApiResponse;
@@ -34,9 +34,9 @@ pub struct ClientOptions {
     /// (e.g. `"claude-code/2.3 (model=opus-4.8)"`, `"codex"`, `"human"`). Sent as
     /// the `X-Relaycast-Harness` header; invalid values are dropped.
     pub harness: Option<String>,
-    /// Agent Relay anonymous installation id. Sent as the
-    /// `X-Agent-Relay-Anonymous-Id` header; invalid values are dropped.
-    pub agent_relay_anonymous_id: Option<String>,
+    /// Agent Relay distinct telemetry id. Sent as the
+    /// `X-Agent-Relay-Distinct-Id` header; invalid values are dropped.
+    pub agent_relay_distinct_id: Option<String>,
 }
 
 impl ClientOptions {
@@ -49,7 +49,7 @@ impl ClientOptions {
             origin_client: None,
             origin_version: None,
             harness: None,
-            agent_relay_anonymous_id: None,
+            agent_relay_distinct_id: None,
         }
     }
 
@@ -78,9 +78,9 @@ impl ClientOptions {
         self
     }
 
-    /// Set Agent Relay's anonymous installation id.
-    pub fn with_agent_relay_anonymous_id(mut self, id: impl Into<String>) -> Self {
-        self.agent_relay_anonymous_id = Some(id.into());
+    /// Set Agent Relay's distinct telemetry id.
+    pub fn with_agent_relay_distinct_id(mut self, id: impl Into<String>) -> Self {
+        self.agent_relay_distinct_id = Some(id.into());
         self
     }
 }
@@ -114,7 +114,7 @@ pub struct HttpClient {
     origin_client: String,
     origin_version: String,
     harness: Option<String>,
-    agent_relay_anonymous_id: Option<String>,
+    agent_relay_distinct_id: Option<String>,
 }
 
 impl HttpClient {
@@ -138,8 +138,8 @@ impl HttpClient {
                 .origin_version
                 .unwrap_or_else(|| SDK_VERSION.to_string()),
             harness: sanitize_harness(options.harness),
-            agent_relay_anonymous_id: sanitize_agent_relay_anonymous_id(
-                options.agent_relay_anonymous_id,
+            agent_relay_distinct_id: sanitize_agent_relay_distinct_id(
+                options.agent_relay_distinct_id,
             ),
         })
     }
@@ -174,9 +174,9 @@ impl HttpClient {
         self.harness.as_deref()
     }
 
-    /// Get the sanitized Agent Relay anonymous id, if one was supplied.
-    pub fn agent_relay_anonymous_id(&self) -> Option<&str> {
-        self.agent_relay_anonymous_id.as_deref()
+    /// Get the sanitized Agent Relay distinct id, if one was supplied.
+    pub fn agent_relay_distinct_id(&self) -> Option<&str> {
+        self.agent_relay_distinct_id.as_deref()
     }
 
     /// Return a cloned client with a different API key while preserving base URL and origin metadata.
@@ -191,8 +191,8 @@ impl HttpClient {
         if let Some(harness) = &self.harness {
             options = options.with_harness(harness.clone());
         }
-        if let Some(id) = &self.agent_relay_anonymous_id {
-            options = options.with_agent_relay_anonymous_id(id.clone());
+        if let Some(id) = &self.agent_relay_distinct_id {
+            options = options.with_agent_relay_distinct_id(id.clone());
         }
         HttpClient::new(options)
     }
@@ -270,8 +270,8 @@ impl HttpClient {
         if let Some(ref harness) = self.harness {
             request = request.header(HARNESS_HEADER, harness);
         }
-        if let Some(ref id) = self.agent_relay_anonymous_id {
-            request = request.header(AGENT_RELAY_ANONYMOUS_ID_HEADER, id);
+        if let Some(ref id) = self.agent_relay_distinct_id {
+            request = request.header(AGENT_RELAY_DISTINCT_ID_HEADER, id);
         }
 
         if let Some(ref key) = options.idempotency_key {

--- a/packages/sdk-rust/src/client.rs
+++ b/packages/sdk-rust/src/client.rs
@@ -5,7 +5,10 @@ use serde::{de::DeserializeOwned, Serialize};
 use std::time::Duration;
 
 use crate::error::{RelayError, Result};
-use crate::harness::{sanitize_harness, HARNESS_HEADER};
+use crate::harness::{
+    sanitize_agent_relay_anonymous_id, sanitize_harness, AGENT_RELAY_ANONYMOUS_ID_HEADER,
+    HARNESS_HEADER,
+};
 use crate::types::ApiResponse;
 
 const SDK_VERSION: &str = env!("CARGO_PKG_VERSION");
@@ -31,6 +34,9 @@ pub struct ClientOptions {
     /// (e.g. `"claude-code/2.3 (model=opus-4.8)"`, `"codex"`, `"human"`). Sent as
     /// the `X-Relaycast-Harness` header; invalid values are dropped.
     pub harness: Option<String>,
+    /// Agent Relay anonymous installation id. Sent as the
+    /// `X-Agent-Relay-Anonymous-Id` header; invalid values are dropped.
+    pub agent_relay_anonymous_id: Option<String>,
 }
 
 impl ClientOptions {
@@ -43,6 +49,7 @@ impl ClientOptions {
             origin_client: None,
             origin_version: None,
             harness: None,
+            agent_relay_anonymous_id: None,
         }
     }
 
@@ -68,6 +75,12 @@ impl ClientOptions {
     /// Set the harness identifier sent as the `X-Relaycast-Harness` header.
     pub fn with_harness(mut self, harness: impl Into<String>) -> Self {
         self.harness = Some(harness.into());
+        self
+    }
+
+    /// Set Agent Relay's anonymous installation id.
+    pub fn with_agent_relay_anonymous_id(mut self, id: impl Into<String>) -> Self {
+        self.agent_relay_anonymous_id = Some(id.into());
         self
     }
 }
@@ -101,6 +114,7 @@ pub struct HttpClient {
     origin_client: String,
     origin_version: String,
     harness: Option<String>,
+    agent_relay_anonymous_id: Option<String>,
 }
 
 impl HttpClient {
@@ -124,6 +138,9 @@ impl HttpClient {
                 .origin_version
                 .unwrap_or_else(|| SDK_VERSION.to_string()),
             harness: sanitize_harness(options.harness),
+            agent_relay_anonymous_id: sanitize_agent_relay_anonymous_id(
+                options.agent_relay_anonymous_id,
+            ),
         })
     }
 
@@ -157,6 +174,11 @@ impl HttpClient {
         self.harness.as_deref()
     }
 
+    /// Get the sanitized Agent Relay anonymous id, if one was supplied.
+    pub fn agent_relay_anonymous_id(&self) -> Option<&str> {
+        self.agent_relay_anonymous_id.as_deref()
+    }
+
     /// Return a cloned client with a different API key while preserving base URL and origin metadata.
     pub fn with_api_key(&self, api_key: impl Into<String>) -> Result<Self> {
         let mut options = ClientOptions::new(api_key)
@@ -168,6 +190,9 @@ impl HttpClient {
             );
         if let Some(harness) = &self.harness {
             options = options.with_harness(harness.clone());
+        }
+        if let Some(id) = &self.agent_relay_anonymous_id {
+            options = options.with_agent_relay_anonymous_id(id.clone());
         }
         HttpClient::new(options)
     }
@@ -244,6 +269,9 @@ impl HttpClient {
 
         if let Some(ref harness) = self.harness {
             request = request.header(HARNESS_HEADER, harness);
+        }
+        if let Some(ref id) = self.agent_relay_anonymous_id {
+            request = request.header(AGENT_RELAY_ANONYMOUS_ID_HEADER, id);
         }
 
         if let Some(ref key) = options.idempotency_key {

--- a/packages/sdk-rust/src/harness.rs
+++ b/packages/sdk-rust/src/harness.rs
@@ -8,14 +8,14 @@
 
 /// HTTP header used to tell the relaycast server which harness drives a request.
 pub const HARNESS_HEADER: &str = "X-Relaycast-Harness";
-/// HTTP header used to forward Agent Relay's anonymous installation id.
-pub const AGENT_RELAY_ANONYMOUS_ID_HEADER: &str = "X-Agent-Relay-Anonymous-Id";
-/// WebSocket query param used to forward Agent Relay's anonymous installation id.
-pub const AGENT_RELAY_ANONYMOUS_ID_QUERY: &str = "agent_relay_anonymous_id";
+/// HTTP header used to forward Agent Relay's distinct telemetry id.
+pub const AGENT_RELAY_DISTINCT_ID_HEADER: &str = "X-Agent-Relay-Distinct-Id";
+/// WebSocket query param used to forward Agent Relay's distinct telemetry id.
+pub const AGENT_RELAY_DISTINCT_ID_QUERY: &str = "agent_relay_distinct_id";
 
 /// Upper bound on the harness value — generous enough for a UA-style token.
 const HARNESS_MAX_LENGTH: usize = 120;
-const AGENT_RELAY_ANONYMOUS_ID_MAX_LENGTH: usize = 128;
+const AGENT_RELAY_DISTINCT_ID_MAX_LENGTH: usize = 128;
 
 /// Characters permitted in a harness identifier. Deliberately broad enough for a
 /// User-Agent-style token (`name/version (model=...; setting)`) while excluding
@@ -28,7 +28,7 @@ fn is_allowed(c: char) -> bool {
         )
 }
 
-fn is_allowed_agent_relay_anonymous_id(c: char) -> bool {
+fn is_allowed_agent_relay_distinct_id(c: char) -> bool {
     c.is_ascii_alphanumeric() || matches!(c, '.' | '_' | ':' | '-')
 }
 
@@ -55,24 +55,24 @@ pub fn sanitize_harness(raw: Option<impl AsRef<str>>) -> Option<String> {
     )
 }
 
-/// Normalize an Agent Relay anonymous installation id to the wire contract.
+/// Normalize an Agent Relay distinct telemetry id to the wire contract.
 ///
 /// Returns a trimmed, length-capped id, or `None` when the input is empty or
 /// contains disallowed characters. Unlike harness values, this preserves case
 /// because the id is an opaque token.
-pub fn sanitize_agent_relay_anonymous_id(raw: Option<impl AsRef<str>>) -> Option<String> {
+pub fn sanitize_agent_relay_distinct_id(raw: Option<impl AsRef<str>>) -> Option<String> {
     let raw = raw?;
     let trimmed = raw.as_ref().trim();
     if trimmed.is_empty() {
         return None;
     }
-    if !trimmed.chars().all(is_allowed_agent_relay_anonymous_id) {
+    if !trimmed.chars().all(is_allowed_agent_relay_distinct_id) {
         return None;
     }
     Some(
         trimmed
             .chars()
-            .take(AGENT_RELAY_ANONYMOUS_ID_MAX_LENGTH)
+            .take(AGENT_RELAY_DISTINCT_ID_MAX_LENGTH)
             .collect::<String>(),
     )
 }
@@ -117,29 +117,29 @@ mod tests {
     }
 
     #[test]
-    fn keeps_agent_relay_anonymous_id_without_lowercasing() {
+    fn keeps_agent_relay_distinct_id_without_lowercasing() {
         assert_eq!(
-            sanitize_agent_relay_anonymous_id(Some("  AgentRelay.abc_123:XYZ-9  ")),
+            sanitize_agent_relay_distinct_id(Some("  AgentRelay.abc_123:XYZ-9  ")),
             Some("AgentRelay.abc_123:XYZ-9".to_string())
         );
     }
 
     #[test]
-    fn drops_invalid_agent_relay_anonymous_ids() {
-        assert_eq!(sanitize_agent_relay_anonymous_id(Some("")), None);
-        assert_eq!(sanitize_agent_relay_anonymous_id(Some("   ")), None);
+    fn drops_invalid_agent_relay_distinct_ids() {
+        assert_eq!(sanitize_agent_relay_distinct_id(Some("")), None);
+        assert_eq!(sanitize_agent_relay_distinct_id(Some("   ")), None);
         assert_eq!(
-            sanitize_agent_relay_anonymous_id(Some("evil\r\nX-Inject: bad")),
+            sanitize_agent_relay_distinct_id(Some("evil\r\nX-Inject: bad")),
             None
         );
-        assert_eq!(sanitize_agent_relay_anonymous_id(Some("a/b")), None);
+        assert_eq!(sanitize_agent_relay_distinct_id(Some("a/b")), None);
     }
 
     #[test]
-    fn caps_agent_relay_anonymous_id_at_128_characters() {
+    fn caps_agent_relay_distinct_id_at_128_characters() {
         let long = "a".repeat(200);
         assert_eq!(
-            sanitize_agent_relay_anonymous_id(Some(&long)),
+            sanitize_agent_relay_distinct_id(Some(&long)),
             Some("a".repeat(128))
         );
     }

--- a/packages/sdk-rust/src/harness.rs
+++ b/packages/sdk-rust/src/harness.rs
@@ -8,9 +8,14 @@
 
 /// HTTP header used to tell the relaycast server which harness drives a request.
 pub const HARNESS_HEADER: &str = "X-Relaycast-Harness";
+/// HTTP header used to forward Agent Relay's anonymous installation id.
+pub const AGENT_RELAY_ANONYMOUS_ID_HEADER: &str = "X-Agent-Relay-Anonymous-Id";
+/// WebSocket query param used to forward Agent Relay's anonymous installation id.
+pub const AGENT_RELAY_ANONYMOUS_ID_QUERY: &str = "agent_relay_anonymous_id";
 
 /// Upper bound on the harness value — generous enough for a UA-style token.
 const HARNESS_MAX_LENGTH: usize = 120;
+const AGENT_RELAY_ANONYMOUS_ID_MAX_LENGTH: usize = 128;
 
 /// Characters permitted in a harness identifier. Deliberately broad enough for a
 /// User-Agent-style token (`name/version (model=...; setting)`) while excluding
@@ -21,6 +26,10 @@ fn is_allowed(c: char) -> bool {
             c,
             ' ' | '.' | '_' | '-' | '/' | '(' | ')' | ':' | '=' | ';' | ',' | '+'
         )
+}
+
+fn is_allowed_agent_relay_anonymous_id(c: char) -> bool {
+    c.is_ascii_alphanumeric() || matches!(c, '.' | '_' | ':' | '-')
 }
 
 /// Normalize a caller-supplied harness identifier to the wire contract.
@@ -43,6 +52,28 @@ pub fn sanitize_harness(raw: Option<impl AsRef<str>>) -> Option<String> {
             .take(HARNESS_MAX_LENGTH)
             .collect::<String>()
             .to_lowercase(),
+    )
+}
+
+/// Normalize an Agent Relay anonymous installation id to the wire contract.
+///
+/// Returns a trimmed, length-capped id, or `None` when the input is empty or
+/// contains disallowed characters. Unlike harness values, this preserves case
+/// because the id is an opaque token.
+pub fn sanitize_agent_relay_anonymous_id(raw: Option<impl AsRef<str>>) -> Option<String> {
+    let raw = raw?;
+    let trimmed = raw.as_ref().trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+    if !trimmed.chars().all(is_allowed_agent_relay_anonymous_id) {
+        return None;
+    }
+    Some(
+        trimmed
+            .chars()
+            .take(AGENT_RELAY_ANONYMOUS_ID_MAX_LENGTH)
+            .collect::<String>(),
     )
 }
 
@@ -83,5 +114,33 @@ mod tests {
     fn caps_at_120_characters() {
         let long = "a".repeat(200);
         assert_eq!(sanitize_harness(Some(&long)), Some("a".repeat(120)));
+    }
+
+    #[test]
+    fn keeps_agent_relay_anonymous_id_without_lowercasing() {
+        assert_eq!(
+            sanitize_agent_relay_anonymous_id(Some("  AgentRelay.abc_123:XYZ-9  ")),
+            Some("AgentRelay.abc_123:XYZ-9".to_string())
+        );
+    }
+
+    #[test]
+    fn drops_invalid_agent_relay_anonymous_ids() {
+        assert_eq!(sanitize_agent_relay_anonymous_id(Some("")), None);
+        assert_eq!(sanitize_agent_relay_anonymous_id(Some("   ")), None);
+        assert_eq!(
+            sanitize_agent_relay_anonymous_id(Some("evil\r\nX-Inject: bad")),
+            None
+        );
+        assert_eq!(sanitize_agent_relay_anonymous_id(Some("a/b")), None);
+    }
+
+    #[test]
+    fn caps_agent_relay_anonymous_id_at_128_characters() {
+        let long = "a".repeat(200);
+        assert_eq!(
+            sanitize_agent_relay_anonymous_id(Some(&long)),
+            Some("a".repeat(128))
+        );
     }
 }

--- a/packages/sdk-rust/src/lib.rs
+++ b/packages/sdk-rust/src/lib.rs
@@ -138,7 +138,10 @@ pub use events::{
     NormalizedCommandInvocation, NormalizedEventKind, NormalizedInboundEvent, RelayPriority,
     SenderKind,
 };
-pub use harness::{sanitize_harness, HARNESS_HEADER};
+pub use harness::{
+    sanitize_agent_relay_anonymous_id, sanitize_harness, AGENT_RELAY_ANONYMOUS_ID_HEADER,
+    AGENT_RELAY_ANONYMOUS_ID_QUERY, HARNESS_HEADER,
+};
 pub use identity::{agent_name_eq, is_self_name};
 pub use registration::{
     format_registration_error, registration_is_retryable, registration_retry_after_secs,

--- a/packages/sdk-rust/src/lib.rs
+++ b/packages/sdk-rust/src/lib.rs
@@ -139,8 +139,8 @@ pub use events::{
     SenderKind,
 };
 pub use harness::{
-    sanitize_agent_relay_anonymous_id, sanitize_harness, AGENT_RELAY_ANONYMOUS_ID_HEADER,
-    AGENT_RELAY_ANONYMOUS_ID_QUERY, HARNESS_HEADER,
+    sanitize_agent_relay_distinct_id, sanitize_harness, AGENT_RELAY_DISTINCT_ID_HEADER,
+    AGENT_RELAY_DISTINCT_ID_QUERY, HARNESS_HEADER,
 };
 pub use identity::{agent_name_eq, is_self_name};
 pub use registration::{

--- a/packages/sdk-rust/src/relay.rs
+++ b/packages/sdk-rust/src/relay.rs
@@ -29,9 +29,9 @@ pub struct RelayCastOptions {
     /// the `X-Relaycast-Harness` header so server-side telemetry can attribute
     /// traffic. Invalid values are dropped.
     pub harness: Option<String>,
-    /// Agent Relay anonymous installation id. Sent as
-    /// `X-Agent-Relay-Anonymous-Id` on HTTP requests; invalid values are dropped.
-    pub agent_relay_anonymous_id: Option<String>,
+    /// Agent Relay distinct telemetry id. Sent as
+    /// `X-Agent-Relay-Distinct-Id` on HTTP requests; invalid values are dropped.
+    pub agent_relay_distinct_id: Option<String>,
 }
 
 impl RelayCastOptions {
@@ -41,7 +41,7 @@ impl RelayCastOptions {
             api_key: api_key.into(),
             base_url: None,
             harness: None,
-            agent_relay_anonymous_id: None,
+            agent_relay_distinct_id: None,
         }
     }
 
@@ -57,9 +57,9 @@ impl RelayCastOptions {
         self
     }
 
-    /// Set Agent Relay's anonymous installation id.
-    pub fn with_agent_relay_anonymous_id(mut self, id: impl Into<String>) -> Self {
-        self.agent_relay_anonymous_id = Some(id.into());
+    /// Set Agent Relay's distinct telemetry id.
+    pub fn with_agent_relay_distinct_id(mut self, id: impl Into<String>) -> Self {
+        self.agent_relay_distinct_id = Some(id.into());
         self
     }
 }
@@ -88,8 +88,8 @@ impl RelayCast {
         if let Some(harness) = options.harness {
             client_options = client_options.with_harness(harness);
         }
-        if let Some(id) = options.agent_relay_anonymous_id {
-            client_options = client_options.with_agent_relay_anonymous_id(id);
+        if let Some(id) = options.agent_relay_distinct_id {
+            client_options = client_options.with_agent_relay_distinct_id(id);
         }
         let client = HttpClient::new(client_options)?;
         Ok(Self { client })

--- a/packages/sdk-rust/src/relay.rs
+++ b/packages/sdk-rust/src/relay.rs
@@ -29,6 +29,9 @@ pub struct RelayCastOptions {
     /// the `X-Relaycast-Harness` header so server-side telemetry can attribute
     /// traffic. Invalid values are dropped.
     pub harness: Option<String>,
+    /// Agent Relay anonymous installation id. Sent as
+    /// `X-Agent-Relay-Anonymous-Id` on HTTP requests; invalid values are dropped.
+    pub agent_relay_anonymous_id: Option<String>,
 }
 
 impl RelayCastOptions {
@@ -38,6 +41,7 @@ impl RelayCastOptions {
             api_key: api_key.into(),
             base_url: None,
             harness: None,
+            agent_relay_anonymous_id: None,
         }
     }
 
@@ -50,6 +54,12 @@ impl RelayCastOptions {
     /// Set the harness identifier sent as the `X-Relaycast-Harness` header.
     pub fn with_harness(mut self, harness: impl Into<String>) -> Self {
         self.harness = Some(harness.into());
+        self
+    }
+
+    /// Set Agent Relay's anonymous installation id.
+    pub fn with_agent_relay_anonymous_id(mut self, id: impl Into<String>) -> Self {
+        self.agent_relay_anonymous_id = Some(id.into());
         self
     }
 }
@@ -77,6 +87,9 @@ impl RelayCast {
         client_options = client_options.with_base_url(base_url);
         if let Some(harness) = options.harness {
             client_options = client_options.with_harness(harness);
+        }
+        if let Some(id) = options.agent_relay_anonymous_id {
+            client_options = client_options.with_agent_relay_anonymous_id(id);
         }
         let client = HttpClient::new(client_options)?;
         Ok(Self { client })

--- a/packages/sdk-rust/src/ws.rs
+++ b/packages/sdk-rust/src/ws.rs
@@ -11,7 +11,7 @@ use url::Url;
 
 use crate::error::{RelayError, Result};
 use crate::harness::{
-    sanitize_agent_relay_anonymous_id, sanitize_harness, AGENT_RELAY_ANONYMOUS_ID_QUERY,
+    sanitize_agent_relay_distinct_id, sanitize_harness, AGENT_RELAY_DISTINCT_ID_QUERY,
 };
 use crate::types::WsEvent;
 
@@ -41,9 +41,9 @@ pub struct WsClientOptions {
     /// User-Agent-style harness identifier, forwarded as the `harness` query
     /// param (browsers can't set custom WS headers). Invalid values are dropped.
     pub harness: Option<String>,
-    /// Agent Relay anonymous installation id, forwarded as the
-    /// `agent_relay_anonymous_id` query param. Invalid values are dropped.
-    pub agent_relay_anonymous_id: Option<String>,
+    /// Agent Relay distinct telemetry id, forwarded as the
+    /// `agent_relay_distinct_id` query param. Invalid values are dropped.
+    pub agent_relay_distinct_id: Option<String>,
     /// Maximum reconnect attempts before giving up (default: 10).
     pub max_reconnect_attempts: Option<u32>,
     /// Maximum reconnect delay in milliseconds (default: 30000).
@@ -61,7 +61,7 @@ impl WsClientOptions {
             origin_client: None,
             origin_version: None,
             harness: None,
-            agent_relay_anonymous_id: None,
+            agent_relay_distinct_id: None,
             max_reconnect_attempts: None,
             max_reconnect_delay_ms: None,
         }
@@ -98,9 +98,9 @@ impl WsClientOptions {
         self
     }
 
-    /// Set Agent Relay's anonymous installation id for WebSocket handshakes.
-    pub fn with_agent_relay_anonymous_id(mut self, id: impl Into<String>) -> Self {
-        self.agent_relay_anonymous_id = Some(id.into());
+    /// Set Agent Relay's distinct telemetry id for WebSocket handshakes.
+    pub fn with_agent_relay_distinct_id(mut self, id: impl Into<String>) -> Self {
+        self.agent_relay_distinct_id = Some(id.into());
         self
     }
 
@@ -142,7 +142,7 @@ pub struct WsClient {
     origin_client: String,
     origin_version: String,
     harness: Option<String>,
-    agent_relay_anonymous_id: Option<String>,
+    agent_relay_distinct_id: Option<String>,
     max_reconnect_attempts: u32,
     max_reconnect_delay_ms: u64,
     event_tx: broadcast::Sender<WsEvent>,
@@ -185,8 +185,8 @@ impl WsClient {
                 .origin_version
                 .unwrap_or_else(|| SDK_VERSION.to_string()),
             harness: sanitize_harness(options.harness),
-            agent_relay_anonymous_id: sanitize_agent_relay_anonymous_id(
-                options.agent_relay_anonymous_id,
+            agent_relay_distinct_id: sanitize_agent_relay_distinct_id(
+                options.agent_relay_distinct_id,
             ),
             max_reconnect_attempts: options
                 .max_reconnect_attempts
@@ -244,8 +244,8 @@ impl WsClient {
             if let Some(ref harness) = self.harness {
                 query.append_pair("harness", harness);
             }
-            if let Some(ref id) = self.agent_relay_anonymous_id {
-                query.append_pair(AGENT_RELAY_ANONYMOUS_ID_QUERY, id);
+            if let Some(ref id) = self.agent_relay_distinct_id {
+                query.append_pair(AGENT_RELAY_DISTINCT_ID_QUERY, id);
             }
         }
 
@@ -265,7 +265,7 @@ impl WsClient {
         let origin_client = self.origin_client.clone();
         let origin_version = self.origin_version.clone();
         let harness = self.harness.clone();
-        let agent_relay_anonymous_id = self.agent_relay_anonymous_id.clone();
+        let agent_relay_distinct_id = self.agent_relay_distinct_id.clone();
         let max_reconnect_attempts = self.max_reconnect_attempts;
         let max_reconnect_delay_ms = self.max_reconnect_delay_ms;
 
@@ -300,8 +300,8 @@ impl WsClient {
                         if let Some(ref harness) = harness {
                             query.append_pair("harness", harness);
                         }
-                        if let Some(ref id) = agent_relay_anonymous_id {
-                            query.append_pair(AGENT_RELAY_ANONYMOUS_ID_QUERY, id);
+                        if let Some(ref id) = agent_relay_distinct_id {
+                            query.append_pair(AGENT_RELAY_DISTINCT_ID_QUERY, id);
                         }
                     }
 

--- a/packages/sdk-rust/src/ws.rs
+++ b/packages/sdk-rust/src/ws.rs
@@ -10,7 +10,9 @@ use tracing::{debug, warn};
 use url::Url;
 
 use crate::error::{RelayError, Result};
-use crate::harness::sanitize_harness;
+use crate::harness::{
+    sanitize_agent_relay_anonymous_id, sanitize_harness, AGENT_RELAY_ANONYMOUS_ID_QUERY,
+};
 use crate::types::WsEvent;
 
 const DEFAULT_BASE_URL: &str = "https://gateway.relaycast.dev";
@@ -39,6 +41,9 @@ pub struct WsClientOptions {
     /// User-Agent-style harness identifier, forwarded as the `harness` query
     /// param (browsers can't set custom WS headers). Invalid values are dropped.
     pub harness: Option<String>,
+    /// Agent Relay anonymous installation id, forwarded as the
+    /// `agent_relay_anonymous_id` query param. Invalid values are dropped.
+    pub agent_relay_anonymous_id: Option<String>,
     /// Maximum reconnect attempts before giving up (default: 10).
     pub max_reconnect_attempts: Option<u32>,
     /// Maximum reconnect delay in milliseconds (default: 30000).
@@ -56,6 +61,7 @@ impl WsClientOptions {
             origin_client: None,
             origin_version: None,
             harness: None,
+            agent_relay_anonymous_id: None,
             max_reconnect_attempts: None,
             max_reconnect_delay_ms: None,
         }
@@ -89,6 +95,12 @@ impl WsClientOptions {
     /// Set the harness identifier forwarded as the `harness` query param.
     pub fn with_harness(mut self, harness: impl Into<String>) -> Self {
         self.harness = Some(harness.into());
+        self
+    }
+
+    /// Set Agent Relay's anonymous installation id for WebSocket handshakes.
+    pub fn with_agent_relay_anonymous_id(mut self, id: impl Into<String>) -> Self {
+        self.agent_relay_anonymous_id = Some(id.into());
         self
     }
 
@@ -130,6 +142,7 @@ pub struct WsClient {
     origin_client: String,
     origin_version: String,
     harness: Option<String>,
+    agent_relay_anonymous_id: Option<String>,
     max_reconnect_attempts: u32,
     max_reconnect_delay_ms: u64,
     event_tx: broadcast::Sender<WsEvent>,
@@ -172,6 +185,9 @@ impl WsClient {
                 .origin_version
                 .unwrap_or_else(|| SDK_VERSION.to_string()),
             harness: sanitize_harness(options.harness),
+            agent_relay_anonymous_id: sanitize_agent_relay_anonymous_id(
+                options.agent_relay_anonymous_id,
+            ),
             max_reconnect_attempts: options
                 .max_reconnect_attempts
                 .unwrap_or(DEFAULT_MAX_RECONNECT_ATTEMPTS),
@@ -228,6 +244,9 @@ impl WsClient {
             if let Some(ref harness) = self.harness {
                 query.append_pair("harness", harness);
             }
+            if let Some(ref id) = self.agent_relay_anonymous_id {
+                query.append_pair(AGENT_RELAY_ANONYMOUS_ID_QUERY, id);
+            }
         }
 
         let (ws_stream, _) = connect_async(url.as_str()).await?;
@@ -246,6 +265,7 @@ impl WsClient {
         let origin_client = self.origin_client.clone();
         let origin_version = self.origin_version.clone();
         let harness = self.harness.clone();
+        let agent_relay_anonymous_id = self.agent_relay_anonymous_id.clone();
         let max_reconnect_attempts = self.max_reconnect_attempts;
         let max_reconnect_delay_ms = self.max_reconnect_delay_ms;
 
@@ -279,6 +299,9 @@ impl WsClient {
                         query.append_pair("origin_version", &origin_version);
                         if let Some(ref harness) = harness {
                             query.append_pair("harness", harness);
+                        }
+                        if let Some(ref id) = agent_relay_anonymous_id {
+                            query.append_pair(AGENT_RELAY_ANONYMOUS_ID_QUERY, id);
                         }
                     }
 

--- a/packages/sdk-rust/tests/parity.rs
+++ b/packages/sdk-rust/tests/parity.rs
@@ -549,6 +549,31 @@ async fn client_sends_sanitized_harness_header() {
 }
 
 #[tokio::test]
+async fn client_sends_agent_relay_anonymous_id_header() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/v1/channels"))
+        .and(header("x-agent-relay-anonymous-id", "abc123def4567890"))
+        .respond_with(ok(json!([])))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let relay = RelayCast::new(
+        RelayCastOptions::new("rk_live_test")
+            .with_base_url(server.uri())
+            .with_agent_relay_anonymous_id("abc123def4567890"),
+    )
+    .expect("failed to create RelayCast client");
+
+    relay
+        .list_channels(false)
+        .await
+        .expect("list_channels failed");
+}
+
+#[tokio::test]
 async fn client_preserves_harness_across_api_key_rotation() {
     let server = MockServer::start().await;
 
@@ -565,6 +590,35 @@ async fn client_preserves_harness_across_api_key_rotation() {
         ClientOptions::new("rk_live_test")
             .with_base_url(server.uri())
             .with_harness("Cursor"),
+    )
+    .expect("failed to create HTTP client");
+    let rotated = client
+        .with_api_key("at_live_rotated")
+        .expect("failed to rotate API key");
+
+    rotated
+        .get::<Vec<serde_json::Value>>("/v1/channels", None, None)
+        .await
+        .expect("list channels failed");
+}
+
+#[tokio::test]
+async fn client_preserves_agent_relay_anonymous_id_across_api_key_rotation() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/v1/channels"))
+        .and(header("authorization", "Bearer at_live_rotated"))
+        .and(header("x-agent-relay-anonymous-id", "abc123def4567890"))
+        .respond_with(ok(json!([])))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let client = HttpClient::new(
+        ClientOptions::new("rk_live_test")
+            .with_base_url(server.uri())
+            .with_agent_relay_anonymous_id("abc123def4567890"),
     )
     .expect("failed to create HTTP client");
     let rotated = client
@@ -618,6 +672,47 @@ async fn ws_client_forwards_sanitized_harness_query_param() {
             .find(|(key, _)| key == "harness")
             .map(|(_, value)| value.into_owned()),
         Some("claude-code/2.3".to_string())
+    );
+
+    ws.disconnect().await;
+    server.join().expect("test WS server panicked");
+}
+
+#[tokio::test]
+async fn ws_client_forwards_agent_relay_anonymous_id_query_param() {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("failed to bind test WS server");
+    let addr = listener.local_addr().expect("failed to read listener addr");
+    let (uri_tx, uri_rx) = mpsc::channel();
+
+    let server = std::thread::spawn(move || {
+        let (stream, _) = listener.accept().expect("failed to accept WS connection");
+        let callback = |request: &Request, response: Response| {
+            uri_tx
+                .send(request.uri().to_string())
+                .expect("failed to send captured request URI");
+            Ok(response)
+        };
+        let _websocket = tokio_tungstenite::tungstenite::accept_hdr(stream, callback)
+            .expect("failed to accept WS handshake");
+    });
+
+    let mut ws = WsClient::new(
+        WsClientOptions::new("at_live_test")
+            .with_base_url(format!("http://{addr}"))
+            .with_agent_relay_anonymous_id("abc123def4567890"),
+    );
+    ws.connect().await.expect("WS connect failed");
+
+    let uri = uri_rx
+        .recv_timeout(Duration::from_secs(2))
+        .expect("test WS server did not capture a request URI");
+    let url = url::Url::parse(&format!("http://localhost{uri}")).expect("invalid captured URI");
+    assert_eq!(url.path(), "/v1/ws");
+    assert_eq!(
+        url.query_pairs()
+            .find(|(key, _)| key == "agent_relay_anonymous_id")
+            .map(|(_, value)| value.into_owned()),
+        Some("abc123def4567890".to_string())
     );
 
     ws.disconnect().await;

--- a/packages/sdk-rust/tests/parity.rs
+++ b/packages/sdk-rust/tests/parity.rs
@@ -549,12 +549,12 @@ async fn client_sends_sanitized_harness_header() {
 }
 
 #[tokio::test]
-async fn client_sends_agent_relay_anonymous_id_header() {
+async fn client_sends_agent_relay_distinct_id_header() {
     let server = MockServer::start().await;
 
     Mock::given(method("GET"))
         .and(path("/v1/channels"))
-        .and(header("x-agent-relay-anonymous-id", "abc123def4567890"))
+        .and(header("x-agent-relay-distinct-id", "abc123def4567890"))
         .respond_with(ok(json!([])))
         .expect(1)
         .mount(&server)
@@ -563,7 +563,7 @@ async fn client_sends_agent_relay_anonymous_id_header() {
     let relay = RelayCast::new(
         RelayCastOptions::new("rk_live_test")
             .with_base_url(server.uri())
-            .with_agent_relay_anonymous_id("abc123def4567890"),
+            .with_agent_relay_distinct_id("abc123def4567890"),
     )
     .expect("failed to create RelayCast client");
 
@@ -603,13 +603,13 @@ async fn client_preserves_harness_across_api_key_rotation() {
 }
 
 #[tokio::test]
-async fn client_preserves_agent_relay_anonymous_id_across_api_key_rotation() {
+async fn client_preserves_agent_relay_distinct_id_across_api_key_rotation() {
     let server = MockServer::start().await;
 
     Mock::given(method("GET"))
         .and(path("/v1/channels"))
         .and(header("authorization", "Bearer at_live_rotated"))
-        .and(header("x-agent-relay-anonymous-id", "abc123def4567890"))
+        .and(header("x-agent-relay-distinct-id", "abc123def4567890"))
         .respond_with(ok(json!([])))
         .expect(1)
         .mount(&server)
@@ -618,7 +618,7 @@ async fn client_preserves_agent_relay_anonymous_id_across_api_key_rotation() {
     let client = HttpClient::new(
         ClientOptions::new("rk_live_test")
             .with_base_url(server.uri())
-            .with_agent_relay_anonymous_id("abc123def4567890"),
+            .with_agent_relay_distinct_id("abc123def4567890"),
     )
     .expect("failed to create HTTP client");
     let rotated = client
@@ -679,7 +679,7 @@ async fn ws_client_forwards_sanitized_harness_query_param() {
 }
 
 #[tokio::test]
-async fn ws_client_forwards_agent_relay_anonymous_id_query_param() {
+async fn ws_client_forwards_agent_relay_distinct_id_query_param() {
     let listener = TcpListener::bind("127.0.0.1:0").expect("failed to bind test WS server");
     let addr = listener.local_addr().expect("failed to read listener addr");
     let (uri_tx, uri_rx) = mpsc::channel();
@@ -699,7 +699,7 @@ async fn ws_client_forwards_agent_relay_anonymous_id_query_param() {
     let mut ws = WsClient::new(
         WsClientOptions::new("at_live_test")
             .with_base_url(format!("http://{addr}"))
-            .with_agent_relay_anonymous_id("abc123def4567890"),
+            .with_agent_relay_distinct_id("abc123def4567890"),
     );
     ws.connect().await.expect("WS connect failed");
 
@@ -710,7 +710,7 @@ async fn ws_client_forwards_agent_relay_anonymous_id_query_param() {
     assert_eq!(url.path(), "/v1/ws");
     assert_eq!(
         url.query_pairs()
-            .find(|(key, _)| key == "agent_relay_anonymous_id")
+            .find(|(key, _)| key == "agent_relay_distinct_id")
             .map(|(_, value)| value.into_owned()),
         Some("abc123def4567890".to_string())
     );

--- a/packages/sdk-typescript/src/__tests__/harness.test.ts
+++ b/packages/sdk-typescript/src/__tests__/harness.test.ts
@@ -10,7 +10,7 @@
  */
 
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { sanitizeHarness } from '../origin.js';
+import { sanitizeAgentRelayAnonymousId, sanitizeHarness } from '../origin.js';
 
 const mockFetch = vi.fn();
 vi.stubGlobal('fetch', mockFetch);
@@ -28,12 +28,20 @@ function harnessHeaderFromLastCall(): string | undefined {
   return (init.headers as Record<string, string>)['X-Relaycast-Harness'];
 }
 
+function agentRelayIdHeaderFromLastCall(): string | undefined {
+  const [, init] = mockFetch.mock.calls.at(-1)!;
+  return (init.headers as Record<string, string>)['X-Agent-Relay-Anonymous-Id'];
+}
+
 describe('sanitizeHarness', () => {
   it('is available from the package root', async () => {
     const sdk = await import('../index.js');
 
     expect(sdk.HARNESS_HEADER).toBe('X-Relaycast-Harness');
+    expect(sdk.AGENT_RELAY_ANONYMOUS_ID_HEADER).toBe('X-Agent-Relay-Anonymous-Id');
+    expect(sdk.AGENT_RELAY_ANONYMOUS_ID_QUERY).toBe('agent_relay_anonymous_id');
     expect(sdk.sanitizeHarness('Codex')).toBe('codex');
+    expect(sdk.sanitizeAgentRelayAnonymousId('abc123def4567890')).toBe('abc123def4567890');
   });
 
   it('keeps a UA-style token, lowercased', () => {
@@ -59,6 +67,31 @@ describe('sanitizeHarness', () => {
 
   it('caps at 120 characters', () => {
     expect(sanitizeHarness('a'.repeat(200))).toBe('a'.repeat(120));
+  });
+});
+
+describe('sanitizeAgentRelayAnonymousId', () => {
+  it('keeps a well-formed id without lowercasing', () => {
+    expect(sanitizeAgentRelayAnonymousId('AgentRelay.abc_123:XYZ-9')).toBe('AgentRelay.abc_123:XYZ-9');
+  });
+
+  it('trims surrounding whitespace', () => {
+    expect(sanitizeAgentRelayAnonymousId('  abc123def4567890  ')).toBe('abc123def4567890');
+  });
+
+  it('drops empty / whitespace-only input', () => {
+    expect(sanitizeAgentRelayAnonymousId('')).toBeUndefined();
+    expect(sanitizeAgentRelayAnonymousId('   ')).toBeUndefined();
+    expect(sanitizeAgentRelayAnonymousId(undefined)).toBeUndefined();
+  });
+
+  it('drops CRLF / control characters rather than sending garbage', () => {
+    expect(sanitizeAgentRelayAnonymousId('evil\r\nX-Inject: bad')).toBeUndefined();
+    expect(sanitizeAgentRelayAnonymousId('a/b')).toBeUndefined();
+  });
+
+  it('caps at 128 characters', () => {
+    expect(sanitizeAgentRelayAnonymousId('a'.repeat(200))).toBe('a'.repeat(128));
   });
 });
 
@@ -142,6 +175,67 @@ describe('harness — HTTP', () => {
 
     expect(harnessHeaderFromLastCall()).toBe('claude-code');
   });
+
+  it('stamps X-Agent-Relay-Anonymous-Id from the public constructor option', async () => {
+    const { RelayCast } = await import('../relay.js');
+    const relay = new RelayCast({
+      apiKey: 'rk_live_test',
+      agentRelayAnonymousId: 'abc123def4567890',
+    });
+
+    mockFetch.mockImplementation(() => jsonOk([]));
+    await relay.activity();
+
+    expect(agentRelayIdHeaderFromLastCall()).toBe('abc123def4567890');
+  });
+
+  it('stamps X-Agent-Relay-Anonymous-Id from the internal origin', async () => {
+    const { createInternalRelayCast } = await import('../internal.js');
+    const relay = createInternalRelayCast(
+      { apiKey: 'rk_live_test' },
+      {
+        surface: 'mcp',
+        client: '@agent-relay/relaycast-mcp',
+        version: '6.0.0',
+        agentRelayAnonymousId: 'abc123def4567890',
+      },
+    );
+
+    mockFetch.mockImplementation(() => jsonOk([]));
+    await relay.activity();
+
+    expect(agentRelayIdHeaderFromLastCall()).toBe('abc123def4567890');
+  });
+
+  it('drops an invalid Agent Relay anonymous id rather than sending garbage', async () => {
+    const { RelayCast } = await import('../relay.js');
+    const relay = new RelayCast({
+      apiKey: 'rk_live_test',
+      agentRelayAnonymousId: 'evil\r\nX-Inject: bad',
+    });
+
+    mockFetch.mockImplementation(() => jsonOk([]));
+    await relay.activity();
+
+    const [, init] = mockFetch.mock.calls.at(-1)!;
+    expect('X-Agent-Relay-Anonymous-Id' in (init.headers as Record<string, string>)).toBe(false);
+  });
+
+  it('preserves the Agent Relay anonymous id across withApiKey()', async () => {
+    const { HttpClient } = await import('../client.js');
+    const client = new HttpClient({
+      apiKey: 'rk_live_test',
+      agentRelayAnonymousId: 'abc123def4567890',
+    });
+    const rotated = client.withApiKey('rk_live_other');
+
+    expect(rotated.apiKey).toBe('rk_live_other');
+    expect(rotated.agentRelayAnonymousId).toBe('abc123def4567890');
+
+    mockFetch.mockImplementation(() => jsonOk([]));
+    await rotated.get('/v1/activity');
+    expect(agentRelayIdHeaderFromLastCall()).toBe('abc123def4567890');
+  });
 });
 
 describe('harness — WS', () => {
@@ -194,5 +288,34 @@ describe('harness — WS', () => {
 
     const url = new URL(constructed[0]!);
     expect(url.searchParams.has('harness')).toBe(false);
+  });
+
+  it('forwards the Agent Relay anonymous id as a query param on connect', async () => {
+    const constructed: string[] = [];
+    class MockWs {
+      static readonly OPEN = 1;
+      onopen: (() => void) | null = null;
+      onclose: (() => void) | null = null;
+      onmessage: ((event: { data: string }) => void) | null = null;
+      onerror: (() => void) | null = null;
+      send = vi.fn();
+      close = vi.fn();
+      constructor(url: string) {
+        constructed.push(url);
+      }
+    }
+    vi.stubGlobal('WebSocket', MockWs);
+
+    const { WsClient } = await import('../ws.js');
+    const ws = new WsClient({
+      token: 'at_live_test',
+      agentRelayAnonymousId: 'abc123def4567890',
+    });
+    ws.connect();
+    ws.disconnect();
+
+    expect(constructed).toHaveLength(1);
+    const url = new URL(constructed[0]!);
+    expect(url.searchParams.get('agent_relay_anonymous_id')).toBe('abc123def4567890');
   });
 });

--- a/packages/sdk-typescript/src/__tests__/harness.test.ts
+++ b/packages/sdk-typescript/src/__tests__/harness.test.ts
@@ -10,7 +10,7 @@
  */
 
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { sanitizeAgentRelayAnonymousId, sanitizeHarness } from '../origin.js';
+import { sanitizeAgentRelayDistinctId, sanitizeHarness } from '../origin.js';
 
 const mockFetch = vi.fn();
 vi.stubGlobal('fetch', mockFetch);
@@ -28,9 +28,9 @@ function harnessHeaderFromLastCall(): string | undefined {
   return (init.headers as Record<string, string>)['X-Relaycast-Harness'];
 }
 
-function agentRelayIdHeaderFromLastCall(): string | undefined {
+function agentRelayDistinctIdHeaderFromLastCall(): string | undefined {
   const [, init] = mockFetch.mock.calls.at(-1)!;
-  return (init.headers as Record<string, string>)['X-Agent-Relay-Anonymous-Id'];
+  return (init.headers as Record<string, string>)['X-Agent-Relay-Distinct-Id'];
 }
 
 describe('sanitizeHarness', () => {
@@ -38,10 +38,10 @@ describe('sanitizeHarness', () => {
     const sdk = await import('../index.js');
 
     expect(sdk.HARNESS_HEADER).toBe('X-Relaycast-Harness');
-    expect(sdk.AGENT_RELAY_ANONYMOUS_ID_HEADER).toBe('X-Agent-Relay-Anonymous-Id');
-    expect(sdk.AGENT_RELAY_ANONYMOUS_ID_QUERY).toBe('agent_relay_anonymous_id');
+    expect(sdk.AGENT_RELAY_DISTINCT_ID_HEADER).toBe('X-Agent-Relay-Distinct-Id');
+    expect(sdk.AGENT_RELAY_DISTINCT_ID_QUERY).toBe('agent_relay_distinct_id');
     expect(sdk.sanitizeHarness('Codex')).toBe('codex');
-    expect(sdk.sanitizeAgentRelayAnonymousId('abc123def4567890')).toBe('abc123def4567890');
+    expect(sdk.sanitizeAgentRelayDistinctId('abc123def4567890')).toBe('abc123def4567890');
   });
 
   it('keeps a UA-style token, lowercased', () => {
@@ -70,28 +70,28 @@ describe('sanitizeHarness', () => {
   });
 });
 
-describe('sanitizeAgentRelayAnonymousId', () => {
+describe('sanitizeAgentRelayDistinctId', () => {
   it('keeps a well-formed id without lowercasing', () => {
-    expect(sanitizeAgentRelayAnonymousId('AgentRelay.abc_123:XYZ-9')).toBe('AgentRelay.abc_123:XYZ-9');
+    expect(sanitizeAgentRelayDistinctId('AgentRelay.abc_123:XYZ-9')).toBe('AgentRelay.abc_123:XYZ-9');
   });
 
   it('trims surrounding whitespace', () => {
-    expect(sanitizeAgentRelayAnonymousId('  abc123def4567890  ')).toBe('abc123def4567890');
+    expect(sanitizeAgentRelayDistinctId('  abc123def4567890  ')).toBe('abc123def4567890');
   });
 
   it('drops empty / whitespace-only input', () => {
-    expect(sanitizeAgentRelayAnonymousId('')).toBeUndefined();
-    expect(sanitizeAgentRelayAnonymousId('   ')).toBeUndefined();
-    expect(sanitizeAgentRelayAnonymousId(undefined)).toBeUndefined();
+    expect(sanitizeAgentRelayDistinctId('')).toBeUndefined();
+    expect(sanitizeAgentRelayDistinctId('   ')).toBeUndefined();
+    expect(sanitizeAgentRelayDistinctId(undefined)).toBeUndefined();
   });
 
   it('drops CRLF / control characters rather than sending garbage', () => {
-    expect(sanitizeAgentRelayAnonymousId('evil\r\nX-Inject: bad')).toBeUndefined();
-    expect(sanitizeAgentRelayAnonymousId('a/b')).toBeUndefined();
+    expect(sanitizeAgentRelayDistinctId('evil\r\nX-Inject: bad')).toBeUndefined();
+    expect(sanitizeAgentRelayDistinctId('a/b')).toBeUndefined();
   });
 
   it('caps at 128 characters', () => {
-    expect(sanitizeAgentRelayAnonymousId('a'.repeat(200))).toBe('a'.repeat(128));
+    expect(sanitizeAgentRelayDistinctId('a'.repeat(200))).toBe('a'.repeat(128));
   });
 });
 
@@ -176,20 +176,20 @@ describe('harness — HTTP', () => {
     expect(harnessHeaderFromLastCall()).toBe('claude-code');
   });
 
-  it('stamps X-Agent-Relay-Anonymous-Id from the public constructor option', async () => {
+  it('stamps X-Agent-Relay-Distinct-Id from the public constructor option', async () => {
     const { RelayCast } = await import('../relay.js');
     const relay = new RelayCast({
       apiKey: 'rk_live_test',
-      agentRelayAnonymousId: 'abc123def4567890',
+      agentRelayDistinctId: 'abc123def4567890',
     });
 
     mockFetch.mockImplementation(() => jsonOk([]));
     await relay.activity();
 
-    expect(agentRelayIdHeaderFromLastCall()).toBe('abc123def4567890');
+    expect(agentRelayDistinctIdHeaderFromLastCall()).toBe('abc123def4567890');
   });
 
-  it('stamps X-Agent-Relay-Anonymous-Id from the internal origin', async () => {
+  it('stamps X-Agent-Relay-Distinct-Id from the internal origin', async () => {
     const { createInternalRelayCast } = await import('../internal.js');
     const relay = createInternalRelayCast(
       { apiKey: 'rk_live_test' },
@@ -197,44 +197,44 @@ describe('harness — HTTP', () => {
         surface: 'mcp',
         client: '@agent-relay/relaycast-mcp',
         version: '6.0.0',
-        agentRelayAnonymousId: 'abc123def4567890',
+        agentRelayDistinctId: 'abc123def4567890',
       },
     );
 
     mockFetch.mockImplementation(() => jsonOk([]));
     await relay.activity();
 
-    expect(agentRelayIdHeaderFromLastCall()).toBe('abc123def4567890');
+    expect(agentRelayDistinctIdHeaderFromLastCall()).toBe('abc123def4567890');
   });
 
-  it('drops an invalid Agent Relay anonymous id rather than sending garbage', async () => {
+  it('drops an invalid Agent Relay distinct id rather than sending garbage', async () => {
     const { RelayCast } = await import('../relay.js');
     const relay = new RelayCast({
       apiKey: 'rk_live_test',
-      agentRelayAnonymousId: 'evil\r\nX-Inject: bad',
+      agentRelayDistinctId: 'evil\r\nX-Inject: bad',
     });
 
     mockFetch.mockImplementation(() => jsonOk([]));
     await relay.activity();
 
     const [, init] = mockFetch.mock.calls.at(-1)!;
-    expect('X-Agent-Relay-Anonymous-Id' in (init.headers as Record<string, string>)).toBe(false);
+    expect('X-Agent-Relay-Distinct-Id' in (init.headers as Record<string, string>)).toBe(false);
   });
 
-  it('preserves the Agent Relay anonymous id across withApiKey()', async () => {
+  it('preserves the Agent Relay distinct id across withApiKey()', async () => {
     const { HttpClient } = await import('../client.js');
     const client = new HttpClient({
       apiKey: 'rk_live_test',
-      agentRelayAnonymousId: 'abc123def4567890',
+      agentRelayDistinctId: 'abc123def4567890',
     });
     const rotated = client.withApiKey('rk_live_other');
 
     expect(rotated.apiKey).toBe('rk_live_other');
-    expect(rotated.agentRelayAnonymousId).toBe('abc123def4567890');
+    expect(rotated.agentRelayDistinctId).toBe('abc123def4567890');
 
     mockFetch.mockImplementation(() => jsonOk([]));
     await rotated.get('/v1/activity');
-    expect(agentRelayIdHeaderFromLastCall()).toBe('abc123def4567890');
+    expect(agentRelayDistinctIdHeaderFromLastCall()).toBe('abc123def4567890');
   });
 });
 
@@ -290,7 +290,7 @@ describe('harness — WS', () => {
     expect(url.searchParams.has('harness')).toBe(false);
   });
 
-  it('forwards the Agent Relay anonymous id as a query param on connect', async () => {
+  it('forwards the Agent Relay distinct id as a query param on connect', async () => {
     const constructed: string[] = [];
     class MockWs {
       static readonly OPEN = 1;
@@ -309,13 +309,13 @@ describe('harness — WS', () => {
     const { WsClient } = await import('../ws.js');
     const ws = new WsClient({
       token: 'at_live_test',
-      agentRelayAnonymousId: 'abc123def4567890',
+      agentRelayDistinctId: 'abc123def4567890',
     });
     ws.connect();
     ws.disconnect();
 
     expect(constructed).toHaveLength(1);
     const url = new URL(constructed[0]!);
-    expect(url.searchParams.get('agent_relay_anonymous_id')).toBe('abc123def4567890');
+    expect(url.searchParams.get('agent_relay_distinct_id')).toBe('abc123def4567890');
   });
 });

--- a/packages/sdk-typescript/src/__tests__/relay.test.ts
+++ b/packages/sdk-typescript/src/__tests__/relay.test.ts
@@ -734,6 +734,30 @@ describe('RelayCast', () => {
       expect(url).toBe('http://localhost:3000/v1/workspaces');
     });
 
+    it('sends Agent Relay anonymous id when supplied', async () => {
+      const { RelayCast } = await import('../relay.js');
+
+      mockFetch.mockImplementation(() =>
+        Promise.resolve({
+          ok: true,
+          status: 201,
+          json: () =>
+            Promise.resolve({
+              ok: true,
+              data: { workspace_id: 'ws_1', api_key: 'rk_live_new', created_at: '2024-01-01' },
+            }),
+        }),
+      );
+
+      await RelayCast.createWorkspace('Test', {
+        baseUrl: 'http://localhost:3000',
+        agentRelayAnonymousId: 'abc123def4567890',
+      });
+
+      const [, init] = mockFetch.mock.calls[0]!;
+      expect(init.headers['X-Agent-Relay-Anonymous-Id']).toBe('abc123def4567890');
+    });
+
     it('returns an existing workspace on idempotent duplicate create', async () => {
       const { RelayCast } = await import('../relay.js');
 
@@ -803,6 +827,31 @@ describe('RelayCast', () => {
       );
 
       await expect(RelayCast.lookupWorkspace('Missing')).resolves.toBeNull();
+    });
+
+    it('sends Agent Relay anonymous id when supplied', async () => {
+      const { RelayCast } = await import('../relay.js');
+
+      mockFetch.mockImplementation(() =>
+        Promise.resolve({
+          ok: true,
+          status: 200,
+          json: () =>
+            Promise.resolve({
+              ok: true,
+              data: { id: 'ws_1', name: 'My Workspace', created_at: '2024-01-01' },
+            }),
+        }),
+      );
+
+      await RelayCast.lookupWorkspace('My Workspace', {
+        baseUrl: 'http://localhost:3000',
+        agentRelayAnonymousId: 'abc123def4567890',
+      });
+
+      const [url, init] = mockFetch.mock.calls[0]!;
+      expect(url).toBe('http://localhost:3000/v1/workspaces/by-name/My%20Workspace');
+      expect(init.headers['X-Agent-Relay-Anonymous-Id']).toBe('abc123def4567890');
     });
   });
 

--- a/packages/sdk-typescript/src/__tests__/relay.test.ts
+++ b/packages/sdk-typescript/src/__tests__/relay.test.ts
@@ -734,7 +734,7 @@ describe('RelayCast', () => {
       expect(url).toBe('http://localhost:3000/v1/workspaces');
     });
 
-    it('sends Agent Relay anonymous id when supplied', async () => {
+    it('sends Agent Relay distinct id when supplied', async () => {
       const { RelayCast } = await import('../relay.js');
 
       mockFetch.mockImplementation(() =>
@@ -751,11 +751,11 @@ describe('RelayCast', () => {
 
       await RelayCast.createWorkspace('Test', {
         baseUrl: 'http://localhost:3000',
-        agentRelayAnonymousId: 'abc123def4567890',
+        agentRelayDistinctId: 'abc123def4567890',
       });
 
       const [, init] = mockFetch.mock.calls[0]!;
-      expect(init.headers['X-Agent-Relay-Anonymous-Id']).toBe('abc123def4567890');
+      expect(init.headers['X-Agent-Relay-Distinct-Id']).toBe('abc123def4567890');
     });
 
     it('returns an existing workspace on idempotent duplicate create', async () => {
@@ -829,7 +829,7 @@ describe('RelayCast', () => {
       await expect(RelayCast.lookupWorkspace('Missing')).resolves.toBeNull();
     });
 
-    it('sends Agent Relay anonymous id when supplied', async () => {
+    it('sends Agent Relay distinct id when supplied', async () => {
       const { RelayCast } = await import('../relay.js');
 
       mockFetch.mockImplementation(() =>
@@ -846,12 +846,12 @@ describe('RelayCast', () => {
 
       await RelayCast.lookupWorkspace('My Workspace', {
         baseUrl: 'http://localhost:3000',
-        agentRelayAnonymousId: 'abc123def4567890',
+        agentRelayDistinctId: 'abc123def4567890',
       });
 
       const [url, init] = mockFetch.mock.calls[0]!;
       expect(url).toBe('http://localhost:3000/v1/workspaces/by-name/My%20Workspace');
-      expect(init.headers['X-Agent-Relay-Anonymous-Id']).toBe('abc123def4567890');
+      expect(init.headers['X-Agent-Relay-Distinct-Id']).toBe('abc123def4567890');
     });
   });
 

--- a/packages/sdk-typescript/src/agent.ts
+++ b/packages/sdk-typescript/src/agent.ts
@@ -214,7 +214,7 @@ export class AgentClient {
         client: this.client.originClient,
         version: this.client.originVersion,
         ...(this.client.originHarness ? { harness: this.client.originHarness } : {}),
-        ...(this.client.agentRelayAnonymousId ? { agentRelayAnonymousId: this.client.agentRelayAnonymousId } : {}),
+        ...(this.client.agentRelayDistinctId ? { agentRelayDistinctId: this.client.agentRelayDistinctId } : {}),
       },
     ));
     this.ws.on('open', () => {

--- a/packages/sdk-typescript/src/agent.ts
+++ b/packages/sdk-typescript/src/agent.ts
@@ -214,6 +214,7 @@ export class AgentClient {
         client: this.client.originClient,
         version: this.client.originVersion,
         ...(this.client.originHarness ? { harness: this.client.originHarness } : {}),
+        ...(this.client.agentRelayAnonymousId ? { agentRelayAnonymousId: this.client.agentRelayAnonymousId } : {}),
       },
     ));
     this.ws.on('open', () => {

--- a/packages/sdk-typescript/src/client.ts
+++ b/packages/sdk-typescript/src/client.ts
@@ -2,10 +2,10 @@ import { z } from 'zod';
 import { ApiErrorSchema } from '@relaycast/types';
 import { SDK_VERSION } from './version.js';
 import {
-  AGENT_RELAY_ANONYMOUS_ID_HEADER,
+  AGENT_RELAY_DISTINCT_ID_HEADER,
   HARNESS_HEADER,
   SDK_ORIGIN,
-  sanitizeAgentRelayAnonymousId,
+  sanitizeAgentRelayDistinctId,
   sanitizeHarness,
   type InternalOrigin,
 } from './origin.js';
@@ -24,12 +24,12 @@ export interface ClientOptions {
    */
   harness?: string;
   /**
-   * Optional Agent Relay anonymous installation id. Sent as the
-   * `X-Agent-Relay-Anonymous-Id` header so Relaycast telemetry can be joined to
+   * Optional Agent Relay distinct telemetry id. Sent as the
+   * `X-Agent-Relay-Distinct-Id` header so Relaycast telemetry can be joined to
    * Agent Relay CLI telemetry without sending user-identifying data. Invalid
    * values are dropped.
    */
-  agentRelayAnonymousId?: string;
+  agentRelayDistinctId?: string;
 }
 
 export interface RequestOptions {
@@ -147,7 +147,7 @@ export class HttpClient {
   private _originClient: string;
   private _originVersion: string;
   private _originHarness?: string;
-  private _agentRelayAnonymousId?: string;
+  private _agentRelayDistinctId?: string;
   private _retryPolicy: RetryPolicy;
 
   constructor(options: ClientOptions) {
@@ -160,8 +160,8 @@ export class HttpClient {
     // A wrapping host's internal origin is authoritative about the harness;
     // fall back to the public `harness` option for plain consumers.
     this._originHarness = sanitizeHarness(origin.harness ?? options.harness);
-    this._agentRelayAnonymousId = sanitizeAgentRelayAnonymousId(
-      origin.agentRelayAnonymousId ?? options.agentRelayAnonymousId,
+    this._agentRelayDistinctId = sanitizeAgentRelayDistinctId(
+      origin.agentRelayDistinctId ?? options.agentRelayDistinctId,
     );
     this._retryPolicy = normalizeRetryPolicy(options.retryPolicy);
   }
@@ -191,9 +191,9 @@ export class HttpClient {
     return this._originHarness;
   }
 
-  /** Sanitized Agent Relay anonymous id, or `undefined` when none was supplied. */
-  get agentRelayAnonymousId(): string | undefined {
-    return this._agentRelayAnonymousId;
+  /** Sanitized Agent Relay distinct id, or `undefined` when none was supplied. */
+  get agentRelayDistinctId(): string | undefined {
+    return this._agentRelayDistinctId;
   }
 
   get retryPolicy(): RetryPolicy {
@@ -208,7 +208,7 @@ export class HttpClient {
         client: this._originClient,
         version: this._originVersion,
         ...(this._originHarness ? { harness: this._originHarness } : {}),
-        ...(this._agentRelayAnonymousId ? { agentRelayAnonymousId: this._agentRelayAnonymousId } : {}),
+        ...(this._agentRelayDistinctId ? { agentRelayDistinctId: this._agentRelayDistinctId } : {}),
       },
     ));
   }
@@ -234,7 +234,7 @@ export class HttpClient {
       'X-Relaycast-Origin-Client': this._originClient,
       'X-Relaycast-Origin-Version': this._originVersion,
       ...(this._originHarness ? { [HARNESS_HEADER]: this._originHarness } : {}),
-      ...(this._agentRelayAnonymousId ? { [AGENT_RELAY_ANONYMOUS_ID_HEADER]: this._agentRelayAnonymousId } : {}),
+      ...(this._agentRelayDistinctId ? { [AGENT_RELAY_DISTINCT_ID_HEADER]: this._agentRelayDistinctId } : {}),
       ...(options?.headers || {}),
     };
 

--- a/packages/sdk-typescript/src/client.ts
+++ b/packages/sdk-typescript/src/client.ts
@@ -1,7 +1,14 @@
 import { z } from 'zod';
 import { ApiErrorSchema } from '@relaycast/types';
 import { SDK_VERSION } from './version.js';
-import { SDK_ORIGIN, HARNESS_HEADER, sanitizeHarness, type InternalOrigin } from './origin.js';
+import {
+  AGENT_RELAY_ANONYMOUS_ID_HEADER,
+  HARNESS_HEADER,
+  SDK_ORIGIN,
+  sanitizeAgentRelayAnonymousId,
+  sanitizeHarness,
+  type InternalOrigin,
+} from './origin.js';
 import { camelizeKeys, decamelizeKey, decamelizeKeys, type Camelize } from './casing.js';
 import { RelayError, relayErrorFromApi } from './errors.js';
 
@@ -16,6 +23,13 @@ export interface ClientOptions {
    * {@link sanitizeHarness}.
    */
   harness?: string;
+  /**
+   * Optional Agent Relay anonymous installation id. Sent as the
+   * `X-Agent-Relay-Anonymous-Id` header so Relaycast telemetry can be joined to
+   * Agent Relay CLI telemetry without sending user-identifying data. Invalid
+   * values are dropped.
+   */
+  agentRelayAnonymousId?: string;
 }
 
 export interface RequestOptions {
@@ -133,6 +147,7 @@ export class HttpClient {
   private _originClient: string;
   private _originVersion: string;
   private _originHarness?: string;
+  private _agentRelayAnonymousId?: string;
   private _retryPolicy: RetryPolicy;
 
   constructor(options: ClientOptions) {
@@ -145,6 +160,9 @@ export class HttpClient {
     // A wrapping host's internal origin is authoritative about the harness;
     // fall back to the public `harness` option for plain consumers.
     this._originHarness = sanitizeHarness(origin.harness ?? options.harness);
+    this._agentRelayAnonymousId = sanitizeAgentRelayAnonymousId(
+      origin.agentRelayAnonymousId ?? options.agentRelayAnonymousId,
+    );
     this._retryPolicy = normalizeRetryPolicy(options.retryPolicy);
   }
 
@@ -173,6 +191,11 @@ export class HttpClient {
     return this._originHarness;
   }
 
+  /** Sanitized Agent Relay anonymous id, or `undefined` when none was supplied. */
+  get agentRelayAnonymousId(): string | undefined {
+    return this._agentRelayAnonymousId;
+  }
+
   get retryPolicy(): RetryPolicy {
     return this._retryPolicy;
   }
@@ -185,6 +208,7 @@ export class HttpClient {
         client: this._originClient,
         version: this._originVersion,
         ...(this._originHarness ? { harness: this._originHarness } : {}),
+        ...(this._agentRelayAnonymousId ? { agentRelayAnonymousId: this._agentRelayAnonymousId } : {}),
       },
     ));
   }
@@ -210,6 +234,7 @@ export class HttpClient {
       'X-Relaycast-Origin-Client': this._originClient,
       'X-Relaycast-Origin-Version': this._originVersion,
       ...(this._originHarness ? { [HARNESS_HEADER]: this._originHarness } : {}),
+      ...(this._agentRelayAnonymousId ? { [AGENT_RELAY_ANONYMOUS_ID_HEADER]: this._agentRelayAnonymousId } : {}),
       ...(options?.headers || {}),
     };
 

--- a/packages/sdk-typescript/src/index.ts
+++ b/packages/sdk-typescript/src/index.ts
@@ -3,6 +3,8 @@ export { RelayCast } from './relay.js';
 export type {
   AgentReconnectOptions,
   RelayCastOptions,
+  WorkspaceBootstrapOptions,
+  WorkspaceLookupOptions,
   EnsureWorkspaceResponse,
 } from './relay.js';
 export { Relay } from './communicate/relay.js';
@@ -29,7 +31,13 @@ export { AgentClient } from './agent.js';
 export type { AgentClientOptions } from './agent.js';
 export { HttpClient, RelayError } from './client.js';
 export type { ClientOptions } from './client.js';
-export { HARNESS_HEADER, sanitizeHarness } from './origin.js';
+export {
+  AGENT_RELAY_ANONYMOUS_ID_HEADER,
+  AGENT_RELAY_ANONYMOUS_ID_QUERY,
+  HARNESS_HEADER,
+  sanitizeAgentRelayAnonymousId,
+  sanitizeHarness,
+} from './origin.js';
 export {
   relayErrorFromApi,
   normalizeRelayErrorCode,

--- a/packages/sdk-typescript/src/index.ts
+++ b/packages/sdk-typescript/src/index.ts
@@ -32,10 +32,10 @@ export type { AgentClientOptions } from './agent.js';
 export { HttpClient, RelayError } from './client.js';
 export type { ClientOptions } from './client.js';
 export {
-  AGENT_RELAY_ANONYMOUS_ID_HEADER,
-  AGENT_RELAY_ANONYMOUS_ID_QUERY,
+  AGENT_RELAY_DISTINCT_ID_HEADER,
+  AGENT_RELAY_DISTINCT_ID_QUERY,
   HARNESS_HEADER,
-  sanitizeAgentRelayAnonymousId,
+  sanitizeAgentRelayDistinctId,
   sanitizeHarness,
 } from './origin.js';
 export {

--- a/packages/sdk-typescript/src/origin.ts
+++ b/packages/sdk-typescript/src/origin.ts
@@ -11,6 +11,12 @@ export interface InternalOrigin {
    * See {@link sanitizeHarness} for the accepted shape.
    */
   harness?: string;
+  /**
+   * Optional Agent Relay anonymous installation id. Wrapping hosts set this so
+   * Relaycast telemetry can join SDK traffic back to Agent Relay CLI telemetry
+   * without sending user-identifying data.
+   */
+  agentRelayAnonymousId?: string;
 }
 
 export const SDK_ORIGIN: InternalOrigin = Object.freeze({
@@ -25,9 +31,12 @@ export const SDK_ORIGIN: InternalOrigin = Object.freeze({
  * `@relaycast/engine`'s `extractHarness`.
  */
 export const HARNESS_HEADER = 'X-Relaycast-Harness';
+export const AGENT_RELAY_ANONYMOUS_ID_HEADER = 'X-Agent-Relay-Anonymous-Id';
+export const AGENT_RELAY_ANONYMOUS_ID_QUERY = 'agent_relay_anonymous_id';
 
 /** Upper bound on the harness identifier — generous enough for a UA-style token. */
 const HARNESS_MAX_LENGTH = 120;
+const AGENT_RELAY_ANONYMOUS_ID_MAX_LENGTH = 128;
 
 /**
  * Characters permitted in a harness identifier. Deliberately broad enough for a
@@ -36,6 +45,7 @@ const HARNESS_MAX_LENGTH = 120;
  * upstream value from smuggling a header injection past the relaycast WAF.
  */
 const HARNESS_ALLOWED = /^[a-z0-9 ._\-/():=;,+]+$/i;
+const AGENT_RELAY_ANONYMOUS_ID_ALLOWED = /^[a-z0-9._:-]+$/i;
 
 /**
  * Normalize a caller-supplied harness identifier to the wire contract.
@@ -50,4 +60,12 @@ export function sanitizeHarness(raw: string | undefined): string | undefined {
   if (!trimmed) return undefined;
   if (!HARNESS_ALLOWED.test(trimmed)) return undefined;
   return trimmed.slice(0, HARNESS_MAX_LENGTH).toLowerCase();
+}
+
+export function sanitizeAgentRelayAnonymousId(raw: string | undefined): string | undefined {
+  if (!raw) return undefined;
+  const trimmed = raw.trim();
+  if (!trimmed) return undefined;
+  if (!AGENT_RELAY_ANONYMOUS_ID_ALLOWED.test(trimmed)) return undefined;
+  return trimmed.slice(0, AGENT_RELAY_ANONYMOUS_ID_MAX_LENGTH);
 }

--- a/packages/sdk-typescript/src/origin.ts
+++ b/packages/sdk-typescript/src/origin.ts
@@ -12,11 +12,11 @@ export interface InternalOrigin {
    */
   harness?: string;
   /**
-   * Optional Agent Relay anonymous installation id. Wrapping hosts set this so
+   * Optional Agent Relay distinct telemetry id. Wrapping hosts set this so
    * Relaycast telemetry can join SDK traffic back to Agent Relay CLI telemetry
    * without sending user-identifying data.
    */
-  agentRelayAnonymousId?: string;
+  agentRelayDistinctId?: string;
 }
 
 export const SDK_ORIGIN: InternalOrigin = Object.freeze({
@@ -31,12 +31,12 @@ export const SDK_ORIGIN: InternalOrigin = Object.freeze({
  * `@relaycast/engine`'s `extractHarness`.
  */
 export const HARNESS_HEADER = 'X-Relaycast-Harness';
-export const AGENT_RELAY_ANONYMOUS_ID_HEADER = 'X-Agent-Relay-Anonymous-Id';
-export const AGENT_RELAY_ANONYMOUS_ID_QUERY = 'agent_relay_anonymous_id';
+export const AGENT_RELAY_DISTINCT_ID_HEADER = 'X-Agent-Relay-Distinct-Id';
+export const AGENT_RELAY_DISTINCT_ID_QUERY = 'agent_relay_distinct_id';
 
 /** Upper bound on the harness identifier — generous enough for a UA-style token. */
 const HARNESS_MAX_LENGTH = 120;
-const AGENT_RELAY_ANONYMOUS_ID_MAX_LENGTH = 128;
+const AGENT_RELAY_DISTINCT_ID_MAX_LENGTH = 128;
 
 /**
  * Characters permitted in a harness identifier. Deliberately broad enough for a
@@ -45,7 +45,7 @@ const AGENT_RELAY_ANONYMOUS_ID_MAX_LENGTH = 128;
  * upstream value from smuggling a header injection past the relaycast WAF.
  */
 const HARNESS_ALLOWED = /^[a-z0-9 ._\-/():=;,+]+$/i;
-const AGENT_RELAY_ANONYMOUS_ID_ALLOWED = /^[a-z0-9._:-]+$/i;
+const AGENT_RELAY_DISTINCT_ID_ALLOWED = /^[a-z0-9._:-]+$/i;
 
 /**
  * Normalize a caller-supplied harness identifier to the wire contract.
@@ -62,10 +62,10 @@ export function sanitizeHarness(raw: string | undefined): string | undefined {
   return trimmed.slice(0, HARNESS_MAX_LENGTH).toLowerCase();
 }
 
-export function sanitizeAgentRelayAnonymousId(raw: string | undefined): string | undefined {
+export function sanitizeAgentRelayDistinctId(raw: string | undefined): string | undefined {
   if (!raw) return undefined;
   const trimmed = raw.trim();
   if (!trimmed) return undefined;
-  if (!AGENT_RELAY_ANONYMOUS_ID_ALLOWED.test(trimmed)) return undefined;
-  return trimmed.slice(0, AGENT_RELAY_ANONYMOUS_ID_MAX_LENGTH);
+  if (!AGENT_RELAY_DISTINCT_ID_ALLOWED.test(trimmed)) return undefined;
+  return trimmed.slice(0, AGENT_RELAY_DISTINCT_ID_MAX_LENGTH);
 }

--- a/packages/sdk-typescript/src/relay.ts
+++ b/packages/sdk-typescript/src/relay.ts
@@ -82,7 +82,7 @@ import {
   type ResolvedIdentity,
 } from './identity.js';
 import { SDK_VERSION } from './version.js';
-import { SDK_ORIGIN } from './origin.js';
+import { AGENT_RELAY_ANONYMOUS_ID_HEADER, SDK_ORIGIN, sanitizeAgentRelayAnonymousId } from './origin.js';
 import { camelizeKeys } from './casing.js';
 
 export interface RelayCastOptions {
@@ -96,6 +96,12 @@ export interface RelayCastOptions {
    * can attribute traffic to a harness.
    */
   harness?: string;
+  /**
+   * Optional Agent Relay anonymous installation id. Sent as
+   * `X-Agent-Relay-Anonymous-Id` on HTTP requests so Relaycast telemetry can be
+   * joined to Agent Relay CLI telemetry without sending user-identifying data.
+   */
+  agentRelayAnonymousId?: string;
 }
 
 export interface WorkspaceStreamConfig {
@@ -107,6 +113,12 @@ export interface WorkspaceStreamConfig {
 export interface WorkspaceBootstrapOptions {
   apiKey?: string;
   baseUrl?: string;
+  agentRelayAnonymousId?: string;
+}
+
+export interface WorkspaceLookupOptions {
+  baseUrl?: string;
+  agentRelayAnonymousId?: string;
 }
 
 export interface AgentReconnectOptions {
@@ -126,6 +138,15 @@ type RegisterIdentityType = NonNullable<CreateAgentRequest['type']>;
 function resolveWorkspaceBootstrapOptions(
   options?: string | WorkspaceBootstrapOptions,
 ): WorkspaceBootstrapOptions {
+  if (typeof options === 'string') {
+    return { baseUrl: options };
+  }
+  return options ?? {};
+}
+
+function resolveWorkspaceLookupOptions(
+  options?: string | WorkspaceLookupOptions,
+): WorkspaceLookupOptions {
   if (typeof options === 'string') {
     return { baseUrl: options };
   }
@@ -159,8 +180,10 @@ export class RelayCast {
     name: string,
     options?: string | WorkspaceBootstrapOptions,
   ): Promise<{ data: CreateWorkspaceResponse; statusCode: number }> {
-    const { apiKey, baseUrl } = resolveWorkspaceBootstrapOptions(options);
+    const { apiKey, baseUrl, agentRelayAnonymousId: rawAgentRelayAnonymousId } =
+      resolveWorkspaceBootstrapOptions(options);
     const requestBaseUrl = baseUrl ?? 'https://gateway.relaycast.dev';
+    const agentRelayAnonymousId = sanitizeAgentRelayAnonymousId(rawAgentRelayAnonymousId);
 
     const url = new URL('/v1/workspaces', requestBaseUrl);
     const res = await fetch(url.toString(), {
@@ -172,6 +195,7 @@ export class RelayCast {
         'X-Relaycast-Origin-Surface': SDK_ORIGIN.surface,
         'X-Relaycast-Origin-Client': SDK_ORIGIN.client,
         'X-Relaycast-Origin-Version': SDK_ORIGIN.version,
+        ...(agentRelayAnonymousId ? { [AGENT_RELAY_ANONYMOUS_ID_HEADER]: agentRelayAnonymousId } : {}),
       },
       body: JSON.stringify({ name }),
     });
@@ -206,8 +230,14 @@ export class RelayCast {
     };
   }
 
-  static async lookupWorkspace(name: string, baseUrl?: string): Promise<WorkspaceLookup | null> {
+  static async lookupWorkspace(
+    name: string,
+    options?: string | WorkspaceLookupOptions,
+  ): Promise<WorkspaceLookup | null> {
+    const { baseUrl, agentRelayAnonymousId: rawAgentRelayAnonymousId } =
+      resolveWorkspaceLookupOptions(options);
     const requestBaseUrl = baseUrl ?? 'https://gateway.relaycast.dev';
+    const agentRelayAnonymousId = sanitizeAgentRelayAnonymousId(rawAgentRelayAnonymousId);
 
     const url = new URL(`/v1/workspaces/by-name/${encodeURIComponent(name)}`, requestBaseUrl);
     const res = await fetch(url.toString(), {
@@ -218,6 +248,7 @@ export class RelayCast {
         'X-Relaycast-Origin-Surface': SDK_ORIGIN.surface,
         'X-Relaycast-Origin-Client': SDK_ORIGIN.client,
         'X-Relaycast-Origin-Version': SDK_ORIGIN.version,
+        ...(agentRelayAnonymousId ? { [AGENT_RELAY_ANONYMOUS_ID_HEADER]: agentRelayAnonymousId } : {}),
       },
     });
 

--- a/packages/sdk-typescript/src/relay.ts
+++ b/packages/sdk-typescript/src/relay.ts
@@ -82,7 +82,7 @@ import {
   type ResolvedIdentity,
 } from './identity.js';
 import { SDK_VERSION } from './version.js';
-import { AGENT_RELAY_ANONYMOUS_ID_HEADER, SDK_ORIGIN, sanitizeAgentRelayAnonymousId } from './origin.js';
+import { AGENT_RELAY_DISTINCT_ID_HEADER, SDK_ORIGIN, sanitizeAgentRelayDistinctId } from './origin.js';
 import { camelizeKeys } from './casing.js';
 
 export interface RelayCastOptions {
@@ -97,11 +97,11 @@ export interface RelayCastOptions {
    */
   harness?: string;
   /**
-   * Optional Agent Relay anonymous installation id. Sent as
-   * `X-Agent-Relay-Anonymous-Id` on HTTP requests so Relaycast telemetry can be
+   * Optional Agent Relay distinct telemetry id. Sent as
+   * `X-Agent-Relay-Distinct-Id` on HTTP requests so Relaycast telemetry can be
    * joined to Agent Relay CLI telemetry without sending user-identifying data.
    */
-  agentRelayAnonymousId?: string;
+  agentRelayDistinctId?: string;
 }
 
 export interface WorkspaceStreamConfig {
@@ -113,12 +113,12 @@ export interface WorkspaceStreamConfig {
 export interface WorkspaceBootstrapOptions {
   apiKey?: string;
   baseUrl?: string;
-  agentRelayAnonymousId?: string;
+  agentRelayDistinctId?: string;
 }
 
 export interface WorkspaceLookupOptions {
   baseUrl?: string;
-  agentRelayAnonymousId?: string;
+  agentRelayDistinctId?: string;
 }
 
 export interface AgentReconnectOptions {
@@ -180,10 +180,10 @@ export class RelayCast {
     name: string,
     options?: string | WorkspaceBootstrapOptions,
   ): Promise<{ data: CreateWorkspaceResponse; statusCode: number }> {
-    const { apiKey, baseUrl, agentRelayAnonymousId: rawAgentRelayAnonymousId } =
+    const { apiKey, baseUrl, agentRelayDistinctId: rawAgentRelayDistinctId } =
       resolveWorkspaceBootstrapOptions(options);
     const requestBaseUrl = baseUrl ?? 'https://gateway.relaycast.dev';
-    const agentRelayAnonymousId = sanitizeAgentRelayAnonymousId(rawAgentRelayAnonymousId);
+    const agentRelayDistinctId = sanitizeAgentRelayDistinctId(rawAgentRelayDistinctId);
 
     const url = new URL('/v1/workspaces', requestBaseUrl);
     const res = await fetch(url.toString(), {
@@ -195,7 +195,7 @@ export class RelayCast {
         'X-Relaycast-Origin-Surface': SDK_ORIGIN.surface,
         'X-Relaycast-Origin-Client': SDK_ORIGIN.client,
         'X-Relaycast-Origin-Version': SDK_ORIGIN.version,
-        ...(agentRelayAnonymousId ? { [AGENT_RELAY_ANONYMOUS_ID_HEADER]: agentRelayAnonymousId } : {}),
+        ...(agentRelayDistinctId ? { [AGENT_RELAY_DISTINCT_ID_HEADER]: agentRelayDistinctId } : {}),
       },
       body: JSON.stringify({ name }),
     });
@@ -234,10 +234,10 @@ export class RelayCast {
     name: string,
     options?: string | WorkspaceLookupOptions,
   ): Promise<WorkspaceLookup | null> {
-    const { baseUrl, agentRelayAnonymousId: rawAgentRelayAnonymousId } =
+    const { baseUrl, agentRelayDistinctId: rawAgentRelayDistinctId } =
       resolveWorkspaceLookupOptions(options);
     const requestBaseUrl = baseUrl ?? 'https://gateway.relaycast.dev';
-    const agentRelayAnonymousId = sanitizeAgentRelayAnonymousId(rawAgentRelayAnonymousId);
+    const agentRelayDistinctId = sanitizeAgentRelayDistinctId(rawAgentRelayDistinctId);
 
     const url = new URL(`/v1/workspaces/by-name/${encodeURIComponent(name)}`, requestBaseUrl);
     const res = await fetch(url.toString(), {
@@ -248,7 +248,7 @@ export class RelayCast {
         'X-Relaycast-Origin-Surface': SDK_ORIGIN.surface,
         'X-Relaycast-Origin-Client': SDK_ORIGIN.client,
         'X-Relaycast-Origin-Version': SDK_ORIGIN.version,
-        ...(agentRelayAnonymousId ? { [AGENT_RELAY_ANONYMOUS_ID_HEADER]: agentRelayAnonymousId } : {}),
+        ...(agentRelayDistinctId ? { [AGENT_RELAY_DISTINCT_ID_HEADER]: agentRelayDistinctId } : {}),
       },
     });
 

--- a/packages/sdk-typescript/src/ws.ts
+++ b/packages/sdk-typescript/src/ws.ts
@@ -8,9 +8,9 @@ import type {
 } from './types.js';
 import { ServerEventSchema } from '@relaycast/types';
 import {
-  AGENT_RELAY_ANONYMOUS_ID_QUERY,
+  AGENT_RELAY_DISTINCT_ID_QUERY,
   SDK_ORIGIN,
-  sanitizeAgentRelayAnonymousId,
+  sanitizeAgentRelayDistinctId,
   sanitizeHarness,
   type InternalOrigin,
 } from './origin.js';
@@ -34,11 +34,11 @@ export interface WsClientOptions {
    */
   harness?: string;
   /**
-   * Optional Agent Relay anonymous installation id, forwarded as the
-   * `agent_relay_anonymous_id` query param (browsers can't set custom WS
+   * Optional Agent Relay distinct telemetry id, forwarded as the
+   * `agent_relay_distinct_id` query param (browsers can't set custom WS
    * headers). Invalid values are dropped.
    */
-  agentRelayAnonymousId?: string;
+  agentRelayDistinctId?: string;
 }
 
 const INTERNAL_WS_ORIGIN = Symbol('relaycast.internal.ws-origin');
@@ -88,7 +88,7 @@ export class WsClient {
   private originClient: string;
   private originVersion: string;
   private originHarness?: string;
-  private agentRelayAnonymousId?: string;
+  private agentRelayDistinctId?: string;
 
   constructor(options: WsClientOptions) {
     const origin = readInternalWsOrigin(options) ?? SDK_ORIGIN;
@@ -113,8 +113,8 @@ export class WsClient {
     this.originClient = origin.client;
     this.originVersion = origin.version;
     this.originHarness = sanitizeHarness(origin.harness ?? options.harness);
-    this.agentRelayAnonymousId = sanitizeAgentRelayAnonymousId(
-      origin.agentRelayAnonymousId ?? options.agentRelayAnonymousId,
+    this.agentRelayDistinctId = sanitizeAgentRelayDistinctId(
+      origin.agentRelayDistinctId ?? options.agentRelayDistinctId,
     );
   }
 
@@ -131,8 +131,8 @@ export class WsClient {
     if (this.originHarness) {
       wsUrl.searchParams.set('harness', this.originHarness);
     }
-    if (this.agentRelayAnonymousId) {
-      wsUrl.searchParams.set(AGENT_RELAY_ANONYMOUS_ID_QUERY, this.agentRelayAnonymousId);
+    if (this.agentRelayDistinctId) {
+      wsUrl.searchParams.set(AGENT_RELAY_DISTINCT_ID_QUERY, this.agentRelayDistinctId);
     }
 
     const ws = new WebSocket(wsUrl.toString());

--- a/packages/sdk-typescript/src/ws.ts
+++ b/packages/sdk-typescript/src/ws.ts
@@ -7,7 +7,13 @@ import type {
   WsCloseEvent,
 } from './types.js';
 import { ServerEventSchema } from '@relaycast/types';
-import { SDK_ORIGIN, sanitizeHarness, type InternalOrigin } from './origin.js';
+import {
+  AGENT_RELAY_ANONYMOUS_ID_QUERY,
+  SDK_ORIGIN,
+  sanitizeAgentRelayAnonymousId,
+  sanitizeHarness,
+  type InternalOrigin,
+} from './origin.js';
 import { camelizeKeys, decamelizeKey } from './casing.js';
 
 export type EventHandler<T = WsClientEvent> = (event: T) => void;
@@ -27,6 +33,12 @@ export interface WsClientOptions {
    * query param (browsers can't set custom WS headers). See {@link sanitizeHarness}.
    */
   harness?: string;
+  /**
+   * Optional Agent Relay anonymous installation id, forwarded as the
+   * `agent_relay_anonymous_id` query param (browsers can't set custom WS
+   * headers). Invalid values are dropped.
+   */
+  agentRelayAnonymousId?: string;
 }
 
 const INTERNAL_WS_ORIGIN = Symbol('relaycast.internal.ws-origin');
@@ -76,6 +88,7 @@ export class WsClient {
   private originClient: string;
   private originVersion: string;
   private originHarness?: string;
+  private agentRelayAnonymousId?: string;
 
   constructor(options: WsClientOptions) {
     const origin = readInternalWsOrigin(options) ?? SDK_ORIGIN;
@@ -100,6 +113,9 @@ export class WsClient {
     this.originClient = origin.client;
     this.originVersion = origin.version;
     this.originHarness = sanitizeHarness(origin.harness ?? options.harness);
+    this.agentRelayAnonymousId = sanitizeAgentRelayAnonymousId(
+      origin.agentRelayAnonymousId ?? options.agentRelayAnonymousId,
+    );
   }
 
   connect(): void {
@@ -114,6 +130,9 @@ export class WsClient {
     wsUrl.searchParams.set(decamelizeKey('originVersion'), this.originVersion);
     if (this.originHarness) {
       wsUrl.searchParams.set('harness', this.originHarness);
+    }
+    if (this.agentRelayAnonymousId) {
+      wsUrl.searchParams.set(AGENT_RELAY_ANONYMOUS_ID_QUERY, this.agentRelayAnonymousId);
     }
 
     const ws = new WebSocket(wsUrl.toString());


### PR DESCRIPTION
## Summary
- add sanitized Agent Relay distinct id options to TypeScript, Python, and Rust SDK HTTP clients
- forward the id on WebSocket handshakes as `agent_relay_distinct_id`, including Rust reconnects and agent handoffs
- let the engine read the same distinct id from WebSocket query params in addition to `X-Agent-Relay-Distinct-Id`

## Verification
- `npm --prefix packages/engine run test -- src/lib/__tests__/origin.test.ts`
- `npm --prefix packages/sdk-typescript run test -- src/__tests__/harness.test.ts src/__tests__/relay.test.ts src/__tests__/ws.test.ts`
- `uv run --project packages/sdk-python --extra dev pytest packages/sdk-python/tests/test_client.py packages/sdk-python/tests/test_relay.py packages/sdk-python/tests/test_ws.py`
- `npm run build` in `packages/sdk-typescript`
- `npm run typecheck` in `packages/engine`
- `cargo test --manifest-path packages/sdk-rust/Cargo.toml`
