### PR TITLE
fix(observer): resolve workspace engine gateway-first with api fallback

### DIFF
--- a/packages/observer-dashboard/package.json
+++ b/packages/observer-dashboard/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "dev": "next dev --port 3100",
     "build": "next build",
+    "test": "vitest run",
     "start": "next start"
   },
   "dependencies": {

--- a/packages/observer-dashboard/src/app/api/auth/check/route.ts
+++ b/packages/observer-dashboard/src/app/api/auth/check/route.ts
@@ -1,14 +1,23 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { cookies } from 'next/headers';
-import { resolveRelayServerUrlFromRequest } from '../../../../lib/relay-server';
+import {
+  orderByRemembered,
+  pickRememberedEngine,
+  resolveRelayServerCandidatesFromRequest,
+  selectEngineForKey,
+} from '../../../../lib/relay-server';
 
 export const runtime = 'edge';
 
 const COOKIE_NAME = 'relaycast_key';
+const AGENT_COOKIE_NAME = 'relaycast_agent_token';
+const ENGINE_COOKIE_NAME = 'relaycast_engine';
+const COOKIE_MAX_AGE = 60 * 60 * 24 * 30; // 30 days
 
 /**
  * GET /api/auth/check
- * Validates the auth cookie against the relay server.
+ * Validates the auth cookie against the candidate engines (remembered one
+ * first, then gateway/api fallback).
  */
 export async function GET(request: NextRequest) {
   const cookieStore = await cookies();
@@ -21,25 +30,41 @@ export async function GET(request: NextRequest) {
     );
   }
 
-  // Validate key against the relay server
-  try {
-    const relayServer = resolveRelayServerUrlFromRequest(request);
-    const res = await fetch(`${relayServer}/v1/workspace`, {
-      headers: { Authorization: `Bearer ${cookie.value}` },
-    });
+  const candidates = resolveRelayServerCandidatesFromRequest(request);
+  const remembered = pickRememberedEngine(
+    cookieStore.get(ENGINE_COOKIE_NAME)?.value,
+    candidates
+  );
+  const { baseUrl, reachedAny } = await selectEngineForKey(
+    orderByRemembered(candidates, remembered),
+    cookie.value
+  );
 
-    if (!res.ok) {
-      // Key is revoked or invalid — clear the cookie
-      cookieStore.delete(COOKIE_NAME);
-      return NextResponse.json(
-        { authenticated: false },
-        { status: 401 }
-      );
+  if (baseUrl) {
+    if (baseUrl !== remembered) {
+      cookieStore.set(ENGINE_COOKIE_NAME, baseUrl, {
+        httpOnly: true,
+        secure: process.env.NODE_ENV === 'production',
+        sameSite: 'lax',
+        path: '/',
+        maxAge: COOKIE_MAX_AGE,
+      });
     }
-  } catch {
-    // Relay server unreachable — allow session to continue
-    // (downstream API calls will fail with proper errors)
+    return NextResponse.json({ authenticated: true });
   }
 
+  if (reachedAny) {
+    // An engine responded and rejected the key — it is revoked or invalid.
+    cookieStore.delete(COOKIE_NAME);
+    cookieStore.delete(AGENT_COOKIE_NAME);
+    cookieStore.delete(ENGINE_COOKIE_NAME);
+    return NextResponse.json(
+      { authenticated: false },
+      { status: 401 }
+    );
+  }
+
+  // No engine reachable — allow the session to continue
+  // (downstream API calls will fail with proper errors).
   return NextResponse.json({ authenticated: true });
 }

--- a/packages/observer-dashboard/src/app/api/auth/check/route.ts
+++ b/packages/observer-dashboard/src/app/api/auth/check/route.ts
@@ -35,7 +35,7 @@ export async function GET(request: NextRequest) {
     cookieStore.get(ENGINE_COOKIE_NAME)?.value,
     candidates
   );
-  const { baseUrl, reachedAny } = await selectEngineForKey(
+  const { baseUrl, rejectedAny, inconclusiveAny } = await selectEngineForKey(
     orderByRemembered(candidates, remembered),
     cookie.value
   );
@@ -53,8 +53,8 @@ export async function GET(request: NextRequest) {
     return NextResponse.json({ authenticated: true });
   }
 
-  if (reachedAny) {
-    // An engine responded and rejected the key — it is revoked or invalid.
+  if (rejectedAny && !inconclusiveAny) {
+    // Every reachable engine rejected the key — it is revoked or invalid.
     cookieStore.delete(COOKIE_NAME);
     cookieStore.delete(AGENT_COOKIE_NAME);
     cookieStore.delete(ENGINE_COOKIE_NAME);
@@ -64,7 +64,7 @@ export async function GET(request: NextRequest) {
     );
   }
 
-  // No engine reachable — allow the session to continue
+  // Validation was inconclusive — allow the session to continue
   // (downstream API calls will fail with proper errors).
   return NextResponse.json({ authenticated: true });
 }

--- a/packages/observer-dashboard/src/app/api/auth/login/route.ts
+++ b/packages/observer-dashboard/src/app/api/auth/login/route.ts
@@ -33,9 +33,20 @@ export async function POST(request: NextRequest) {
     // Always probe the server-configured candidates (prevents SSRF). The first
     // engine that accepts the key wins; gateway is tried before legacy api.
     const candidates = resolveRelayServerCandidatesFromRequest(request);
-    const { baseUrl: relayServer } = await selectEngineForKey(candidates, apiKey);
+    const {
+      baseUrl: relayServer,
+      rejectedAny,
+      inconclusiveAny,
+    } = await selectEngineForKey(candidates, apiKey);
 
     if (!relayServer) {
+      if (!rejectedAny || inconclusiveAny) {
+        return NextResponse.json(
+          { success: false, error: 'Unable to validate API key' },
+          { status: 503 }
+        );
+      }
+
       return NextResponse.json(
         { success: false, error: 'Invalid API key' },
         { status: 401 }

--- a/packages/observer-dashboard/src/app/api/auth/login/route.ts
+++ b/packages/observer-dashboard/src/app/api/auth/login/route.ts
@@ -1,18 +1,23 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { cookies } from 'next/headers';
 import { RelayCast, RelayError } from '@relaycast/sdk';
-import { resolveRelayServerUrlFromRequest } from '../../../../lib/relay-server';
+import {
+  resolveRelayServerCandidatesFromRequest,
+  selectEngineForKey,
+} from '../../../../lib/relay-server';
 
 export const runtime = 'edge';
 
 const COOKIE_NAME = 'relaycast_key';
 const AGENT_COOKIE_NAME = 'relaycast_agent_token';
+const ENGINE_COOKIE_NAME = 'relaycast_engine';
 const COOKIE_MAX_AGE = 60 * 60 * 24 * 30; // 30 days
 
 /**
  * POST /api/auth/login
- * Validates the API key and sets httpOnly cookies.
- * WebSocket stream authenticates directly with workspace key.
+ * Validates the API key against the candidate engines (gateway first, api
+ * fallback), remembers the resolved engine, and sets httpOnly cookies.
+ * WebSocket stream authenticates directly with the workspace key.
  */
 export async function POST(request: NextRequest) {
   try {
@@ -25,19 +30,19 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    // Always validate against the server-configured relay URL (prevents SSRF)
-    const relayServer = resolveRelayServerUrlFromRequest(request);
-    const relay = new RelayCast({ apiKey, baseUrl: relayServer });
+    // Always probe the server-configured candidates (prevents SSRF). The first
+    // engine that accepts the key wins; gateway is tried before legacy api.
+    const candidates = resolveRelayServerCandidatesFromRequest(request);
+    const { baseUrl: relayServer } = await selectEngineForKey(candidates, apiKey);
 
-    // Validate key by fetching workspace
-    try {
-      await relay.workspace.info();
-    } catch {
+    if (!relayServer) {
       return NextResponse.json(
         { success: false, error: 'Invalid API key' },
         { status: 401 }
       );
     }
+
+    const relay = new RelayCast({ apiKey, baseUrl: relayServer });
 
     // Enable workspace stream for this workspace so observer dashboard
     // receives realtime event fanout.
@@ -60,24 +65,23 @@ export async function POST(request: NextRequest) {
     }
 
     const cookieStore = await cookies();
-
-    cookieStore.set(COOKIE_NAME, apiKey, {
+    const cookieOptions = {
       httpOnly: true,
       secure: process.env.NODE_ENV === 'production',
-      sameSite: 'lax',
+      sameSite: 'lax' as const,
       path: '/',
       maxAge: COOKIE_MAX_AGE,
-    });
+    };
+
+    cookieStore.set(COOKIE_NAME, apiKey, cookieOptions);
 
     // Agent cookie remains for compatibility with existing client shape.
     // Workspace keys are accepted by read-only endpoints used in dashboard.
-    cookieStore.set(AGENT_COOKIE_NAME, apiKey, {
-      httpOnly: true,
-      secure: process.env.NODE_ENV === 'production',
-      sameSite: 'lax',
-      path: '/',
-      maxAge: COOKIE_MAX_AGE,
-    });
+    cookieStore.set(AGENT_COOKIE_NAME, apiKey, cookieOptions);
+
+    // Remember the resolved engine so session/check/logout target it directly
+    // without re-probing both engines on every request.
+    cookieStore.set(ENGINE_COOKIE_NAME, relayServer, cookieOptions);
 
     return NextResponse.json({
       success: true,

--- a/packages/observer-dashboard/src/app/api/auth/logout/route.ts
+++ b/packages/observer-dashboard/src/app/api/auth/logout/route.ts
@@ -1,12 +1,18 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { cookies } from 'next/headers';
 import { RelayCast, RelayError } from '@relaycast/sdk';
-import { resolveRelayServerUrlFromRequest } from '../../../../lib/relay-server';
+import {
+  orderByRemembered,
+  pickRememberedEngine,
+  resolveRelayServerCandidatesFromRequest,
+  selectEngineForKey,
+} from '../../../../lib/relay-server';
 
 export const runtime = 'edge';
 
 const COOKIE_NAME = 'relaycast_key';
 const AGENT_COOKIE_NAME = 'relaycast_agent_token';
+const ENGINE_COOKIE_NAME = 'relaycast_engine';
 
 /**
  * POST /api/auth/logout
@@ -17,7 +23,17 @@ export async function POST(request: NextRequest) {
   const apiKey = cookieStore.get(COOKIE_NAME)?.value;
 
   if (apiKey?.startsWith('rk_live_')) {
-    const relayServer = resolveRelayServerUrlFromRequest(request);
+    const candidates = resolveRelayServerCandidatesFromRequest(request);
+    const remembered = pickRememberedEngine(
+      cookieStore.get(ENGINE_COOKIE_NAME)?.value,
+      candidates
+    );
+    // Disable the stream on the engine the workspace actually lives on.
+    const { baseUrl } = await selectEngineForKey(
+      orderByRemembered(candidates, remembered),
+      apiKey
+    );
+    const relayServer = baseUrl ?? remembered ?? candidates[0]!;
     const relay = new RelayCast({ apiKey, baseUrl: relayServer });
     try {
       await relay.workspace.stream.set(false);
@@ -39,5 +55,6 @@ export async function POST(request: NextRequest) {
 
   cookieStore.delete(COOKIE_NAME);
   cookieStore.delete(AGENT_COOKIE_NAME);
+  cookieStore.delete(ENGINE_COOKIE_NAME);
   return NextResponse.json({ success: true });
 }

--- a/packages/observer-dashboard/src/app/api/auth/session/route.ts
+++ b/packages/observer-dashboard/src/app/api/auth/session/route.ts
@@ -37,12 +37,23 @@ export async function GET(request: NextRequest) {
     cookieStore.get(ENGINE_COOKIE_NAME)?.value,
     candidates
   );
-  const { baseUrl } = await selectEngineForKey(
+  const {
+    baseUrl,
+    rejectedAny,
+    inconclusiveAny,
+  } = await selectEngineForKey(
     orderByRemembered(candidates, remembered),
     apiKey
   );
 
   if (!baseUrl) {
+    if (!rejectedAny || inconclusiveAny) {
+      return NextResponse.json(
+        { authenticated: false, error: 'Unable to validate session' },
+        { status: 503 }
+      );
+    }
+
     return NextResponse.json(
       { authenticated: false },
       { status: 401 }

--- a/packages/observer-dashboard/src/app/api/auth/session/route.ts
+++ b/packages/observer-dashboard/src/app/api/auth/session/route.ts
@@ -1,16 +1,23 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { cookies } from 'next/headers';
-import { RelayCast } from '@relaycast/sdk';
-import { resolveRelayServerUrlFromRequest } from '../../../../lib/relay-server';
+import {
+  orderByRemembered,
+  pickRememberedEngine,
+  resolveRelayServerCandidatesFromRequest,
+  selectEngineForKey,
+} from '../../../../lib/relay-server';
 
 export const runtime = 'edge';
 
 const COOKIE_NAME = 'relaycast_key';
 const AGENT_COOKIE_NAME = 'relaycast_agent_token';
+const ENGINE_COOKIE_NAME = 'relaycast_engine';
+const COOKIE_MAX_AGE = 60 * 60 * 24 * 30; // 30 days
 
 /**
  * GET /api/auth/session
- * Returns session tokens for the RelayProvider.
+ * Returns session tokens for the RelayProvider, resolving the engine the
+ * workspace lives on (the remembered one first, then gateway/api fallback).
  * Called by the client on mount/refresh.
  */
 export async function GET(request: NextRequest) {
@@ -25,16 +32,31 @@ export async function GET(request: NextRequest) {
     );
   }
 
-  const baseUrl = resolveRelayServerUrlFromRequest(request);
-  const relay = new RelayCast({ apiKey, baseUrl });
+  const candidates = resolveRelayServerCandidatesFromRequest(request);
+  const remembered = pickRememberedEngine(
+    cookieStore.get(ENGINE_COOKIE_NAME)?.value,
+    candidates
+  );
+  const { baseUrl } = await selectEngineForKey(
+    orderByRemembered(candidates, remembered),
+    apiKey
+  );
 
-  try {
-    await relay.workspace.info();
-  } catch {
+  if (!baseUrl) {
     return NextResponse.json(
       { authenticated: false },
       { status: 401 }
     );
+  }
+
+  if (baseUrl !== remembered) {
+    cookieStore.set(ENGINE_COOKIE_NAME, baseUrl, {
+      httpOnly: true,
+      secure: process.env.NODE_ENV === 'production',
+      sameSite: 'lax',
+      path: '/',
+      maxAge: COOKIE_MAX_AGE,
+    });
   }
 
   return NextResponse.json({

--- a/packages/observer-dashboard/src/lib/relay-server.test.ts
+++ b/packages/observer-dashboard/src/lib/relay-server.test.ts
@@ -1,0 +1,177 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  orderByRemembered,
+  pickRememberedEngine,
+  resolveRelayServerCandidatesFromHost,
+  selectEngineForKey,
+} from './relay-server';
+
+const originalRelayServerUrl = process.env.RELAY_SERVER_URL;
+
+function mockFetch(...responses: Array<Response | Error>) {
+  const fetchMock = vi.fn();
+  for (const response of responses) {
+    if (response instanceof Error) {
+      fetchMock.mockRejectedValueOnce(response);
+    } else {
+      fetchMock.mockResolvedValueOnce(response);
+    }
+  }
+  vi.stubGlobal('fetch', fetchMock);
+  return fetchMock;
+}
+
+describe('relay server resolution', () => {
+  beforeEach(() => {
+    delete process.env.RELAY_SERVER_URL;
+  });
+
+  afterEach(() => {
+    if (originalRelayServerUrl === undefined) {
+      delete process.env.RELAY_SERVER_URL;
+    } else {
+      process.env.RELAY_SERVER_URL = originalRelayServerUrl;
+    }
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it('tries gateway before legacy api for hosted observer', () => {
+    expect(resolveRelayServerCandidatesFromHost('observer.relaycast.dev')).toEqual([
+      'https://gateway.relaycast.dev',
+      'https://api.relaycast.dev',
+    ]);
+  });
+
+  it('pins explicit server override to a single candidate', () => {
+    process.env.RELAY_SERVER_URL = 'https://self-hosted.example.com/';
+
+    expect(resolveRelayServerCandidatesFromHost('observer.relaycast.dev')).toEqual([
+      'https://self-hosted.example.com/',
+    ]);
+  });
+
+  it('only accepts remembered engines from the current host candidates', () => {
+    const candidates = [
+      'https://gateway.relaycast.dev',
+      'https://api.relaycast.dev',
+    ];
+
+    expect(pickRememberedEngine('https://api.relaycast.dev', candidates)).toBe(
+      'https://api.relaycast.dev'
+    );
+    expect(
+      pickRememberedEngine('https://attacker.example.com', candidates)
+    ).toBeNull();
+  });
+
+  it('orders remembered engine first without duplicating candidates', () => {
+    expect(
+      orderByRemembered(
+        ['https://gateway.relaycast.dev', 'https://api.relaycast.dev'],
+        'https://api.relaycast.dev'
+      )
+    ).toEqual(['https://api.relaycast.dev', 'https://gateway.relaycast.dev']);
+  });
+});
+
+describe('selectEngineForKey', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('falls back to the legacy api engine when gateway rejects the key', async () => {
+    const fetchMock = mockFetch(
+      new Response(null, { status: 401 }),
+      new Response(null, { status: 200 })
+    );
+
+    await expect(
+      selectEngineForKey(
+        ['https://gateway.relaycast.dev', 'https://api.relaycast.dev'],
+        'rk_live_test'
+      )
+    ).resolves.toEqual({
+      baseUrl: 'https://api.relaycast.dev',
+      reachedAny: true,
+      rejectedAny: true,
+      inconclusiveAny: false,
+    });
+
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      1,
+      'https://gateway.relaycast.dev/v1/workspace',
+      expect.objectContaining({ cache: 'no-store' })
+    );
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      2,
+      'https://api.relaycast.dev/v1/workspace',
+      expect.objectContaining({ cache: 'no-store' })
+    );
+  });
+
+  it('marks all-auth-rejection failures as conclusive invalid credentials', async () => {
+    mockFetch(
+      new Response(null, { status: 401 }),
+      new Response(null, { status: 403 })
+    );
+
+    await expect(
+      selectEngineForKey(
+        ['https://gateway.relaycast.dev', 'https://api.relaycast.dev'],
+        'rk_live_test'
+      )
+    ).resolves.toEqual({
+      baseUrl: null,
+      reachedAny: true,
+      rejectedAny: true,
+      inconclusiveAny: false,
+    });
+  });
+
+  it('keeps transient failures inconclusive even when fallback rejects the key', async () => {
+    mockFetch(
+      new Response(null, { status: 503 }),
+      new Response(null, { status: 401 })
+    );
+
+    await expect(
+      selectEngineForKey(
+        ['https://gateway.relaycast.dev', 'https://api.relaycast.dev'],
+        'rk_live_test'
+      )
+    ).resolves.toEqual({
+      baseUrl: null,
+      reachedAny: true,
+      rejectedAny: true,
+      inconclusiveAny: true,
+    });
+  });
+
+  it('keeps network failures inconclusive when no engine accepts the key', async () => {
+    mockFetch(new Error('dns failed'), new Response(null, { status: 401 }));
+
+    await expect(
+      selectEngineForKey(
+        ['https://gateway.relaycast.dev', 'https://api.relaycast.dev'],
+        'rk_live_test'
+      )
+    ).resolves.toEqual({
+      baseUrl: null,
+      reachedAny: true,
+      rejectedAny: true,
+      inconclusiveAny: true,
+    });
+  });
+
+  it('constructs probe URLs correctly for trailing-slash base URLs', async () => {
+    const fetchMock = mockFetch(new Response(null, { status: 200 }));
+
+    await selectEngineForKey(['https://self-hosted.example.com/'], 'rk_live_test');
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://self-hosted.example.com/v1/workspace',
+      expect.any(Object)
+    );
+  });
+});

--- a/packages/observer-dashboard/src/lib/relay-server.ts
+++ b/packages/observer-dashboard/src/lib/relay-server.ts
@@ -18,39 +18,146 @@ function isLocalHost(host: string): boolean {
 }
 
 /**
- * Resolve the Relay API base URL from observer host.
+ * Resolve the ordered list of Relay engine base URLs to try for an observer host.
+ *
+ * The new hosted engine (`gateway.relaycast.dev`) is the happy path and comes
+ * first; the legacy engine (`api.relaycast.dev`) runs alongside it for
+ * workspaces that have not migrated and is used as a fallback. Callers probe the
+ * candidates in order and keep the first one that accepts the workspace key.
  *
  * Examples:
- * - observer.relaycast.dev -> https://api.relaycast.dev
- * - pr23-observer.relaycast.dev -> https://pr23-api.relaycast.dev
+ * - observer.relaycast.dev -> [gateway.relaycast.dev, api.relaycast.dev]
+ * - pr23-observer.relaycast.dev -> [pr23-gateway.relaycast.dev, pr23-api.relaycast.dev]
+ *
+ * Per-environment gateway hostnames (`staging-gateway`, `prNN-gateway`) are
+ * assumed to mirror the legacy `-api` naming. If a gateway host does not exist
+ * for an environment, the probe simply fails over to its `-api` counterpart, so
+ * the assumption carries no risk.
  */
-export function resolveRelayServerUrlFromHost(host: string | null | undefined): string {
+export function resolveRelayServerCandidatesFromHost(
+  host: string | null | undefined
+): string[] {
   const normalized = normalizeHost(host);
 
+  // An explicit override pins a single engine (self-hosted / local dev).
+  const override = process.env.RELAY_SERVER_URL;
+  if (override) {
+    return [override];
+  }
+
   if (!normalized || isLocalHost(normalized)) {
-    return process.env.RELAY_SERVER_URL || 'http://localhost:3890';
+    return ['http://localhost:3890'];
   }
 
   // Accept both custom domains and workers/pages preview hostnames that begin with prNN-observer.
   const prMatch = normalized.match(/^pr(\d+)-observer(?:[.-]|$)/);
   if (prMatch) {
-    return `https://pr${prMatch[1]}-api.relaycast.dev`;
+    const n = prMatch[1];
+    return [
+      `https://pr${n}-gateway.relaycast.dev`,
+      `https://pr${n}-api.relaycast.dev`,
+    ];
   }
 
   if (normalized === 'staging-observer.relaycast.dev') {
-    return 'https://staging-api.relaycast.dev';
+    return [
+      'https://staging-gateway.relaycast.dev',
+      'https://staging-api.relaycast.dev',
+    ];
   }
 
   if (normalized === 'observer.relaycast.dev') {
-    return 'https://api.relaycast.dev';
+    return ['https://gateway.relaycast.dev', 'https://api.relaycast.dev'];
   }
 
-  return process.env.RELAY_SERVER_URL || 'https://api.relaycast.dev';
+  return ['https://gateway.relaycast.dev', 'https://api.relaycast.dev'];
 }
 
-export function resolveRelayServerUrlFromRequest(request: NextRequest | Request): string {
+export function resolveRelayServerCandidatesFromRequest(
+  request: NextRequest | Request
+): string[] {
   const observerHost = request.headers.get('x-relaycast-observer-host');
   const forwardedHost = request.headers.get('x-forwarded-host');
   const host = request.headers.get('host');
-  return resolveRelayServerUrlFromHost(observerHost ?? forwardedHost ?? host);
+  return resolveRelayServerCandidatesFromHost(
+    observerHost ?? forwardedHost ?? host
+  );
+}
+
+/**
+ * Resolve the single happy-path engine URL for an observer host (first
+ * candidate). Prefer {@link resolveRelayServerCandidatesFromRequest} when a key
+ * is available so legacy workspaces can fall back to the `api` engine.
+ */
+export function resolveRelayServerUrlFromHost(
+  host: string | null | undefined
+): string {
+  return resolveRelayServerCandidatesFromHost(host)[0]!;
+}
+
+export function resolveRelayServerUrlFromRequest(
+  request: NextRequest | Request
+): string {
+  return resolveRelayServerCandidatesFromRequest(request)[0]!;
+}
+
+/**
+ * Restrict a remembered engine cookie to the candidates valid for the current
+ * host before trusting it, so a stale or forged cookie cannot redirect probes
+ * to an arbitrary origin (SSRF).
+ */
+export function pickRememberedEngine(
+  value: string | null | undefined,
+  candidates: string[]
+): string | null {
+  if (value && candidates.includes(value)) {
+    return value;
+  }
+  return null;
+}
+
+export interface EngineSelection {
+  /** The engine that accepted the key, or null if none did. */
+  baseUrl: string | null;
+  /** True if at least one candidate responded (even to reject the key). */
+  reachedAny: boolean;
+}
+
+/**
+ * Probe the candidate engines in order and return the first whose
+ * `/v1/workspace` accepts the workspace key. A candidate that is unreachable
+ * (network/DNS error) is skipped; one that responds with a non-OK status counts
+ * as reached but not authenticated.
+ */
+export async function selectEngineForKey(
+  candidates: string[],
+  apiKey: string
+): Promise<EngineSelection> {
+  let reachedAny = false;
+  for (const baseUrl of candidates) {
+    try {
+      const res = await fetch(`${baseUrl}/v1/workspace`, {
+        headers: { Authorization: `Bearer ${apiKey}` },
+      });
+      reachedAny = true;
+      if (res.ok) {
+        return { baseUrl, reachedAny };
+      }
+    } catch {
+      // Unreachable engine — fall through to the next candidate.
+    }
+  }
+  return { baseUrl: null, reachedAny };
+}
+
+/**
+ * Order candidates so a previously resolved engine is tried first, avoiding a
+ * redundant probe of the other engine on every session/check call.
+ */
+export function orderByRemembered(
+  candidates: string[],
+  remembered: string | null
+): string[] {
+  if (!remembered) return candidates;
+  return [remembered, ...candidates.filter((c) => c !== remembered)];
 }

--- a/packages/observer-dashboard/src/lib/relay-server.ts
+++ b/packages/observer-dashboard/src/lib/relay-server.ts
@@ -121,33 +121,46 @@ export interface EngineSelection {
   baseUrl: string | null;
   /** True if at least one candidate responded (even to reject the key). */
   reachedAny: boolean;
+  /** True if at least one candidate definitively rejected the key. */
+  rejectedAny: boolean;
+  /** True if at least one candidate could not definitively validate the key. */
+  inconclusiveAny: boolean;
 }
 
 /**
  * Probe the candidate engines in order and return the first whose
- * `/v1/workspace` accepts the workspace key. A candidate that is unreachable
- * (network/DNS error) is skipped; one that responds with a non-OK status counts
- * as reached but not authenticated.
+ * `/v1/workspace` accepts the workspace key. Auth failures (401/403) are
+ * conclusive rejections; network failures and other statuses are inconclusive.
  */
 export async function selectEngineForKey(
   candidates: string[],
   apiKey: string
 ): Promise<EngineSelection> {
   let reachedAny = false;
+  let rejectedAny = false;
+  let inconclusiveAny = false;
   for (const baseUrl of candidates) {
     try {
-      const res = await fetch(`${baseUrl}/v1/workspace`, {
+      const url = new URL('/v1/workspace', baseUrl);
+      const res = await fetch(url.toString(), {
         headers: { Authorization: `Bearer ${apiKey}` },
+        cache: 'no-store',
       });
       reachedAny = true;
       if (res.ok) {
-        return { baseUrl, reachedAny };
+        return { baseUrl, reachedAny, rejectedAny, inconclusiveAny };
+      }
+      if (res.status === 401 || res.status === 403) {
+        rejectedAny = true;
+      } else {
+        inconclusiveAny = true;
       }
     } catch {
+      inconclusiveAny = true;
       // Unreachable engine — fall through to the next candidate.
     }
   }
-  return { baseUrl: null, reachedAny };
+  return { baseUrl: null, reachedAny, rejectedAny, inconclusiveAny };
 }
 
 /**

--- a/packages/observer-dashboard/vitest.config.ts
+++ b/packages/observer-dashboard/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    globals: true,
+  },
+});


### PR DESCRIPTION
## **User description**
## Problem

The observer dashboard hard-coded the legacy `api.relaycast.dev` engine for every host (`packages/observer-dashboard/src/lib/relay-server.ts`). Workspaces created on the new hosted engine (`gateway.relaycast.dev`) — the v8 SDK/MCP/CLI default — showed no traffic, because the observer was querying an engine that has no record of them.

## Approach

Both engines run side by side: **gateway is the happy path**, **api runs alongside** for workspaces that haven't migrated. A workspace lives on exactly one engine and the key format doesn't reveal which, so the observer now probes.

- `relay-server.ts` resolves an **ordered candidate list** per observer host (gateway first, api fallback) and adds `selectEngineForKey` (probes `/v1/workspace` in order, keeps the first engine that accepts the workspace key), `pickRememberedEngine` (SSRF guard), and `orderByRemembered`. The old single-URL helpers remain as thin wrappers returning the happy-path engine.
- `api/auth/login` probes candidates, validates on whichever engine accepts the key, and stores the choice in a new httpOnly **`relaycast_engine`** cookie.
- `api/auth/session` / `check` try the remembered engine first, then fall back; refresh the cookie if it moved. `check` only clears auth when an engine actually **rejected** the key — network errors keep the session (preserves prior behavior).
- `api/auth/logout` disables the stream on the correct engine and clears the new cookie.

## Behavior

- New workspaces: one probe, resolve on gateway.
- Legacy workspaces: resolve on api transparently at the same `observer.relaycast.dev?key=…` URL — nothing breaks.
- The `relaycast_engine` cookie is validated against the host's candidate list before use, so a stale/forged cookie can't redirect probes (SSRF).

## Notes / assumptions

- Per-environment gateway hostnames (`staging-gateway`, `prNN-gateway`) are assumed to mirror the `-api` naming. If a gateway host doesn't exist for an env, the probe **fails over to `-api`**, so the assumption carries no risk. Only production `gateway.relaycast.dev` is referenced elsewhere in the repo — worth confirming the staging/PR gateway hosts exist if staging observability matters.
- No unit test added: `observer-dashboard` has no test setup (only a `build` script). The resolver is pure and would be worth a test if a runner is stood up.

## Verification

- `tsc --noEmit` passes against installed deps.
- `git diff` is limited to the 5 intended files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Resolve observer workspaces on the correct engine and remember it**

### What Changed
- The observer now checks the gateway engine first, then falls back to the legacy api engine, so new and migrated workspaces load traffic correctly.
- Login remembers which engine accepted the workspace key, and session/check/logout use that remembered engine first to avoid re-checking both engines every time.
- If a workspace key is no longer valid, auth cookies are cleared; if the engine is temporarily unreachable, the session stays active and continues to fail only on the affected downstream calls.
- Logout now turns off the workspace stream on the engine the workspace actually uses, then clears all auth cookies.

### Impact
`✅ New workspaces show traffic in the observer`
`✅ Legacy workspaces keep working at the same URL`
`✅ Fewer repeated engine checks on page load`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
