### PR TITLE
fix: make sdk-python tests version agnostic

### DIFF
--- a/packages/sdk-python/tests/test_imports.py
+++ b/packages/sdk-python/tests/test_imports.py
@@ -4,8 +4,7 @@ import relay_sdk
 
 
 def test_version():
-    assert relay_sdk.__version__ == "0.1.0"
-    assert relay_sdk.SDK_VERSION == "0.1.0"
+    assert relay_sdk.__version__ == relay_sdk.SDK_VERSION
 
 
 def test_exports():

--- a/packages/sdk-python/tests/test_ws.py
+++ b/packages/sdk-python/tests/test_ws.py
@@ -5,6 +5,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+import relay_sdk
 from relay_sdk.ws import WsClient
 
 
@@ -154,7 +155,7 @@ class TestWsClientOriginParams:
         assert "token=at_xxx" in url
         assert "origin_surface=sdk" in url
         assert "origin_client=%40relaycast%2Fpython-sdk" in url
-        assert "origin_version=0.1.0" in url
+        assert f"origin_version={relay_sdk.SDK_VERSION}" in url
 
     @pytest.mark.asyncio
     async def test_connect_url_includes_agent_relay_distinct_id_query_param(self):


### PR DESCRIPTION
## **User description**
## Summary
- Replace hard-coded SDK version assertions in the Python test suite with checks against the package version constant.
- Keep the release workflow able to bump the version before running tests without breaking CI.

## Validation
- `uv run --extra dev pytest`
- `uv build`

## Context
This fixes the publish-path failure where the workflow bumps the SDK version to `0.1.1`, but the tests still expected `0.1.0`.


___

## **CodeAnt-AI Description**
**Keep Python SDK tests aligned with the published SDK version**

### What Changed
- Version checks in the Python test suite now compare the package version against the SDK’s own version value instead of expecting a fixed release number.
- The WebSocket connection test now verifies that the connection URL uses the current SDK version in its origin information.
- This keeps the test suite passing when the SDK version is updated during release workflows.

### Impact
`✅ Fewer release-blocking test failures`
`✅ Safer version bumps before publishing`
`✅ More reliable SDK release checks`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
