### PR TITLE
fix(telemetry): use hosted ingestion proxy

### DIFF
--- a/packages/engine/src/lib/__tests__/logger.test.ts
+++ b/packages/engine/src/lib/__tests__/logger.test.ts
@@ -1,0 +1,62 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { createLogger } from '../logger.js';
+
+describe('engine logger PostHog export', () => {
+  const originalFetch = globalThis.fetch;
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    vi.restoreAllMocks();
+  });
+
+  it('exports logs through the hosted ingestion proxy by default', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true });
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    const logger = createLogger(
+      {
+        environment: 'test',
+        appSemver: '1.2.3',
+        posthogApiKey: 'phc_example',
+      },
+      { source: 'test' },
+    );
+
+    logger.info('hello');
+    await logger.flush();
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://i.agentrelay.com/i/v1/logs',
+      expect.objectContaining({
+        method: 'POST',
+        headers: expect.objectContaining({
+          Authorization: 'Bearer phc_example',
+          'Content-Type': 'application/json',
+        }),
+      }),
+    );
+  });
+
+  it('allows a custom PostHog host override', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true });
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    const logger = createLogger(
+      {
+        environment: 'test',
+        posthogApiKey: 'phc_example',
+        posthogHost: 'https://posthog.example.test/',
+      },
+      { source: 'test' },
+    );
+
+    logger.info('hello');
+    await logger.flush();
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://posthog.example.test/i/v1/logs',
+      expect.any(Object),
+    );
+  });
+});

--- a/packages/engine/src/lib/logger.ts
+++ b/packages/engine/src/lib/logger.ts
@@ -4,7 +4,7 @@ import type { AppEnv, EngineRuntime } from '../env.js';
 type LogLevel = 'debug' | 'info' | 'warn' | 'error';
 type LogFields = Record<string, unknown>;
 
-const DEFAULT_POSTHOG_HOST = 'https://us.i.posthog.com';
+const DEFAULT_POSTHOG_HOST = 'https://i.agentrelay.com';
 const DEFAULT_APP_VERSION = '0.1.0';
 const DEFAULT_SDK_VERSION = 'unknown';
 const SERVICE_NAME = 'relaycast-server';

--- a/packages/mcp/src/__tests__/telemetry.test.ts
+++ b/packages/mcp/src/__tests__/telemetry.test.ts
@@ -91,11 +91,10 @@ describe('createMcpTelemetry', () => {
     expect(fs.readFileSync).toHaveBeenCalledWith(mockTelemetryPath, 'utf8');
   });
 
-  it('posts telemetry directly to PostHog capture endpoint', async () => {
+  it('posts telemetry to the hosted capture proxy by default', async () => {
     vi.mocked(fs.readFileSync).mockReturnValue(JSON.stringify({ anonymousId: 'anon-123' }));
 
     const telemetry = createMcpTelemetry('1.0.0', {
-      posthogHost: 'https://app.posthog.example/',
       posthogApiKey: 'phc_example',
       originSurface: 'mcp',
       originClient: '@relaycast/mcp',
@@ -111,7 +110,7 @@ describe('createMcpTelemetry', () => {
       path: string;
       headers: Record<string, string>;
     };
-    expect(options.hostname).toBe('app.posthog.example');
+    expect(options.hostname).toBe('i.agentrelay.com');
     expect(options.path).toBe('/capture/');
 
     const body = JSON.parse(capturedBodies[0] ?? '{}') as {
@@ -122,6 +121,25 @@ describe('createMcpTelemetry', () => {
     expect(body.properties.origin_surface).toBe('mcp');
     expect(body.properties.origin_client).toBe('@relaycast/mcp');
     expect(body.properties.origin_version).toBe('1.0.0');
+  });
+
+  it('allows a custom PostHog host override', async () => {
+    vi.mocked(fs.readFileSync).mockReturnValue(JSON.stringify({ anonymousId: 'anon-123' }));
+
+    const telemetry = createMcpTelemetry('1.0.0', {
+      posthogHost: 'https://app.posthog.example/',
+      posthogApiKey: 'phc_example',
+    });
+
+    telemetry.capture('relaycast_mcp_server_started', { transport: 'stdio' });
+    await telemetry.flush();
+
+    const options = nodeRequestMock.mock.calls[0]?.[0] as {
+      hostname: string;
+      path: string;
+    };
+    expect(options.hostname).toBe('app.posthog.example');
+    expect(options.path).toBe('/capture/');
   });
 
   it('prefers fetch transport when worker globals are present', async () => {

--- a/packages/mcp/src/telemetry.ts
+++ b/packages/mcp/src/telemetry.ts
@@ -29,7 +29,7 @@ export interface McpTelemetry {
 }
 
 const TELEMETRY_PATH = path.join(os.homedir(), '.relay', 'telemetry.json');
-const DEFAULT_POSTHOG_HOST = 'https://us.i.posthog.com';
+const DEFAULT_POSTHOG_HOST = 'https://i.agentrelay.com';
 
 function isTruthy(value: string | undefined): boolean {
   if (!value) return false;


### PR DESCRIPTION
## **User description**
## Summary
- default MCP telemetry capture to the hosted ingestion proxy at `https://i.agentrelay.com`
- default engine PostHog log export to the same hosted proxy
- keep explicit `POSTHOG_HOST` / Relaycast host overrides working

## Verification
- `npm --prefix packages/mcp run test -- src/__tests__/telemetry.test.ts`
- `npm --prefix packages/engine run test -- src/lib/__tests__/logger.test.ts src/lib/__tests__/origin.test.ts`


___

## **CodeAnt-AI Description**
**Send telemetry and logs through the hosted proxy by default, while still allowing custom host overrides**

### What Changed
- MCP telemetry now sends events to the hosted ingestion proxy by default instead of PostHog directly
- Engine log export also uses the hosted proxy by default
- Custom PostHog host settings still work for both telemetry and log export
- Added test coverage for the default hosted proxy path and for host overrides

### Impact
`✅ Centralized telemetry delivery`
`✅ Fewer blocked log and event uploads`
`✅ Existing custom telemetry endpoints still work`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
