### PR TITLE
Fix release commit-back race in publish workflows; reconcile npm versions to 2.6.0

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -303,7 +303,30 @@ jobs:
           git add package.json package-lock.json packages/*/package.json
           if ! git diff --staged --quiet; then
             git commit -m "chore(release): v${NEW_VERSION}"
-            git push origin HEAD:main
+            # main can advance during the (multi-minute) build — e.g. a
+            # concurrent SDK publish — so rebase onto the latest main and retry
+            # to avoid non-fast-forward rejections. The release commit only
+            # touches version metadata, so it rebases cleanly onto another
+            # release's commit.
+            pushed=false
+            for attempt in 1 2 3 4 5; do
+              git fetch origin main
+              if ! git rebase origin/main; then
+                git rebase --abort
+                echo "::error::rebase onto origin/main failed (unexpected conflict)"
+                exit 1
+              fi
+              if git push origin HEAD:main; then
+                pushed=true
+                break
+              fi
+              echo "push rejected (main moved); retry ${attempt}"
+              sleep $(( attempt * 3 ))
+            done
+            if [ "$pushed" != "true" ]; then
+              echo "::error::failed to push release commit to main after retries"
+              exit 1
+            fi
           fi
 
           git tag -a "v${NEW_VERSION}" -m "Release v${NEW_VERSION}"

--- a/.github/workflows/publish-rust.yml
+++ b/.github/workflows/publish-rust.yml
@@ -193,7 +193,30 @@ jobs:
           git add packages/sdk-rust/Cargo.toml
           if ! git diff --staged --quiet; then
             git commit -m "chore(sdk-rust): v${NEW_VERSION}"
-            git push origin HEAD:main
+            # main can advance during the (multi-minute) build — e.g. a
+            # concurrent npm publish — so rebase onto the latest main and retry
+            # to avoid non-fast-forward rejections. The release commit only
+            # touches version metadata, so it rebases cleanly onto another
+            # release's commit.
+            pushed=false
+            for attempt in 1 2 3 4 5; do
+              git fetch origin main
+              if ! git rebase origin/main; then
+                git rebase --abort
+                echo "::error::rebase onto origin/main failed (unexpected conflict)"
+                exit 1
+              fi
+              if git push origin HEAD:main; then
+                pushed=true
+                break
+              fi
+              echo "push rejected (main moved); retry ${attempt}"
+              sleep $(( attempt * 3 ))
+            done
+            if [ "$pushed" != "true" ]; then
+              echo "::error::failed to push release commit to main after retries"
+              exit 1
+            fi
           fi
 
           git tag -a "sdk-rust-v${NEW_VERSION}" -m "sdk-rust v${NEW_VERSION}"

--- a/package-lock.json
+++ b/package-lock.json
@@ -206,7 +206,7 @@
     },
     "node_modules/@clack/prompts/node_modules/is-unicode-supported": {
       "version": "1.3.0",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -10536,17 +10536,17 @@
     },
     "packages/a2a": {
       "name": "@relaycast/a2a",
-      "version": "2.5.1",
+      "version": "2.6.0",
       "dependencies": {
         "zod": "^4.3.6"
       }
     },
     "packages/cli": {
       "name": "relaycast",
-      "version": "2.5.1",
+      "version": "2.6.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.26.0",
-        "@relaycast/mcp": "2.5.1"
+        "@relaycast/mcp": "2.6.0"
       },
       "bin": {
         "relaycast": "dist/cli.js"
@@ -10559,11 +10559,11 @@
     },
     "packages/engine": {
       "name": "@relaycast/engine",
-      "version": "2.5.1",
+      "version": "2.6.0",
       "dependencies": {
         "@hono/node-server": "^1.13.7",
-        "@relaycast/a2a": "2.5.1",
-        "@relaycast/types": "2.5.1",
+        "@relaycast/a2a": "2.6.0",
+        "@relaycast/types": "2.6.0",
         "better-sqlite3": "^11.10.0",
         "drizzle-orm": "^0.45.1",
         "hono": "^4.11.9",
@@ -10600,11 +10600,11 @@
     },
     "packages/mcp": {
       "name": "@relaycast/mcp",
-      "version": "2.5.1",
+      "version": "2.6.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.26.0",
-        "@relaycast/sdk": "2.5.1",
-        "@relaycast/types": "2.5.1",
+        "@relaycast/sdk": "2.6.0",
+        "@relaycast/types": "2.6.0",
         "express": "^5.2.1",
         "zod": "^4.3.6"
       },
@@ -10618,11 +10618,11 @@
     },
     "packages/observer-dashboard": {
       "name": "@relaycast/observer-dashboard",
-      "version": "2.5.1",
+      "version": "2.6.0",
       "dependencies": {
-        "@relaycast/react": "2.5.1",
-        "@relaycast/sdk": "2.5.1",
-        "@relaycast/types": "2.5.1",
+        "@relaycast/react": "2.6.0",
+        "@relaycast/sdk": "2.6.0",
+        "@relaycast/types": "2.6.0",
         "class-variance-authority": "^0.7.0",
         "clsx": "^2.1.0",
         "lucide-react": "^0.400.0",
@@ -10653,11 +10653,11 @@
     },
     "packages/openclaw": {
       "name": "@relaycast/openclaw",
-      "version": "2.5.1",
+      "version": "2.6.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@relaycast/sdk": "2.5.1",
-        "@relaycast/types": "2.5.1"
+        "@relaycast/sdk": "2.6.0",
+        "@relaycast/types": "2.6.0"
       },
       "bin": {
         "relaycast-openclaw": "dist/cli.js"
@@ -10899,11 +10899,11 @@
     },
     "packages/react": {
       "name": "@relaycast/react",
-      "version": "2.5.1",
+      "version": "2.6.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@relaycast/sdk": "2.5.1",
-        "@relaycast/types": "2.5.1",
+        "@relaycast/sdk": "2.6.0",
+        "@relaycast/types": "2.6.0",
         "prism-react-renderer": "^2.4.1",
         "react-markdown": "^10.1.0",
         "remark-breaks": "^4.0.0",
@@ -11153,9 +11153,9 @@
     },
     "packages/sdk-typescript": {
       "name": "@relaycast/sdk",
-      "version": "2.5.1",
+      "version": "2.6.0",
       "dependencies": {
-        "@relaycast/types": "2.5.1",
+        "@relaycast/types": "2.6.0",
         "zod": "^4.3.6"
       },
       "devDependencies": {
@@ -11166,7 +11166,7 @@
     },
     "packages/types": {
       "name": "@relaycast/types",
-      "version": "2.5.1",
+      "version": "2.6.0",
       "dependencies": {
         "zod": "^4.3.6"
       }

--- a/packages/a2a/package.json
+++ b/packages/a2a/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@relaycast/a2a",
-  "version": "2.5.1",
+  "version": "2.6.0",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "relaycast",
-  "version": "2.5.1",
+  "version": "2.6.0",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -21,7 +21,7 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.26.0",
-    "@relaycast/mcp": "2.5.1"
+    "@relaycast/mcp": "2.6.0"
   },
   "devDependencies": {
     "@types/node": "^20.0.0",

--- a/packages/engine/package.json
+++ b/packages/engine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@relaycast/engine",
-  "version": "2.5.1",
+  "version": "2.6.0",
   "type": "module",
   "description": "Portable, platform-agnostic engine for Relaycast — channels, threads, DMs, presence, real-time events. Runs on Node + SQLite (self-host) or behind a Cloudflare Durable Object adapter (hosted).",
   "bin": {
@@ -43,8 +43,8 @@
   },
   "dependencies": {
     "@hono/node-server": "^1.13.7",
-    "@relaycast/a2a": "2.5.1",
-    "@relaycast/types": "2.5.1",
+    "@relaycast/a2a": "2.6.0",
+    "@relaycast/types": "2.6.0",
     "better-sqlite3": "^11.10.0",
     "drizzle-orm": "^0.45.1",
     "hono": "^4.11.9",

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@relaycast/mcp",
-  "version": "2.5.1",
+  "version": "2.6.0",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -13,8 +13,8 @@
     "lint": "eslint src/"
   },
   "dependencies": {
-    "@relaycast/sdk": "2.5.1",
-    "@relaycast/types": "2.5.1",
+    "@relaycast/sdk": "2.6.0",
+    "@relaycast/types": "2.6.0",
     "@modelcontextprotocol/sdk": "^1.26.0",
     "express": "^5.2.1",
     "zod": "^4.3.6"

--- a/packages/observer-dashboard/package.json
+++ b/packages/observer-dashboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@relaycast/observer-dashboard",
-  "version": "2.5.1",
+  "version": "2.6.0",
   "private": true,
   "scripts": {
     "dev": "next dev --port 3100",
@@ -9,9 +9,9 @@
     "start": "next start"
   },
   "dependencies": {
-    "@relaycast/react": "2.5.1",
-    "@relaycast/sdk": "2.5.1",
-    "@relaycast/types": "2.5.1",
+    "@relaycast/react": "2.6.0",
+    "@relaycast/sdk": "2.6.0",
+    "@relaycast/types": "2.6.0",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.0",
     "lucide-react": "^0.400.0",

--- a/packages/openclaw/package.json
+++ b/packages/openclaw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@relaycast/openclaw",
-  "version": "2.5.1",
+  "version": "2.6.0",
   "description": "Drop-in Relaycast integration for OpenClaw — structured messaging for multi-claw setups.",
   "keywords": [
     "openclaw",
@@ -36,8 +36,8 @@
     "lint": "eslint src/"
   },
   "dependencies": {
-    "@relaycast/sdk": "2.5.1",
-    "@relaycast/types": "2.5.1"
+    "@relaycast/sdk": "2.6.0",
+    "@relaycast/types": "2.6.0"
   },
   "devDependencies": {
     "@types/node": "^20.0.0",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@relaycast/react",
-  "version": "2.5.1",
+  "version": "2.6.0",
   "description": "Headless React hooks for Relaycast real-time agent messaging",
   "keywords": [
     "relaycast",
@@ -33,8 +33,8 @@
     "lint": "eslint src/"
   },
   "dependencies": {
-    "@relaycast/sdk": "2.5.1",
-    "@relaycast/types": "2.5.1",
+    "@relaycast/sdk": "2.6.0",
+    "@relaycast/types": "2.6.0",
     "prism-react-renderer": "^2.4.1",
     "react-markdown": "^10.1.0",
     "remark-breaks": "^4.0.0",

--- a/packages/sdk-typescript/package.json
+++ b/packages/sdk-typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@relaycast/sdk",
-  "version": "2.5.1",
+  "version": "2.6.0",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -27,7 +27,7 @@
     "lint": "eslint src/"
   },
   "dependencies": {
-    "@relaycast/types": "2.5.1",
+    "@relaycast/types": "2.6.0",
     "zod": "^4.3.6"
   },
   "devDependencies": {

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@relaycast/types",
-  "version": "2.5.1",
+  "version": "2.6.0",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
Fixes #181.

## Problem

The `Commit and tag` step in `publish-npm.yml` and `publish-rust.yml` pushed the version-bump commit with `git push origin HEAD:main` off a **stale checkout**, with no rebase. When `main` advanced during the multi-minute build — e.g. a concurrent SDK publish — the push was rejected as a **non-fast-forward** (`failed to push some refs`). That made the workflow **fail after the packages had already published**, and skipped the git tag + GitHub Release.

This happened on 2026-06-10: `@relaycast/sdk`/`@relaycast/types` **2.6.0** published fine, but the npm job failed because the Rust publish (`5a5b154 chore(sdk-rust): v2.4.0`) landed on `main` mid-build. Net effect: registry at 2.6.0, but `main`'s `package.json` files stuck at 2.5.1, and no `v2.6.0` tag/release.

Not a branch-protection issue — the Rust job pushed to `main` fine; it just won the race.

## Fix

**1. Rebase-and-retry (both workflows).** Before pushing the release commit, `git fetch origin main` + `git rebase origin/main` and retry with backoff (5 attempts). The release commit only touches version metadata, so it rebases cleanly onto another release's commit. Tag + GitHub Release still run after a successful push.

**2. Reconcile the current drift.** Bump all npm packages `2.5.1 → 2.6.0` and sync internal `@relaycast/*` deps + the lockfile to match what's already on the registry.

## Notes

- The Rust job shared the identical latent race (it just happened to land first) — fixed there too.
- Concurrency groups already serialize *same-kind* publishes; this fixes the cross-kind (npm-vs-rust) and merge-during-build cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)