### PR TITLE
feat(engine): accept node roster snapshot in node.heartbeat

### DIFF
--- a/packages/engine/src/__tests__/conformance/node.test.ts
+++ b/packages/engine/src/__tests__/conformance/node.test.ts
@@ -742,5 +742,98 @@ describe('node adapter conformance', () => {
       const triggerInvokes = alpha.sock.ofType('action.invoke').filter((event) => event.action === 'echo');
       expect(triggerInvokes).toHaveLength(1);
     });
+
+    it('refreshes the node roster snapshot from a roster-carrying heartbeat and stamps receipt time server-side', async () => {
+      const ws = await createWorkspace(stack.app, 'fleet-heartbeat-roster-ws');
+
+      const alpha = await enrollAndAttachNode(ws, {
+        id: 'node_alpha',
+        name: 'alpha',
+        capabilities: [capability('spawn:claude', 'spawn', { agent: 'claude' })],
+        maxAgents: 4,
+      });
+
+      // enrollAndAttachNode intentionally provokes one error frame (a bad
+      // node.register), so baseline from the current count.
+      const errorsBefore = alpha.sock.ofType('error').length;
+      // lastHeartbeatAt is persisted at second granularity (unixepoch), so floor
+      // the baseline to the second to compare against the server stamp.
+      const before = Math.floor(Date.now() / 1000) * 1000;
+      // Roster-carrying heartbeat: a new capability appears, capacity grows, and
+      // the version bumps. The engine must adopt these from the heartbeat without
+      // a fresh node.register, and must ignore any broker-sent last_heartbeat_at
+      // in favor of its own server stamp.
+      await alpha.handle.handleMessage(JSON.stringify({
+        v: 1,
+        type: 'node.heartbeat',
+        load: 0.5,
+        active_agents: 1,
+        handlers_live: true,
+        node_id: 'node_alpha',
+        name: 'alpha',
+        capabilities: [
+          capability('spawn:claude', 'spawn', { agent: 'claude' }),
+          capability('echo', 'tool'),
+        ],
+        max_agents: 8,
+        version: 'test-node-v2',
+      }));
+
+      // No new error frame from the strict schema: the roster fields are accepted.
+      expect(alpha.sock.ofType('error')).toHaveLength(errorsBefore);
+
+      const [node] = await stack.runtime.handle.db
+        .select()
+        .from(nodes)
+        .where(and(eq(nodes.workspaceId, ws.workspaceId), eq(nodes.id, 'node_alpha')));
+      expect(node).toBeDefined();
+      expect(node.maxAgents).toBe(8);
+      expect(node.version).toBe('test-node-v2');
+      expect(node.load).toBe(0.5);
+      expect(node.activeAgents).toBe(1);
+      expect(node.capabilities.map((cap) => cap.name).sort()).toEqual(['echo', 'spawn:claude']);
+      // Receipt time is stamped server-side, not trusted from the wire.
+      expect(node.lastHeartbeatAt?.getTime()).toBeGreaterThanOrEqual(before);
+
+      // The newly-advertised capability became a node-handled action.
+      const echoAction = await stack.app.request('/v1/nodes?capability=echo', {
+        headers: { authorization: `Bearer ${ws.workspaceKey}` },
+      });
+      expect(echoAction.status).toBe(200);
+      const echoBody = await echoAction.json() as { data: Array<{ id: string }> };
+      expect(echoBody.data.map((n) => n.id)).toContain('node_alpha');
+
+      // A roster_id mismatch on the heartbeat is rejected like node.register.
+      await alpha.handle.handleMessage(JSON.stringify({
+        v: 1,
+        id: 'heartbeat-bad-node-id',
+        type: 'node.heartbeat',
+        load: 0,
+        active_agents: 0,
+        handlers_live: true,
+        node_id: 'wrong-node',
+      }));
+      expect(alpha.sock.ofType('error').at(-1)).toMatchObject({
+        id: 'heartbeat-bad-node-id',
+        ok: false,
+        code: 'node_id_mismatch',
+      });
+
+      // A minimal heartbeat (no roster) remains valid and preserves the roster.
+      await alpha.handle.handleMessage(JSON.stringify({
+        v: 1,
+        type: 'node.heartbeat',
+        load: 0.1,
+        active_agents: 0,
+        handlers_live: true,
+      }));
+      const [stillNode] = await stack.runtime.handle.db
+        .select()
+        .from(nodes)
+        .where(and(eq(nodes.workspaceId, ws.workspaceId), eq(nodes.id, 'node_alpha')));
+      expect(stillNode.maxAgents).toBe(8);
+      expect(stillNode.version).toBe('test-node-v2');
+      expect(stillNode.capabilities.map((cap) => cap.name).sort()).toEqual(['echo', 'spawn:claude']);
+    });
   });
 });

--- a/packages/engine/src/engine/node.ts
+++ b/packages/engine/src/engine/node.ts
@@ -212,9 +212,29 @@ export async function heartbeatNode(
   nodeId: string,
   message: FleetNodeHeartbeatMessage,
 ) {
+  // A heartbeat may carry the node's roster snapshot so the engine can keep its
+  // node descriptor fresh between (or in the absence of a fresh) node.register —
+  // e.g. after an engine restart where the broker keeps heartbeating an
+  // already-registered node. The roster fields are optional; a minimal heartbeat
+  // updates only liveness/capacity. lastHeartbeatAt is always stamped
+  // server-side here as the authoritative receipt time — the broker never sends
+  // it, and any client-supplied value would be ignored.
+  if (message.node_id !== undefined && message.node_id !== nodeId) {
+    throw codedError('node_id does not match the authenticated node token', 'node_id_mismatch', 403);
+  }
+
+  const rosterUpdate: Partial<typeof nodes.$inferInsert> = {};
+  if (message.name !== undefined) rosterUpdate.name = message.name;
+  if (message.capabilities !== undefined) {
+    rosterUpdate.capabilities = normalizeCapabilities(message.capabilities);
+  }
+  if (message.max_agents !== undefined) rosterUpdate.maxAgents = message.max_agents;
+  if (message.version !== undefined) rosterUpdate.version = message.version;
+
   const [updated] = await db
     .update(nodes)
     .set({
+      ...rosterUpdate,
       status: 'online',
       load: message.load,
       activeAgents: message.active_agents,
@@ -223,6 +243,11 @@ export async function heartbeatNode(
     })
     .where(and(eq(nodes.workspaceId, workspaceId), eq(nodes.id, nodeId)))
     .returning();
+
+  if (updated && message.capabilities !== undefined) {
+    await ensureCapabilityActions(db, workspaceId, updated.id, message.capabilities);
+  }
+
   return updated ? publicNode(updated) : null;
 }
 

--- a/packages/types/fixtures/fleet-wire/node.heartbeat.json
+++ b/packages/types/fixtures/fleet-wire/node.heartbeat.json
@@ -3,5 +3,22 @@
   "type": "node.heartbeat",
   "load": 0.42,
   "active_agents": 2,
-  "handlers_live": true
+  "handlers_live": true,
+  "node_id": "node_01J7FLEET000000000000001",
+  "name": "builder-1",
+  "capabilities": [
+    {
+      "name": "spawn:codex",
+      "kind": "spawn",
+      "metadata": {
+        "agent": "codex"
+      }
+    },
+    {
+      "name": "spawn:claude",
+      "kind": "spawn"
+    }
+  ],
+  "max_agents": 8,
+  "version": "relay-broker/0.7.0"
 }

--- a/packages/types/src/fleet-wire.ts
+++ b/packages/types/src/fleet-wire.ts
@@ -83,6 +83,20 @@ export const FleetNodeHeartbeatMessageSchema = z
     load: z.number().finite().nonnegative(),
     active_agents: z.number().int().nonnegative(),
     handlers_live: z.boolean(),
+    // Roster snapshot carried for liveness: lets the engine refresh a node's
+    // descriptor (name/capabilities/max_agents/version) from the steady-state
+    // heartbeat without waiting for a fresh node.register — important after an
+    // engine restart where the broker keeps heartbeating an already-registered
+    // node. All optional and backward-compatible: a minimal heartbeat
+    // (load/active_agents/handlers_live only) is still valid.
+    //
+    // NOTE: the broker does NOT send last_heartbeat_at — receipt time is stamped
+    // server-side by the engine as the single source of truth for liveness.
+    name: z.string().optional(),
+    node_id: z.string().optional(),
+    capabilities: z.array(FleetCapabilitySchema).optional(),
+    max_agents: z.number().int().nonnegative().optional(),
+    version: z.string().optional(),
   })
   .strict();
 export type FleetNodeHeartbeatMessage = z.infer<typeof FleetNodeHeartbeatMessageSchema>;


### PR DESCRIPTION
## What

Extends the `node.heartbeat` fleet-wire schema so the broker can carry the node **roster snapshot** (`name`, `node_id`, `capabilities`, `max_agents`, `version`) on the steady-state heartbeat, and has the engine adopt it.

Previously `FleetNodeHeartbeatMessageSchema` was `.strict()` and accepted only `load`/`active_agents`/`handlers_live`. The relay broker (relay#1139, branch `ricky/factory-p11-broker-heartbeat`) wants the heartbeat to carry the roster for liveness so the engine keeps a node's descriptor fresh between — or in the absence of — a fresh `node.register` (e.g. after an engine restart where the broker keeps heartbeating an already-registered node). With the strict schema, every roster-carrying heartbeat was rejected, so node `load`/`active_agents` never updated and the Fleet E2E spawn/load scenarios timed out.

## Changes

- `packages/types/src/fleet-wire.ts`: add optional `name`/`node_id`/`capabilities`/`max_agents`/`version` to `FleetNodeHeartbeatMessageSchema` (still `.strict()`, still backward-compatible with a minimal heartbeat).
- `packages/engine/src/engine/node.ts` (`heartbeatNode`): when roster fields are present, refresh `name`/`capabilities`/`maxAgents`/`version` on the node row and register newly-advertised capability actions via `ensureCapabilityActions`. Validate `node_id` against the authenticated token (`node_id_mismatch`) like `node.register`.
- `packages/types/fixtures/fleet-wire/node.heartbeat.json`: fixture now carries the roster (round-tripped by the wire-contract test).
- New conformance test asserting roster adoption, server-stamped receipt time, `node_id` mismatch rejection, and minimal-heartbeat preservation.

## Single source of truth: `last_heartbeat_at`

`last_heartbeat_at` is intentionally **not** part of the wire. Receipt time is stamped **server-side** in `heartbeatNode` as the single source of truth for liveness; the broker does not send it.

## Verification (local)

- `npm run build --workspace @relaycast/types` / `@relaycast/engine`: clean.
- engine suite: 133/133 pass (incl. new roster heartbeat test + existing `fleetRolloutFlag`).
- types suite: 68/68 pass.
- engine `tsc --noEmit`: clean; `lint`: clean (one pre-existing unrelated warning in `delivery.ts`).

## Dependency note

relay #1139's **Fleet E2E** is being repointed at this branch's commit so CI runs the broker's roster-in-heartbeat feature against an engine that accepts it. **Do not merge** until that cross-repo verification is reviewed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/AgentWorkforce/relaycast/pull/197?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

