### PR TITLE
[codex] Expose workspace fleet node flag in SDK

### DIFF
--- a/.agentworkforce/trajectories/completed/2026-06/traj_how3l2dy5jb8/summary.md
+++ b/.agentworkforce/trajectories/completed/2026-06/traj_how3l2dy5jb8/summary.md
@@ -1,0 +1,31 @@
+# Trajectory: Expose fleet node workspace flag in TypeScript SDK
+
+> **Status:** ✅ Completed
+> **Confidence:** 90%
+> **Started:** June 18, 2026 at 01:04 PM
+> **Completed:** June 18, 2026 at 01:10 PM
+
+---
+
+## Summary
+
+Added Relaycast TypeScript SDK workspace.fleetNodes get/set/inherit helpers for the existing /v1/workspace/fleet-nodes endpoint, with tests and README docs. Kept package versions unchanged for the normal release process.
+
+**Approach:** Standard approach
+
+---
+
+## Key Decisions
+
+### Did not manually bump @relaycast/sdk version
+- **Chose:** Did not manually bump @relaycast/sdk version
+- **Reasoning:** Versioning follows the repo release process; kept Relaycast package and lockfile versions unchanged while adding SDK source/tests.
+
+---
+
+## Chapters
+
+### 1. Work
+*Agent: default*
+
+- Did not manually bump @relaycast/sdk version: Did not manually bump @relaycast/sdk version

--- a/.agentworkforce/trajectories/completed/2026-06/traj_how3l2dy5jb8/trajectory.json
+++ b/.agentworkforce/trajectories/completed/2026-06/traj_how3l2dy5jb8/trajectory.json
@@ -1,0 +1,53 @@
+{
+  "id": "traj_how3l2dy5jb8",
+  "version": 1,
+  "task": {
+    "title": "Expose fleet node workspace flag in TypeScript SDK"
+  },
+  "status": "completed",
+  "startedAt": "2026-06-18T17:04:18.696Z",
+  "completedAt": "2026-06-18T17:10:24.521Z",
+  "agents": [
+    {
+      "name": "default",
+      "role": "lead",
+      "joinedAt": "2026-06-18T17:10:17.854Z"
+    }
+  ],
+  "chapters": [
+    {
+      "id": "chap_lkprvlefzfos",
+      "title": "Work",
+      "agentName": "default",
+      "startedAt": "2026-06-18T17:10:17.854Z",
+      "endedAt": "2026-06-18T17:10:24.521Z",
+      "events": [
+        {
+          "ts": 1781802617855,
+          "type": "decision",
+          "content": "Did not manually bump @relaycast/sdk version: Did not manually bump @relaycast/sdk version",
+          "raw": {
+            "question": "Did not manually bump @relaycast/sdk version",
+            "chosen": "Did not manually bump @relaycast/sdk version",
+            "alternatives": [],
+            "reasoning": "Versioning follows the repo release process; kept Relaycast package and lockfile versions unchanged while adding SDK source/tests."
+          },
+          "significance": "high"
+        }
+      ]
+    }
+  ],
+  "retrospective": {
+    "summary": "Added Relaycast TypeScript SDK workspace.fleetNodes get/set/inherit helpers for the existing /v1/workspace/fleet-nodes endpoint, with tests and README docs. Kept package versions unchanged for the normal release process.",
+    "approach": "Standard approach",
+    "confidence": 0.9
+  },
+  "commits": [],
+  "filesChanged": [],
+  "projectId": "AgentWorkforce/relaycast",
+  "tags": [],
+  "_trace": {
+    "startRef": "e24fb635409e3c262d94a004f5080e2795ace5a3",
+    "endRef": "e24fb635409e3c262d94a004f5080e2795ace5a3"
+  }
+}

--- a/README.md
+++ b/README.md
@@ -374,6 +374,18 @@ and outbound subscriptions: `message.created`, `message.reacted`, `message.read`
 `agent.status.blocked`, `agent.status.waiting`, `agent.status.offline`,
 `action.invoked`, `action.completed`, `action.failed`, and `action.denied`.
 
+Fleet node presence is published to the workspace stream (workspace-key
+subscribers only) as `node.online`, `node.heartbeat`, and `node.offline`. Each
+carries a `node` payload matching the `GET /nodes` roster entry (capabilities,
+tags, `load`, `active_agents`/`max_agents`, `handlers_live`, `last_heartbeat_at`),
+so a single event fully refreshes a node's row. These mirror node register /
+heartbeat / disconnect (including the heartbeat-TTL sweep) and are emitted only
+when the workspace stream is enabled.
+
+Enable the fleet-node control surface per workspace with
+`await relay.workspace.fleetNodes.set(true)`; call
+`relay.workspace.fleetNodes.inherit()` to return to the deployment default.
+
 Actions are async fire-and-forget: invoking an action returns an ack with
 `invocation_id`, emits `action.invoked` to the handler agent, and completion emits
 `action.completed` or `action.failed` to listeners and subscriptions. Action discovery

--- a/packages/sdk-typescript/src/__tests__/workspace.test.ts
+++ b/packages/sdk-typescript/src/__tests__/workspace.test.ts
@@ -50,6 +50,52 @@ describe('Relay workspace methods', () => {
     expect(init.method).toBe('GET');
   });
 
+  it('workspace.fleetNodes.get() calls GET /v1/workspace/fleet-nodes', async () => {
+    const { RelayCast } = await import('../relay.js');
+    const relay = new RelayCast({ apiKey: 'rk_live_test123' });
+
+    mockFetch.mockImplementation(() =>
+      mockResponse({ enabled: true, default_enabled: false, override: true }),
+    );
+    const result = await relay.workspace.fleetNodes.get();
+
+    const [url, init] = mockFetch.mock.calls[0]!;
+    expect(url).toBe('https://gateway.relaycast.dev/v1/workspace/fleet-nodes');
+    expect(init.method).toBe('GET');
+    expect(result).toEqual({ enabled: true, defaultEnabled: false, override: true });
+  });
+
+  it('workspace.fleetNodes.set() calls PUT /v1/workspace/fleet-nodes with enabled', async () => {
+    const { RelayCast } = await import('../relay.js');
+    const relay = new RelayCast({ apiKey: 'rk_live_test123' });
+
+    mockFetch.mockImplementation(() =>
+      mockResponse({ enabled: true, default_enabled: false, override: true }),
+    );
+    await relay.workspace.fleetNodes.set(true);
+
+    const [url, init] = mockFetch.mock.calls[0]!;
+    expect(url).toBe('https://gateway.relaycast.dev/v1/workspace/fleet-nodes');
+    expect(init.method).toBe('PUT');
+    expect(JSON.parse(init.body as string)).toEqual({ enabled: true });
+  });
+
+  it('workspace.fleetNodes.inherit() calls PUT /v1/workspace/fleet-nodes with inherit mode', async () => {
+    const { RelayCast } = await import('../relay.js');
+    const relay = new RelayCast({ apiKey: 'rk_live_test123' });
+
+    mockFetch.mockImplementation(() =>
+      mockResponse({ enabled: false, default_enabled: false, override: null }),
+    );
+    const result = await relay.workspace.fleetNodes.inherit();
+
+    const [url, init] = mockFetch.mock.calls[0]!;
+    expect(url).toBe('https://gateway.relaycast.dev/v1/workspace/fleet-nodes');
+    expect(init.method).toBe('PUT');
+    expect(JSON.parse(init.body as string)).toEqual({ mode: 'inherit' });
+    expect(result).toEqual({ enabled: false, defaultEnabled: false, override: null });
+  });
+
   it('dmMessages() camelizes DM message fields', async () => {
     const { RelayCast } = await import('../relay.js');
     const relay = new RelayCast({ apiKey: 'rk_live_test123' });

--- a/packages/sdk-typescript/src/relay.ts
+++ b/packages/sdk-typescript/src/relay.ts
@@ -148,6 +148,12 @@ export interface WorkspaceStreamConfig {
   override: boolean | null;
 }
 
+export interface WorkspaceFleetNodesConfig {
+  enabled: boolean;
+  defaultEnabled: boolean;
+  override: boolean | null;
+}
+
 export interface WorkspaceBootstrapOptions {
   apiKey?: string;
   baseUrl?: string;
@@ -599,6 +605,13 @@ export class RelayCast {
         this.client.put('/v1/workspace/stream', { enabled }),
       inherit: (): Promise<WorkspaceStreamConfig> =>
         this.client.put('/v1/workspace/stream', { mode: 'inherit' }),
+    },
+    fleetNodes: {
+      get: (): Promise<WorkspaceFleetNodesConfig> => this.client.get('/v1/workspace/fleet-nodes'),
+      set: (enabled: boolean): Promise<WorkspaceFleetNodesConfig> =>
+        this.client.put('/v1/workspace/fleet-nodes', { enabled }),
+      inherit: (): Promise<WorkspaceFleetNodesConfig> =>
+        this.client.put('/v1/workspace/fleet-nodes', { mode: 'inherit' }),
     },
   };
 


### PR DESCRIPTION
## Summary
- add TypeScript SDK workspace.fleetNodes.get/set/inherit for /v1/workspace/fleet-nodes
- add tests for GET, PUT enabled, and PUT inherit mode
- document enabling and inheriting the workspace fleet-node rollout flag

## Context
@relaycast/sdk@4.1.0 was published from main before this SDK helper reached main. This PR applies the helper directly to the release lineage so the next Relaycast SDK release ships it in the npm package.

## Validation
- npm --prefix packages/sdk-typescript test -- --run src/__tests__/workspace.test.ts
- npm --prefix packages/sdk-typescript run build

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/AgentWorkforce/relaycast/pull/199?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

