### PR TITLE
refactor(engine): consolidate duplicated error/serialization/attachment helpers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,5 @@ Cargo.lock
 # Staged local binary artifacts for npm packaging
 packages/sdk-typescript/bin/*
 !packages/sdk-typescript/bin/.gitkeep
+relaycast-files/
+*.db

--- a/packages/engine/src/engine/a2a.ts
+++ b/packages/engine/src/engine/a2a.ts
@@ -26,6 +26,7 @@ import { rotateAgentToken } from './tokenRotate.js';
 import { createAndRunCertification } from './certify.js';
 import { isSafeExternalUrl } from '../lib/ssrf.js';
 import { randomUuid, sha256Hex } from '../lib/crypto.js';
+import { codedError } from '../lib/httpError.js';
 
 type Db = ReturnType<typeof getDb>;
 
@@ -110,9 +111,7 @@ export interface A2aAgentRecord {
 
 function ensureString(value: string | undefined, message: string): string {
   if (!value) {
-    const err = new Error(message);
-    Object.assign(err, { code: 'invalid_request', status: 400 });
-    throw err;
+    throw codedError(message, 'invalid_request', 400);
   }
   return value;
 }
@@ -147,9 +146,7 @@ function sleep(ms: number): Promise<void> {
 
 export async function fetchAgentCard(agentCardUrl: string): Promise<A2aAgentCard> {
   if (!isSafeExternalUrl(agentCardUrl)) {
-    const err = new Error(`Refusing to fetch agent card from non-public URL: ${agentCardUrl}`);
-    Object.assign(err, { code: 'a2a_agent_url_forbidden', status: 400 });
-    throw err;
+    throw codedError(`Refusing to fetch agent card from non-public URL: ${agentCardUrl}`, 'a2a_agent_url_forbidden', 400);
   }
   const response = await globalThis.fetch(agentCardUrl, {
     method: 'GET',
@@ -158,9 +155,7 @@ export async function fetchAgentCard(agentCardUrl: string): Promise<A2aAgentCard
   });
 
   if (!response.ok) {
-    const err = new Error(`Failed to fetch agent card from ${agentCardUrl}: ${response.status}`);
-    Object.assign(err, { code: 'a2a_agent_card_fetch_failed', status: 502 });
-    throw err;
+    throw codedError(`Failed to fetch agent card from ${agentCardUrl}: ${response.status}`, 'a2a_agent_card_fetch_failed', 502);
   }
 
   const payload = await response.json();
@@ -285,9 +280,7 @@ export async function registerA2aAgent(
     .where(and(eq(a2aAgents.workspaceId, workspaceId), eq(agents.name, relayName)));
 
   if (existing) {
-    const err = new Error(`A2A agent "${relayName}" already exists in this workspace`);
-    Object.assign(err, { code: 'a2a_agent_already_exists', status: 409 });
-    throw err;
+    throw codedError(`A2A agent "${relayName}" already exists in this workspace`, 'a2a_agent_already_exists', 409);
   }
 
   const proxyMetadata = {
@@ -311,9 +304,7 @@ export async function registerA2aAgent(
     // type 'external', so an unrelated agent can never be hijacked by name.
     const isA2aProxy = existingProxy.type === 'external' && meta.a2a === true;
     if (!isA2aProxy) {
-      const err = new Error(`Agent "${relayName}" already exists in this workspace`);
-      Object.assign(err, { code: 'agent_already_exists', status: 409 });
-      throw err;
+      throw codedError(`Agent "${relayName}" already exists in this workspace`, 'agent_already_exists', 409);
     }
     await updateAgent(db, workspaceId, relayName, { status: 'active', metadata: proxyMetadata });
     const rotated = await rotateAgentToken(db, workspaceId, relayName);
@@ -521,9 +512,7 @@ export async function sendToExternalAgent(
   const targetUrl = normalizeBaseUrl(agentUrl);
 
   if (!isSafeExternalUrl(targetUrl)) {
-    const err = new Error(`Refusing to send to non-public A2A URL: ${targetUrl}`);
-    Object.assign(err, { code: 'a2a_agent_url_forbidden', status: 400 });
-    throw err;
+    throw codedError(`Refusing to send to non-public A2A URL: ${targetUrl}`, 'a2a_agent_url_forbidden', 400);
   }
 
   let lastError: unknown;

--- a/packages/engine/src/engine/action.ts
+++ b/packages/engine/src/engine/action.ts
@@ -1,9 +1,9 @@
 import { and, eq, inArray, lte, sql } from 'drizzle-orm';
-import type { FleetWireJsonValue } from '@relaycast/types';
 import type { getDb } from '../db/index.js';
 import { actions, actionInvocations, agents, nodes } from '../db/schema.js';
 import { generateId } from './snowflake.js';
 import { codedError } from '../lib/httpError.js';
+import { toFleetWireJson } from './deliveryWire.js';
 import type { NodeConnectionRegistry } from '../ports/realtime.js';
 import { claimSpawnNode, chooseNodeForAction, releaseNodeCapacity, reserveNodeCapacity } from './placement.js';
 
@@ -74,21 +74,6 @@ function recordInput(value: unknown): Record<string, unknown> {
   return value && typeof value === 'object' && !Array.isArray(value)
     ? value as Record<string, unknown>
     : {};
-}
-
-function toFleetWireJson(value: unknown): FleetWireJsonValue {
-  if (value === null) return null;
-  if (typeof value === 'string' || typeof value === 'boolean') return value;
-  if (typeof value === 'number') return Number.isFinite(value) ? value : null;
-  if (Array.isArray(value)) return value.map(toFleetWireJson);
-  if (value && typeof value === 'object') {
-    const out: Record<string, FleetWireJsonValue> = {};
-    for (const [key, nested] of Object.entries(value)) {
-      out[key] = toFleetWireJson(nested);
-    }
-    return out;
-  }
-  return null;
 }
 
 function publicAction(row: {

--- a/packages/engine/src/engine/agent.ts
+++ b/packages/engine/src/engine/agent.ts
@@ -3,6 +3,7 @@ import type { getDb } from '../db/index.js';
 import { agents, channels, channelMembers, actions, deliveries } from '../db/schema.js';
 import { randomHex, sha256Hex } from '../lib/crypto.js';
 import { generateId } from './snowflake.js';
+import { codedError } from '../lib/httpError.js';
 
 type Db = ReturnType<typeof getDb>;
 
@@ -66,9 +67,7 @@ export async function registerAgent(
     // D1 uses .code = 'SQLITE_CONSTRAINT_UNIQUE', drizzle may wrap in its own error,
     // and the message may contain 'UNIQUE constraint failed' or 'D1_ERROR: UNIQUE'
     if (isUniqueConstraintError(insertErr)) {
-      const err = new Error(`Agent "${data.name}" already exists in this workspace`);
-      Object.assign(err, { code: 'agent_already_exists', status: 409 });
-      throw err;
+      throw codedError(`Agent "${data.name}" already exists in this workspace`, 'agent_already_exists', 409);
     }
     throw insertErr;
   }

--- a/packages/engine/src/engine/attachments.ts
+++ b/packages/engine/src/engine/attachments.ts
@@ -1,0 +1,55 @@
+import { and, asc, eq, inArray } from 'drizzle-orm';
+import type { getDb } from '../db/index.js';
+import { messageAttachments, files } from '../db/schema.js';
+
+type Db = ReturnType<typeof getDb>;
+
+/** A message attachment rendered onto the snake_case JSON wire. */
+export type AttachmentRow = {
+  file_id: string;
+  filename: string;
+  content_type: string;
+  size_bytes: number;
+};
+
+/**
+ * Load attachments for a batch of message ids, grouped by message id.
+ *
+ * Shared by every read path that hydrates attachments (channel messages,
+ * threads, DMs, group DMs, delivery payloads) so they all scope by workspace
+ * and order attachments by their stored `position` identically. Returns an
+ * empty map for an empty id list without touching the database.
+ */
+export async function fetchAttachmentsBatch(
+  db: Db,
+  workspaceId: string,
+  msgIds: string[],
+): Promise<Map<string, AttachmentRow[]>> {
+  const map = new Map<string, AttachmentRow[]>();
+  if (msgIds.length === 0) return map;
+
+  const rows = await db
+    .select({
+      messageId: messageAttachments.messageId,
+      fileId: messageAttachments.fileId,
+      filename: files.filename,
+      contentType: files.contentType,
+      sizeBytes: files.sizeBytes,
+    })
+    .from(messageAttachments)
+    .innerJoin(files, eq(messageAttachments.fileId, files.id))
+    .where(and(inArray(messageAttachments.messageId, msgIds), eq(files.workspaceId, workspaceId)))
+    .orderBy(asc(messageAttachments.messageId), asc(messageAttachments.position));
+
+  for (const row of rows) {
+    const list = map.get(row.messageId) || [];
+    list.push({
+      file_id: row.fileId,
+      filename: row.filename,
+      content_type: row.contentType,
+      size_bytes: row.sizeBytes,
+    });
+    map.set(row.messageId, list);
+  }
+  return map;
+}

--- a/packages/engine/src/engine/channel.ts
+++ b/packages/engine/src/engine/channel.ts
@@ -3,6 +3,7 @@ import type { getDb } from '../db/index.js';
 import { channels, channelMembers, agents } from '../db/schema.js';
 import { generateId } from './snowflake.js';
 import { getCachedChannel, setCachedChannel, invalidateChannelCache } from './cache.js';
+import { codedError } from '../lib/httpError.js';
 
 type Db = ReturnType<typeof getDb>;
 
@@ -14,11 +15,7 @@ export async function createChannel(
 ) {
   // Validate channel name: lowercase alphanumeric + hyphens
   if (!/^[a-z0-9][a-z0-9-]*$/.test(data.name)) {
-    const err = new Error(
-      'Channel name must be lowercase alphanumeric and hyphens, starting with a letter or number',
-    );
-    Object.assign(err, { code: 'invalid_channel_name', status: 400 });
-    throw err;
+    throw codedError('Channel name must be lowercase alphanumeric and hyphens, starting with a letter or number', 'invalid_channel_name', 400);
   }
 
   // Check for duplicate name within workspace
@@ -29,9 +26,7 @@ export async function createChannel(
       and(eq(channels.workspaceId, workspaceId), eq(channels.name, data.name)),
     );
   if (existing) {
-    const err = new Error(`Channel "${data.name}" already exists`);
-    Object.assign(err, { code: 'channel_already_exists', status: 409 });
-    throw err;
+    throw codedError(`Channel "${data.name}" already exists`, 'channel_already_exists', 409);
   }
 
   const channelId = generateId();
@@ -186,9 +181,7 @@ export async function updateChannel(
   if (!channel) return null;
 
   if (channel.isArchived) {
-    const err = new Error('Cannot update an archived channel');
-    Object.assign(err, { code: 'channel_archived', status: 400 });
-    throw err;
+    throw codedError('Cannot update an archived channel', 'channel_archived', 400);
   }
 
   const setClause: Record<string, unknown> = {};
@@ -221,9 +214,7 @@ export async function updateChannel(
 export async function archiveChannel(db: Db, workspaceId: string, name: string) {
   // #general cannot be deleted
   if (name === 'general') {
-    const err = new Error('The #general channel cannot be archived');
-    Object.assign(err, { code: 'cannot_archive_general', status: 400 });
-    throw err;
+    throw codedError('The #general channel cannot be archived', 'cannot_archive_general', 400);
   }
 
   const [channel] = await db
@@ -262,15 +253,11 @@ export async function joinChannel(
     );
 
   if (!channel) {
-    const err = new Error(`Channel "${channelName}" not found`);
-    Object.assign(err, { code: 'channel_not_found', status: 404 });
-    throw err;
+    throw codedError(`Channel "${channelName}" not found`, 'channel_not_found', 404);
   }
 
   if (channel.isArchived) {
-    const err = new Error('Cannot join an archived channel');
-    Object.assign(err, { code: 'channel_archived', status: 400 });
-    throw err;
+    throw codedError('Cannot join an archived channel', 'channel_archived', 400);
   }
 
   // Check if already a member
@@ -316,9 +303,7 @@ export async function leaveChannel(
     );
 
   if (!channel) {
-    const err = new Error(`Channel "${channelName}" not found`);
-    Object.assign(err, { code: 'channel_not_found', status: 404 });
-    throw err;
+    throw codedError(`Channel "${channelName}" not found`, 'channel_not_found', 404);
   }
 
   await db
@@ -345,9 +330,7 @@ export async function getMembers(db: Db, workspaceId: string, channelName: strin
     );
 
   if (!channel) {
-    const err = new Error(`Channel "${channelName}" not found`);
-    Object.assign(err, { code: 'channel_not_found', status: 404 });
-    throw err;
+    throw codedError(`Channel "${channelName}" not found`, 'channel_not_found', 404);
   }
 
   const members = await db
@@ -389,15 +372,11 @@ export async function inviteAgent(
     );
 
   if (!channel) {
-    const err = new Error(`Channel "${channelName}" not found`);
-    Object.assign(err, { code: 'channel_not_found', status: 404 });
-    throw err;
+    throw codedError(`Channel "${channelName}" not found`, 'channel_not_found', 404);
   }
 
   if (channel.isArchived) {
-    const err = new Error('Cannot invite to an archived channel');
-    Object.assign(err, { code: 'channel_archived', status: 400 });
-    throw err;
+    throw codedError('Cannot invite to an archived channel', 'channel_archived', 400);
   }
 
   // Check inviter is a member
@@ -412,9 +391,7 @@ export async function inviteAgent(
     );
 
   if (!inviterMembership) {
-    const err = new Error('You must be a member of the channel to invite others');
-    Object.assign(err, { code: 'not_a_member', status: 403 });
-    throw err;
+    throw codedError('You must be a member of the channel to invite others', 'not_a_member', 403);
   }
 
   // Find invitee agent
@@ -429,9 +406,7 @@ export async function inviteAgent(
     );
 
   if (!invitee) {
-    const err = new Error(`Agent "${inviteeAgentName}" not found`);
-    Object.assign(err, { code: 'agent_not_found', status: 404 });
-    throw err;
+    throw codedError(`Agent "${inviteeAgentName}" not found`, 'agent_not_found', 404);
   }
 
   // Check if already a member
@@ -474,9 +449,7 @@ export async function muteChannel(
     );
 
   if (!channel) {
-    const err = new Error(`Channel "${channelName}" not found`);
-    Object.assign(err, { code: 'channel_not_found', status: 404 });
-    throw err;
+    throw codedError(`Channel "${channelName}" not found`, 'channel_not_found', 404);
   }
 
   const [membership] = await db
@@ -490,9 +463,7 @@ export async function muteChannel(
     );
 
   if (!membership) {
-    const err = new Error('You must be a member of the channel to mute it');
-    Object.assign(err, { code: 'not_a_member', status: 403 });
-    throw err;
+    throw codedError('You must be a member of the channel to mute it', 'not_a_member', 403);
   }
 
   await db
@@ -527,9 +498,7 @@ export async function unmuteChannel(
     );
 
   if (!channel) {
-    const err = new Error(`Channel "${channelName}" not found`);
-    Object.assign(err, { code: 'channel_not_found', status: 404 });
-    throw err;
+    throw codedError(`Channel "${channelName}" not found`, 'channel_not_found', 404);
   }
 
   const [membership] = await db
@@ -543,9 +512,7 @@ export async function unmuteChannel(
     );
 
   if (!membership) {
-    const err = new Error('You must be a member of the channel to unmute it');
-    Object.assign(err, { code: 'not_a_member', status: 403 });
-    throw err;
+    throw codedError('You must be a member of the channel to unmute it', 'not_a_member', 403);
   }
 
   await db

--- a/packages/engine/src/engine/delivery.ts
+++ b/packages/engine/src/engine/delivery.ts
@@ -1,18 +1,18 @@
 import { eq, and, not, asc, isNull, inArray, notInArray, lte, gt, sql } from 'drizzle-orm';
 import type { getDb } from '../db/index.js';
-import { deliveries, messages, agents, readReceipts, channelMembers, channels, dmConversations, messageAttachments, files } from '../db/schema.js';
+import { deliveries, messages, agents, readReceipts, channelMembers, channels, dmConversations } from '../db/schema.js';
 import type { DeliveryStatus } from '@relaycast/types';
 import { runAtomic } from '../ports/database.js';
 import type { NodeConnectionRegistry } from '../ports/realtime.js';
 import { buildDeliverFrame, buildDeliverPayload, buildMessageCreatedEventData, buildThreadReplyEventData, buildDmReceivedEventData, buildGroupDmReceivedEventData } from './deliveryWire.js';
 import { publicMessageMetadata } from './messageMetadata.js';
 import { toIso } from '../lib/serialize.js';
+import { fetchAttachmentsBatch } from './attachments.js';
 
 type Db = ReturnType<typeof getDb>;
 
 type DeliveryRow = typeof deliveries.$inferSelect;
 type DeliveryWithChannel = DeliveryRow & { channelId: string };
-type AttachmentRow = { file_id: string; filename: string; content_type: string; size_bytes: number };
 
 const ACTIVE_DELIVERY_STATUSES = ['queued', 'delivered'] as const;
 const TERMINAL_SUCCESS_STATUS = 'acked';
@@ -43,34 +43,6 @@ function serializeDelivery(row: DeliveryRow & { channelId?: string }) {
   };
 }
 
-async function fetchAttachmentsBatch(db: Db, workspaceId: string, msgIds: string[]): Promise<Map<string, AttachmentRow[]>> {
-  const map = new Map<string, AttachmentRow[]>();
-  if (msgIds.length === 0) return map;
-
-  const rows = await db
-    .select({
-      messageId: messageAttachments.messageId,
-      fileId: messageAttachments.fileId,
-      filename: files.filename,
-      contentType: files.contentType,
-      sizeBytes: files.sizeBytes,
-    })
-    .from(messageAttachments)
-    .innerJoin(files, eq(messageAttachments.fileId, files.id))
-    .where(and(inArray(messageAttachments.messageId, msgIds), eq(files.workspaceId, workspaceId)));
-
-  for (const row of rows) {
-    const list = map.get(row.messageId) || [];
-    list.push({
-      file_id: row.fileId,
-      filename: row.filename,
-      content_type: row.contentType,
-      size_bytes: row.sizeBytes,
-    });
-    map.set(row.messageId, list);
-  }
-  return map;
-}
 
 /**
  * List durable delivery items for an agent. Defaults to the non-terminal

--- a/packages/engine/src/engine/delivery.ts
+++ b/packages/engine/src/engine/delivery.ts
@@ -1,4 +1,4 @@
-import { eq, ne, and, not, asc, isNull, inArray, notInArray, lte, gt, sql } from 'drizzle-orm';
+import { eq, and, not, asc, isNull, inArray, notInArray, lte, gt, sql } from 'drizzle-orm';
 import type { getDb } from '../db/index.js';
 import { deliveries, messages, agents, readReceipts, channelMembers, channels, dmConversations, messageAttachments, files } from '../db/schema.js';
 import type { DeliveryStatus } from '@relaycast/types';
@@ -6,6 +6,7 @@ import { runAtomic } from '../ports/database.js';
 import type { NodeConnectionRegistry } from '../ports/realtime.js';
 import { buildDeliverFrame, buildDeliverPayload, buildMessageCreatedEventData, buildThreadReplyEventData, buildDmReceivedEventData, buildGroupDmReceivedEventData } from './deliveryWire.js';
 import { publicMessageMetadata } from './messageMetadata.js';
+import { toIso } from '../lib/serialize.js';
 
 type Db = ReturnType<typeof getDb>;
 
@@ -15,10 +16,6 @@ type AttachmentRow = { file_id: string; filename: string; content_type: string; 
 
 const ACTIVE_DELIVERY_STATUSES = ['queued', 'delivered'] as const;
 const TERMINAL_SUCCESS_STATUS = 'acked';
-
-function toIso(value: Date | null | undefined): string | null {
-  return value ? value.toISOString() : null;
-}
 
 function serializeDelivery(row: DeliveryRow & { channelId?: string }) {
   return {

--- a/packages/engine/src/engine/directory.ts
+++ b/packages/engine/src/engine/directory.ts
@@ -3,6 +3,7 @@ import type { getDb } from '../db/index.js';
 import { agents, directoryAgents, directoryRatings, directorySkills } from '../db/schema.js';
 import { buildFtsQuery } from './searchQuery.js';
 import { generateId } from './snowflake.js';
+import { codedError } from '../lib/httpError.js';
 
 type Db = ReturnType<typeof getDb>;
 
@@ -62,11 +63,6 @@ export interface DirectoryRatingInput {
 
 type DirectoryAgentRow = typeof directoryAgents.$inferSelect;
 
-function createError(message: string, code: string, status: number) {
-  const err = new Error(message);
-  Object.assign(err, { code, status });
-  return err;
-}
 
 function slugify(value: string): string {
   return value
@@ -126,7 +122,7 @@ async function resolveSourceAgentId(
     .where(and(eq(agents.workspaceId, workspaceId), eq(agents.name, sourceAgentName)));
 
   if (!agent) {
-    throw createError(`Agent "${sourceAgentName}" not found`, 'agent_not_found', 404);
+    throw codedError(`Agent "${sourceAgentName}" not found`, 'agent_not_found', 404);
   }
 
   return agent.id;
@@ -277,7 +273,7 @@ export async function createDirectoryAgent(
 ) {
   const slug = slugify(data.slug || data.name);
   if (!slug) {
-    throw createError('slug could not be derived from name', 'invalid_request', 400);
+    throw codedError('slug could not be derived from name', 'invalid_request', 400);
   }
 
   const sourceAgentId = await resolveSourceAgentId(db, workspaceId, data.source_agent_name);
@@ -353,7 +349,7 @@ export async function updateDirectoryAgent(
 
   const nextSlug = data.slug || (data.name ? slugify(data.name) : existing.slug);
   if (!nextSlug) {
-    throw createError('slug could not be derived from name', 'invalid_request', 400);
+    throw codedError('slug could not be derived from name', 'invalid_request', 400);
   }
 
   const sourceAgentId = data.source_agent_name === undefined
@@ -407,7 +403,7 @@ export async function listDirectoryRatings(
 ) {
   const row = await getDirectoryAgentRow(db, workspaceId, slug);
   if (!row) {
-    throw createError(`Directory agent "${slug}" not found`, 'directory_agent_not_found', 404);
+    throw codedError(`Directory agent "${slug}" not found`, 'directory_agent_not_found', 404);
   }
 
   const ratings = await db
@@ -444,7 +440,7 @@ export async function upsertDirectoryRating(
 ) {
   const row = await getDirectoryAgentRow(db, workspaceId, slug);
   if (!row) {
-    throw createError(`Directory agent "${slug}" not found`, 'directory_agent_not_found', 404);
+    throw codedError(`Directory agent "${slug}" not found`, 'directory_agent_not_found', 404);
   }
 
   const [existingRating] = await db
@@ -701,7 +697,7 @@ export async function syncSourceAgentDirectoryEntry(
 
   const slug = slugify(sourceAgent.name);
   if (!slug) {
-    throw createError('slug could not be derived from source agent name', 'invalid_request', 400);
+    throw codedError('slug could not be derived from source agent name', 'invalid_request', 400);
   }
 
   const tags = normalizeTags([

--- a/packages/engine/src/engine/dm.ts
+++ b/packages/engine/src/engine/dm.ts
@@ -21,6 +21,7 @@ import {
   type DeliveryOutcomeRecords,
 } from './deliveryWrites.js';
 import { DEFAULT_MAILBOX_DEPTH_CAP, DEFAULT_MAILBOX_TTL_MS, type MailboxConfig } from './mailboxConfig.js';
+import { codedError } from '../lib/httpError.js';
 
 type Db = ReturnType<typeof getDb>;
 
@@ -132,9 +133,7 @@ async function resolveConversation(
     );
 
   if (!conv) {
-    const err = new Error('Conversation not found');
-    Object.assign(err, { code: 'not_found', status: 404 });
-    throw err;
+    throw codedError('Conversation not found', 'not_found', 404);
   }
 
   return conv;
@@ -149,9 +148,7 @@ async function resolveAttachments(
 
   const unique = new Set(attachmentIds);
   if (unique.size !== attachmentIds.length) {
-    const err = new Error('Invalid attachments: duplicate file ids are not allowed');
-    Object.assign(err, { code: 'invalid_attachments', status: 400 });
-    throw err;
+    throw codedError('Invalid attachments: duplicate file ids are not allowed', 'invalid_attachments', 400);
   }
 
   const validFiles = await db
@@ -173,9 +170,7 @@ async function resolveAttachments(
   const validIds = new Set(validFiles.map((f) => f.file_id));
   const invalid = attachmentIds.filter((id) => !validIds.has(id));
   if (invalid.length > 0) {
-    const err = new Error('Invalid attachments: file ids must exist in workspace and be complete');
-    Object.assign(err, { code: 'invalid_attachments', status: 400 });
-    throw err;
+    throw codedError('Invalid attachments: file ids must exist in workspace and be complete', 'invalid_attachments', 400);
   }
 
   const ordered = new Map(validFiles.map((file) => [file.file_id, file]));
@@ -242,9 +237,7 @@ export async function sendDm(
       .where(and(eq(agents.workspaceId, workspaceId), eq(agents.name, data.to)));
 
   if (!toAgent) {
-    const err = new Error(`Agent "${data.to}" not found`);
-    Object.assign(err, { code: 'agent_not_found', status: 404 });
-    throw err;
+    throw codedError(`Agent "${data.to}" not found`, 'agent_not_found', 404);
   }
 
   const [fromAgent] = await db
@@ -253,9 +246,7 @@ export async function sendDm(
     .where(and(eq(agents.workspaceId, workspaceId), eq(agents.id, fromAgentId)));
 
   if (!fromAgent?.name) {
-    const err = new Error('Sender agent not found');
-    Object.assign(err, { code: 'internal_error', status: 500 });
-    throw err;
+    throw codedError('Sender agent not found', 'internal_error', 500);
   }
 
   const conv = await resolveConversation(db, workspaceId, fromAgentId, toAgent.id);
@@ -496,9 +487,7 @@ export async function getDmMessages(
     );
 
   if (!participant) {
-    const err = new Error('Not a participant in this conversation');
-    Object.assign(err, { code: 'forbidden', status: 403 });
-    throw err;
+    throw codedError('Not a participant in this conversation', 'forbidden', 403);
   }
 
   // Get the conversation to find the channel
@@ -513,9 +502,7 @@ export async function getDmMessages(
     );
 
   if (!conv) {
-    const err = new Error('Conversation not found');
-    Object.assign(err, { code: 'not_found', status: 404 });
-    throw err;
+    throw codedError('Conversation not found', 'not_found', 404);
   }
 
   const conditions = [eq(messages.channelId, conv.channelId)];

--- a/packages/engine/src/engine/dm.ts
+++ b/packages/engine/src/engine/dm.ts
@@ -1,4 +1,4 @@
-import { eq, and, sql, lt, gt, isNull, inArray, asc } from 'drizzle-orm';
+import { eq, and, sql, lt, gt, isNull, inArray } from 'drizzle-orm';
 import type { DmMessage } from '@relaycast/types';
 import type { getDb } from '../db/index.js';
 import {
@@ -22,44 +22,13 @@ import {
 } from './deliveryWrites.js';
 import { DEFAULT_MAILBOX_DEPTH_CAP, DEFAULT_MAILBOX_TTL_MS, type MailboxConfig } from './mailboxConfig.js';
 import { codedError } from '../lib/httpError.js';
+import { fetchAttachmentsBatch, type AttachmentRow } from './attachments.js';
 
 type Db = ReturnType<typeof getDb>;
-
-type AttachmentRow = { file_id: string; filename: string; content_type: string; size_bytes: number };
 
 interface SendDmOptions {
   skipA2aIntercept?: boolean;
   mailbox?: MailboxConfig;
-}
-
-async function fetchAttachmentsBatch(db: Db, workspaceId: string, msgIds: string[]): Promise<Map<string, AttachmentRow[]>> {
-  const map = new Map<string, AttachmentRow[]>();
-  if (msgIds.length === 0) return map;
-
-  const rows = await db
-    .select({
-      messageId: messageAttachments.messageId,
-      fileId: messageAttachments.fileId,
-      filename: files.filename,
-      contentType: files.contentType,
-      sizeBytes: files.sizeBytes,
-    })
-    .from(messageAttachments)
-    .innerJoin(files, eq(messageAttachments.fileId, files.id))
-    .where(and(inArray(messageAttachments.messageId, msgIds), eq(files.workspaceId, workspaceId)))
-    .orderBy(asc(messageAttachments.messageId), asc(messageAttachments.position));
-
-  for (const row of rows) {
-    const list = map.get(row.messageId) || [];
-    list.push({
-      file_id: row.fileId,
-      filename: row.filename,
-      content_type: row.contentType,
-      size_bytes: row.sizeBytes,
-    });
-    map.set(row.messageId, list);
-  }
-  return map;
 }
 
 async function getDmPairKey(workspaceId: string, agentA: string, agentB: string): Promise<string> {

--- a/packages/engine/src/engine/dmAll.ts
+++ b/packages/engine/src/engine/dmAll.ts
@@ -7,6 +7,7 @@ import {
   messages,
   agents,
 } from '../db/schema.js';
+import { codedError } from '../lib/httpError.js';
 
 type Db = ReturnType<typeof getDb>;
 
@@ -117,9 +118,7 @@ export async function getDmMessagesForWorkspace(
     );
 
   if (!conv) {
-    const err = new Error('Conversation not found');
-    Object.assign(err, { code: 'not_found', status: 404 });
-    throw err;
+    throw codedError('Conversation not found', 'not_found', 404);
   }
 
   // Compare/sort on the indexed text PK directly: snowflake ids are fixed-width

--- a/packages/engine/src/engine/eventDelivery.ts
+++ b/packages/engine/src/engine/eventDelivery.ts
@@ -1,6 +1,7 @@
 import type { getDb } from '../db/index.js';
 import { hmacSha256Hex } from '../lib/crypto.js';
 import { getActiveSubscriptions } from './eventSubscription.js';
+import { codedError } from '../lib/httpError.js';
 
 type Db = ReturnType<typeof getDb>;
 
@@ -162,11 +163,7 @@ export async function deliverEvent(
   const retryableFailures = deliveryResults.filter((r) => !r.ok && r.retryable).length;
 
   if (retryableFailures > 0) {
-    const err = new Error(
-      `Retryable webhook delivery failures: ${retryableFailures} of ${attempted}`,
-    );
-    Object.assign(err, { code: 'event_delivery_retryable_failure', status: 503 });
-    throw err;
+    throw codedError(`Retryable webhook delivery failures: ${retryableFailures} of ${attempted}`, 'event_delivery_retryable_failure', 503);
   }
 
   return { attempted, succeeded, failed, retryableFailures };

--- a/packages/engine/src/engine/groupDm.ts
+++ b/packages/engine/src/engine/groupDm.ts
@@ -1,4 +1,4 @@
-import { eq, and, isNull, inArray, asc } from 'drizzle-orm';
+import { eq, and, isNull, inArray } from 'drizzle-orm';
 import type { getDb } from '../db/index.js';
 import { messages, channels, agents, dmConversations, dmParticipants, messageAttachments, files } from '../db/schema.js';
 import { runAtomicWrites, type AtomicWrite } from '../ports/database.js';
@@ -10,40 +10,9 @@ import {
 } from './deliveryWrites.js';
 import { DEFAULT_MAILBOX_DEPTH_CAP, DEFAULT_MAILBOX_TTL_MS, type MailboxConfig } from './mailboxConfig.js';
 import { codedError } from '../lib/httpError.js';
+import { fetchAttachmentsBatch, type AttachmentRow } from './attachments.js';
 
 type Db = ReturnType<typeof getDb>;
-
-type AttachmentRow = { file_id: string; filename: string; content_type: string; size_bytes: number };
-
-async function fetchAttachmentsBatch(db: Db, workspaceId: string, msgIds: string[]): Promise<Map<string, AttachmentRow[]>> {
-  const map = new Map<string, AttachmentRow[]>();
-  if (msgIds.length === 0) return map;
-
-  const rows = await db
-    .select({
-      messageId: messageAttachments.messageId,
-      fileId: messageAttachments.fileId,
-      filename: files.filename,
-      contentType: files.contentType,
-      sizeBytes: files.sizeBytes,
-    })
-    .from(messageAttachments)
-    .innerJoin(files, eq(messageAttachments.fileId, files.id))
-    .where(and(inArray(messageAttachments.messageId, msgIds), eq(files.workspaceId, workspaceId)))
-    .orderBy(asc(messageAttachments.messageId), asc(messageAttachments.position));
-
-  for (const row of rows) {
-    const list = map.get(row.messageId) || [];
-    list.push({
-      file_id: row.fileId,
-      filename: row.filename,
-      content_type: row.contentType,
-      size_bytes: row.sizeBytes,
-    });
-    map.set(row.messageId, list);
-  }
-  return map;
-}
 
 export async function createGroupDm(
   db: Db,

--- a/packages/engine/src/engine/groupDm.ts
+++ b/packages/engine/src/engine/groupDm.ts
@@ -9,6 +9,7 @@ import {
   type DeliveryOutcomeRecords,
 } from './deliveryWrites.js';
 import { DEFAULT_MAILBOX_DEPTH_CAP, DEFAULT_MAILBOX_TTL_MS, type MailboxConfig } from './mailboxConfig.js';
+import { codedError } from '../lib/httpError.js';
 
 type Db = ReturnType<typeof getDb>;
 
@@ -59,9 +60,7 @@ export async function createGroupDm(
       .where(and(eq(agents.workspaceId, workspaceId), eq(agents.name, name)));
 
     if (!agent) {
-      const err = new Error(`Agent "${name}" not found`);
-      Object.assign(err, { code: 'agent_not_found', status: 404 });
-      throw err;
+      throw codedError(`Agent "${name}" not found`, 'agent_not_found', 404);
     }
     participantAgents.push(agent);
   }
@@ -131,9 +130,7 @@ export async function postGroupMessage(
     );
 
   if (!participant) {
-    const err = new Error('Not a participant in this conversation');
-    Object.assign(err, { code: 'forbidden', status: 403 });
-    throw err;
+    throw codedError('Not a participant in this conversation', 'forbidden', 403);
   }
 
   // Get the conversation to find the channel
@@ -148,9 +145,7 @@ export async function postGroupMessage(
     );
 
   if (!conv) {
-    const err = new Error('Conversation not found');
-    Object.assign(err, { code: 'not_found', status: 404 });
-    throw err;
+    throw codedError('Conversation not found', 'not_found', 404);
   }
 
   const [fromAgent] = await db
@@ -159,17 +154,13 @@ export async function postGroupMessage(
     .where(and(eq(agents.workspaceId, workspaceId), eq(agents.id, agentId)));
 
   if (!fromAgent?.name) {
-    const err = new Error('Sender agent not found');
-    Object.assign(err, { code: 'internal_error', status: 500 });
-    throw err;
+    throw codedError('Sender agent not found', 'internal_error', 500);
   }
 
   if (data.attachments && data.attachments.length > 0) {
     const unique = new Set(data.attachments);
     if (unique.size !== data.attachments.length) {
-      const err = new Error('Invalid attachments: duplicate file ids are not allowed');
-      Object.assign(err, { code: 'invalid_attachments', status: 400 });
-      throw err;
+      throw codedError('Invalid attachments: duplicate file ids are not allowed', 'invalid_attachments', 400);
     }
 
     const validFiles = await db
@@ -185,9 +176,7 @@ export async function postGroupMessage(
     const validIds = new Set(validFiles.map((f) => f.id));
     const invalid = data.attachments.filter((id) => !validIds.has(id));
     if (invalid.length > 0) {
-      const err = new Error('Invalid attachments: file ids must exist in workspace and be complete');
-      Object.assign(err, { code: 'invalid_attachments', status: 400 });
-      throw err;
+      throw codedError('Invalid attachments: file ids must exist in workspace and be complete', 'invalid_attachments', 400);
     }
   }
 
@@ -299,9 +288,7 @@ export async function addParticipant(
     );
 
   if (!requester) {
-    const err = new Error('Not a participant in this conversation');
-    Object.assign(err, { code: 'forbidden', status: 403 });
-    throw err;
+    throw codedError('Not a participant in this conversation', 'forbidden', 403);
   }
 
   // Find the invitee agent
@@ -311,9 +298,7 @@ export async function addParticipant(
     .where(and(eq(agents.workspaceId, workspaceId), eq(agents.name, inviteeAgentName)));
 
   if (!invitee) {
-    const err = new Error(`Agent "${inviteeAgentName}" not found`);
-    Object.assign(err, { code: 'agent_not_found', status: 404 });
-    throw err;
+    throw codedError(`Agent "${inviteeAgentName}" not found`, 'agent_not_found', 404);
   }
 
   // Check if already a participant
@@ -371,9 +356,7 @@ export async function removeParticipant(
     );
 
   if (!participant) {
-    const err = new Error('Not a participant in this conversation');
-    Object.assign(err, { code: 'forbidden', status: 403 });
-    throw err;
+    throw codedError('Not a participant in this conversation', 'forbidden', 403);
   }
 
   // Set left_at timestamp

--- a/packages/engine/src/engine/message.ts
+++ b/packages/engine/src/engine/message.ts
@@ -11,39 +11,9 @@ import {
 } from './deliveryWrites.js';
 import { displayAgentName, publicMessageMetadata, sanitizeUserMessageMetadata } from './messageMetadata.js';
 import { DEFAULT_MAILBOX_DEPTH_CAP, DEFAULT_MAILBOX_TTL_MS, type MailboxConfig } from './mailboxConfig.js';
+import { fetchAttachmentsBatch, type AttachmentRow } from './attachments.js';
 
 type Db = ReturnType<typeof getDb>;
-
-type AttachmentRow = { file_id: string; filename: string; content_type: string; size_bytes: number };
-
-async function fetchAttachmentsBatch(db: Db, msgIds: string[]): Promise<Map<string, AttachmentRow[]>> {
-  const map = new Map<string, AttachmentRow[]>();
-  if (msgIds.length === 0) return map;
-
-  const rows = await db
-    .select({
-      messageId: messageAttachments.messageId,
-      fileId: messageAttachments.fileId,
-      filename: files.filename,
-      contentType: files.contentType,
-      sizeBytes: files.sizeBytes,
-    })
-    .from(messageAttachments)
-    .innerJoin(files, eq(messageAttachments.fileId, files.id))
-    .where(inArray(messageAttachments.messageId, msgIds));
-
-  for (const row of rows) {
-    const list = map.get(row.messageId) || [];
-    list.push({
-      file_id: row.fileId,
-      filename: row.filename,
-      content_type: row.contentType,
-      size_bytes: row.sizeBytes,
-    });
-    map.set(row.messageId, list);
-  }
-  return map;
-}
 
 /**
  * Fetch attachment details straight from `files` by id, preserving the
@@ -305,7 +275,7 @@ export async function getMessages(
 
   // Batch: attachments (single query for all messages with attachments)
   const attachmentMsgIds = rows.filter((r) => r.hasAttachments).map((r) => r.id);
-  const attachmentMap = await fetchAttachmentsBatch(db, attachmentMsgIds);
+  const attachmentMap = await fetchAttachmentsBatch(db, workspaceId, attachmentMsgIds);
 
   return rows.map((row) => ({
     id: row.id,
@@ -365,7 +335,7 @@ export async function getMessage(db: Db, workspaceId: string, messageId: string)
       .select({ count: sql<number>`count(*)` })
       .from(readReceipts)
       .where(eq(readReceipts.messageId, row.id)),
-    row.hasAttachments ? fetchAttachmentsBatch(db, [row.id]) : Promise.resolve(new Map<string, AttachmentRow[]>()),
+    row.hasAttachments ? fetchAttachmentsBatch(db, workspaceId, [row.id]) : Promise.resolve(new Map<string, AttachmentRow[]>()),
   ]);
 
   return {

--- a/packages/engine/src/engine/routing.ts
+++ b/packages/engine/src/engine/routing.ts
@@ -3,6 +3,7 @@ import type { getDb } from '../db/index.js';
 import { agents, routingConfigs, routingFailures } from '../db/schema.js';
 import { buildFtsQuery } from './searchQuery.js';
 import { codedError } from '../lib/httpError.js';
+import { toIso } from '../lib/serialize.js';
 
 type Db = ReturnType<typeof getDb>;
 
@@ -83,11 +84,6 @@ function safeJsonArray(value: string): string[] {
     return [];
   }
 }
-
-function toIso(date?: Date | null): string | null {
-  return date ? date.toISOString() : null;
-}
-
 
 function withDefaultWeights(value: unknown): RoutingWeights {
   if (!value || typeof value !== 'object') return { ...DEFAULT_WEIGHTS };

--- a/packages/engine/src/engine/routing.ts
+++ b/packages/engine/src/engine/routing.ts
@@ -2,6 +2,7 @@ import { and, eq, sql } from 'drizzle-orm';
 import type { getDb } from '../db/index.js';
 import { agents, routingConfigs, routingFailures } from '../db/schema.js';
 import { buildFtsQuery } from './searchQuery.js';
+import { codedError } from '../lib/httpError.js';
 
 type Db = ReturnType<typeof getDb>;
 
@@ -87,11 +88,6 @@ function toIso(date?: Date | null): string | null {
   return date ? date.toISOString() : null;
 }
 
-function createError(message: string, code: string, status: number) {
-  const err = new Error(message);
-  Object.assign(err, { code, status });
-  return err;
-}
 
 function withDefaultWeights(value: unknown): RoutingWeights {
   if (!value || typeof value !== 'object') return { ...DEFAULT_WEIGHTS };
@@ -282,7 +278,7 @@ export async function recordRoutingSuccess(
     .where(and(eq(agents.workspaceId, workspaceId), eq(agents.name, agentName)));
 
   if (!agent) {
-    throw createError(`Agent "${agentName}" not found`, 'agent_not_found', 404);
+    throw codedError(`Agent "${agentName}" not found`, 'agent_not_found', 404);
   }
 
   const now = new Date();
@@ -326,7 +322,7 @@ export async function recordRoutingFailure(
     .where(and(eq(agents.workspaceId, workspaceId), eq(agents.name, agentName)));
 
   if (!agent) {
-    throw createError(`Agent "${agentName}" not found`, 'agent_not_found', 404);
+    throw codedError(`Agent "${agentName}" not found`, 'agent_not_found', 404);
   }
 
   const config = await getRoutingConfig(db, workspaceId);
@@ -384,7 +380,7 @@ export async function routeBySkill(
 }> {
   const normalizedSkill = normalizeText(skill);
   if (!normalizedSkill) {
-    throw createError('skill is required', 'invalid_request', 400);
+    throw codedError('skill is required', 'invalid_request', 400);
   }
 
   const config = await getRoutingConfig(db, workspaceId);
@@ -458,7 +454,7 @@ export async function routeBySkill(
   }));
 
   if (rows.length === 0) {
-    throw createError(`No active agents found for skill "${skill}"`, 'route_not_found', 404);
+    throw codedError(`No active agents found for skill "${skill}"`, 'route_not_found', 404);
   }
 
   const nowEpochSeconds = Math.floor(Date.now() / 1000);
@@ -491,7 +487,7 @@ export async function routeBySkill(
       || left.row.agent_name.localeCompare(right.row.agent_name));
 
   if (candidates.length === 0) {
-    throw createError(`No healthy agents found for skill "${skill}"`, 'route_not_found', 404);
+    throw codedError(`No healthy agents found for skill "${skill}"`, 'route_not_found', 404);
   }
 
   const best = candidates[0];

--- a/packages/engine/src/engine/thread.ts
+++ b/packages/engine/src/engine/thread.ts
@@ -10,6 +10,7 @@ import {
 } from './deliveryWrites.js';
 import { displayAgentName, publicMessageMetadata, sanitizeUserMessageMetadata } from './messageMetadata.js';
 import { DEFAULT_MAILBOX_DEPTH_CAP, DEFAULT_MAILBOX_TTL_MS, type MailboxConfig } from './mailboxConfig.js';
+import { codedError } from '../lib/httpError.js';
 
 type Db = ReturnType<typeof getDb>;
 
@@ -28,9 +29,7 @@ export async function postReply(
     .where(and(eq(messages.id, parentId), eq(messages.workspaceId, workspaceId)));
 
   if (!parent) {
-    const err = new Error('Parent message not found');
-    Object.assign(err, { code: 'message_not_found', status: 404 });
-    throw err;
+    throw codedError('Parent message not found', 'message_not_found', 404);
   }
 
   // If parent itself has a thread_id, resolve to root (reply-to-reply goes to original parent)
@@ -135,9 +134,7 @@ export async function getThread(
     .where(and(eq(messages.id, parentId), eq(messages.workspaceId, workspaceId)));
 
   if (!parent) {
-    const err = new Error('Parent message not found');
-    Object.assign(err, { code: 'message_not_found', status: 404 });
-    throw err;
+    throw codedError('Parent message not found', 'message_not_found', 404);
   }
 
   // Get reply count

--- a/packages/engine/src/engine/tokenRotate.ts
+++ b/packages/engine/src/engine/tokenRotate.ts
@@ -2,6 +2,7 @@ import { eq, and } from 'drizzle-orm';
 import type { getDb } from '../db/index.js';
 import { agents } from '../db/schema.js';
 import { randomHex, sha256Hex } from '../lib/crypto.js';
+import { codedError } from '../lib/httpError.js';
 
 type Db = ReturnType<typeof getDb>;
 
@@ -12,9 +13,7 @@ export async function rotateAgentToken(db: Db, workspaceId: string, agentName: s
     .where(and(eq(agents.workspaceId, workspaceId), eq(agents.name, agentName)));
 
   if (!agent) {
-    const err = new Error(`Agent "${agentName}" not found`);
-    Object.assign(err, { code: 'agent_not_found', status: 404 });
-    throw err;
+    throw codedError(`Agent "${agentName}" not found`, 'agent_not_found', 404);
   }
 
   const newToken = `at_live_${randomHex(16)}`;

--- a/packages/engine/src/engine/workspace.ts
+++ b/packages/engine/src/engine/workspace.ts
@@ -3,6 +3,7 @@ import type { getDb } from '../db/index.js';
 import { workspaces, channels } from '../db/schema.js';
 import { randomHex, sha256Hex } from '../lib/crypto.js';
 import { generateId } from './snowflake.js';
+import { codedError } from '../lib/httpError.js';
 
 type Db = ReturnType<typeof getDb>;
 
@@ -38,9 +39,7 @@ export async function createWorkspace(
   const derivedOwnerApiKeyHash = providedOwnerApiKey ? await hashApiKey(providedOwnerApiKey) : undefined;
 
   if (providedOwnerApiKeyHash && derivedOwnerApiKeyHash && providedOwnerApiKeyHash !== derivedOwnerApiKeyHash) {
-    const err = new Error('ownerApiKeyHash must match the provided ownerApiKey');
-    Object.assign(err, { code: 'invalid_owner_api_key_hash', status: 400 });
-    throw err;
+    throw codedError('ownerApiKeyHash must match the provided ownerApiKey', 'invalid_owner_api_key_hash', 400);
   }
 
   const ownerApiKeyHash = providedOwnerApiKeyHash ?? derivedOwnerApiKeyHash;

--- a/packages/engine/src/lib/serialize.ts
+++ b/packages/engine/src/lib/serialize.ts
@@ -1,0 +1,12 @@
+/**
+ * Small pure helpers for shaping engine values onto the snake_case JSON wire.
+ *
+ * Centralized so every module renders nullable timestamps the same way instead
+ * of each re-deriving `date ? date.toISOString() : null` (the idiom this
+ * replaces, which had drifted into per-module copies).
+ */
+
+/** Render a nullable `Date` as an ISO-8601 string, or `null` when absent. */
+export function toIso(date: Date | null | undefined): string | null {
+  return date ? date.toISOString() : null;
+}


### PR DESCRIPTION
## Summary

An architecture-focused pass over `packages/engine` that eliminates genuine duplication and fixes a couple of latent inconsistencies, without churning the already-clean hexagonal structure. Three independently-verified commits.

### 1. Single source of truth for coded errors
The engine already had a canonical `codedError(message, code, status)` helper (in `lib/httpError.ts`), and newer modules used it — but ~45 older call sites still hand-rolled `new Error()` + `Object.assign(err, { code, status })` + `throw err`, and `routing.ts`/`directory.ts` each defined their own duplicate local `createError`. All consolidated onto the one helper. Behavior-identical; the two `a2a.ts` sites that attach extra fields (`retryable`, `data`) were intentionally left raw.

### 2. Centralized wire-serialization helpers
- Added `lib/serialize.ts` with a single `toIso`, replacing the duplicate copies in `delivery.ts` and `routing.ts`.
- Dropped `action.ts`'s private `toFleetWireJson`, which was **missing the `Date → ISO` branch** the canonical `deliveryWire.ts` version has (a latent serialization bug), in favor of the complete shared implementation.
- Removed an unused `ne` import (clears the last lint warning — lint is now 0 warnings).

### 3. Consolidated attachment hydration
`delivery.ts`, `dm.ts`, `groupDm.ts`, and `message.ts` each carried a verbatim copy of `fetchAttachmentsBatch` + the `AttachmentRow` type, and the copies had **drifted**: `delivery.ts` lacked the `position` ordering, and `message.ts` lacked both the `files.workspaceId` scope and the ordering. Extracted a single `engine/attachments.ts` helper that always scopes by workspace and orders by `(message_id, position)`, and pointed all four modules at it — aligning every read path on the safest, most-correct variant. Delivery payloads and channel/thread message lists now return attachments in deterministic position order.

Net: **−214 lines** of duplicated code, one latent Date-serialization bug fixed, and attachment ordering made deterministic everywhere.

## Verification (run after each step)
- `turbo build`, `turbo test` (133 unit + conformance), `turbo lint` (now **0 warnings**, was 1) — all green
- Full live e2e against a self-hosted Node+SQLite server: **107 passed, 0 failed**
- Manual upload→send→list check confirming attachments serialize with correct fields and position ordering (the read path is not covered by existing tests)

## Intentionally out of scope
- Splitting the 700–900-line domain files (action/directory/a2a/node) — cohesive, high-churn/low-value.
- Routes building drizzle queries directly — a pervasive, deliberate style (small membership/lookup reads in routes, business logic in `engine/`); fixing one site would be inconsistent churn. Noted as a possible follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WfmtpEM9NFvxEBxtsAAV1S

---
_Generated by [Claude Code](https://claude.ai/code/session_01WfmtpEM9NFvxEBxtsAAV1S)_

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/AgentWorkforce/relaycast/pull/200?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

