### PR TITLE
fix(engine,sdk-rust): return workspace_id from agent registration

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -95,6 +95,12 @@ components:
       properties:
         id:
           type: string
+        workspace_id:
+          type: string
+          description: >-
+            Snowflake ID of the workspace the agent belongs to. Returned on
+            registration so a client that joined by workspace key (and has no id
+            locally) can record which workspace it registered into.
         name:
           type: string
         type:

--- a/packages/engine/src/engine/agent.ts
+++ b/packages/engine/src/engine/agent.ts
@@ -90,6 +90,10 @@ export async function registerAgent(
 
   return {
     id: agentId,
+    // Return the workspace id so a client that joined by workspace key (and
+    // thus has no id locally) can record which workspace it registered into,
+    // instead of falling back to an "unknown workspace" placeholder.
+    workspace_id: workspaceId,
     name: agent.name,
     handle: agent.handle ?? `@${agent.name}`,
     token,
@@ -191,6 +195,7 @@ export async function getAgentByName(db: Db, workspaceId: string, name: string) 
 
   return {
     id: agent.id,
+    workspace_id: workspaceId,
     name: agent.name,
     handle: agent.handle ?? `@${agent.name}`,
     type: agent.type,

--- a/packages/sdk-rust/src/relay.rs
+++ b/packages/sdk-rust/src/relay.rs
@@ -423,6 +423,7 @@ impl RelayCast {
                 let created_at = agent.created_at.or(agent.last_seen).unwrap_or_default();
                 Ok(CreateAgentResponse {
                     id: agent.id,
+                    workspace_id: agent.workspace_id,
                     name: agent.name,
                     token: token_response.token,
                     status: agent.status,
@@ -1239,5 +1240,74 @@ impl RelayCast {
             Some(slice.as_slice())
         };
         self.client.get("/v1/console/costs", query_ref, None).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{CreateAgentRequest, RelayCast, RelayCastOptions};
+    use serde_json::json;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    fn ok(data: serde_json::Value) -> ResponseTemplate {
+        ResponseTemplate::new(200).set_body_json(json!({ "ok": true, "data": data }))
+    }
+
+    fn request() -> CreateAgentRequest {
+        CreateAgentRequest {
+            name: "scout".to_string(),
+            agent_type: Some("agent".to_string()),
+            persona: None,
+            metadata: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn register_agent_parses_workspace_id() {
+        let server = MockServer::start().await;
+        let relay = RelayCast::new(RelayCastOptions::new("rk_live_test").with_base_url(server.uri()))
+            .expect("relay init");
+
+        Mock::given(method("POST"))
+            .and(path("/v1/agents"))
+            .respond_with(ok(json!({
+                "id": "a1",
+                "workspace_id": "ws_123",
+                "name": "scout",
+                "token": "at_live_1",
+                "status": "active",
+                "created_at": "2026-01-01T00:00:00.000Z"
+            })))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let response = relay.register_agent(request()).await.expect("register");
+        assert_eq!(response.workspace_id.as_deref(), Some("ws_123"));
+    }
+
+    #[tokio::test]
+    async fn register_agent_without_workspace_id_defaults_to_none() {
+        // Engines that predate the field omit it; the client must still parse.
+        let server = MockServer::start().await;
+        let relay = RelayCast::new(RelayCastOptions::new("rk_live_test").with_base_url(server.uri()))
+            .expect("relay init");
+
+        Mock::given(method("POST"))
+            .and(path("/v1/agents"))
+            .respond_with(ok(json!({
+                "id": "a1",
+                "name": "scout",
+                "token": "at_live_1",
+                "status": "active",
+                "created_at": "2026-01-01T00:00:00.000Z"
+            })))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let response = relay.register_agent(request()).await.expect("register");
+        assert_eq!(response.workspace_id, None);
     }
 }

--- a/packages/sdk-rust/src/types.rs
+++ b/packages/sdk-rust/src/types.rs
@@ -147,6 +147,8 @@ pub struct TokenRotateResponse {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Agent {
     pub id: String,
+    #[serde(default)]
+    pub workspace_id: Option<String>,
     pub name: String,
     #[serde(rename = "type")]
     pub agent_type: String,
@@ -184,6 +186,11 @@ pub struct CreateAgentRequest {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CreateAgentResponse {
     pub id: String,
+    /// Workspace the agent registered into. `None` against engines that predate
+    /// this field — callers that joined by workspace key rely on it to avoid an
+    /// "unknown workspace" fallback.
+    #[serde(default)]
+    pub workspace_id: Option<String>,
     pub name: String,
     pub token: String,
     pub status: String,


### PR DESCRIPTION
## Problem

When a client **joins a workspace by key** (no workspace id locally), the agent-registration response (`POST /v1/agents`) returns `{id, name, token, status, created_at}` — **no `workspace_id`**. A consumer therefore has nothing to record and falls back to an `"unknown workspace"` placeholder. In the broker this enrolls the agent — and any **fleet node** it spawns — under a phantom workspace, so the node never appears in the real workspace's registry (`GET /v1/nodes` stays empty even with `fleet_nodes_enabled` on).

This is the upstream half of the fix: have the server simply return the id it already has, instead of consumers making an extra round-trip to discover it.

## Changes

- **Engine** (`packages/engine/src/engine/agent.ts`): include `workspace_id` in the `registerAgent` response (and in `getAgentByName`, used by the strict-name reclaim path). `workspaceId` is already in scope, so it's a pure additive field.
- **Rust SDK** (`packages/sdk-rust`): add `workspace_id: Option<String>` to `CreateAgentResponse` and `Agent`, both `#[serde(default)]` so responses from **older engines that omit the field still deserialize** (→ `None`). The strict-name reclaim path in `register_or_get_agent` now carries it through.
- **OpenAPI** (`openapi.yaml`): document `workspace_id` on the `Agent` schema.

Backward compatible in both directions: new SDK ↔ old engine yields `None` (no breakage); old SDK ↔ new engine ignores the extra field.

## Tests

Rust SDK (`cargo test -p relaycast`, 39 passing) including two new:
- `register_agent_parses_workspace_id` — response with the field → `Some("ws_123")`.
- `register_agent_without_workspace_id_defaults_to_none` — response omitting it (old engine) → `None`.

`cargo fmt`/`clippy` clean for the changed files. TS engine typecheck/tests rely on CI (local checkout has no installed deps); the engine change is an additive property on an inferred-return object and no test asserts the register response by strict deep-equal.

## Follow-up (separate repo)

The broker (`AgentWorkforce/relay`) reads this: replace its hardcoded `None` for the registration workspace id with `result.workspace_id`. That lands once a `relaycast` crate version carrying this field is published. Supersedes the broker-side `GET /v1/workspace` workaround in relay#1175.

🤖 Generated with [Claude Code](https://claude.com/claude-code)