### PR TITLE
ci: rebase-and-retry release commit-back to survive a moving main

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -303,7 +303,30 @@ jobs:
           git add package.json package-lock.json packages/*/package.json
           if ! git diff --staged --quiet; then
             git commit -m "chore(release): v${NEW_VERSION}"
-            git push origin HEAD:main
+            # main can advance during the (multi-minute) build — e.g. a
+            # concurrent SDK publish — so rebase onto the latest main and retry
+            # to avoid non-fast-forward rejections. The release commit only
+            # touches version metadata, so it rebases cleanly onto another
+            # release's commit.
+            pushed=false
+            for attempt in 1 2 3 4 5; do
+              git fetch origin main
+              if ! git rebase origin/main; then
+                git rebase --abort
+                echo "::error::rebase onto origin/main failed (unexpected conflict)"
+                exit 1
+              fi
+              if git push origin HEAD:main; then
+                pushed=true
+                break
+              fi
+              echo "push rejected (main moved); retry ${attempt}"
+              sleep $(( attempt * 3 ))
+            done
+            if [ "$pushed" != "true" ]; then
+              echo "::error::failed to push release commit to main after retries"
+              exit 1
+            fi
           fi
 
           git tag -a "v${NEW_VERSION}" -m "Release v${NEW_VERSION}"

--- a/.github/workflows/publish-rust.yml
+++ b/.github/workflows/publish-rust.yml
@@ -193,7 +193,30 @@ jobs:
           git add packages/sdk-rust/Cargo.toml
           if ! git diff --staged --quiet; then
             git commit -m "chore(sdk-rust): v${NEW_VERSION}"
-            git push origin HEAD:main
+            # main can advance during the (multi-minute) build — e.g. a
+            # concurrent npm publish — so rebase onto the latest main and retry
+            # to avoid non-fast-forward rejections. The release commit only
+            # touches version metadata, so it rebases cleanly onto another
+            # release's commit.
+            pushed=false
+            for attempt in 1 2 3 4 5; do
+              git fetch origin main
+              if ! git rebase origin/main; then
+                git rebase --abort
+                echo "::error::rebase onto origin/main failed (unexpected conflict)"
+                exit 1
+              fi
+              if git push origin HEAD:main; then
+                pushed=true
+                break
+              fi
+              echo "push rejected (main moved); retry ${attempt}"
+              sleep $(( attempt * 3 ))
+            done
+            if [ "$pushed" != "true" ]; then
+              echo "::error::failed to push release commit to main after retries"
+              exit 1
+            fi
           fi
 
           git tag -a "sdk-rust-v${NEW_VERSION}" -m "sdk-rust v${NEW_VERSION}"


### PR DESCRIPTION
Replaces #182. Carries over only the principle from that PR — the release commit-back race fix — rebuilt cleanly on top of current `main`, so the diff is just the two workflow files.

## Problem
The `Commit and tag` step in `publish-npm.yml` and `publish-rust.yml` pushed the version-bump commit with `git push origin HEAD:main` off a **stale checkout**, with no rebase. When `main` advanced during the multi-minute build — e.g. a concurrent cross-kind publish — the push was rejected as a **non-fast-forward**, failing the workflow *after* the packages had already published and skipping the git tag + GitHub Release.

## Fix
Before pushing the release commit, `git fetch origin main` + `git rebase origin/main` and retry with backoff (5 attempts). The release commit only touches version metadata, so it rebases cleanly onto another release's commit. Tag + GitHub Release still run after a successful push. Applied to both publish workflows.

## Notes
- Supersedes #182, which also reconciled npm versions 2.5.1 → 2.6.0 — that part is obsolete now that `main` is at 4.x, so it's dropped here.
- Net diff: only `.github/workflows/publish-npm.yml` and `.github/workflows/publish-rust.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_013c2kNLweXdjA5dMpmMRPBM)_

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/AgentWorkforce/relaycast/pull/203?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

