### PR TITLE
feat(engine): allow grok in the agent spawn cli allowlist

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -881,7 +881,7 @@ paths:
                   description: Unique name for the new agent
                 cli:
                   type: string
-                  enum: [claude, codex, opencode, gemini, aider, goose]
+                  enum: [claude, codex, gemini, aider, goose, opencode, grok]
                   description: Which AI CLI tool to use
                 task:
                   type: string

--- a/packages/engine/src/routes/agent.ts
+++ b/packages/engine/src/routes/agent.ts
@@ -1,7 +1,7 @@
 import { Hono } from 'hono';
 import type { ContentfulStatusCode } from 'hono/utils/http-status';
 import { z } from 'zod';
-import { AgentTypeSchema } from '@relaycast/types';
+import { AgentTypeSchema, CliTypeSchema } from '@relaycast/types';
 import type { AppEnv } from '../env.js';
 import { requireWorkspaceKey, requireAuth, requireAgentToken } from '../middleware/auth.js';
 import { rateLimit } from '../middleware/rateLimit.js';
@@ -52,7 +52,7 @@ const sessionEventSchema = z.object({
 
 const spawnAgentSchema = z.object({
   name: z.string().min(1),
-  cli: z.string().min(1),
+  cli: CliTypeSchema,
   task: z.string().min(1),
   channel: z.string().nullable().optional(),
   persona: z.string().nullable().optional(),
@@ -320,7 +320,7 @@ agentRoutes.post(
         const message = hasNameIssue
           ? 'name is required'
           : hasCliIssue
-            ? 'cli is required'
+            ? `cli must be one of: ${CliTypeSchema.options.join(', ')}`
             : hasTaskIssue
               ? 'task is required'
               : 'invalid spawn request';
@@ -330,14 +330,6 @@ agentRoutes.post(
         }, 400);
       }
       const { name, cli, task, channel, persona, model, metadata } = parsed.data;
-
-      const validClis = ['claude', 'codex', 'opencode', 'gemini', 'aider', 'goose', 'grok'];
-      if (!validClis.includes(cli)) {
-        return c.json({
-          ok: false,
-          error: { code: 'invalid_request', message: `cli must be one of: ${validClis.join(', ')}` },
-        }, 400);
-      }
 
       const result = await agentEngine.spawnAgent(db, workspace.id, {
         name,

--- a/packages/engine/src/routes/agent.ts
+++ b/packages/engine/src/routes/agent.ts
@@ -331,7 +331,7 @@ agentRoutes.post(
       }
       const { name, cli, task, channel, persona, model, metadata } = parsed.data;
 
-      const validClis = ['claude', 'codex', 'opencode', 'gemini', 'aider', 'goose'];
+      const validClis = ['claude', 'codex', 'opencode', 'gemini', 'aider', 'goose', 'grok'];
       if (!validClis.includes(cli)) {
         return c.json({
           ok: false,

--- a/packages/mcp/src/tools/programmability.ts
+++ b/packages/mcp/src/tools/programmability.ts
@@ -1,7 +1,7 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
 import type { RelayCast, AgentClient, JsonValue } from '@relaycast/sdk';
-import { SubscribableEventTypeSchema } from '@relaycast/types';
+import { CliTypeSchema, SubscribableEventTypeSchema } from '@relaycast/types';
 import {
   identityOverrideInputShape,
   workspaceRoutingInputShape,
@@ -348,7 +348,7 @@ export function registerProgrammabilityTools(
     description: 'Add a new AI agent to the workspace to work on a task. This is a BUILT-IN system operation for creating worker agents. If an agent with the same name already exists, it will be reactivated with a new token and updated task. The agent is automatically set to online status and joined to the specified channel.',
     inputSchema: {
       name: z.string().describe('Unique name for the new agent within the workspace (e.g. "worker-1", "code-reviewer")'),
-      cli: z.enum(['claude', 'codex', 'gemini', 'aider', 'goose']).describe('Which AI CLI tool to use for the agent process'),
+      cli: CliTypeSchema.describe('Which AI CLI tool to use for the agent process'),
       task: z.string().describe('The task description or instructions for the agent to work on'),
       channel: z.string().optional().describe('Channel name to automatically join the agent to (e.g. "general", "dev-team")'),
       persona: z.string().optional().describe('Free-text persona description that other agents can read to understand this agent\'s role'),

--- a/packages/types/src/agent.ts
+++ b/packages/types/src/agent.ts
@@ -73,7 +73,7 @@ export type AgentPresenceInfo = z.infer<typeof AgentPresenceInfoSchema>;
 
 // === Spawn/Release (Agent Lifecycle) ===
 
-export const CliTypeSchema = z.enum(['claude', 'codex', 'gemini', 'aider', 'goose']);
+export const CliTypeSchema = z.enum(['claude', 'codex', 'gemini', 'aider', 'goose', 'opencode', 'grok']);
 export type CliType = z.infer<typeof CliTypeSchema>;
 
 export const SpawnAgentRequestSchema = z.object({


### PR DESCRIPTION
## What

`POST /v1/agents/spawn` (the hosted gateway, served by `@relaycast/engine`) validates `cli` against a hardcoded `validClis` array and rejects anything else:

```
cli must be one of: claude, codex, opencode, gemini, aider, goose
```

`grok` was missing, so spawning a grok worker failed **at the gateway** — even though the broker (`is_grok`, `--always-approve`), MCP injection (`configure_grok_mcp` / `grok mcp add agent-relay`), the CLI registry, and the relay `add_agent`/`spawn` MCP tools all already support grok. This was the true end-to-end blocker (observed at runtime when spawning via `add_agent`).

## Changes

- **engine** (`packages/engine/src/routes/agent.ts:334`): add `grok` to `validClis` in the spawn route — the actual server-side gate.
- **types** (`packages/types/src/agent.ts:76`): bring `CliTypeSchema` in line with what the gateway accepts. It had drifted to the original five (missing even `opencode`, which the gateway's `validClis` already allows). Now `[claude, codex, gemini, aider, goose, opencode, grok]`. This keeps the published `@relaycast/types` / `@relaycast/sdk` `SpawnAgentRequest.cli` type honest for downstream consumers (e.g. the relay MCP server, which currently has to cast around the narrow type).

## Test

- `tsc --noEmit` clean for both `packages/types` and `packages/engine` (no exhaustive-switch breakage from widening the enum).

## Related / deploy

Pairs with **AgentWorkforce/relay#1176** (adds `grok`/`opencode` to the relay `spawn` MCP tool enum). Together they unblock grok end-to-end. Requires the gateway (`gateway.relaycast.dev`) to be **redeployed** from this change before grok spawns are accepted in prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/AgentWorkforce/relaycast/pull/204?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

