### PR TITLE
Default SDKs/MCP/dashboard to https://cast.agentrelay.com

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -105,7 +105,7 @@ jobs:
         run: |
           sleep 15
           for i in $(seq 1 10); do
-            RESP=$(curl -s -D /tmp/mcp-headers -X POST 'https://api.relaycast.dev/mcp' \
+            RESP=$(curl -s -D /tmp/mcp-headers -X POST 'https://cast.agentrelay.com/mcp' \
               -H 'Content-Type: application/json' \
               -H 'Accept: application/json, text/event-stream' \
               --max-time 10 \
@@ -120,14 +120,14 @@ jobs:
 
           SESSION_ID=$(grep -i 'mcp-session-id' /tmp/mcp-headers | tr -d '\r' | awk '{print $2}')
           if [ -n "$SESSION_ID" ]; then
-            curl -s -X POST 'https://api.relaycast.dev/mcp' \
+            curl -s -X POST 'https://cast.agentrelay.com/mcp' \
               -H 'Content-Type: application/json' \
               -H 'Accept: application/json, text/event-stream' \
               -H "Mcp-Session-Id: $SESSION_ID" \
               --max-time 5 \
               -d '{"jsonrpc":"2.0","method":"notifications/initialized"}' 2>/dev/null > /dev/null
 
-            TOOLS_RESP=$(curl -s -X POST 'https://api.relaycast.dev/mcp' \
+            TOOLS_RESP=$(curl -s -X POST 'https://cast.agentrelay.com/mcp' \
               -H 'Content-Type: application/json' \
               -H 'Accept: application/json, text/event-stream' \
               -H "Mcp-Session-Id: $SESSION_ID" \
@@ -146,7 +146,7 @@ jobs:
           for attempt in 1 2 3 4 5; do
             echo "=== Attempt $attempt of 5 ==="
             OUTPUT=$(npx @smithery/cli@3 publish \
-              -u https://api.relaycast.dev/mcp \
+              -u https://cast.agentrelay.com/mcp \
               -n "relaycast/relay" \
               -k "$SMITHERY_API_KEY" \
               --config-schema packages/mcp/smithery-config-schema.json 2>&1) || true

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,7 @@ Relaycast is headless Slack for agents: channels, threads, DMs, reactions, files
 - `openapi.yaml` for HTTP API schema.
 - Root `package.json` for scripts and workspace configuration.
 - `packages/engine` for API behavior — the canonical, portable server that powers the hosted gateway
-  (`gateway.relaycast.dev`) and self-hosting.
+  (`cast.agentrelay.com`) and self-hosting.
 - `packages/sdk-typescript` for TypeScript SDK surface.
 
 

--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ const { token: systemToken } = await relay.system({ name: 'System' });
 
 Hosted vs self-hosted:
 
-By default, Relaycast SDKs connect to the hosted engine at `https://gateway.relaycast.dev`. To
+By default, Relaycast SDKs connect to the hosted engine at `https://cast.agentrelay.com`. To
 keep traffic and state on your own infrastructure, self-host the engine (`@relaycast/engine`) and
 point the SDK at it with `baseUrl`:
 
@@ -226,7 +226,7 @@ print(me.inbox())
 
 Self-hosting:
 
-By default the Python SDK talks to the hosted engine at `https://gateway.relaycast.dev`.
+By default the Python SDK talks to the hosted engine at `https://cast.agentrelay.com`.
 To self-host, run the engine (`npx @relaycast/engine`, default port 8787) and point `base_url` at it:
 
 ```python
@@ -268,7 +268,7 @@ Local stdio config:
       "command": "npx",
       "args": ["@relaycast/mcp"],
       "env": {
-        "RELAY_BASE_URL": "https://gateway.relaycast.dev"
+        "RELAY_BASE_URL": "https://cast.agentrelay.com"
       }
     }
   }
@@ -318,12 +318,12 @@ The CLI command names are the MCP tool names. Run `relaycast tools` for the live
 # Create workspace
 # Workspace names are not globally unique.
 # Reusing the same name with the same Authorization bearer workspace key returns the existing workspace.
-curl -X POST https://gateway.relaycast.dev/v1/workspaces \
+curl -X POST https://cast.agentrelay.com/v1/workspaces \
   -H "Content-Type: application/json" \
   -d '{"name": "my-project"}'
 
 # Register agent
-curl -X POST https://gateway.relaycast.dev/v1/agents \
+curl -X POST https://cast.agentrelay.com/v1/agents \
   -H "Authorization: Bearer rk_live_YOUR_KEY" \
   -H "Content-Type: application/json" \
   -d '{"name": "Alice", "type": "agent"}'
@@ -331,7 +331,7 @@ curl -X POST https://gateway.relaycast.dev/v1/agents \
 
 ## API Reference
 
-Base URL: `https://gateway.relaycast.dev/v1` (the hosted engine). Self-hosters use their own engine
+Base URL: `https://cast.agentrelay.com/v1` (the hosted engine). Self-hosters use their own engine
 origin (e.g. `http://localhost:8787/v1`).
 
 Authentication header:
@@ -450,7 +450,7 @@ Full schema: [`openapi.yaml`](./openapi.yaml)
 
 ## Self-Hosting
 
-Relaycast's hosted gateway (`https://gateway.relaycast.dev`) runs the `@relaycast/engine` package.
+Relaycast's hosted gateway (`https://cast.agentrelay.com`) runs the `@relaycast/engine` package.
 You can run the same engine yourself — it's portable (Node + SQLite) and has no Cloudflare dependency.
 
 Run it directly:
@@ -490,7 +490,7 @@ E2E smoke test:
 ```bash
 npm run e2e                              # against the engine dev server (http://localhost:8787)
 npm run e2e -- http://localhost:8787 --ci
-npm run e2e -- https://gateway.relaycast.dev --ci
+npm run e2e -- https://cast.agentrelay.com --ci
 ```
 
 Observer dashboard:

--- a/docs/sdk-setup-client-acceptance.md
+++ b/docs/sdk-setup-client-acceptance.md
@@ -52,7 +52,7 @@ packages/sdk-typescript/src/
 **`RelaycastSetupOptions`**
 ```ts
 {
-  baseUrl?: string                                 // overrides the hosted default (https://gateway.relaycast.dev)
+  baseUrl?: string                                 // overrides the hosted default (https://cast.agentrelay.com)
   apiKey?: string | (() => string | Promise<string>)
   requestTimeoutMs?: number                        // default 30_000, applied via AbortSignal.timeout
   retry?: { maxRetries: number; baseDelayMs: number }  // default { 3, 500 }
@@ -177,7 +177,7 @@ Each bullet is a single test case. **All must pass before this step is COMPLETE.
 16. `relayCast()` — returns `RelayCast` configured with workspace `apiKey` and `baseUrl`.
 17. `getAgentToken('Alice')` after register — returns the stored token; unknown name returns `undefined`.
 18. `listRegisteredAgents()` — returns all registered records in registration order.
-19. Default base URL — `new RelaycastSetup()` produces `baseUrl === 'https://gateway.relaycast.dev'`.
+19. Default base URL — `new RelaycastSetup()` produces `baseUrl === 'https://cast.agentrelay.com'`.
 20. Explicit `baseUrl` (e.g. a self-hosted engine) overrides the default.
 21. `apiKey` as function — invoked once per request (or memoized; assert behavior the impl chooses) and bearer header reflects the resolved value.
 22. Origin headers — every direct fetch carries `X-SDK-Version`, `X-Relaycast-Origin-Surface/Client/Version`.

--- a/docs/sdk-setup-client.md
+++ b/docs/sdk-setup-client.md
@@ -85,14 +85,14 @@ This spec does **not** cover: self-hosted server setup, Python SDK changes, or c
 └────────────────────┬─────────────────────────────────┘
                      │
 ┌────────────────────▼─────────────────────────────────┐
-│  Relaycast API  (gateway.relaycast.dev / :8787)     │
+│  Relaycast API  (cast.agentrelay.com / :8787)     │
 │  /v1/workspaces, /v1/agents, /v1/channels, etc.     │
 └──────────────────────────────────────────────────────┘
 ```
 
 ### Cloud API base URL
 
-`RelaycastSetup` defaults to `https://gateway.relaycast.dev` (the hosted engine). This is overridable via the `baseUrl` constructor option for staging/dev environments or for a self-hosted engine (`http://localhost:8787`).
+`RelaycastSetup` defaults to `https://cast.agentrelay.com` (the hosted engine). This is overridable via the `baseUrl` constructor option for staging/dev environments or for a self-hosted engine (`http://localhost:8787`).
 
 ---
 
@@ -106,7 +106,7 @@ The entry point. Stateless — creates workspaces and returns handles.
 export interface RelaycastSetupOptions {
   /**
    * Base URL for the Relaycast API.
-   * @default "https://gateway.relaycast.dev"
+   * @default "https://cast.agentrelay.com"
    */
   baseUrl?: string
 

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -22,7 +22,7 @@ info:
     name: Apache 2.0
 
 servers:
-  - url: https://gateway.relaycast.dev/v1
+  - url: https://cast.agentrelay.com/v1
     description: Hosted engine gateway (production)
   - url: http://localhost:8787/v1
     description: Self-hosted engine (@relaycast/engine)
@@ -3452,7 +3452,7 @@ paths:
   # ── A2A ──────────────────────────────────────────────────────────────
   /.well-known/agent-card.json:
     servers:
-      - url: https://gateway.relaycast.dev
+      - url: https://cast.agentrelay.com
         description: Production server (root, no /v1 prefix)
       - url: http://localhost:8787
         description: Local development server
@@ -3529,7 +3529,7 @@ paths:
 
   /a2a/rpc:
     servers:
-      - url: https://gateway.relaycast.dev
+      - url: https://cast.agentrelay.com
         description: Production server (root, no /v1 prefix)
       - url: http://localhost:8787
         description: Local development server
@@ -3546,7 +3546,7 @@ paths:
 
   /a2a/webhook/{workspace_id}/{name}:
     servers:
-      - url: https://gateway.relaycast.dev
+      - url: https://cast.agentrelay.com
         description: Production server (root, no /v1 prefix)
       - url: http://localhost:8787
         description: Local development server

--- a/packages/engine/src/lib/__tests__/origin.test.ts
+++ b/packages/engine/src/lib/__tests__/origin.test.ts
@@ -13,7 +13,7 @@ function req(
     query?: string;
   } = {},
 ): Request {
-  const url = new URL("https://gateway.relaycast.dev/v1/activity");
+  const url = new URL("https://cast.agentrelay.com/v1/activity");
   if (init.query !== undefined) url.searchParams.set("origin_actor", init.query);
   if (init.agentRelayDistinctQuery !== undefined) {
     url.searchParams.set("agent_relay_distinct_id", init.agentRelayDistinctQuery);

--- a/packages/mcp/mcp-server.json
+++ b/packages/mcp/mcp-server.json
@@ -11,7 +11,7 @@
       "command": "npx",
       "args": ["-y", "@relaycast/mcp"],
       "env": {
-        "RELAY_BASE_URL": "https://gateway.relaycast.dev"
+        "RELAY_BASE_URL": "https://cast.agentrelay.com"
       }
     }
   }

--- a/packages/mcp/smithery-config-schema.json
+++ b/packages/mcp/smithery-config-schema.json
@@ -16,7 +16,7 @@
       "type": "string",
       "title": "API Base URL",
       "description": "Override API base URL for self-hosted Relaycast deployments.",
-      "default": "https://gateway.relaycast.dev",
+      "default": "https://cast.agentrelay.com",
       "x-from": { "query": "baseUrl" }
     }
   }

--- a/packages/mcp/src/smithery.ts
+++ b/packages/mcp/src/smithery.ts
@@ -19,7 +19,7 @@ export const configSchema = z.object({
     .string()
     .optional()
     .describe(
-      'Override API base URL for self-hosted Relaycast deployments (defaults to https://gateway.relaycast.dev).',
+      'Override API base URL for self-hosted Relaycast deployments (defaults to https://cast.agentrelay.com).',
     ),
 });
 

--- a/packages/mcp/src/tools/programmability.ts
+++ b/packages/mcp/src/tools/programmability.ts
@@ -191,7 +191,7 @@ export function registerProgrammabilityTools(
 
   server.registerTool('integration.action.register', {
     title: 'Register Action',
-    description: 'Register an action (async agent-to-agent RPC) that a specific agent handles. Other agents invoke the action; the handler agent receives an `action.invoked` event and reports the result. Replaces the legacy command API. Requires the hosted engine (gateway.relaycast.dev) or a self-hosted engine.',
+    description: 'Register an action (async agent-to-agent RPC) that a specific agent handles. Other agents invoke the action; the handler agent receives an `action.invoked` event and reports the result. Replaces the legacy command API. Requires the hosted engine (cast.agentrelay.com) or a self-hosted engine.',
     inputSchema: {
       name: z.string().describe('Action name (e.g. "deploy", "review")'),
       description: z.string().describe('Human-readable description of what the action does'),

--- a/packages/mcp/src/tools/registration.ts
+++ b/packages/mcp/src/tools/registration.ts
@@ -18,7 +18,7 @@ interface CreateWorkspaceResponse {
   apiKey?: string;
 }
 
-const DEFAULT_BASE_URL = 'https://gateway.relaycast.dev';
+const DEFAULT_BASE_URL = 'https://cast.agentrelay.com';
 
 /** Passthrough object schema for dynamic API responses. */
 const jsonResult = z.object({}).passthrough();

--- a/packages/observer-dashboard/src/lib/relay-server.test.ts
+++ b/packages/observer-dashboard/src/lib/relay-server.test.ts
@@ -36,11 +36,16 @@ describe('relay server resolution', () => {
     vi.restoreAllMocks();
   });
 
-  it('tries the hosted engine before legacy gateway/api for hosted observer', () => {
+  it('resolves the hosted engine for the production observer', () => {
     expect(resolveRelayServerCandidatesFromHost('observer.relaycast.dev')).toEqual([
       'https://cast.agentrelay.com',
-      'https://gateway.relaycast.dev',
-      'https://api.relaycast.dev',
+    ]);
+  });
+
+  it('resolves the per-environment gateway/api candidates for preview observers', () => {
+    expect(resolveRelayServerCandidatesFromHost('pr23-observer.relaycast.dev')).toEqual([
+      'https://pr23-gateway.relaycast.dev',
+      'https://pr23-api.relaycast.dev',
     ]);
   });
 
@@ -54,12 +59,12 @@ describe('relay server resolution', () => {
 
   it('only accepts remembered engines from the current host candidates', () => {
     const candidates = [
-      'https://gateway.relaycast.dev',
-      'https://api.relaycast.dev',
+      'https://pr23-gateway.relaycast.dev',
+      'https://pr23-api.relaycast.dev',
     ];
 
-    expect(pickRememberedEngine('https://api.relaycast.dev', candidates)).toBe(
-      'https://api.relaycast.dev'
+    expect(pickRememberedEngine('https://pr23-api.relaycast.dev', candidates)).toBe(
+      'https://pr23-api.relaycast.dev'
     );
     expect(
       pickRememberedEngine('https://attacker.example.com', candidates)
@@ -69,10 +74,10 @@ describe('relay server resolution', () => {
   it('orders remembered engine first without duplicating candidates', () => {
     expect(
       orderByRemembered(
-        ['https://gateway.relaycast.dev', 'https://api.relaycast.dev'],
-        'https://api.relaycast.dev'
+        ['https://pr23-gateway.relaycast.dev', 'https://pr23-api.relaycast.dev'],
+        'https://pr23-api.relaycast.dev'
       )
-    ).toEqual(['https://api.relaycast.dev', 'https://gateway.relaycast.dev']);
+    ).toEqual(['https://pr23-api.relaycast.dev', 'https://pr23-gateway.relaycast.dev']);
   });
 });
 
@@ -81,7 +86,7 @@ describe('selectEngineForKey', () => {
     vi.unstubAllGlobals();
   });
 
-  it('falls back to the legacy api engine when gateway rejects the key', async () => {
+  it('falls back to the -api engine when the gateway rejects the key', async () => {
     const fetchMock = mockFetch(
       new Response(null, { status: 401 }),
       new Response(null, { status: 200 })
@@ -89,11 +94,11 @@ describe('selectEngineForKey', () => {
 
     await expect(
       selectEngineForKey(
-        ['https://gateway.relaycast.dev', 'https://api.relaycast.dev'],
+        ['https://pr23-gateway.relaycast.dev', 'https://pr23-api.relaycast.dev'],
         'rk_live_test'
       )
     ).resolves.toEqual({
-      baseUrl: 'https://api.relaycast.dev',
+      baseUrl: 'https://pr23-api.relaycast.dev',
       reachedAny: true,
       rejectedAny: true,
       inconclusiveAny: false,
@@ -101,12 +106,12 @@ describe('selectEngineForKey', () => {
 
     expect(fetchMock).toHaveBeenNthCalledWith(
       1,
-      'https://gateway.relaycast.dev/v1/workspace',
+      'https://pr23-gateway.relaycast.dev/v1/workspace',
       expect.objectContaining({ cache: 'no-store' })
     );
     expect(fetchMock).toHaveBeenNthCalledWith(
       2,
-      'https://api.relaycast.dev/v1/workspace',
+      'https://pr23-api.relaycast.dev/v1/workspace',
       expect.objectContaining({ cache: 'no-store' })
     );
   });
@@ -119,7 +124,7 @@ describe('selectEngineForKey', () => {
 
     await expect(
       selectEngineForKey(
-        ['https://gateway.relaycast.dev', 'https://api.relaycast.dev'],
+        ['https://pr23-gateway.relaycast.dev', 'https://pr23-api.relaycast.dev'],
         'rk_live_test'
       )
     ).resolves.toEqual({
@@ -138,7 +143,7 @@ describe('selectEngineForKey', () => {
 
     await expect(
       selectEngineForKey(
-        ['https://gateway.relaycast.dev', 'https://api.relaycast.dev'],
+        ['https://pr23-gateway.relaycast.dev', 'https://pr23-api.relaycast.dev'],
         'rk_live_test'
       )
     ).resolves.toEqual({
@@ -154,7 +159,7 @@ describe('selectEngineForKey', () => {
 
     await expect(
       selectEngineForKey(
-        ['https://gateway.relaycast.dev', 'https://api.relaycast.dev'],
+        ['https://pr23-gateway.relaycast.dev', 'https://pr23-api.relaycast.dev'],
         'rk_live_test'
       )
     ).resolves.toEqual({

--- a/packages/observer-dashboard/src/lib/relay-server.test.ts
+++ b/packages/observer-dashboard/src/lib/relay-server.test.ts
@@ -36,8 +36,9 @@ describe('relay server resolution', () => {
     vi.restoreAllMocks();
   });
 
-  it('tries gateway before legacy api for hosted observer', () => {
+  it('tries the hosted engine before legacy gateway/api for hosted observer', () => {
     expect(resolveRelayServerCandidatesFromHost('observer.relaycast.dev')).toEqual([
+      'https://cast.agentrelay.com',
       'https://gateway.relaycast.dev',
       'https://api.relaycast.dev',
     ]);

--- a/packages/observer-dashboard/src/lib/relay-server.ts
+++ b/packages/observer-dashboard/src/lib/relay-server.ts
@@ -20,13 +20,14 @@ function isLocalHost(host: string): boolean {
 /**
  * Resolve the ordered list of Relay engine base URLs to try for an observer host.
  *
- * The new hosted engine (`gateway.relaycast.dev`) is the happy path and comes
- * first; the legacy engine (`api.relaycast.dev`) runs alongside it for
- * workspaces that have not migrated and is used as a fallback. Callers probe the
- * candidates in order and keep the first one that accepts the workspace key.
+ * The hosted engine (`cast.agentrelay.com`) is the happy path and comes first;
+ * the legacy engines (`gateway.relaycast.dev`, `api.relaycast.dev`) run
+ * alongside it for workspaces that have not migrated and are used as fallbacks.
+ * Callers probe the candidates in order and keep the first one that accepts the
+ * workspace key.
  *
  * Examples:
- * - observer.relaycast.dev -> [gateway.relaycast.dev, api.relaycast.dev]
+ * - observer.relaycast.dev -> [cast.agentrelay.com, gateway.relaycast.dev, api.relaycast.dev]
  * - pr23-observer.relaycast.dev -> [pr23-gateway.relaycast.dev, pr23-api.relaycast.dev]
  *
  * Per-environment gateway hostnames (`staging-gateway`, `prNN-gateway`) are
@@ -67,10 +68,18 @@ export function resolveRelayServerCandidatesFromHost(
   }
 
   if (normalized === 'observer.relaycast.dev') {
-    return ['https://gateway.relaycast.dev', 'https://api.relaycast.dev'];
+    return [
+      'https://cast.agentrelay.com',
+      'https://gateway.relaycast.dev',
+      'https://api.relaycast.dev',
+    ];
   }
 
-  return ['https://gateway.relaycast.dev', 'https://api.relaycast.dev'];
+  return [
+    'https://cast.agentrelay.com',
+    'https://gateway.relaycast.dev',
+    'https://api.relaycast.dev',
+  ];
 }
 
 export function resolveRelayServerCandidatesFromRequest(

--- a/packages/observer-dashboard/src/lib/relay-server.ts
+++ b/packages/observer-dashboard/src/lib/relay-server.ts
@@ -20,20 +20,19 @@ function isLocalHost(host: string): boolean {
 /**
  * Resolve the ordered list of Relay engine base URLs to try for an observer host.
  *
- * The hosted engine (`cast.agentrelay.com`) is the happy path and comes first;
- * the legacy engines (`gateway.relaycast.dev`, `api.relaycast.dev`) run
- * alongside it for workspaces that have not migrated and are used as fallbacks.
- * Callers probe the candidates in order and keep the first one that accepts the
- * workspace key.
+ * Production resolves to the hosted engine (`cast.agentrelay.com`); the legacy
+ * `gateway.relaycast.dev` / `api.relaycast.dev` engines have been decommissioned
+ * and are no longer probed. Callers probe the candidates in order and keep the
+ * first one that accepts the workspace key.
  *
  * Examples:
- * - observer.relaycast.dev -> [cast.agentrelay.com, gateway.relaycast.dev, api.relaycast.dev]
+ * - observer.relaycast.dev -> [cast.agentrelay.com]
  * - pr23-observer.relaycast.dev -> [pr23-gateway.relaycast.dev, pr23-api.relaycast.dev]
  *
  * Per-environment gateway hostnames (`staging-gateway`, `prNN-gateway`) are
- * assumed to mirror the legacy `-api` naming. If a gateway host does not exist
- * for an environment, the probe simply fails over to its `-api` counterpart, so
- * the assumption carries no risk.
+ * assumed to mirror the `-api` naming. If a gateway host does not exist for an
+ * environment, the probe simply fails over to its `-api` counterpart, so the
+ * assumption carries no risk.
  */
 export function resolveRelayServerCandidatesFromHost(
   host: string | null | undefined
@@ -67,19 +66,7 @@ export function resolveRelayServerCandidatesFromHost(
     ];
   }
 
-  if (normalized === 'observer.relaycast.dev') {
-    return [
-      'https://cast.agentrelay.com',
-      'https://gateway.relaycast.dev',
-      'https://api.relaycast.dev',
-    ];
-  }
-
-  return [
-    'https://cast.agentrelay.com',
-    'https://gateway.relaycast.dev',
-    'https://api.relaycast.dev',
-  ];
+  return ['https://cast.agentrelay.com'];
 }
 
 export function resolveRelayServerCandidatesFromRequest(
@@ -96,7 +83,7 @@ export function resolveRelayServerCandidatesFromRequest(
 /**
  * Resolve the single happy-path engine URL for an observer host (first
  * candidate). Prefer {@link resolveRelayServerCandidatesFromRequest} when a key
- * is available so legacy workspaces can fall back to the `api` engine.
+ * is available so per-environment hosts can fall back to their `-api` engine.
  */
 export function resolveRelayServerUrlFromHost(
   host: string | null | undefined

--- a/packages/openclaw/skill/SKILL.md
+++ b/packages/openclaw/skill/SKILL.md
@@ -11,14 +11,14 @@ DMs, reactions, search, and persistent message history across OpenClaw instances
 
 - `RELAY_API_KEY` — Your Relaycast workspace key (required)
 - `RELAY_CLAW_NAME` — This claw's agent name in Relaycast (required)
-- `RELAY_BASE_URL` — API endpoint (default: https://api.relaycast.dev)
+- `RELAY_BASE_URL` — API endpoint (default: https://cast.agentrelay.com)
 
 ## Setup
 
 1. Create a free workspace:
 
 ```bash
-curl -X POST https://api.relaycast.dev/v1/workspaces \
+curl -X POST https://cast.agentrelay.com/v1/workspaces \
   -H "Content-Type: application/json" \
   -d '{"name": "my-project"}'
 ```

--- a/packages/openclaw/src/setup.ts
+++ b/packages/openclaw/src/setup.ts
@@ -7,7 +7,7 @@ export interface SetupOptions {
   apiKey: string;
   /** Name for this claw in Relaycast. Defaults to hostname or 'my-claw'. */
   clawName?: string;
-  /** Relaycast API base URL. Defaults to https://api.relaycast.dev. */
+  /** Relaycast API base URL. Defaults to https://cast.agentrelay.com. */
   baseUrl?: string;
 }
 
@@ -29,7 +29,7 @@ DMs, reactions, search, and persistent message history across OpenClaw instances
 
 - \`RELAY_API_KEY\` — Your Relaycast workspace key (required)
 - \`RELAY_CLAW_NAME\` — This claw's agent name in Relaycast (required)
-- \`RELAY_BASE_URL\` — API endpoint (default: https://api.relaycast.dev)
+- \`RELAY_BASE_URL\` — API endpoint (default: https://cast.agentrelay.com)
 
 ## Setup
 
@@ -88,7 +88,7 @@ export async function setupSkill(options: SetupOptions): Promise<SetupResult> {
   const env = ENV_TEMPLATE
     .replace('__API_KEY__', options.apiKey)
     .replace('__CLAW_NAME__', options.clawName ?? 'my-claw')
-    .replace('__BASE_URL__', options.baseUrl ?? 'https://api.relaycast.dev');
+    .replace('__BASE_URL__', options.baseUrl ?? 'https://cast.agentrelay.com');
   await writeFile(join(skillDir, '.env'), env, 'utf-8');
 
   // If openclaw.json exists, add MCP server config

--- a/packages/sdk-python/README.md
+++ b/packages/sdk-python/README.md
@@ -29,7 +29,7 @@ me.mark_offline()  # alias: me.disconnect()
 
 Self-hosting:
 
-By default, this SDK talks to the hosted engine at `https://gateway.relaycast.dev`.
+By default, this SDK talks to the hosted engine at `https://cast.agentrelay.com`.
 To keep traffic and state on your own infrastructure, run the engine yourself
 (`npx @relaycast/engine`, default port 8787 — containerize it with Docker if you like)
 and point `base_url` at it:

--- a/packages/sdk-python/src/relay_sdk/client.py
+++ b/packages/sdk-python/src/relay_sdk/client.py
@@ -15,7 +15,7 @@ SDK_VERSION = "0.1.1"
 AGENT_RELAY_DISTINCT_ID_HEADER = "X-Agent-Relay-Distinct-Id"
 AGENT_RELAY_DISTINCT_ID_QUERY = "agent_relay_distinct_id"
 
-_DEFAULT_BASE_URL = "https://gateway.relaycast.dev"
+_DEFAULT_BASE_URL = "https://cast.agentrelay.com"
 _RETRY_BACKOFFS = [0.2, 0.4, 0.8]
 _DEFAULT_ORIGIN_CLIENT = "@relaycast/python-sdk"
 _AGENT_RELAY_DISTINCT_ID_ALLOWED = re.compile(r"^[a-z0-9._:-]+$", re.IGNORECASE)

--- a/packages/sdk-python/src/relay_sdk/ws.py
+++ b/packages/sdk-python/src/relay_sdk/ws.py
@@ -42,7 +42,7 @@ class WsClient:
         agent_relay_distinct_id: str | None = None,
     ) -> None:
         self._token = token
-        base = (base_url or "https://gateway.relaycast.dev").rstrip("/")
+        base = (base_url or "https://cast.agentrelay.com").rstrip("/")
         self._base_url = base.replace("https://", "wss://").replace("http://", "ws://")
         self._origin_client = (origin_client or "@relaycast/python-sdk").strip()[:80]
         self._origin_version = (origin_version or SDK_VERSION).strip()[:48]

--- a/packages/sdk-python/tests/test_client.py
+++ b/packages/sdk-python/tests/test_client.py
@@ -31,7 +31,7 @@ def test_http_client_constructor_sets_api_key_and_base_url():
 def test_http_client_constructor_default_base_url_is_set_and_stripped():
     c = HttpClient(api_key=API_KEY)
     assert c.api_key == API_KEY
-    assert c.base_url == "https://gateway.relaycast.dev"
+    assert c.base_url == "https://cast.agentrelay.com"
 
 
 def test_sanitize_agent_relay_distinct_id():

--- a/packages/sdk-python/tests/test_ws.py
+++ b/packages/sdk-python/tests/test_ws.py
@@ -12,7 +12,7 @@ from relay_sdk.ws import WsClient
 class TestWsClientInit:
     def test_default_base_url(self):
         ws = WsClient(token="at_xxx")
-        assert ws._base_url == "wss://gateway.relaycast.dev"
+        assert ws._base_url == "wss://cast.agentrelay.com"
 
     def test_custom_base_url_https(self):
         ws = WsClient(token="at_xxx", base_url="https://custom.example.com")

--- a/packages/sdk-rust/README.md
+++ b/packages/sdk-rust/README.md
@@ -317,7 +317,7 @@ let relay = RelayCast::new(options)?;
 
 Self-hosting:
 
-By default, the Rust SDK talks to the hosted engine at `https://gateway.relaycast.dev`.
+By default, the Rust SDK talks to the hosted engine at `https://cast.agentrelay.com`.
 To keep traffic and state on your own infrastructure, run the engine yourself
 (`npx @relaycast/engine`, default port 8787 — containerize it with Docker if you like)
 and point `base_url` at it:

--- a/packages/sdk-rust/src/client.rs
+++ b/packages/sdk-rust/src/client.rs
@@ -12,7 +12,7 @@ use crate::origin_actor::{
 use crate::types::ApiResponse;
 
 const SDK_VERSION: &str = env!("CARGO_PKG_VERSION");
-const DEFAULT_BASE_URL: &str = "https://gateway.relaycast.dev";
+const DEFAULT_BASE_URL: &str = "https://cast.agentrelay.com";
 const DEFAULT_ORIGIN_CLIENT: &str = "@relaycast/sdk-rust";
 const RETRY_BACKOFFS_MS: [u64; 3] = [200, 400, 800];
 
@@ -21,7 +21,7 @@ const RETRY_BACKOFFS_MS: [u64; 3] = [200, 400, 800];
 pub struct ClientOptions {
     /// The API key for authentication.
     pub api_key: String,
-    /// The base URL for the API (defaults to https://gateway.relaycast.dev).
+    /// The base URL for the API (defaults to https://cast.agentrelay.com).
     pub base_url: Option<String>,
     /// SDK origin client metadata.
     pub origin_client: Option<String>,

--- a/packages/sdk-rust/src/credentials.rs
+++ b/packages/sdk-rust/src/credentials.rs
@@ -80,7 +80,7 @@ pub struct BootstrapConfig {
     pub preferred_name: Option<String>,
     /// Agent type (e.g. "agent", "human", "system"). Defaults to "agent".
     pub agent_type: Option<String>,
-    /// Custom base URL. Defaults to https://gateway.relaycast.dev.
+    /// Custom base URL. Defaults to https://cast.agentrelay.com.
     pub base_url: Option<String>,
     /// Workspace API key from environment or config.
     /// If not set, a new workspace is created.

--- a/packages/sdk-rust/src/relay.rs
+++ b/packages/sdk-rust/src/relay.rs
@@ -6,7 +6,7 @@ use crate::error::{RelayError, Result};
 use crate::types::*;
 
 const SDK_VERSION: &str = env!("CARGO_PKG_VERSION");
-const DEFAULT_BASE_URL: &str = "https://gateway.relaycast.dev";
+const DEFAULT_BASE_URL: &str = "https://cast.agentrelay.com";
 const DEFAULT_ORIGIN_CLIENT: &str = "@relaycast/sdk-rust";
 
 fn strip_hash(channel: &str) -> &str {
@@ -18,7 +18,7 @@ fn strip_hash(channel: &str) -> &str {
 pub struct RelayCastOptions {
     /// The API key for authentication.
     pub api_key: String,
-    /// The base URL for the API (defaults to https://gateway.relaycast.dev).
+    /// The base URL for the API (defaults to https://cast.agentrelay.com).
     ///
     /// To self-host, run the engine (`relaycast-engine`, default port 8787) and
     /// set this to e.g. `http://localhost:8787`.

--- a/packages/sdk-rust/src/ws.rs
+++ b/packages/sdk-rust/src/ws.rs
@@ -15,7 +15,7 @@ use crate::origin_actor::{
 };
 use crate::types::WsEvent;
 
-const DEFAULT_BASE_URL: &str = "https://gateway.relaycast.dev";
+const DEFAULT_BASE_URL: &str = "https://cast.agentrelay.com";
 const SDK_VERSION: &str = env!("CARGO_PKG_VERSION");
 const DEFAULT_ORIGIN_CLIENT: &str = "@relaycast/sdk-rust";
 const PING_INTERVAL_SECS: u64 = 30;
@@ -27,7 +27,7 @@ const DEFAULT_MAX_RECONNECT_DELAY_MS: u64 = 30_000;
 pub struct WsClientOptions {
     /// The agent token for authentication.
     pub token: String,
-    /// The base URL for the API (defaults to https://gateway.relaycast.dev).
+    /// The base URL for the API (defaults to https://cast.agentrelay.com).
     pub base_url: Option<String>,
     /// Enable debug logging for dropped/malformed messages.
     pub debug: bool,

--- a/packages/sdk-swift/README.md
+++ b/packages/sdk-swift/README.md
@@ -70,7 +70,7 @@ encoding and decoding centrally.
 
 ## Self-Hosting
 
-By default, the SDK talks to `https://gateway.relaycast.dev`. To self-host, run the engine and pass
+By default, the SDK talks to `https://cast.agentrelay.com`. To self-host, run the engine and pass
 your base URL:
 
 ```swift

--- a/packages/sdk-swift/Sources/Relaycast/HttpClient.swift
+++ b/packages/sdk-swift/Sources/Relaycast/HttpClient.swift
@@ -81,7 +81,7 @@ public final class HttpClient: @unchecked Sendable {
     private let decoder: JSONDecoder
 
     public init(options: ClientOptions, session: URLSession = .shared) throws {
-        guard let baseURL = URL(string: options.baseURL ?? "https://gateway.relaycast.dev") else {
+        guard let baseURL = URL(string: options.baseURL ?? "https://cast.agentrelay.com") else {
             throw RelayError.invalidRequest("Invalid Relaycast baseURL")
         }
         self.apiKey = options.apiKey

--- a/packages/sdk-swift/Sources/Relaycast/RelayCast.swift
+++ b/packages/sdk-swift/Sources/Relaycast/RelayCast.swift
@@ -760,7 +760,7 @@ private extension RelayCast {
         body: Body?,
         options: WorkspaceBootstrapOptions
     ) async throws -> (T, Int) {
-        let base = options.baseURL ?? "https://gateway.relaycast.dev"
+        let base = options.baseURL ?? "https://cast.agentrelay.com"
         guard let baseURL = URL(string: base),
               let url = URL(string: path.hasPrefix("/") ? String(path.dropFirst()) : path, relativeTo: baseURL.appendingPathComponent(""))?.absoluteURL
         else {

--- a/packages/sdk-swift/Sources/Relaycast/WsClient.swift
+++ b/packages/sdk-swift/Sources/Relaycast/WsClient.swift
@@ -367,7 +367,7 @@ public final class WsClient: @unchecked Sendable {
     }
 
     private func websocketURL() -> URL? {
-        let rawBase = (options.baseURL ?? "https://gateway.relaycast.dev")
+        let rawBase = (options.baseURL ?? "https://cast.agentrelay.com")
             .trimmingCharacters(in: CharacterSet(charactersIn: "/"))
             .replacingOccurrences(of: "https://", with: "wss://")
             .replacingOccurrences(of: "http://", with: "ws://")

--- a/packages/sdk-typescript/README.md
+++ b/packages/sdk-typescript/README.md
@@ -80,7 +80,7 @@ A first connection sends no resync request — replay only happens once at least
 
 ## Self-hosting
 
-By default the SDK talks to the hosted engine at `https://gateway.relaycast.dev`. To keep traffic on your own infrastructure, run the engine yourself (`npx @relaycast/engine`, default port 8787) and point `baseUrl` at it:
+By default the SDK talks to the hosted engine at `https://cast.agentrelay.com`. To keep traffic on your own infrastructure, run the engine yourself (`npx @relaycast/engine`, default port 8787) and point `baseUrl` at it:
 
 ```ts
 const relay = new RelayCast({ apiKey: 'rk_live_...', baseUrl: 'http://localhost:8787' });

--- a/packages/sdk-typescript/src/__tests__/agent-features.test.ts
+++ b/packages/sdk-typescript/src/__tests__/agent-features.test.ts
@@ -30,7 +30,7 @@ describe('AgentClient features', () => {
       await me.channels.create({ name: 'dev', topic: 'Dev channel' });
 
       const [url, init] = mockFetch.mock.calls[0]!;
-      expect(url).toBe('https://gateway.relaycast.dev/v1/channels');
+      expect(url).toBe('https://cast.agentrelay.com/v1/channels');
       expect(init.method).toBe('POST');
       expect(init.body).toBe(
         JSON.stringify({ name: 'dev', topic: 'Dev channel' }),
@@ -42,7 +42,7 @@ describe('AgentClient features', () => {
       await me.channels.list();
 
       const [url, init] = mockFetch.mock.calls[0]!;
-      expect(url).toBe('https://gateway.relaycast.dev/v1/channels');
+      expect(url).toBe('https://cast.agentrelay.com/v1/channels');
       expect(init.method).toBe('GET');
     });
 
@@ -52,7 +52,7 @@ describe('AgentClient features', () => {
 
       const [url] = mockFetch.mock.calls[0]!;
       expect(url).toBe(
-        'https://gateway.relaycast.dev/v1/channels?include_archived=true',
+        'https://cast.agentrelay.com/v1/channels?include_archived=true',
       );
     });
 
@@ -63,7 +63,7 @@ describe('AgentClient features', () => {
       await me.channels.get('dev');
 
       const [url] = mockFetch.mock.calls[0]!;
-      expect(url).toBe('https://gateway.relaycast.dev/v1/channels/dev');
+      expect(url).toBe('https://cast.agentrelay.com/v1/channels/dev');
     });
 
     it('join() posts to /v1/channels/:name/join', async () => {
@@ -71,7 +71,7 @@ describe('AgentClient features', () => {
       await me.channels.join('dev');
 
       const [url, init] = mockFetch.mock.calls[0]!;
-      expect(url).toBe('https://gateway.relaycast.dev/v1/channels/dev/join');
+      expect(url).toBe('https://cast.agentrelay.com/v1/channels/dev/join');
       expect(init.method).toBe('POST');
     });
 
@@ -80,7 +80,7 @@ describe('AgentClient features', () => {
       await me.channels.leave('dev');
 
       const [url, init] = mockFetch.mock.calls[0]!;
-      expect(url).toBe('https://gateway.relaycast.dev/v1/channels/dev/leave');
+      expect(url).toBe('https://cast.agentrelay.com/v1/channels/dev/leave');
       expect(init.method).toBe('POST');
     });
 
@@ -89,7 +89,7 @@ describe('AgentClient features', () => {
       await me.channels.setTopic('dev', 'New');
 
       const [url, init] = mockFetch.mock.calls[0]!;
-      expect(url).toBe('https://gateway.relaycast.dev/v1/channels/dev/topic');
+      expect(url).toBe('https://cast.agentrelay.com/v1/channels/dev/topic');
       expect(init.method).toBe('PATCH');
       expect(init.body).toBe(JSON.stringify({ topic: 'New' }));
     });
@@ -99,7 +99,7 @@ describe('AgentClient features', () => {
       await me.channels.archive('dev');
 
       const [url, init] = mockFetch.mock.calls[0]!;
-      expect(url).toBe('https://gateway.relaycast.dev/v1/channels/dev');
+      expect(url).toBe('https://cast.agentrelay.com/v1/channels/dev');
       expect(init.method).toBe('DELETE');
     });
 
@@ -108,7 +108,7 @@ describe('AgentClient features', () => {
       await me.channels.invite('dev', 'Bot');
 
       const [url, init] = mockFetch.mock.calls[0]!;
-      expect(url).toBe('https://gateway.relaycast.dev/v1/channels/dev/invite');
+      expect(url).toBe('https://cast.agentrelay.com/v1/channels/dev/invite');
       expect(init.method).toBe('POST');
       expect(init.body).toBe(JSON.stringify({ agent_name: 'Bot' }));
     });
@@ -120,7 +120,7 @@ describe('AgentClient features', () => {
       await me.channels.update('dev', { topic: 'Updated topic' });
 
       const [url, init] = mockFetch.mock.calls[0]!;
-      expect(url).toBe('https://gateway.relaycast.dev/v1/channels/dev');
+      expect(url).toBe('https://cast.agentrelay.com/v1/channels/dev');
       expect(init.method).toBe('PATCH');
       expect(init.body).toBe(JSON.stringify({ topic: 'Updated topic' }));
     });
@@ -130,7 +130,7 @@ describe('AgentClient features', () => {
       await me.channels.members('dev');
 
       const [url, init] = mockFetch.mock.calls[0]!;
-      expect(url).toBe('https://gateway.relaycast.dev/v1/channels/dev/members');
+      expect(url).toBe('https://cast.agentrelay.com/v1/channels/dev/members');
       expect(init.method).toBe('GET');
     });
 
@@ -139,7 +139,7 @@ describe('AgentClient features', () => {
       await me.channels.mute('dev');
 
       const [url, init] = mockFetch.mock.calls[0]!;
-      expect(url).toBe('https://gateway.relaycast.dev/v1/channels/dev/mute');
+      expect(url).toBe('https://cast.agentrelay.com/v1/channels/dev/mute');
       expect(init.method).toBe('POST');
     });
 
@@ -148,7 +148,7 @@ describe('AgentClient features', () => {
       await me.channels.unmute('dev');
 
       const [url, init] = mockFetch.mock.calls[0]!;
-      expect(url).toBe('https://gateway.relaycast.dev/v1/channels/dev/unmute');
+      expect(url).toBe('https://cast.agentrelay.com/v1/channels/dev/unmute');
       expect(init.method).toBe('POST');
     });
   });
@@ -160,7 +160,7 @@ describe('AgentClient features', () => {
 
       const [url, init] = mockFetch.mock.calls[0]!;
       expect(url).toBe(
-        'https://gateway.relaycast.dev/v1/messages/m_1/reactions',
+        'https://cast.agentrelay.com/v1/messages/m_1/reactions',
       );
       expect(init.method).toBe('POST');
       expect(init.body).toBe(JSON.stringify({ emoji: 'eyes' }));
@@ -172,7 +172,7 @@ describe('AgentClient features', () => {
 
       const [url, init] = mockFetch.mock.calls[0]!;
       expect(url).toBe(
-        'https://gateway.relaycast.dev/v1/messages/m_1/reactions/eyes',
+        'https://cast.agentrelay.com/v1/messages/m_1/reactions/eyes',
       );
       expect(init.method).toBe('DELETE');
     });
@@ -183,7 +183,7 @@ describe('AgentClient features', () => {
 
       const [url, init] = mockFetch.mock.calls[0]!;
       expect(url).toBe(
-        'https://gateway.relaycast.dev/v1/messages/m_1/reactions',
+        'https://cast.agentrelay.com/v1/messages/m_1/reactions',
       );
       expect(init.method).toBe('GET');
     });
@@ -196,7 +196,7 @@ describe('AgentClient features', () => {
 
       const [url] = mockFetch.mock.calls[0]!;
       expect(url).toBe(
-        'https://gateway.relaycast.dev/v1/search?q=deploy+error',
+        'https://cast.agentrelay.com/v1/search?q=deploy+error',
       );
     });
 
@@ -206,7 +206,7 @@ describe('AgentClient features', () => {
 
       const [url] = mockFetch.mock.calls[0]!;
       expect(url).toBe(
-        'https://gateway.relaycast.dev/v1/search?q=err&channel=dev&from=Bot&limit=5',
+        'https://cast.agentrelay.com/v1/search?q=err&channel=dev&from=Bot&limit=5',
       );
     });
   });
@@ -227,7 +227,7 @@ describe('AgentClient features', () => {
         unreadDms: [],
       });
       const [url, init] = mockFetch.mock.calls[0]!;
-      expect(url).toBe('https://gateway.relaycast.dev/v1/inbox');
+      expect(url).toBe('https://cast.agentrelay.com/v1/inbox');
       expect(init.method).toBe('GET');
     });
   });
@@ -238,7 +238,7 @@ describe('AgentClient features', () => {
       await me.markRead('m_1');
 
       const [url, init] = mockFetch.mock.calls[0]!;
-      expect(url).toBe('https://gateway.relaycast.dev/v1/messages/m_1/read');
+      expect(url).toBe('https://cast.agentrelay.com/v1/messages/m_1/read');
       expect(init.method).toBe('POST');
     });
 
@@ -247,7 +247,7 @@ describe('AgentClient features', () => {
       await me.readers('m_1');
 
       const [url, init] = mockFetch.mock.calls[0]!;
-      expect(url).toBe('https://gateway.relaycast.dev/v1/messages/m_1/readers');
+      expect(url).toBe('https://cast.agentrelay.com/v1/messages/m_1/readers');
       expect(init.method).toBe('GET');
     });
 
@@ -257,7 +257,7 @@ describe('AgentClient features', () => {
 
       const [url] = mockFetch.mock.calls[0]!;
       expect(url).toBe(
-        'https://gateway.relaycast.dev/v1/channels/general/read-status',
+        'https://cast.agentrelay.com/v1/channels/general/read-status',
       );
     });
 
@@ -267,7 +267,7 @@ describe('AgentClient features', () => {
 
       const [url] = mockFetch.mock.calls[0]!;
       expect(url).toBe(
-        'https://gateway.relaycast.dev/v1/channels/general/read-status',
+        'https://cast.agentrelay.com/v1/channels/general/read-status',
       );
     });
   });
@@ -284,7 +284,7 @@ describe('AgentClient features', () => {
       });
 
       const [url, init] = mockFetch.mock.calls[0]!;
-      expect(url).toBe('https://gateway.relaycast.dev/v1/files/upload');
+      expect(url).toBe('https://cast.agentrelay.com/v1/files/upload');
       expect(init.method).toBe('POST');
       expect(init.body).toBe(
         JSON.stringify({
@@ -300,7 +300,7 @@ describe('AgentClient features', () => {
       await me.files.complete('f_1');
 
       const [url, init] = mockFetch.mock.calls[0]!;
-      expect(url).toBe('https://gateway.relaycast.dev/v1/files/f_1/complete');
+      expect(url).toBe('https://cast.agentrelay.com/v1/files/f_1/complete');
       expect(init.method).toBe('POST');
     });
 
@@ -309,7 +309,7 @@ describe('AgentClient features', () => {
       await me.files.get('f_1');
 
       const [url, init] = mockFetch.mock.calls[0]!;
-      expect(url).toBe('https://gateway.relaycast.dev/v1/files/f_1');
+      expect(url).toBe('https://cast.agentrelay.com/v1/files/f_1');
       expect(init.method).toBe('GET');
     });
 
@@ -318,7 +318,7 @@ describe('AgentClient features', () => {
       await me.files.delete('f_1');
 
       const [url, init] = mockFetch.mock.calls[0]!;
-      expect(url).toBe('https://gateway.relaycast.dev/v1/files/f_1');
+      expect(url).toBe('https://cast.agentrelay.com/v1/files/f_1');
       expect(init.method).toBe('DELETE');
     });
 
@@ -327,7 +327,7 @@ describe('AgentClient features', () => {
       await me.files.list();
 
       const [url, init] = mockFetch.mock.calls[0]!;
-      expect(url).toBe('https://gateway.relaycast.dev/v1/files');
+      expect(url).toBe('https://cast.agentrelay.com/v1/files');
       expect(init.method).toBe('GET');
     });
 
@@ -337,7 +337,7 @@ describe('AgentClient features', () => {
 
       const [url] = mockFetch.mock.calls[0]!;
       expect(url).toBe(
-        'https://gateway.relaycast.dev/v1/files?uploaded_by=Bot&limit=10',
+        'https://cast.agentrelay.com/v1/files?uploaded_by=Bot&limit=10',
       );
     });
 

--- a/packages/sdk-typescript/src/__tests__/agent-messaging.test.ts
+++ b/packages/sdk-typescript/src/__tests__/agent-messaging.test.ts
@@ -29,7 +29,7 @@ describe('AgentClient', () => {
 
       expect(mockFetch).toHaveBeenCalledTimes(1);
       const [url, init] = mockFetch.mock.calls[0]!;
-      expect(url).toBe('https://gateway.relaycast.dev/v1/channels/general/messages');
+      expect(url).toBe('https://cast.agentrelay.com/v1/channels/general/messages');
       expect(init.method).toBe('POST');
       expect(init.body).toBe(JSON.stringify({ text: 'hello', mode: 'wait' }));
     });
@@ -40,7 +40,7 @@ describe('AgentClient', () => {
       await me.send('#general', 'hello');
 
       const [url] = mockFetch.mock.calls[0]!;
-      expect(url).toBe('https://gateway.relaycast.dev/v1/channels/general/messages');
+      expect(url).toBe('https://cast.agentrelay.com/v1/channels/general/messages');
     });
 
     it('URL-encodes channel name', async () => {
@@ -49,7 +49,7 @@ describe('AgentClient', () => {
       await me.send('#a/b', 'hello');
 
       const [url] = mockFetch.mock.calls[0]!;
-      expect(url).toBe('https://gateway.relaycast.dev/v1/channels/a%2Fb/messages');
+      expect(url).toBe('https://cast.agentrelay.com/v1/channels/a%2Fb/messages');
     });
 
     it('includes attachments when provided', async () => {
@@ -112,7 +112,7 @@ describe('AgentClient', () => {
 
       expect(mockFetch).toHaveBeenCalledTimes(1);
       const [url, init] = mockFetch.mock.calls[0]!;
-      expect(url).toBe('https://gateway.relaycast.dev/v1/channels/general/messages');
+      expect(url).toBe('https://cast.agentrelay.com/v1/channels/general/messages');
       expect(init.method).toBe('POST');
       expect(init.body).toBe(JSON.stringify({ text: 'hello', mode: 'wait' }));
     });
@@ -126,7 +126,7 @@ describe('AgentClient', () => {
 
       expect(res).toEqual([{ id: 'm_1' }]);
       const [url, init] = mockFetch.mock.calls[0]!;
-      expect(url).toBe('https://gateway.relaycast.dev/v1/channels/general/messages');
+      expect(url).toBe('https://cast.agentrelay.com/v1/channels/general/messages');
       expect(init.method).toBe('GET');
     });
 
@@ -137,7 +137,7 @@ describe('AgentClient', () => {
 
       const [url] = mockFetch.mock.calls[0]!;
       expect(url).toBe(
-        'https://gateway.relaycast.dev/v1/channels/general/messages?limit=10&before=m_2&after=m_0',
+        'https://cast.agentrelay.com/v1/channels/general/messages?limit=10&before=m_2&after=m_0',
       );
     });
   });
@@ -149,7 +149,7 @@ describe('AgentClient', () => {
       await me.message('m_1');
 
       const [url, init] = mockFetch.mock.calls[0]!;
-      expect(url).toBe('https://gateway.relaycast.dev/v1/messages/m_1');
+      expect(url).toBe('https://cast.agentrelay.com/v1/messages/m_1');
       expect(init.method).toBe('GET');
     });
 
@@ -159,7 +159,7 @@ describe('AgentClient', () => {
       await me.message('m/1');
 
       const [url] = mockFetch.mock.calls[0]!;
-      expect(url).toBe('https://gateway.relaycast.dev/v1/messages/m%2F1');
+      expect(url).toBe('https://cast.agentrelay.com/v1/messages/m%2F1');
     });
   });
 
@@ -170,7 +170,7 @@ describe('AgentClient', () => {
       await me.reply('m_1', 'reply');
 
       const [url, init] = mockFetch.mock.calls[0]!;
-      expect(url).toBe('https://gateway.relaycast.dev/v1/messages/m_1/replies');
+      expect(url).toBe('https://cast.agentrelay.com/v1/messages/m_1/replies');
       expect(init.method).toBe('POST');
       expect(init.body).toBe(JSON.stringify({ text: 'reply' }));
     });
@@ -209,7 +209,7 @@ describe('AgentClient', () => {
 
       expect(res).toEqual(payload);
       const [url, init] = mockFetch.mock.calls[0]!;
-      expect(url).toBe('https://gateway.relaycast.dev/v1/messages/m_1/replies');
+      expect(url).toBe('https://cast.agentrelay.com/v1/messages/m_1/replies');
       expect(init.method).toBe('GET');
     });
 
@@ -219,7 +219,7 @@ describe('AgentClient', () => {
       await me.thread('m_1', { limit: 25 } as any);
 
       const [url] = mockFetch.mock.calls[0]!;
-      expect(url).toBe('https://gateway.relaycast.dev/v1/messages/m_1/replies?limit=25');
+      expect(url).toBe('https://cast.agentrelay.com/v1/messages/m_1/replies?limit=25');
     });
   });
 
@@ -230,7 +230,7 @@ describe('AgentClient', () => {
       await me.dm('Worker-1', 'hi');
 
       const [url, init] = mockFetch.mock.calls[0]!;
-      expect(url).toBe('https://gateway.relaycast.dev/v1/dm');
+      expect(url).toBe('https://cast.agentrelay.com/v1/dm');
       expect(init.method).toBe('POST');
       expect(init.body).toBe(JSON.stringify({ to: 'Worker-1', text: 'hi', mode: 'wait' }));
     });
@@ -287,7 +287,7 @@ describe('AgentClient', () => {
 
       expect(res).toEqual([{ id: 'c_1' }]);
       const [url, init] = mockFetch.mock.calls[0]!;
-      expect(url).toBe('https://gateway.relaycast.dev/v1/dm/conversations');
+      expect(url).toBe('https://cast.agentrelay.com/v1/dm/conversations');
       expect(init.method).toBe('GET');
     });
 
@@ -303,7 +303,7 @@ describe('AgentClient', () => {
       const res = await me.dms.messages('c_1');
 
       const [url, init] = mockFetch.mock.calls[0]!;
-      expect(url).toBe('https://gateway.relaycast.dev/v1/dm/c_1/messages');
+      expect(url).toBe('https://cast.agentrelay.com/v1/dm/c_1/messages');
       expect(init.method).toBe('GET');
       expect(res[0]).toEqual({
         id: 'm_1',
@@ -320,7 +320,7 @@ describe('AgentClient', () => {
       await me.dms.messages('c_1', { limit: 2, before: 'm_9' } as any);
 
       const [url] = mockFetch.mock.calls[0]!;
-      expect(url).toBe('https://gateway.relaycast.dev/v1/dm/c_1/messages?limit=2&before=m_9');
+      expect(url).toBe('https://cast.agentrelay.com/v1/dm/c_1/messages?limit=2&before=m_9');
     });
 
     it('createGroup() creates group DM', async () => {
@@ -329,7 +329,7 @@ describe('AgentClient', () => {
       await me.dms.createGroup({ participants: ['a', 'b'] } as any);
 
       const [url, init] = mockFetch.mock.calls[0]!;
-      expect(url).toBe('https://gateway.relaycast.dev/v1/dm/group');
+      expect(url).toBe('https://cast.agentrelay.com/v1/dm/group');
       expect(init.method).toBe('POST');
       expect(init.body).toBe(JSON.stringify({ participants: ['a', 'b'] }));
       const headers = init.headers as Record<string, string>;
@@ -356,7 +356,7 @@ describe('AgentClient', () => {
       await me.dms.sendMessage('c_1', 'hello');
 
       const [url, init] = mockFetch.mock.calls[0]!;
-      expect(url).toBe('https://gateway.relaycast.dev/v1/dm/c_1/messages');
+      expect(url).toBe('https://cast.agentrelay.com/v1/dm/c_1/messages');
       expect(init.method).toBe('POST');
       expect(init.body).toBe(JSON.stringify({ text: 'hello', mode: 'wait' }));
       const headers = init.headers as Record<string, string>;
@@ -395,7 +395,7 @@ describe('AgentClient', () => {
       await me.dms.addParticipant('c_1', 'Worker-2');
 
       const [url, init] = mockFetch.mock.calls[0]!;
-      expect(url).toBe('https://gateway.relaycast.dev/v1/dm/c_1/participants');
+      expect(url).toBe('https://cast.agentrelay.com/v1/dm/c_1/participants');
       expect(init.method).toBe('POST');
       expect(init.body).toBe(JSON.stringify({ agent_name: 'Worker-2' }));
     });
@@ -406,7 +406,7 @@ describe('AgentClient', () => {
       await me.dms.removeParticipant('c_1', 'a/b');
 
       const [url, init] = mockFetch.mock.calls[0]!;
-      expect(url).toBe('https://gateway.relaycast.dev/v1/dm/c_1/participants/a%2Fb');
+      expect(url).toBe('https://cast.agentrelay.com/v1/dm/c_1/participants/a%2Fb');
       expect(init.method).toBe('DELETE');
       expect(init.body).toBeUndefined();
     });

--- a/packages/sdk-typescript/src/__tests__/deliveries.test.ts
+++ b/packages/sdk-typescript/src/__tests__/deliveries.test.ts
@@ -28,7 +28,7 @@ describe('AgentClient durable delivery', () => {
       await me.deliveries();
 
       const [url, init] = mockFetch.mock.calls[0]!;
-      expect(url).toBe('https://gateway.relaycast.dev/v1/deliveries');
+      expect(url).toBe('https://cast.agentrelay.com/v1/deliveries');
       expect(init.method).toBe('GET');
     });
 
@@ -63,7 +63,7 @@ describe('AgentClient durable delivery', () => {
       await me.ackDelivery('del_1');
 
       const [url, init] = mockFetch.mock.calls[0]!;
-      expect(url).toBe('https://gateway.relaycast.dev/v1/deliveries/del_1/ack');
+      expect(url).toBe('https://cast.agentrelay.com/v1/deliveries/del_1/ack');
       expect(init.method).toBe('POST');
     });
 
@@ -73,7 +73,7 @@ describe('AgentClient durable delivery', () => {
       await me.ackDelivery('del/1');
 
       const [url] = mockFetch.mock.calls[0]!;
-      expect(url).toBe('https://gateway.relaycast.dev/v1/deliveries/del%2F1/ack');
+      expect(url).toBe('https://cast.agentrelay.com/v1/deliveries/del%2F1/ack');
     });
   });
 
@@ -84,7 +84,7 @@ describe('AgentClient durable delivery', () => {
       await me.failDelivery('del_1', { error: 'boom', retryable: true });
 
       const [url, init] = mockFetch.mock.calls[0]!;
-      expect(url).toBe('https://gateway.relaycast.dev/v1/deliveries/del_1/fail');
+      expect(url).toBe('https://cast.agentrelay.com/v1/deliveries/del_1/fail');
       expect(init.method).toBe('POST');
       expect(JSON.parse(init.body)).toEqual({ error: 'boom', retryable: true });
     });
@@ -107,7 +107,7 @@ describe('AgentClient durable delivery', () => {
       await me.deferDelivery('del_1', { availableAt, reason: 'busy' });
 
       const [url, init] = mockFetch.mock.calls[0]!;
-      expect(url).toBe('https://gateway.relaycast.dev/v1/deliveries/del_1/defer');
+      expect(url).toBe('https://cast.agentrelay.com/v1/deliveries/del_1/defer');
       expect(init.method).toBe('POST');
       expect(JSON.parse(init.body)).toEqual({ available_at: availableAt, reason: 'busy' });
     });

--- a/packages/sdk-typescript/src/__tests__/invite-consumption.test.ts
+++ b/packages/sdk-typescript/src/__tests__/invite-consumption.test.ts
@@ -436,7 +436,7 @@ describe('relayfile invite consumption', () => {
       'rk_live_from_invite',
     );
 
-    expect(workspace.info.baseUrl).toBe('https://gateway.relaycast.dev');
+    expect(workspace.info.baseUrl).toBe('https://cast.agentrelay.com');
   });
 
   it('surfaces invalid invite credentials as unauthorized without retrying', async () => {

--- a/packages/sdk-typescript/src/__tests__/programmability.test.ts
+++ b/packages/sdk-typescript/src/__tests__/programmability.test.ts
@@ -50,7 +50,7 @@ describe('Programmability SDK', () => {
       const created = await relay.webhooks.create({ name: 'GitHub', channel: 'dev' });
 
       const [url, init] = mockFetch.mock.calls[0]!;
-      expect(url).toBe('https://gateway.relaycast.dev/v1/webhooks');
+      expect(url).toBe('https://cast.agentrelay.com/v1/webhooks');
       expect(init.method).toBe('POST');
       expect(init.body).toBe(JSON.stringify({ name: 'GitHub', channel: 'dev' }));
       expect(created.token).toBe('wh_live_1');
@@ -65,7 +65,7 @@ describe('Programmability SDK', () => {
           webhook_id: 'wh_1',
           name: 'dev',
           channel: 'dev',
-          url: 'https://gateway.relaycast.dev/v1/hooks/wh_1',
+          url: 'https://cast.agentrelay.com/v1/hooks/wh_1',
           token: 'wh_live_1',
           is_active: true,
           created_at: '2025-01-01',
@@ -74,7 +74,7 @@ describe('Programmability SDK', () => {
       await relay.webhooks.createInbound({ channel: 'dev' });
 
       const [url, init] = mockFetch.mock.calls[0]!;
-      expect(url).toBe('https://gateway.relaycast.dev/v1/webhooks');
+      expect(url).toBe('https://cast.agentrelay.com/v1/webhooks');
       expect(init.method).toBe('POST');
       expect(init.body).toBe(JSON.stringify({ channel: 'dev' }));
     });
@@ -87,7 +87,7 @@ describe('Programmability SDK', () => {
       await relay.webhooks.list();
 
       const [url, init] = mockFetch.mock.calls[0]!;
-      expect(url).toBe('https://gateway.relaycast.dev/v1/webhooks');
+      expect(url).toBe('https://cast.agentrelay.com/v1/webhooks');
       expect(init.method).toBe('GET');
     });
 
@@ -99,7 +99,7 @@ describe('Programmability SDK', () => {
       await relay.webhooks.delete('wh_1');
 
       const [url, init] = mockFetch.mock.calls[0]!;
-      expect(url).toBe('https://gateway.relaycast.dev/v1/webhooks/wh_1');
+      expect(url).toBe('https://cast.agentrelay.com/v1/webhooks/wh_1');
       expect(init.method).toBe('DELETE');
     });
 
@@ -120,7 +120,7 @@ describe('Programmability SDK', () => {
       await relay.webhooks.trigger('wh_1', { message: 'alert', author: 'GitHub' }, 'wh_live_1');
 
       const [url, init] = mockFetch.mock.calls[0]!;
-      expect(url).toBe('https://gateway.relaycast.dev/v1/hooks/wh_1');
+      expect(url).toBe('https://cast.agentrelay.com/v1/hooks/wh_1');
       expect(init.method).toBe('POST');
       expect(init.headers.Authorization).toBe('Bearer wh_live_1');
       expect(init.body).toBe(JSON.stringify({ message: 'alert', author: 'GitHub' }));
@@ -144,7 +144,7 @@ describe('Programmability SDK', () => {
       });
 
       const [url, init] = mockFetch.mock.calls[0]!;
-      expect(url).toBe('https://gateway.relaycast.dev/v1/subscriptions');
+      expect(url).toBe('https://cast.agentrelay.com/v1/subscriptions');
       expect(init.method).toBe('POST');
       expect(JSON.parse(init.body)).toEqual({
         events: ['message.created'],
@@ -161,7 +161,7 @@ describe('Programmability SDK', () => {
       await relay.subscriptions.list();
 
       const [url, init] = mockFetch.mock.calls[0]!;
-      expect(url).toBe('https://gateway.relaycast.dev/v1/subscriptions');
+      expect(url).toBe('https://cast.agentrelay.com/v1/subscriptions');
       expect(init.method).toBe('GET');
     });
 
@@ -175,7 +175,7 @@ describe('Programmability SDK', () => {
       await relay.subscriptions.get('sub_1');
 
       const [url, init] = mockFetch.mock.calls[0]!;
-      expect(url).toBe('https://gateway.relaycast.dev/v1/subscriptions/sub_1');
+      expect(url).toBe('https://cast.agentrelay.com/v1/subscriptions/sub_1');
       expect(init.method).toBe('GET');
     });
 
@@ -187,7 +187,7 @@ describe('Programmability SDK', () => {
       await relay.subscriptions.delete('sub_1');
 
       const [url, init] = mockFetch.mock.calls[0]!;
-      expect(url).toBe('https://gateway.relaycast.dev/v1/subscriptions/sub_1');
+      expect(url).toBe('https://cast.agentrelay.com/v1/subscriptions/sub_1');
       expect(init.method).toBe('DELETE');
     });
   });
@@ -209,7 +209,7 @@ describe('Programmability SDK', () => {
       });
 
       const [url, init] = mockFetch.mock.calls[0]!;
-      expect(url).toBe('https://gateway.relaycast.dev/v1/actions');
+      expect(url).toBe('https://cast.agentrelay.com/v1/actions');
       expect(init.method).toBe('POST');
       expect(JSON.parse(init.body)).toEqual({
         name: 'deploy',
@@ -226,7 +226,7 @@ describe('Programmability SDK', () => {
       await relay.actions.list();
 
       const [url, init] = mockFetch.mock.calls[0]!;
-      expect(url).toBe('https://gateway.relaycast.dev/v1/actions');
+      expect(url).toBe('https://cast.agentrelay.com/v1/actions');
       expect(init.method).toBe('GET');
     });
 
@@ -238,7 +238,7 @@ describe('Programmability SDK', () => {
       await relay.actions.delete('deploy');
 
       const [url, init] = mockFetch.mock.calls[0]!;
-      expect(url).toBe('https://gateway.relaycast.dev/v1/actions/deploy');
+      expect(url).toBe('https://cast.agentrelay.com/v1/actions/deploy');
       expect(init.method).toBe('DELETE');
     });
 
@@ -258,7 +258,7 @@ describe('Programmability SDK', () => {
       await me.actions.invoke('deploy', { force: true });
 
       const [url, init] = mockFetch.mock.calls[0]!;
-      expect(url).toBe('https://gateway.relaycast.dev/v1/actions/deploy/invoke');
+      expect(url).toBe('https://cast.agentrelay.com/v1/actions/deploy/invoke');
       expect(init.method).toBe('POST');
       expect(init.headers.Authorization).toBe('Bearer at_live_agent123');
       expect(JSON.parse(init.body)).toEqual({ input: { force: true } });
@@ -274,7 +274,7 @@ describe('Programmability SDK', () => {
       await me.actions.completeInvocation('deploy', 'inv_1', { output: { ok: true }, durationMs: 12 });
 
       const [url, init] = mockFetch.mock.calls[0]!;
-      expect(url).toBe('https://gateway.relaycast.dev/v1/actions/deploy/invocations/inv_1/complete');
+      expect(url).toBe('https://cast.agentrelay.com/v1/actions/deploy/invocations/inv_1/complete');
       expect(init.method).toBe('POST');
       expect(JSON.parse(init.body)).toEqual({ output: { ok: true }, duration_ms: 12 });
     });
@@ -286,7 +286,7 @@ describe('Programmability SDK', () => {
       await relay.agents.events.emit('Worker', { type: 'status.active' });
 
       const [url, init] = mockFetch.mock.calls[0]!;
-      expect(url).toBe('https://gateway.relaycast.dev/v1/agents/Worker/events');
+      expect(url).toBe('https://cast.agentrelay.com/v1/agents/Worker/events');
       expect(init.method).toBe('POST');
       expect(JSON.parse(init.body)).toEqual({ type: 'status.active' });
     });
@@ -298,7 +298,7 @@ describe('Programmability SDK', () => {
       await relay.agents.events.list('Worker', { type: 'status.active', limit: 50 });
 
       const [url, init] = mockFetch.mock.calls[0]!;
-      expect(url).toBe('https://gateway.relaycast.dev/v1/agents/Worker/events?type=status.active&limit=50');
+      expect(url).toBe('https://cast.agentrelay.com/v1/agents/Worker/events?type=status.active&limit=50');
       expect(init.method).toBe('GET');
     });
 
@@ -309,7 +309,7 @@ describe('Programmability SDK', () => {
       await relay.certify.submit({ agentUrl: 'https://a.dev', level: 1 });
 
       const [url, init] = mockFetch.mock.calls[0]!;
-      expect(url).toBe('https://gateway.relaycast.dev/v1/certify');
+      expect(url).toBe('https://cast.agentrelay.com/v1/certify');
       expect(init.method).toBe('POST');
       expect(JSON.parse(init.body)).toEqual({ agent_url: 'https://a.dev', level: 1 });
     });
@@ -317,7 +317,7 @@ describe('Programmability SDK', () => {
     it('certify.badgeUrl() builds the public badge URL', async () => {
       const { RelayCast } = await import('../relay.js');
       const relay = new RelayCast({ apiKey: 'rk_live_test123' });
-      expect(relay.certify.badgeUrl('cert_1')).toBe('https://gateway.relaycast.dev/v1/certify/cert_1/badge.svg');
+      expect(relay.certify.badgeUrl('cert_1')).toBe('https://cast.agentrelay.com/v1/certify/cert_1/badge.svg');
     });
 
     it('listDirectory() gets /v1/directory/agents with status filter', async () => {
@@ -327,7 +327,7 @@ describe('Programmability SDK', () => {
       await relay.listDirectory({ status: 'active', limit: 10 });
 
       const [url, init] = mockFetch.mock.calls[0]!;
-      expect(url).toBe('https://gateway.relaycast.dev/v1/directory/agents?status=active&limit=10');
+      expect(url).toBe('https://cast.agentrelay.com/v1/directory/agents?status=active&limit=10');
       expect(init.method).toBe('GET');
     });
 
@@ -338,7 +338,7 @@ describe('Programmability SDK', () => {
       await relay.rateDirectoryAgent('my-agent', { score: 5, review: 'great' });
 
       const [url, init] = mockFetch.mock.calls[0]!;
-      expect(url).toBe('https://gateway.relaycast.dev/v1/directory/agents/my-agent/ratings');
+      expect(url).toBe('https://cast.agentrelay.com/v1/directory/agents/my-agent/ratings');
       expect(init.method).toBe('POST');
       expect(JSON.parse(init.body)).toEqual({ score: 5, review: 'great' });
     });
@@ -350,7 +350,7 @@ describe('Programmability SDK', () => {
       await relay.searchSkills({ q: 'deploy', limit: 5 });
 
       const [url, init] = mockFetch.mock.calls[0]!;
-      expect(url).toBe('https://gateway.relaycast.dev/v1/skills/search?q=deploy&limit=5');
+      expect(url).toBe('https://cast.agentrelay.com/v1/skills/search?q=deploy&limit=5');
       expect(init.method).toBe('GET');
     });
 
@@ -361,7 +361,7 @@ describe('Programmability SDK', () => {
       await relay.routeFeedback({ agentName: 'Worker', success: true });
 
       const [url, init] = mockFetch.mock.calls[0]!;
-      expect(url).toBe('https://gateway.relaycast.dev/v1/route/feedback');
+      expect(url).toBe('https://cast.agentrelay.com/v1/route/feedback');
       expect(init.method).toBe('POST');
       expect(JSON.parse(init.body)).toEqual({ agent_name: 'Worker', success: true });
     });
@@ -373,7 +373,7 @@ describe('Programmability SDK', () => {
       await relay.console.stats({ days: 7 });
 
       const [url, init] = mockFetch.mock.calls[0]!;
-      expect(url).toBe('https://gateway.relaycast.dev/v1/console/stats?days=7');
+      expect(url).toBe('https://cast.agentrelay.com/v1/console/stats?days=7');
       expect(init.method).toBe('GET');
     });
   });
@@ -398,7 +398,7 @@ describe('Programmability SDK', () => {
       await me.send('#ops', 'Deploy complete', { blocks });
 
       const [url, init] = mockFetch.mock.calls[0]!;
-      expect(url).toBe('https://gateway.relaycast.dev/v1/channels/ops/messages');
+      expect(url).toBe('https://cast.agentrelay.com/v1/channels/ops/messages');
       expect(init.method).toBe('POST');
       const body = JSON.parse(init.body);
       expect(body.text).toBe('Deploy complete');
@@ -434,7 +434,7 @@ describe('Programmability SDK', () => {
       await me.reply('m_1', 'Please review', { blocks });
 
       const [url, init] = mockFetch.mock.calls[0]!;
-      expect(url).toBe('https://gateway.relaycast.dev/v1/messages/m_1/replies');
+      expect(url).toBe('https://cast.agentrelay.com/v1/messages/m_1/replies');
       expect(init.method).toBe('POST');
       const body = JSON.parse(init.body);
       expect(body.text).toBe('Please review');

--- a/packages/sdk-typescript/src/__tests__/relay-connection.test.ts
+++ b/packages/sdk-typescript/src/__tests__/relay-connection.test.ts
@@ -52,7 +52,7 @@ describe('RelayCast baseUrl options', () => {
     await RelayCast.createWorkspace('Test Workspace');
 
     const [url] = mockFetch.mock.calls[0]!;
-    expect(url).toBe('https://gateway.relaycast.dev/v1/workspaces');
+    expect(url).toBe('https://cast.agentrelay.com/v1/workspaces');
   });
 
   it('createWorkspace supports options object with auth', async () => {

--- a/packages/sdk-typescript/src/__tests__/relay.test.ts
+++ b/packages/sdk-typescript/src/__tests__/relay.test.ts
@@ -277,7 +277,7 @@ describe('RelayCast', () => {
 
       expect(mockFetch).toHaveBeenCalledTimes(1);
       const [url, init] = mockFetch.mock.calls[0]!;
-      expect(url).toBe('https://gateway.relaycast.dev/v1/workspace');
+      expect(url).toBe('https://cast.agentrelay.com/v1/workspace');
       expect(init.method).toBe('GET');
       expect(init.headers.Authorization).toBe('Bearer rk_live_test123');
       expect(init.headers['X-SDK-Version']).toBeDefined();
@@ -294,7 +294,7 @@ describe('RelayCast', () => {
 
       expect(mockFetch).toHaveBeenCalledTimes(1);
       const [url, init] = mockFetch.mock.calls[0]!;
-      expect(url).toBe('https://gateway.relaycast.dev/v1/workspace');
+      expect(url).toBe('https://cast.agentrelay.com/v1/workspace');
       expect(init.method).toBe('PATCH');
       expect(init.headers['Content-Type']).toBe('application/json');
       expect(init.body).toBe(JSON.stringify({ name: 'new' }));
@@ -325,7 +325,7 @@ describe('RelayCast', () => {
       const result = await relay.workspace.stream.get();
 
       const [url, init] = mockFetch.mock.calls[0]!;
-      expect(url).toBe('https://gateway.relaycast.dev/v1/workspace/stream');
+      expect(url).toBe('https://cast.agentrelay.com/v1/workspace/stream');
       expect(init.method).toBe('GET');
       expect(result).toEqual({ enabled: true, defaultEnabled: false, override: null });
     });
@@ -340,7 +340,7 @@ describe('RelayCast', () => {
       const result = await relay.workspace.stream.set(false);
 
       const [url, init] = mockFetch.mock.calls[0]!;
-      expect(url).toBe('https://gateway.relaycast.dev/v1/workspace/stream');
+      expect(url).toBe('https://cast.agentrelay.com/v1/workspace/stream');
       expect(init.method).toBe('PUT');
       expect(init.body).toBe(JSON.stringify({ enabled: false }));
       expect(result).toEqual({ enabled: false, defaultEnabled: false, override: true });
@@ -356,7 +356,7 @@ describe('RelayCast', () => {
       const result = await relay.workspace.stream.inherit();
 
       const [url, init] = mockFetch.mock.calls[0]!;
-      expect(url).toBe('https://gateway.relaycast.dev/v1/workspace/stream');
+      expect(url).toBe('https://cast.agentrelay.com/v1/workspace/stream');
       expect(init.method).toBe('PUT');
       expect(init.body).toBe(JSON.stringify({ mode: 'inherit' }));
       expect(result).toEqual({ enabled: true, defaultEnabled: true, override: null });
@@ -372,7 +372,7 @@ describe('RelayCast', () => {
       await relay.agents.register({ name: 'Worker' } as any);
 
       const [url, init] = mockFetch.mock.calls[0]!;
-      expect(url).toBe('https://gateway.relaycast.dev/v1/agents');
+      expect(url).toBe('https://cast.agentrelay.com/v1/agents');
       expect(init.method).toBe('POST');
       expect(init.body).toBe(JSON.stringify({ name: 'Worker' }));
     });
@@ -385,7 +385,7 @@ describe('RelayCast', () => {
       await relay.system({ name: 'System' } as any);
 
       const [url, init] = mockFetch.mock.calls[0]!;
-      expect(url).toBe('https://gateway.relaycast.dev/v1/agents');
+      expect(url).toBe('https://cast.agentrelay.com/v1/agents');
       expect(init.method).toBe('POST');
       expect(init.body).toBe(JSON.stringify({ name: 'System', type: 'system' }));
     });
@@ -398,7 +398,7 @@ describe('RelayCast', () => {
       await relay.agents.list();
 
       const [url, init] = mockFetch.mock.calls[0]!;
-      expect(url).toBe('https://gateway.relaycast.dev/v1/agents');
+      expect(url).toBe('https://cast.agentrelay.com/v1/agents');
       expect(init.method).toBe('GET');
     });
 
@@ -410,7 +410,7 @@ describe('RelayCast', () => {
       await relay.agents.list({ status: 'active' } as any);
 
       const [url] = mockFetch.mock.calls[0]!;
-      expect(url).toBe('https://gateway.relaycast.dev/v1/agents?status=active');
+      expect(url).toBe('https://cast.agentrelay.com/v1/agents?status=active');
     });
 
     it('get() calls GET /v1/agents/:name with URL encoding', async () => {
@@ -421,7 +421,7 @@ describe('RelayCast', () => {
       await relay.agents.get('a/b');
 
       const [url] = mockFetch.mock.calls[0]!;
-      expect(url).toBe('https://gateway.relaycast.dev/v1/agents/a%2Fb');
+      expect(url).toBe('https://cast.agentrelay.com/v1/agents/a%2Fb');
     });
   });
 
@@ -433,7 +433,7 @@ describe('RelayCast', () => {
       mockFetch.mockImplementation(() => mockResponse({
         relay_name: 'ext-weather-123',
         relay_token: 'rt_test',
-        webhook_url: 'https://gateway.relaycast.dev/a2a/webhook/ext-weather-123',
+        webhook_url: 'https://cast.agentrelay.com/a2a/webhook/ext-weather-123',
         certification: 'level_1',
       }));
 
@@ -444,7 +444,7 @@ describe('RelayCast', () => {
       });
 
       const [url, init] = mockFetch.mock.calls[0]!;
-      expect(url).toBe('https://gateway.relaycast.dev/v1/a2a/register');
+      expect(url).toBe('https://cast.agentrelay.com/v1/a2a/register');
       expect(init.method).toBe('POST');
       expect(init.body).toBe(JSON.stringify({
         agent_card_url: 'https://agent.example/.well-known/agent-card.json',
@@ -454,7 +454,7 @@ describe('RelayCast', () => {
       expect(result).toEqual({
         relayName: 'ext-weather-123',
         relayToken: 'rt_test',
-        webhookUrl: 'https://gateway.relaycast.dev/a2a/webhook/ext-weather-123',
+        webhookUrl: 'https://cast.agentrelay.com/a2a/webhook/ext-weather-123',
         certification: 'level_1',
       });
     });
@@ -467,7 +467,7 @@ describe('RelayCast', () => {
       await relay.listA2aAgents();
 
       const [url, init] = mockFetch.mock.calls[0]!;
-      expect(url).toBe('https://gateway.relaycast.dev/v1/a2a/agents');
+      expect(url).toBe('https://cast.agentrelay.com/v1/a2a/agents');
       expect(init.method).toBe('GET');
     });
 
@@ -479,7 +479,7 @@ describe('RelayCast', () => {
       const result = await relay.removeA2aAgent('a/b');
 
       const [url, init] = mockFetch.mock.calls[0]!;
-      expect(url).toBe('https://gateway.relaycast.dev/v1/a2a/agents/a%2Fb');
+      expect(url).toBe('https://cast.agentrelay.com/v1/a2a/agents/a%2Fb');
       expect(init.method).toBe('DELETE');
       expect(result).toEqual({ name: 'a/b', removed: true });
     });
@@ -509,7 +509,7 @@ describe('RelayCast', () => {
       const result = await relay.getA2aAgentCard('a/b');
 
       const [url, init] = mockFetch.mock.calls[0]!;
-      expect(url).toBe('https://gateway.relaycast.dev/v1/a2a/agents/a%2Fb/card');
+      expect(url).toBe('https://cast.agentrelay.com/v1/a2a/agents/a%2Fb/card');
       expect(init.method).toBe('GET');
       expect(result).toEqual({
         name: 'Weather Agent',
@@ -536,7 +536,7 @@ describe('RelayCast', () => {
       const result = await relay.route('refund_lookup', 'Need a refund decision');
 
       const [url, init] = mockFetch.mock.calls[0]!;
-      expect(url).toBe('https://gateway.relaycast.dev/v1/route');
+      expect(url).toBe('https://cast.agentrelay.com/v1/route');
       expect(init.method).toBe('POST');
       expect(init.body).toBe(JSON.stringify({
         skill: 'refund_lookup',
@@ -562,7 +562,7 @@ describe('RelayCast', () => {
       });
 
       const [url, init] = mockFetch.mock.calls[0]!;
-      expect(url).toBe('https://gateway.relaycast.dev/v1/directory/search?q=refund&tags=billing%2Cpriority&status=active&limit=5');
+      expect(url).toBe('https://cast.agentrelay.com/v1/directory/search?q=refund&tags=billing%2Cpriority&status=active&limit=5');
       expect(init.method).toBe('GET');
     });
 
@@ -600,7 +600,7 @@ describe('RelayCast', () => {
       });
 
       const [url, init] = mockFetch.mock.calls[0]!;
-      expect(url).toBe('https://gateway.relaycast.dev/v1/directory/agents');
+      expect(url).toBe('https://cast.agentrelay.com/v1/directory/agents');
       expect(init.method).toBe('POST');
       expect(init.body).toBe(JSON.stringify({
         source_agent_name: 'billing-router',
@@ -628,7 +628,7 @@ describe('RelayCast', () => {
       });
 
       const [url, init] = mockFetch.mock.calls[0]!;
-      expect(url).toBe('https://gateway.relaycast.dev/v1/skills/sync');
+      expect(url).toBe('https://cast.agentrelay.com/v1/skills/sync');
       expect(init.method).toBe('POST');
       expect(init.body).toBe(JSON.stringify({
         agent_name: 'billing-router',
@@ -659,7 +659,7 @@ describe('RelayCast', () => {
       const result = await relay.getRoutingConfig();
 
       const [url, init] = mockFetch.mock.calls[0]!;
-      expect(url).toBe('https://gateway.relaycast.dev/v1/routing/config');
+      expect(url).toBe('https://cast.agentrelay.com/v1/routing/config');
       expect(init.method).toBe('GET');
       expect(result).toEqual({
         weights: {
@@ -699,7 +699,7 @@ describe('RelayCast', () => {
       });
 
       const [url, init] = mockFetch.mock.calls[0]!;
-      expect(url).toBe('https://gateway.relaycast.dev/v1/routing/config');
+      expect(url).toBe('https://cast.agentrelay.com/v1/routing/config');
       expect(init.method).toBe('PUT');
       expect(init.body).toBe(JSON.stringify({
         weights: {
@@ -841,7 +841,7 @@ describe('RelayCast', () => {
       await relay.workspace.delete();
 
       const [url, init] = mockFetch.mock.calls[0]!;
-      expect(url).toBe('https://gateway.relaycast.dev/v1/workspace');
+      expect(url).toBe('https://cast.agentrelay.com/v1/workspace');
       expect(init.method).toBe('DELETE');
     });
   });
@@ -857,7 +857,7 @@ describe('RelayCast', () => {
       const result = await relay.systemPrompt.get();
 
       const [url, init] = mockFetch.mock.calls[0]!;
-      expect(url).toBe('https://gateway.relaycast.dev/v1/workspace/system-prompt');
+      expect(url).toBe('https://cast.agentrelay.com/v1/workspace/system-prompt');
       expect(init.method).toBe('GET');
       expect(result).toEqual({ prompt: 'Be helpful', isDefault: false });
     });
@@ -872,7 +872,7 @@ describe('RelayCast', () => {
       await relay.systemPrompt.set({ prompt: 'New prompt' });
 
       const [url, init] = mockFetch.mock.calls[0]!;
-      expect(url).toBe('https://gateway.relaycast.dev/v1/workspace/system-prompt');
+      expect(url).toBe('https://cast.agentrelay.com/v1/workspace/system-prompt');
       expect(init.method).toBe('PUT');
       expect(init.body).toBe(JSON.stringify({ prompt: 'New prompt' }));
     });
@@ -887,7 +887,7 @@ describe('RelayCast', () => {
       await relay.agents.update('Bot', { status: 'online' });
 
       const [url, init] = mockFetch.mock.calls[0]!;
-      expect(url).toBe('https://gateway.relaycast.dev/v1/agents/Bot');
+      expect(url).toBe('https://cast.agentrelay.com/v1/agents/Bot');
       expect(init.method).toBe('PATCH');
       expect(init.body).toBe(JSON.stringify({ status: 'online' }));
     });
@@ -904,7 +904,7 @@ describe('RelayCast', () => {
       await relay.agents.delete('Bot');
 
       const [url, init] = mockFetch.mock.calls[0]!;
-      expect(url).toBe('https://gateway.relaycast.dev/v1/agents/Bot');
+      expect(url).toBe('https://cast.agentrelay.com/v1/agents/Bot');
       expect(init.method).toBe('DELETE');
     });
   });
@@ -919,7 +919,7 @@ describe('RelayCast', () => {
       const result = await relay.agents.presence();
 
       const [url, init] = mockFetch.mock.calls[0]!;
-      expect(url).toBe('https://gateway.relaycast.dev/v1/agents/presence');
+      expect(url).toBe('https://cast.agentrelay.com/v1/agents/presence');
       expect(init.method).toBe('GET');
       expect(result).toEqual([{ agentId: 'a_1', agentName: 'Bot', status: 'online' }]);
     });
@@ -944,7 +944,7 @@ describe('RelayCast', () => {
       const result = await RelayCast.createWorkspace('My Workspace');
 
       const [url, init] = mockFetch.mock.calls[0]!;
-      expect(url).toBe('https://gateway.relaycast.dev/v1/workspaces');
+      expect(url).toBe('https://cast.agentrelay.com/v1/workspaces');
       expect(init.method).toBe('POST');
       expect(init.body).toBe(JSON.stringify({ name: 'My Workspace' }));
       expect(init.headers.Authorization).toBeUndefined();
@@ -1045,7 +1045,7 @@ describe('RelayCast', () => {
       const result = await RelayCast.lookupWorkspace('My Workspace');
 
       const [url, init] = mockFetch.mock.calls[0]!;
-      expect(url).toBe('https://gateway.relaycast.dev/v1/workspaces/by-name/My%20Workspace');
+      expect(url).toBe('https://cast.agentrelay.com/v1/workspaces/by-name/My%20Workspace');
       expect(init.method).toBe('GET');
       expect(init.headers.Authorization).toBeUndefined();
       expect(result).toEqual({ id: 'ws_1', name: 'My Workspace', createdAt: '2024-01-01' });
@@ -1212,7 +1212,7 @@ describe('RelayCast', () => {
       expect(result).toMatchObject({ id: 'a_1', name: 'Bot', token: 'at_live_new' });
 
       const [url, init] = mockFetch.mock.calls[0]!;
-      expect(url).toBe('https://gateway.relaycast.dev/v1/agents');
+      expect(url).toBe('https://cast.agentrelay.com/v1/agents');
       expect(init.body).toBe(JSON.stringify({ name: 'Bot' }));
     });
 
@@ -1253,7 +1253,7 @@ describe('RelayCast', () => {
       });
 
       const [workspaceUrl] = mockFetch.mock.calls[1]!;
-      expect(workspaceUrl).toBe('https://gateway.relaycast.dev/v1/workspace');
+      expect(workspaceUrl).toBe('https://cast.agentrelay.com/v1/workspace');
     });
   });
 
@@ -1266,7 +1266,7 @@ describe('RelayCast', () => {
       await relay.channels.list();
 
       const [url, init] = mockFetch.mock.calls[0]!;
-      expect(url).toBe('https://gateway.relaycast.dev/v1/channels');
+      expect(url).toBe('https://cast.agentrelay.com/v1/channels');
       expect(init.method).toBe('GET');
     });
 
@@ -1278,7 +1278,7 @@ describe('RelayCast', () => {
       await relay.channels.list({ includeArchived: true });
 
       const [url] = mockFetch.mock.calls[0]!;
-      expect(url).toBe('https://gateway.relaycast.dev/v1/channels?include_archived=true');
+      expect(url).toBe('https://cast.agentrelay.com/v1/channels?include_archived=true');
     });
 
     it('get() calls GET /v1/channels/:name', async () => {
@@ -1289,7 +1289,7 @@ describe('RelayCast', () => {
       await relay.channels.get('general');
 
       const [url, init] = mockFetch.mock.calls[0]!;
-      expect(url).toBe('https://gateway.relaycast.dev/v1/channels/general');
+      expect(url).toBe('https://cast.agentrelay.com/v1/channels/general');
       expect(init.method).toBe('GET');
     });
   });
@@ -1313,7 +1313,7 @@ describe('RelayCast', () => {
       const result = await relay.dmMessages('conv_1');
 
       const [url, init] = mockFetch.mock.calls[0]!;
-      expect(url).toBe('https://gateway.relaycast.dev/v1/dm/conversations/conv_1/messages');
+      expect(url).toBe('https://cast.agentrelay.com/v1/dm/conversations/conv_1/messages');
       expect(init.method).toBe('GET');
       expect(result).toEqual([
         {
@@ -1336,7 +1336,7 @@ describe('RelayCast', () => {
       await relay.messages.list('general');
 
       const [url, init] = mockFetch.mock.calls[0]!;
-      expect(url).toBe('https://gateway.relaycast.dev/v1/channels/general/messages');
+      expect(url).toBe('https://cast.agentrelay.com/v1/channels/general/messages');
       expect(init.method).toBe('GET');
     });
 
@@ -1348,7 +1348,7 @@ describe('RelayCast', () => {
       await relay.messages.list('general', { limit: 50 });
 
       const [url] = mockFetch.mock.calls[0]!;
-      expect(url).toBe('https://gateway.relaycast.dev/v1/channels/general/messages?limit=50');
+      expect(url).toBe('https://cast.agentrelay.com/v1/channels/general/messages?limit=50');
     });
 
     it('list() strips # prefix from channel name', async () => {
@@ -1359,7 +1359,7 @@ describe('RelayCast', () => {
       await relay.messages.list('#general');
 
       const [url] = mockFetch.mock.calls[0]!;
-      expect(url).toBe('https://gateway.relaycast.dev/v1/channels/general/messages');
+      expect(url).toBe('https://cast.agentrelay.com/v1/channels/general/messages');
     });
 
     it('get() calls GET /v1/messages/:id', async () => {
@@ -1370,7 +1370,7 @@ describe('RelayCast', () => {
       await relay.messages.get('msg_1');
 
       const [url, init] = mockFetch.mock.calls[0]!;
-      expect(url).toBe('https://gateway.relaycast.dev/v1/messages/msg_1');
+      expect(url).toBe('https://cast.agentrelay.com/v1/messages/msg_1');
       expect(init.method).toBe('GET');
     });
 
@@ -1382,7 +1382,7 @@ describe('RelayCast', () => {
       await relay.messages.thread('msg_1');
 
       const [url, init] = mockFetch.mock.calls[0]!;
-      expect(url).toBe('https://gateway.relaycast.dev/v1/messages/msg_1/replies');
+      expect(url).toBe('https://cast.agentrelay.com/v1/messages/msg_1/replies');
       expect(init.method).toBe('GET');
     });
 
@@ -1394,7 +1394,7 @@ describe('RelayCast', () => {
       await relay.messages.thread('msg_1', { limit: 20 });
 
       const [url] = mockFetch.mock.calls[0]!;
-      expect(url).toBe('https://gateway.relaycast.dev/v1/messages/msg_1/replies?limit=20');
+      expect(url).toBe('https://cast.agentrelay.com/v1/messages/msg_1/replies?limit=20');
     });
 
     it('reactions() calls GET /v1/messages/:id/reactions', async () => {
@@ -1405,7 +1405,7 @@ describe('RelayCast', () => {
       await relay.messages.reactions('msg_1');
 
       const [url, init] = mockFetch.mock.calls[0]!;
-      expect(url).toBe('https://gateway.relaycast.dev/v1/messages/msg_1/reactions');
+      expect(url).toBe('https://cast.agentrelay.com/v1/messages/msg_1/reactions');
       expect(init.method).toBe('GET');
     });
   });
@@ -1448,7 +1448,7 @@ describe('RelayCast', () => {
 
       expect(agentClient).toBeInstanceOf(AgentClient);
       const [url, init] = mockFetch.mock.calls[0]!;
-      expect(url).toBe('https://gateway.relaycast.dev/v1/agent');
+      expect(url).toBe('https://cast.agentrelay.com/v1/agent');
       expect(init.method).toBe('GET');
       expect(init.headers.Authorization).toBe('Bearer at_live_agent123');
     });

--- a/packages/sdk-typescript/src/__tests__/setup.test.ts
+++ b/packages/sdk-typescript/src/__tests__/setup.test.ts
@@ -59,7 +59,7 @@ describe('RelaycastSetup', () => {
     expect(workspace.info).toEqual({
       workspaceId: 'ws_1',
       apiKey: 'rk_live_workspace',
-      baseUrl: 'https://gateway.relaycast.dev',
+      baseUrl: 'https://cast.agentrelay.com',
       createdAt: '2026-04-30T12:00:00.000Z',
       name: 'Acme Ops',
     });
@@ -67,7 +67,7 @@ describe('RelaycastSetup', () => {
     expect(workspace.apiKey).toBe('rk_live_workspace');
 
     const [url, init] = mockFetch.mock.calls[0]!;
-    expect(url).toBe('https://gateway.relaycast.dev/v1/workspaces');
+    expect(url).toBe('https://cast.agentrelay.com/v1/workspaces');
     expect(init.method).toBe('POST');
     expect(init.headers['Content-Type']).toBe('application/json');
     expect(init.headers['X-SDK-Version']).toBeDefined();
@@ -327,7 +327,7 @@ describe('RelaycastSetup', () => {
     expect(workspace.info).toEqual({
       workspaceId: 'ws_join',
       apiKey: 'rk_live_join',
-      baseUrl: 'https://gateway.relaycast.dev',
+      baseUrl: 'https://cast.agentrelay.com',
     });
     expect(mockFetch).not.toHaveBeenCalled();
   });
@@ -356,7 +356,7 @@ describe('RelaycastSetup', () => {
     });
 
     const [url, init] = mockFetch.mock.calls[0]!;
-    expect(url).toBe('https://gateway.relaycast.dev/v1/workspaces/by-name/Lookup%20Workspace');
+    expect(url).toBe('https://cast.agentrelay.com/v1/workspaces/by-name/Lookup%20Workspace');
     expect(init.method).toBe('GET');
   });
 
@@ -430,7 +430,7 @@ describe('WorkspaceHandle', () => {
     expect(workspace.getAgentToken('Alice')).toBe('at_live_alice');
 
     const [url, init] = mockFetch.mock.calls[0]!;
-    expect(url).toBe('https://gateway.relaycast.dev/v1/agents');
+    expect(url).toBe('https://cast.agentrelay.com/v1/agents');
     expect(init.method).toBe('POST');
     expect(init.headers.Authorization).toBe('Bearer rk_live_workspace');
     expect(JSON.parse(init.body)).toEqual({

--- a/packages/sdk-typescript/src/__tests__/strict-identity.test.ts
+++ b/packages/sdk-typescript/src/__tests__/strict-identity.test.ts
@@ -29,7 +29,7 @@ describe('strict identity APIs', () => {
       expect(mockFetch).toHaveBeenCalledTimes(1);
 
       const [url, init] = mockFetch.mock.calls[0]!;
-      expect(url).toBe('https://gateway.relaycast.dev/v1/agents');
+      expect(url).toBe('https://cast.agentrelay.com/v1/agents');
       expect(init.method).toBe('POST');
       expect(init.body).toBe(JSON.stringify({ name: 'Bot' }));
     });
@@ -137,9 +137,9 @@ describe('strict identity APIs', () => {
 
       // Verify get + rotateToken were called
       const [getUrl] = mockFetch.mock.calls[1]!;
-      expect(getUrl).toBe('https://gateway.relaycast.dev/v1/agents/Bot');
+      expect(getUrl).toBe('https://cast.agentrelay.com/v1/agents/Bot');
       const [rotateUrl] = mockFetch.mock.calls[2]!;
-      expect(rotateUrl).toBe('https://gateway.relaycast.dev/v1/agents/Bot/rotate-token');
+      expect(rotateUrl).toBe('https://cast.agentrelay.com/v1/agents/Bot/rotate-token');
     });
 
     it('rethrows non-conflict errors', async () => {

--- a/packages/sdk-typescript/src/__tests__/workspace.test.ts
+++ b/packages/sdk-typescript/src/__tests__/workspace.test.ts
@@ -24,7 +24,7 @@ describe('Relay workspace methods', () => {
     await relay.activity();
 
     const [url] = mockFetch.mock.calls[0]!;
-    expect(url).toBe('https://gateway.relaycast.dev/v1/activity');
+    expect(url).toBe('https://cast.agentrelay.com/v1/activity');
   });
 
   it('activity(5) calls GET /v1/activity?limit=5', async () => {
@@ -35,7 +35,7 @@ describe('Relay workspace methods', () => {
     await relay.activity(5);
 
     const [url] = mockFetch.mock.calls[0]!;
-    expect(url).toBe('https://gateway.relaycast.dev/v1/activity?limit=5');
+    expect(url).toBe('https://cast.agentrelay.com/v1/activity?limit=5');
   });
 
   it('allDmConversations() calls GET /v1/dm/conversations/all', async () => {
@@ -46,7 +46,7 @@ describe('Relay workspace methods', () => {
     await relay.allDmConversations();
 
     const [url, init] = mockFetch.mock.calls[0]!;
-    expect(url).toBe('https://gateway.relaycast.dev/v1/dm/conversations/all');
+    expect(url).toBe('https://cast.agentrelay.com/v1/dm/conversations/all');
     expect(init.method).toBe('GET');
   });
 
@@ -60,7 +60,7 @@ describe('Relay workspace methods', () => {
     const result = await relay.workspace.fleetNodes.get();
 
     const [url, init] = mockFetch.mock.calls[0]!;
-    expect(url).toBe('https://gateway.relaycast.dev/v1/workspace/fleet-nodes');
+    expect(url).toBe('https://cast.agentrelay.com/v1/workspace/fleet-nodes');
     expect(init.method).toBe('GET');
     expect(result).toEqual({ enabled: true, defaultEnabled: false, override: true });
   });
@@ -75,7 +75,7 @@ describe('Relay workspace methods', () => {
     await relay.workspace.fleetNodes.set(true);
 
     const [url, init] = mockFetch.mock.calls[0]!;
-    expect(url).toBe('https://gateway.relaycast.dev/v1/workspace/fleet-nodes');
+    expect(url).toBe('https://cast.agentrelay.com/v1/workspace/fleet-nodes');
     expect(init.method).toBe('PUT');
     expect(JSON.parse(init.body as string)).toEqual({ enabled: true });
   });
@@ -90,7 +90,7 @@ describe('Relay workspace methods', () => {
     const result = await relay.workspace.fleetNodes.inherit();
 
     const [url, init] = mockFetch.mock.calls[0]!;
-    expect(url).toBe('https://gateway.relaycast.dev/v1/workspace/fleet-nodes');
+    expect(url).toBe('https://cast.agentrelay.com/v1/workspace/fleet-nodes');
     expect(init.method).toBe('PUT');
     expect(JSON.parse(init.body as string)).toEqual({ mode: 'inherit' });
     expect(result).toEqual({ enabled: false, defaultEnabled: false, override: null });
@@ -110,7 +110,7 @@ describe('Relay workspace methods', () => {
     const result = await relay.dmMessages('c_1', { limit: 10, before: 'msg_9' });
 
     const [url, init] = mockFetch.mock.calls[0]!;
-    expect(url).toBe('https://gateway.relaycast.dev/v1/dm/conversations/c_1/messages?limit=10&before=msg_9');
+    expect(url).toBe('https://cast.agentrelay.com/v1/dm/conversations/c_1/messages?limit=10&before=msg_9');
     expect(init.method).toBe('GET');
     expect(result[0]).toEqual({
       id: 'msg_1',
@@ -131,7 +131,7 @@ describe('Relay workspace methods', () => {
     const result = await relay.agents.rotateToken('TestBot');
 
     const [url, init] = mockFetch.mock.calls[0]!;
-    expect(url).toBe('https://gateway.relaycast.dev/v1/agents/TestBot/rotate-token');
+    expect(url).toBe('https://cast.agentrelay.com/v1/agents/TestBot/rotate-token');
     expect(init.method).toBe('POST');
     expect(result).toEqual({ token: 'at_live_newtoken' });
   });
@@ -146,6 +146,6 @@ describe('Relay workspace methods', () => {
     await relay.agents.rotateToken('a/b');
 
     const [url] = mockFetch.mock.calls[0]!;
-    expect(url).toBe('https://gateway.relaycast.dev/v1/agents/a%2Fb/rotate-token');
+    expect(url).toBe('https://cast.agentrelay.com/v1/agents/a%2Fb/rotate-token');
   });
 });

--- a/packages/sdk-typescript/src/__tests__/ws.test.ts
+++ b/packages/sdk-typescript/src/__tests__/ws.test.ts
@@ -55,7 +55,7 @@ describe('WsClient', () => {
 
     expect(MockWebSocket.instances).toHaveLength(1);
     const url = new URL(MockWebSocket.instances[0]!.url);
-    expect(url.origin).toBe('wss://gateway.relaycast.dev');
+    expect(url.origin).toBe('wss://cast.agentrelay.com');
     expect(url.pathname).toBe('/v1/ws');
     expect(url.searchParams.get('token')).toBe('at_live_test');
     expect(url.searchParams.get('origin_client')).toBe('@relaycast/sdk');

--- a/packages/sdk-typescript/src/client.ts
+++ b/packages/sdk-typescript/src/client.ts
@@ -152,7 +152,7 @@ export class HttpClient {
   constructor(options: ClientOptions) {
     const origin = readInternalOrigin(options) ?? SDK_ORIGIN;
     this._apiKey = options.apiKey;
-    this._baseUrl = options.baseUrl ?? 'https://gateway.relaycast.dev';
+    this._baseUrl = options.baseUrl ?? 'https://cast.agentrelay.com';
     this._originClient = origin.client;
     this._originVersion = origin.version;
     // A wrapping host's internal origin is authoritative about the originActor;

--- a/packages/sdk-typescript/src/relay.ts
+++ b/packages/sdk-typescript/src/relay.ts
@@ -295,7 +295,7 @@ export class RelayCast {
   ): Promise<{ data: CreateWorkspaceResponse; statusCode: number }> {
     const { apiKey, baseUrl, agentRelayDistinctId: rawAgentRelayDistinctId } =
       resolveWorkspaceBootstrapOptions(options);
-    const requestBaseUrl = baseUrl ?? 'https://gateway.relaycast.dev';
+    const requestBaseUrl = baseUrl ?? 'https://cast.agentrelay.com';
     const agentRelayDistinctId = sanitizeAgentRelayDistinctId(rawAgentRelayDistinctId);
 
     const url = new URL('/v1/workspaces', requestBaseUrl);
@@ -348,7 +348,7 @@ export class RelayCast {
   ): Promise<WorkspaceLookup | null> {
     const { baseUrl, agentRelayDistinctId: rawAgentRelayDistinctId } =
       resolveWorkspaceLookupOptions(options);
-    const requestBaseUrl = baseUrl ?? 'https://gateway.relaycast.dev';
+    const requestBaseUrl = baseUrl ?? 'https://cast.agentrelay.com';
     const agentRelayDistinctId = sanitizeAgentRelayDistinctId(rawAgentRelayDistinctId);
 
     const url = new URL(`/v1/workspaces/by-name/${encodeURIComponent(name)}`, requestBaseUrl);

--- a/packages/sdk-typescript/src/setup-types.ts
+++ b/packages/sdk-typescript/src/setup-types.ts
@@ -3,7 +3,7 @@ import type { CreateAgentRequest, CreateAgentResponse } from './types.js';
 export interface RelaycastSetupOptions {
   /**
    * Base URL for the Relaycast API.
-   * @default "https://gateway.relaycast.dev"
+   * @default "https://cast.agentrelay.com"
    */
   baseUrl?: string;
 

--- a/packages/sdk-typescript/src/setup.ts
+++ b/packages/sdk-typescript/src/setup.ts
@@ -26,7 +26,7 @@ import type {
 } from './setup-types.js';
 import type { WorkspaceLookup } from './types.js';
 
-const DEFAULT_CLOUD_BASE_URL = 'https://gateway.relaycast.dev';
+const DEFAULT_CLOUD_BASE_URL = 'https://cast.agentrelay.com';
 const DEFAULT_REQUEST_TIMEOUT_MS = 30_000;
 const DEFAULT_MAX_RETRIES = 3;
 const DEFAULT_BASE_DELAY_MS = 500;

--- a/packages/sdk-typescript/src/ws.ts
+++ b/packages/sdk-typescript/src/ws.ts
@@ -119,7 +119,7 @@ export class WsClient {
     this.circuitBreakerMaxAttempts = Number.isFinite(options.circuitBreakerMaxAttempts)
       ? Math.max(1, Math.floor(options.circuitBreakerMaxAttempts!))
       : 30;
-    const base = (options.baseUrl ?? 'https://gateway.relaycast.dev').replace(/\/+$/, '');
+    const base = (options.baseUrl ?? 'https://cast.agentrelay.com').replace(/\/+$/, '');
     this.baseUrl = base.replace(/^http/, 'ws');
     this.originClient = origin.client;
     this.originVersion = origin.version;

--- a/scripts/e2e.ts
+++ b/scripts/e2e.ts
@@ -9,7 +9,7 @@
  *   npm run e2e                                   # defaults to the engine dev server (http://localhost:8787)
  *   npm run e2e -- http://localhost:8787 --ci     # self-hosted engine in CI
  *   npm run e2e -- --continue-on-failure          # keep running after step failures
- *   npm run e2e -- https://gateway.relaycast.dev --ci
+ *   npm run e2e -- https://cast.agentrelay.com --ci
  */
 
 import { createServer } from 'node:http';
@@ -50,10 +50,6 @@ function resolveDashboardUrl(baseUrl: string): string {
 
   if (host === 'staging-api.relaycast.dev') {
     return 'https://staging-observer.relaycast.dev';
-  }
-
-  if (host === 'api.relaycast.dev') {
-    return 'https://observer.relaycast.dev';
   }
 
   return 'https://observer.relaycast.dev';

--- a/site/index.html
+++ b/site/index.html
@@ -267,14 +267,14 @@
         <p>Create a webhook, get a URL, POST to it from GitHub Actions, Sentry, PagerDuty, or any service. Messages appear in your channel instantly.</p>
         <div class="webhook-code">
           <pre><code><span class="c-comment"># Create an inbound webhook</span>
-<span class="c-fn">curl</span> -X POST https://api.relaycast.dev/v1/webhooks \
+<span class="c-fn">curl</span> -X POST https://cast.agentrelay.com/v1/webhooks \
   -H <span class="c-str">"Authorization: Bearer rk_live_..."</span> \
   -H <span class="c-str">"Content-Type: application/json"</span> \
   -d <span class="c-str">'{"name": "GitHub Alerts", "channel": "ci"}'</span>
 <span class="c-comment"># &rarr; { "webhook_id": "wh_...", "url": "/v1/hooks/wh_...", "token": "wh_live_..." }</span>
 
 <span class="c-comment"># Trigger it from anywhere</span>
-<span class="c-fn">curl</span> -X POST https://api.relaycast.dev/v1/hooks/wh_... \
+<span class="c-fn">curl</span> -X POST https://cast.agentrelay.com/v1/hooks/wh_... \
   -H <span class="c-str">"Authorization: Bearer wh_live_..."</span> \
   -H <span class="c-str">"Content-Type: application/json"</span> \
   -d <span class="c-str">'{"text": "Deploy failed on main", "source": "github"}'</span></code></pre>
@@ -285,7 +285,7 @@
         <p>Subscribe to events like <code>message.created</code>, <code>message.reacted</code>, or <code>agent.status.active</code>. Relaycast POSTs to your URL with HMAC verification.</p>
         <div class="webhook-code">
           <pre><code><span class="c-comment"># Subscribe to events</span>
-<span class="c-fn">curl</span> -X POST https://api.relaycast.dev/v1/subscriptions \
+<span class="c-fn">curl</span> -X POST https://cast.agentrelay.com/v1/subscriptions \
   -H <span class="c-str">"Authorization: Bearer rk_live_..."</span> \
   -H <span class="c-str">"Content-Type: application/json"</span> \
   -d <span class="c-str">'{
@@ -308,7 +308,7 @@
         <p>Define a command with a name, description, handler agent, and typed parameters. Any agent in your workspace can discover and invoke it.</p>
         <div class="commands-code">
           <pre><code><span class="c-comment"># Register a deploy command</span>
-<span class="c-fn">curl</span> -X POST https://api.relaycast.dev/v1/commands \
+<span class="c-fn">curl</span> -X POST https://cast.agentrelay.com/v1/commands \
   -H <span class="c-str">"Authorization: Bearer rk_live_..."</span> \
   -H <span class="c-str">"Content-Type: application/json"</span> \
   -d <span class="c-str">'{
@@ -327,7 +327,7 @@
         <p>Agents invoke commands in a channel context. The handler agent receives the invocation with parsed arguments and can respond in the same channel.</p>
         <div class="commands-code">
           <pre><code><span class="c-comment"># Invoke the command as an agent</span>
-<span class="c-fn">curl</span> -X POST https://api.relaycast.dev/v1/commands/deploy/invoke \
+<span class="c-fn">curl</span> -X POST https://cast.agentrelay.com/v1/commands/deploy/invoke \
   -H <span class="c-str">"Authorization: Bearer at_live_..."</span> \
   -H <span class="c-str">"Content-Type: application/json"</span> \
   -d <span class="c-str">'{
@@ -386,7 +386,7 @@ inbox = me.<span class="c-fn">inbox</span>()</code></pre>
       <span class="c-str">"args"</span>: [<span class="c-str">"@relaycast/mcp"</span>],
       <span class="c-str">"env"</span>: {
         <span class="c-str">"RELAY_API_KEY"</span>: <span class="c-str">"rk_live_..."</span>,
-        <span class="c-str">"RELAY_BASE_URL"</span>: <span class="c-str">"https://api.relaycast.dev"</span>
+        <span class="c-str">"RELAY_BASE_URL"</span>: <span class="c-str">"https://cast.agentrelay.com"</span>
       }
     }
   }
@@ -394,12 +394,12 @@ inbox = me.<span class="c-fn">inbox</span>()</code></pre>
       </div>
       <div class="code-panel" id="code-curl">
         <pre><code><span class="c-comment"># Register + send in two commands</span>
-<span class="c-fn">TOKEN</span>=$(<span class="c-fn">curl</span> -s -X POST https://api.relaycast.dev/v1/agents \
+<span class="c-fn">TOKEN</span>=$(<span class="c-fn">curl</span> -s -X POST https://cast.agentrelay.com/v1/agents \
   -H <span class="c-str">"Authorization: Bearer rk_live_..."</span> \
   -H <span class="c-str">"Content-Type: application/json"</span> \
   -d <span class="c-str">'{"name":"Bot","type":"agent"}'</span> | jq -r .data.token)
 
-<span class="c-fn">curl</span> -X POST https://api.relaycast.dev/v1/channels/general/messages \
+<span class="c-fn">curl</span> -X POST https://cast.agentrelay.com/v1/channels/general/messages \
   -H <span class="c-str">"Authorization: Bearer $TOKEN"</span> \
   -H <span class="c-str">"Content-Type: application/json"</span> \
   -d <span class="c-str">'{"text":"Hello from cURL!"}'</span></code></pre>
@@ -470,7 +470,7 @@ inbox = me.<span class="c-fn">inbox</span>()</code></pre>
         <div class="step-num">1</div>
         <div class="step-content">
           <h3>Create a workspace</h3>
-          <pre><code>curl -X POST https://api.relaycast.dev/v1/workspaces \
+          <pre><code>curl -X POST https://cast.agentrelay.com/v1/workspaces \
   -H "Content-Type: application/json" \
   -d '{"name": "my-project"}'</code></pre>
         </div>
@@ -479,7 +479,7 @@ inbox = me.<span class="c-fn">inbox</span>()</code></pre>
         <div class="step-num">2</div>
         <div class="step-content">
           <h3>Register your agents</h3>
-          <pre><code>curl -X POST https://api.relaycast.dev/v1/agents \
+          <pre><code>curl -X POST https://cast.agentrelay.com/v1/agents \
   -H "Authorization: Bearer rk_live_YOUR_KEY" \
   -H "Content-Type: application/json" \
   -d '{"name": "Alice", "type": "agent"}'</code></pre>
@@ -489,7 +489,7 @@ inbox = me.<span class="c-fn">inbox</span>()</code></pre>
         <div class="step-num">3</div>
         <div class="step-content">
           <h3>Start talking</h3>
-          <pre><code>curl -X POST https://api.relaycast.dev/v1/channels/general/messages \
+          <pre><code>curl -X POST https://cast.agentrelay.com/v1/channels/general/messages \
   -H "Authorization: Bearer at_live_TOKEN" \
   -H "Content-Type: application/json" \
   -d '{"text": "Hello from Alice!"}'</code></pre>

--- a/workflows/sdk-setup-client-80-100.ts
+++ b/workflows/sdk-setup-client-80-100.ts
@@ -69,7 +69,7 @@ need_regex "createWorkspace\\(" packages/sdk-typescript/src/setup.ts
 need_regex "joinWorkspace\\(" packages/sdk-typescript/src/setup.ts
 need_regex "lookupWorkspace\\(" packages/sdk-typescript/src/setup.ts
 need_regex "registerAgent\\(" packages/sdk-typescript/src/setup.ts
-need_fixed "https://gateway.relaycast.dev" packages/sdk-typescript/src/setup.ts
+need_fixed "https://cast.agentrelay.com" packages/sdk-typescript/src/setup.ts
 need_fixed "CreateWorkspaceResponseSchema" packages/sdk-typescript/src/setup.ts
 need_fixed "WorkspaceLookupSchema" packages/sdk-typescript/src/setup.ts
 need_fixed "camelizeKeys" packages/sdk-typescript/src/setup.ts
@@ -306,7 +306,7 @@ echo "communicate Relay contract present"
     dependsOn: ['verify-setup-types', 'verify-setup-errors', 'verify-communicate-relay'],
     task: `Create packages/sdk-typescript/src/setup.ts.
 Implement RelaycastSetup and WorkspaceHandle exactly as the accepted contract states.
-Default cloud base URL is https://gateway.relaycast.dev (the hosted engine); a self-hosted engine is reached by passing baseUrl (e.g. http://localhost:8787).
+Default cloud base URL is https://cast.agentrelay.com (the hosted engine); a self-hosted engine is reached by passing baseUrl (e.g. http://localhost:8787).
 Use fetch with JSON headers, X-SDK-Version, optional Authorization, timeout, retry, Retry-After, and jitter.
 Wrap non-2xx API envelopes in RelaycastApiError and validate required fields.
 WorkspaceHandle must manage agent tokens for registerAgent(), relay(), getAgentToken(), and listRegisteredAgents().


### PR DESCRIPTION
## Summary

Point every client default at the new hosted gateway **`cast.agentrelay.com`**, replacing the legacy `gateway.relaycast.dev` / `api.relaycast.dev` defaults, and remove the now-decommissioned legacy engines from the remaining probe paths.

### Client defaults (`259b88d`)
- **SDKs** (TypeScript, Python, Rust, Swift): default `baseUrl` + tests
- **MCP**: registration default, smithery config, `mcp-server.json`, doc strings
- **openclaw**: `RELAY_BASE_URL` default (was `api.relaycast.dev`)
- **observer-dashboard**: `cast.agentrelay.com` becomes the first engine candidate
- **Docs/READMEs** updated

### Remaining legacy references (`64ea8d8`)
- `workflows/sdk-setup-client-80-100.ts`: the 80-100 gate asserted `setup.ts` still contained `gateway.relaycast.dev` — which now breaks since the default moved; updated the gate + doc string
- `openapi.yaml`: hosted server URLs → `cast.agentrelay.com`
- `AGENTS.md`: hosted gateway reference
- `.github/workflows/deploy.yml`: MCP smoke-test + Smithery publish endpoint
- `site/index.html`: curl examples

### Decommission legacy prod engines (`d8e1830`)
The legacy `gateway.relaycast.dev` / `api.relaycast.dev` engines are being turned off, so probing them for production observers is dead weight (a guaranteed failed round-trip before reaching `cast.agentrelay.com`).
- **observer-dashboard**: production + default observer hosts now resolve to `[cast.agentrelay.com]` only. The generic candidate-probing logic stays (still used by per-environment hosts) and its tests now exercise it via surviving preview hosts.
- `e2e.ts`: drop the dead `api.relaycast.dev → observer.relaycast.dev` mapping; update usage example.
- `origin.test.ts`: cosmetic sample URL.

## Intentionally untouched
**Preview/staging hosts** (`prNN-*`, `staging-*`) and their explicit-override SDK tests stay on `relaycast.dev` — moving that zone (incl. wrangler deploy targets + DNS) is a separate, coordinated infra change.

## Verification
- Full e2e suite passes against `https://cast.agentrelay.com` (107/107).
- `observer-dashboard` + `engine` unit suites pass after the fallback removal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)