### PR TITLE
[codex] Refactor engine route response helpers

### DIFF
--- a/packages/engine/src/__tests__/conformance/httpResponse.test.ts
+++ b/packages/engine/src/__tests__/conformance/httpResponse.test.ts
@@ -55,4 +55,48 @@ describe('route response helpers', () => {
       },
     });
   });
+
+  it('keeps custom validation messages when routes use the shared parser', async () => {
+    const ws = await createWorkspace(stack.app, 'subscription-validation-ws');
+
+    const missingEvents = await stack.app.request('/v1/subscriptions', {
+      method: 'POST',
+      headers: {
+        authorization: `Bearer ${ws.workspaceKey}`,
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({ url: 'https://example.test/relay' }),
+    });
+
+    expect(missingEvents.status).toBe(400);
+    await expect(missingEvents.json()).resolves.toEqual({
+      ok: false,
+      error: {
+        code: 'invalid_request',
+        message: 'events array is required',
+      },
+    });
+  });
+
+  it('returns invalid_json for another route migrated to the shared parser', async () => {
+    const ws = await createWorkspace(stack.app, 'malformed-subscription-ws');
+
+    const res = await stack.app.request('/v1/subscriptions', {
+      method: 'POST',
+      headers: {
+        authorization: `Bearer ${ws.workspaceKey}`,
+        'content-type': 'application/json',
+      },
+      body: '{',
+    });
+
+    expect(res.status).toBe(400);
+    await expect(res.json()).resolves.toEqual({
+      ok: false,
+      error: {
+        code: 'invalid_json',
+        message: 'Malformed JSON in request body',
+      },
+    });
+  });
 });

--- a/packages/engine/src/__tests__/conformance/httpResponse.test.ts
+++ b/packages/engine/src/__tests__/conformance/httpResponse.test.ts
@@ -1,0 +1,58 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { createWorkspace, makeNodeStack, registerAgent, type TestStack } from './harness.js';
+
+describe('route response helpers', () => {
+  let stack: TestStack;
+
+  beforeEach(() => {
+    stack = makeNodeStack();
+  });
+
+  afterEach(() => stack.close());
+
+  it('returns invalid_json for malformed bodies handled by the shared parser', async () => {
+    const ws = await createWorkspace(stack.app, 'malformed-trigger-ws');
+    const agent = await registerAgent(stack.app, ws.workspaceKey, 'parser-agent');
+
+    const res = await stack.app.request('/v1/triggers', {
+      method: 'POST',
+      headers: {
+        authorization: `Bearer ${agent.token}`,
+        'content-type': 'application/json',
+      },
+      body: '{',
+    });
+
+    expect(res.status).toBe(400);
+    await expect(res.json()).resolves.toEqual({
+      ok: false,
+      error: {
+        code: 'invalid_json',
+        message: 'Malformed JSON in request body',
+      },
+    });
+  });
+
+  it('returns invalid_json for malformed bodies that still flow through route catches', async () => {
+    const ws = await createWorkspace(stack.app, 'malformed-channel-ws');
+    const agent = await registerAgent(stack.app, ws.workspaceKey, 'channel-agent');
+
+    const res = await stack.app.request('/v1/channels', {
+      method: 'POST',
+      headers: {
+        authorization: `Bearer ${agent.token}`,
+        'content-type': 'application/json',
+      },
+      body: '{',
+    });
+
+    expect(res.status).toBe(400);
+    await expect(res.json()).resolves.toEqual({
+      ok: false,
+      error: {
+        code: 'invalid_json',
+        message: 'Malformed JSON in request body',
+      },
+    });
+  });
+});

--- a/packages/engine/src/lib/__tests__/httpError.test.ts
+++ b/packages/engine/src/lib/__tests__/httpError.test.ts
@@ -1,0 +1,43 @@
+import type { Context } from 'hono';
+import { describe, expect, it, vi } from 'vitest';
+
+import { codedError, errorResponse } from '../httpError.js';
+
+function testContext(): Context {
+  return {
+    json: vi.fn((body: unknown, status?: number) =>
+      new Response(JSON.stringify(body), { status: status ?? 200 }),
+    ),
+  } as unknown as Context;
+}
+
+describe('errorResponse', () => {
+  it('maps JSON syntax errors to malformed body responses', async () => {
+    const response = errorResponse(testContext(), new SyntaxError('Unexpected end of JSON input'));
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({
+      ok: false,
+      error: {
+        code: 'invalid_json',
+        message: 'Malformed JSON in request body',
+      },
+    });
+  });
+
+  it('preserves coded errors whose message mentions JSON', async () => {
+    const response = errorResponse(
+      testContext(),
+      codedError('No active agents found for skill "JSON"', 'route_not_found', 404),
+    );
+
+    expect(response.status).toBe(404);
+    await expect(response.json()).resolves.toEqual({
+      ok: false,
+      error: {
+        code: 'route_not_found',
+        message: 'No active agents found for skill "JSON"',
+      },
+    });
+  });
+});

--- a/packages/engine/src/lib/httpError.ts
+++ b/packages/engine/src/lib/httpError.ts
@@ -44,7 +44,7 @@ export function codedError(message: string, code: string, status: number): Coded
  */
 export function errorResponse(c: Context, err: unknown) {
   const error = asCodedError(err);
-  if (error.message?.includes('JSON')) {
+  if (error instanceof SyntaxError && error.message?.includes('JSON')) {
     return jsonMalformedBody(c);
   }
   return jsonError(

--- a/packages/engine/src/lib/httpError.ts
+++ b/packages/engine/src/lib/httpError.ts
@@ -44,7 +44,7 @@ export function codedError(message: string, code: string, status: number): Coded
  */
 export function errorResponse(c: Context, err: unknown) {
   const error = asCodedError(err);
-  if (error instanceof SyntaxError && error.message?.includes('JSON')) {
+  if (err instanceof SyntaxError) {
     return jsonMalformedBody(c);
   }
   return jsonError(

--- a/packages/engine/src/lib/httpError.ts
+++ b/packages/engine/src/lib/httpError.ts
@@ -1,5 +1,6 @@
 import type { Context } from 'hono';
 import type { ContentfulStatusCode } from 'hono/utils/http-status';
+import { jsonError, jsonMalformedBody } from './httpResponse.js';
 
 /**
  * Errors thrown inside the engine optionally carry a stable error `code` and an
@@ -43,11 +44,13 @@ export function codedError(message: string, code: string, status: number): Coded
  */
 export function errorResponse(c: Context, err: unknown) {
   const error = asCodedError(err);
-  return c.json(
-    {
-      ok: false as const,
-      error: { code: error.code || 'internal_error', message: error.message },
-    },
+  if (error.message?.includes('JSON')) {
+    return jsonMalformedBody(c);
+  }
+  return jsonError(
+    c,
+    error.code || 'internal_error',
+    error.message,
     (error.status || 500) as ContentfulStatusCode,
   );
 }

--- a/packages/engine/src/lib/httpResponse.ts
+++ b/packages/engine/src/lib/httpResponse.ts
@@ -2,8 +2,19 @@ import type { Context } from 'hono';
 import type { ContentfulStatusCode } from 'hono/utils/http-status';
 
 interface SafeParseSchema<T> {
-  safeParse(value: unknown): { success: true; data: T } | { success: false };
+  safeParse(value: unknown): { success: true; data: T } | SafeParseFailure;
 }
+
+interface ValidationIssue {
+  path: Array<string | number | symbol>;
+}
+
+interface SafeParseFailure {
+  success: false;
+  error?: { issues?: ValidationIssue[] };
+}
+
+type InvalidRequestMessage = string | ((failure: SafeParseFailure) => string);
 
 type ParsedJsonBody<T> =
   | { ok: true; data: T }
@@ -40,7 +51,7 @@ export function jsonMalformedBody(c: Context) {
 export async function parseJsonBody<T>(
   c: Context,
   schema: SafeParseSchema<T>,
-  invalidMessage: string,
+  invalidMessage: InvalidRequestMessage,
 ): Promise<ParsedJsonBody<T>> {
   let body: unknown;
 
@@ -52,7 +63,8 @@ export async function parseJsonBody<T>(
 
   const parsed = schema.safeParse(body);
   if (!parsed.success) {
-    return { ok: false, response: jsonInvalidRequest(c, invalidMessage) };
+    const message = typeof invalidMessage === 'function' ? invalidMessage(parsed) : invalidMessage;
+    return { ok: false, response: jsonInvalidRequest(c, message) };
   }
 
   return { ok: true, data: parsed.data };

--- a/packages/engine/src/lib/httpResponse.ts
+++ b/packages/engine/src/lib/httpResponse.ts
@@ -1,0 +1,59 @@
+import type { Context } from 'hono';
+import type { ContentfulStatusCode } from 'hono/utils/http-status';
+
+interface SafeParseSchema<T> {
+  safeParse(value: unknown): { success: true; data: T } | { success: false };
+}
+
+type ParsedJsonBody<T> =
+  | { ok: true; data: T }
+  | { ok: false; response: Response };
+
+export function jsonOk<T>(c: Context, data: T, status: ContentfulStatusCode = 200) {
+  return c.json({ ok: true as const, data }, status);
+}
+
+export function jsonCreated<T>(c: Context, data: T) {
+  return jsonOk(c, data, 201);
+}
+
+export function jsonNoContent(c: Context) {
+  return c.body(null, 204);
+}
+
+export function jsonError(c: Context, code: string, message: string, status: ContentfulStatusCode) {
+  return c.json({ ok: false as const, error: { code, message } }, status);
+}
+
+export function jsonInvalidRequest(c: Context, message: string) {
+  return jsonError(c, 'invalid_request', message, 400);
+}
+
+export function jsonNotFound(c: Context, code: string, message: string) {
+  return jsonError(c, code, message, 404);
+}
+
+export function jsonMalformedBody(c: Context) {
+  return jsonError(c, 'invalid_json', 'Malformed JSON in request body', 400);
+}
+
+export async function parseJsonBody<T>(
+  c: Context,
+  schema: SafeParseSchema<T>,
+  invalidMessage: string,
+): Promise<ParsedJsonBody<T>> {
+  let body: unknown;
+
+  try {
+    body = await c.req.json();
+  } catch {
+    return { ok: false, response: jsonMalformedBody(c) };
+  }
+
+  const parsed = schema.safeParse(body);
+  if (!parsed.success) {
+    return { ok: false, response: jsonInvalidRequest(c, invalidMessage) };
+  }
+
+  return { ok: true, data: parsed.data };
+}

--- a/packages/engine/src/lib/httpResponse.ts
+++ b/packages/engine/src/lib/httpResponse.ts
@@ -6,12 +6,14 @@ interface SafeParseSchema<T> {
 }
 
 interface ValidationIssue {
-  path: Array<string | number | symbol>;
+  code: string;
+  message: string;
+  path: PropertyKey[];
 }
 
 interface SafeParseFailure {
   success: false;
-  error?: { issues?: ValidationIssue[] };
+  error: { issues: ValidationIssue[] };
 }
 
 type InvalidRequestMessage = string | ((failure: SafeParseFailure) => string);

--- a/packages/engine/src/routes/eventSubscription.ts
+++ b/packages/engine/src/routes/eventSubscription.ts
@@ -6,6 +6,13 @@ import { rateLimit } from '../middleware/rateLimit.js';
 import * as eventSubscriptionEngine from '../engine/eventSubscription.js';
 import { emitServerEvent } from '../lib/serverTelemetry.js';
 import { errorResponse } from '../lib/httpError.js';
+import {
+  jsonCreated,
+  jsonNoContent,
+  jsonNotFound,
+  jsonOk,
+  parseJsonBody,
+} from '../lib/httpResponse.js';
 
 export const eventSubscriptionRoutes = new Hono<AppEnv>();
 
@@ -28,19 +35,18 @@ eventSubscriptionRoutes.post('/subscriptions', requireAuth, rateLimit, async (c)
   try {
     const db = c.get('db');
     const workspace = c.get('workspace');
-    const parsed = createSubscriptionSchema.safeParse(await c.req.json());
-    if (!parsed.success) {
-      const hasEventsIssue = parsed.error.issues.some((issue) => issue.path[0] === 'events');
-      const hasUrlIssue = parsed.error.issues.some((issue) => issue.path[0] === 'url');
-      const message = hasEventsIssue
+    const parsed = await parseJsonBody(c, createSubscriptionSchema, (failure) => {
+      const issues = failure.error?.issues ?? [];
+      const hasEventsIssue = issues.some((issue) => issue.path[0] === 'events');
+      const hasUrlIssue = issues.some((issue) => issue.path[0] === 'url');
+      return hasEventsIssue
         ? 'events array is required'
         : hasUrlIssue
           ? 'url is required'
           : 'invalid subscription body';
-      return c.json({
-        ok: false,
-        error: { code: 'invalid_request', message },
-      }, 400);
+    });
+    if (!parsed.ok) {
+      return parsed.response;
     }
     const { events, filter, url, headers, secret } = parsed.data;
 
@@ -53,7 +59,7 @@ eventSubscriptionRoutes.post('/subscriptions', requireAuth, rateLimit, async (c)
       subscription_id: result.id,
       event_count: result.events.length,
     });
-    return c.json({ ok: true, data: result }, 201);
+    return jsonCreated(c, result);
   } catch (err: unknown) {
     return errorResponse(c, err);
   }
@@ -65,7 +71,7 @@ eventSubscriptionRoutes.get('/subscriptions', requireAuth, rateLimit, async (c) 
     const db = c.get('db');
     const workspace = c.get('workspace');
     const result = await eventSubscriptionEngine.listSubscriptions(db, workspace.id);
-    return c.json({ ok: true, data: result });
+    return jsonOk(c, result);
   } catch (err: unknown) {
     return errorResponse(c, err);
   }
@@ -82,12 +88,9 @@ eventSubscriptionRoutes.get('/subscriptions/:id', requireAuth, rateLimit, async 
       c.req.param('id'),
     );
     if (!result) {
-      return c.json({
-        ok: false,
-        error: { code: 'subscription_not_found', message: 'Subscription not found' },
-      }, 404);
+      return jsonNotFound(c, 'subscription_not_found', 'Subscription not found');
     }
-    return c.json({ ok: true, data: result });
+    return jsonOk(c, result);
   } catch (err: unknown) {
     return errorResponse(c, err);
   }
@@ -104,15 +107,12 @@ eventSubscriptionRoutes.delete('/subscriptions/:id', requireAuth, rateLimit, asy
       c.req.param('id'),
     );
     if (!deleted) {
-      return c.json({
-        ok: false,
-        error: { code: 'subscription_not_found', message: 'Subscription not found' },
-      }, 404);
+      return jsonNotFound(c, 'subscription_not_found', 'Subscription not found');
     }
     emitServerEvent(c, workspace.id, 'relaycast_server_subscription_deleted', {
       subscription_id: c.req.param('id'),
     });
-    return c.body(null, 204);
+    return jsonNoContent(c);
   } catch (err: unknown) {
     return errorResponse(c, err);
   }

--- a/packages/engine/src/routes/eventSubscription.ts
+++ b/packages/engine/src/routes/eventSubscription.ts
@@ -36,7 +36,7 @@ eventSubscriptionRoutes.post('/subscriptions', requireAuth, rateLimit, async (c)
     const db = c.get('db');
     const workspace = c.get('workspace');
     const parsed = await parseJsonBody(c, createSubscriptionSchema, (failure) => {
-      const issues = failure.error?.issues ?? [];
+      const issues = failure.error.issues;
       const hasEventsIssue = issues.some((issue) => issue.path[0] === 'events');
       const hasUrlIssue = issues.some((issue) => issue.path[0] === 'url');
       return hasEventsIssue

--- a/packages/engine/src/routes/node.ts
+++ b/packages/engine/src/routes/node.ts
@@ -5,6 +5,12 @@ import { requireAuth, requireWorkspaceKey } from '../middleware/auth.js';
 import { rateLimit } from '../middleware/rateLimit.js';
 import { requireFleetNodes } from '../middleware/fleetNodes.js';
 import { errorResponse } from '../lib/httpError.js';
+import {
+  jsonCreated,
+  jsonNotFound,
+  jsonOk,
+  parseJsonBody,
+} from '../lib/httpResponse.js';
 import * as nodeEngine from '../engine/node.js';
 
 export const nodeRoutes = new Hono<AppEnv>();
@@ -21,12 +27,12 @@ const createNodeSchema = z.object({
 // POST /v1/nodes - enroll or rotate a node token (workspace-key only)
 nodeRoutes.post('/nodes', requireWorkspaceKey, requireFleetNodes, rateLimit, async (c) => {
   try {
-    const parsed = createNodeSchema.safeParse(await c.req.json());
-    if (!parsed.success) {
-      return c.json({ ok: false, error: { code: 'invalid_request', message: 'invalid node body' } }, 400);
+    const parsed = await parseJsonBody(c, createNodeSchema, 'invalid node body');
+    if (!parsed.ok) {
+      return parsed.response;
     }
     const result = await nodeEngine.createNodeToken(c.get('db'), c.get('workspace').id, parsed.data);
-    return c.json({ ok: true, data: result }, 201);
+    return jsonCreated(c, result);
   } catch (err: unknown) {
     return errorResponse(c, err);
   }
@@ -39,7 +45,7 @@ nodeRoutes.get('/nodes', requireAuth, requireFleetNodes, rateLimit, async (c) =>
       capability: c.req.query('capability'),
       name: c.req.query('name'),
     });
-    return c.json({ ok: true, data: result });
+    return jsonOk(c, result);
   } catch (err: unknown) {
     return errorResponse(c, err);
   }
@@ -50,9 +56,9 @@ nodeRoutes.get('/nodes/:name', requireAuth, requireFleetNodes, rateLimit, async 
   try {
     const result = await nodeEngine.getPublicNode(c.get('db'), c.get('workspace').id, c.req.param('name'));
     if (!result) {
-      return c.json({ ok: false, error: { code: 'node_not_found', message: 'Node not found' } }, 404);
+      return jsonNotFound(c, 'node_not_found', 'Node not found');
     }
-    return c.json({ ok: true, data: result });
+    return jsonOk(c, result);
   } catch (err: unknown) {
     return errorResponse(c, err);
   }

--- a/packages/engine/src/routes/receipt.ts
+++ b/packages/engine/src/routes/receipt.ts
@@ -10,6 +10,7 @@ import { runInBackground } from './background.js';
 import { sendWebhookEvent } from './webhookOutbox.js';
 import { emitServerEvent } from '../lib/serverTelemetry.js';
 import { errorResponse } from '../lib/httpError.js';
+import { jsonNotFound, jsonOk } from '../lib/httpResponse.js';
 
 export const receiptRoutes = new Hono<AppEnv>();
 
@@ -30,10 +31,7 @@ receiptRoutes.post(
         agent!.id,
       );
       if (!result) {
-        return c.json({
-          ok: false,
-          error: { code: 'message_not_found', message: 'Message not found' },
-        }, 404);
+        return jsonNotFound(c, 'message_not_found', 'Message not found');
       }
 
       const eventData = { ...result, agent_name: agent!.name };
@@ -59,7 +57,7 @@ receiptRoutes.post(
         agent_id: result.agent_id,
       });
 
-      return c.json({ ok: true, data: result }, 200);
+      return jsonOk(c, result);
     } catch (err: unknown) {
       return errorResponse(c, err);
     }
@@ -81,13 +79,10 @@ receiptRoutes.get(
         c.req.param('id'),
       );
       if (result === null) {
-        return c.json({
-          ok: false,
-          error: { code: 'message_not_found', message: 'Message not found' },
-        }, 404);
+        return jsonNotFound(c, 'message_not_found', 'Message not found');
       }
 
-      return c.json({ ok: true, data: result });
+      return jsonOk(c, result);
     } catch (err: unknown) {
       return errorResponse(c, err);
     }
@@ -109,13 +104,10 @@ receiptRoutes.get(
         c.req.param('name'),
       );
       if (result === null) {
-        return c.json({
-          ok: false,
-          error: { code: 'channel_not_found', message: 'Channel not found' },
-        }, 404);
+        return jsonNotFound(c, 'channel_not_found', 'Channel not found');
       }
 
-      return c.json({ ok: true, data: result });
+      return jsonOk(c, result);
     } catch (err: unknown) {
       return errorResponse(c, err);
     }

--- a/packages/engine/src/routes/systemPrompt.ts
+++ b/packages/engine/src/routes/systemPrompt.ts
@@ -6,6 +6,7 @@ import { rateLimit } from '../middleware/rateLimit.js';
 import * as systemPromptEngine from '../engine/systemPrompt.js';
 import { emitServerEvent } from '../lib/serverTelemetry.js';
 import { errorResponse } from '../lib/httpError.js';
+import { jsonInvalidRequest, jsonOk, parseJsonBody } from '../lib/httpResponse.js';
 
 export const systemPromptRoutes = new Hono<AppEnv>();
 
@@ -19,7 +20,7 @@ systemPromptRoutes.get('/workspace/system-prompt', requireAuth, rateLimit, async
     const db = c.get('db');
     const workspace = c.get('workspace');
     const result = await systemPromptEngine.getSystemPrompt(db, workspace.id);
-    return c.json({ ok: true, data: result });
+    return jsonOk(c, result);
   } catch (err: unknown) {
     return errorResponse(c, err);
   }
@@ -29,12 +30,9 @@ systemPromptRoutes.put('/workspace/system-prompt', requireWorkspaceKey, rateLimi
   try {
     const db = c.get('db');
     const workspace = c.get('workspace');
-    const parsed = updateSystemPromptSchema.safeParse(await c.req.json());
-    if (!parsed.success) {
-      return c.json({
-        ok: false,
-        error: { code: 'invalid_request', message: 'invalid system prompt body' },
-      }, 400);
+    const parsed = await parseJsonBody(c, updateSystemPromptSchema, 'invalid system prompt body');
+    if (!parsed.ok) {
+      return parsed.response;
     }
     const { prompt, reset } = parsed.data;
 
@@ -43,21 +41,18 @@ systemPromptRoutes.put('/workspace/system-prompt', requireWorkspaceKey, rateLimi
       emitServerEvent(c, workspace.id, 'relaycast_server_system_prompt_updated', {
         operation: 'reset',
       });
-      return c.json({ ok: true, data: result });
+      return jsonOk(c, result);
     }
 
     if (!prompt || typeof prompt !== 'string') {
-      return c.json({
-        ok: false,
-        error: { code: 'invalid_request', message: 'prompt must be a non-empty string' },
-      }, 400);
+      return jsonInvalidRequest(c, 'prompt must be a non-empty string');
     }
 
     const result = await systemPromptEngine.setSystemPrompt(db, workspace.id, prompt);
     emitServerEvent(c, workspace.id, 'relaycast_server_system_prompt_updated', {
       operation: 'set',
     });
-    return c.json({ ok: true, data: result });
+    return jsonOk(c, result);
   } catch (err: unknown) {
     return errorResponse(c, err);
   }

--- a/packages/engine/src/routes/trigger.ts
+++ b/packages/engine/src/routes/trigger.ts
@@ -4,6 +4,13 @@ import type { AppEnv } from '../env.js';
 import { requireAuth } from '../middleware/auth.js';
 import { rateLimit } from '../middleware/rateLimit.js';
 import { errorResponse } from '../lib/httpError.js';
+import {
+  jsonCreated,
+  jsonNoContent,
+  jsonNotFound,
+  jsonOk,
+  parseJsonBody,
+} from '../lib/httpResponse.js';
 import * as triggerEngine from '../engine/trigger.js';
 
 export const triggerRoutes = new Hono<AppEnv>();
@@ -21,12 +28,12 @@ const updateTriggerBodySchema = triggerBodySchema.partial();
 // POST /v1/triggers
 triggerRoutes.post('/triggers', requireAuth, rateLimit, async (c) => {
   try {
-    const parsed = triggerBodySchema.safeParse(await c.req.json());
-    if (!parsed.success) {
-      return c.json({ ok: false, error: { code: 'invalid_request', message: 'invalid trigger body' } }, 400);
+    const parsed = await parseJsonBody(c, triggerBodySchema, 'invalid trigger body');
+    if (!parsed.ok) {
+      return parsed.response;
     }
     const result = await triggerEngine.createTrigger(c.get('db'), c.get('workspace').id, parsed.data);
-    return c.json({ ok: true, data: result }, 201);
+    return jsonCreated(c, result);
   } catch (err: unknown) {
     return errorResponse(c, err);
   }
@@ -36,7 +43,7 @@ triggerRoutes.post('/triggers', requireAuth, rateLimit, async (c) => {
 triggerRoutes.get('/triggers', requireAuth, rateLimit, async (c) => {
   try {
     const result = await triggerEngine.listTriggers(c.get('db'), c.get('workspace').id);
-    return c.json({ ok: true, data: result });
+    return jsonOk(c, result);
   } catch (err: unknown) {
     return errorResponse(c, err);
   }
@@ -47,9 +54,9 @@ triggerRoutes.get('/triggers/:id', requireAuth, rateLimit, async (c) => {
   try {
     const result = await triggerEngine.getTrigger(c.get('db'), c.get('workspace').id, c.req.param('id'));
     if (!result) {
-      return c.json({ ok: false, error: { code: 'trigger_not_found', message: 'Trigger not found' } }, 404);
+      return jsonNotFound(c, 'trigger_not_found', 'Trigger not found');
     }
-    return c.json({ ok: true, data: result });
+    return jsonOk(c, result);
   } catch (err: unknown) {
     return errorResponse(c, err);
   }
@@ -58,15 +65,15 @@ triggerRoutes.get('/triggers/:id', requireAuth, rateLimit, async (c) => {
 // PATCH /v1/triggers/:id
 triggerRoutes.patch('/triggers/:id', requireAuth, rateLimit, async (c) => {
   try {
-    const parsed = updateTriggerBodySchema.safeParse(await c.req.json());
-    if (!parsed.success) {
-      return c.json({ ok: false, error: { code: 'invalid_request', message: 'invalid trigger body' } }, 400);
+    const parsed = await parseJsonBody(c, updateTriggerBodySchema, 'invalid trigger body');
+    if (!parsed.ok) {
+      return parsed.response;
     }
     const result = await triggerEngine.updateTrigger(c.get('db'), c.get('workspace').id, c.req.param('id'), parsed.data);
     if (!result) {
-      return c.json({ ok: false, error: { code: 'trigger_not_found', message: 'Trigger not found' } }, 404);
+      return jsonNotFound(c, 'trigger_not_found', 'Trigger not found');
     }
-    return c.json({ ok: true, data: result });
+    return jsonOk(c, result);
   } catch (err: unknown) {
     return errorResponse(c, err);
   }
@@ -77,9 +84,9 @@ triggerRoutes.delete('/triggers/:id', requireAuth, rateLimit, async (c) => {
   try {
     const deleted = await triggerEngine.deleteTrigger(c.get('db'), c.get('workspace').id, c.req.param('id'));
     if (!deleted) {
-      return c.json({ ok: false, error: { code: 'trigger_not_found', message: 'Trigger not found' } }, 404);
+      return jsonNotFound(c, 'trigger_not_found', 'Trigger not found');
     }
-    return c.body(null, 204);
+    return jsonNoContent(c);
   } catch (err: unknown) {
     return errorResponse(c, err);
   }


### PR DESCRIPTION
## What changed

This refactors a slice of the engine route layer around HTTP response envelopes and JSON body parsing.

- Added shared response helpers for success, created, no-content, invalid request, not found, malformed JSON, and zod-backed JSON body parsing.
- Reused the helpers in node, trigger, system prompt, event subscription, and receipt routes.
- Preserved custom validation messages for event subscriptions by allowing parser callers to derive the invalid-request message from schema issues.
- Added conformance coverage for malformed JSON handling and custom validation message preservation.

## Why

Route modules were repeatedly hand-rendering the same `{ ok: true, data }` and `{ ok: false, error }` envelopes and each `try/catch` could decide malformed JSON behavior independently. Centralizing the common response paths gives the engine one pattern for new routes while preserving the existing snake_case wire contract and route-specific validation semantics.

## Validation

- `git diff --check`
- `npm --workspace @relaycast/engine run typecheck`
- `npm --workspace @relaycast/engine run lint`
- `npm --workspace @relaycast/engine test -- src/__tests__/conformance/httpResponse.test.ts`
- `npm --workspace @relaycast/engine test -- src/__tests__/conformance/httpResponse.test.ts src/__tests__/conformance/sdk-contract.test.ts`
- `npm --workspace @relaycast/engine test`
- `npm --workspace @relaycast/engine run build`
- Live built-server HTTP exercise on `127.0.0.1:18788` for workspace/agent creation, malformed JSON, trigger create/list.
- Live built-server HTTP exercise on `127.0.0.1:18789` for system prompt, subscription validation/create/list/get/delete, and read receipt flows.

External `codex review --uncommitted` was attempted after user approval, but tenant policy still rejected uploading uncommitted private repository contents. I used the local automated review gate above as the safer substitute and recorded that in `/tmp/refactor-relaycast.md`.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/AgentWorkforce/relaycast/pull/207?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

