### PR TITLE
[codex] Refactor engine architecture helpers

### DIFF
--- a/packages/engine/src/__tests__/conformance/httpResponse.test.ts
+++ b/packages/engine/src/__tests__/conformance/httpResponse.test.ts
@@ -524,4 +524,26 @@ describe('route response helpers', () => {
       },
     });
   });
+
+  it('returns invalid_json for malformed workspace update request bodies', async () => {
+    const ws = await createWorkspace(stack.app, 'malformed-workspace-update-ws');
+
+    const res = await stack.app.request('/v1/workspace', {
+      method: 'PATCH',
+      headers: {
+        authorization: `Bearer ${ws.workspaceKey}`,
+        'content-type': 'application/json',
+      },
+      body: '{',
+    });
+
+    expect(res.status).toBe(400);
+    await expect(res.json()).resolves.toEqual({
+      ok: false,
+      error: {
+        code: 'invalid_json',
+        message: 'Malformed JSON in request body',
+      },
+    });
+  });
 });

--- a/packages/engine/src/__tests__/conformance/httpResponse.test.ts
+++ b/packages/engine/src/__tests__/conformance/httpResponse.test.ts
@@ -546,4 +546,26 @@ describe('route response helpers', () => {
       },
     });
   });
+
+  it('returns invalid_json for malformed A2A registration request bodies', async () => {
+    const ws = await createWorkspace(stack.app, 'malformed-a2a-ws');
+
+    const res = await stack.app.request('/v1/a2a/register', {
+      method: 'POST',
+      headers: {
+        authorization: `Bearer ${ws.workspaceKey}`,
+        'content-type': 'application/json',
+      },
+      body: '{',
+    });
+
+    expect(res.status).toBe(400);
+    await expect(res.json()).resolves.toEqual({
+      ok: false,
+      error: {
+        code: 'invalid_json',
+        message: 'Malformed JSON in request body',
+      },
+    });
+  });
 });

--- a/packages/engine/src/__tests__/conformance/httpResponse.test.ts
+++ b/packages/engine/src/__tests__/conformance/httpResponse.test.ts
@@ -230,4 +230,26 @@ describe('route response helpers', () => {
       },
     });
   });
+
+  it('returns invalid_json for malformed certification request bodies', async () => {
+    const ws = await createWorkspace(stack.app, 'malformed-certification-ws');
+
+    const res = await stack.app.request('/v1/certify/monitor', {
+      method: 'POST',
+      headers: {
+        authorization: `Bearer ${ws.workspaceKey}`,
+        'content-type': 'application/json',
+      },
+      body: '{',
+    });
+
+    expect(res.status).toBe(400);
+    await expect(res.json()).resolves.toEqual({
+      ok: false,
+      error: {
+        code: 'invalid_json',
+        message: 'Malformed JSON in request body',
+      },
+    });
+  });
 });

--- a/packages/engine/src/__tests__/conformance/httpResponse.test.ts
+++ b/packages/engine/src/__tests__/conformance/httpResponse.test.ts
@@ -211,6 +211,29 @@ describe('route response helpers', () => {
     });
   });
 
+  it('returns invalid_json for malformed channel message request bodies', async () => {
+    const ws = await createWorkspace(stack.app, 'malformed-message-ws');
+    const agent = await registerAgent(stack.app, ws.workspaceKey, 'message-agent');
+
+    const res = await stack.app.request('/v1/channels/general/messages', {
+      method: 'POST',
+      headers: {
+        authorization: `Bearer ${agent.token}`,
+        'content-type': 'application/json',
+      },
+      body: '{',
+    });
+
+    expect(res.status).toBe(400);
+    await expect(res.json()).resolves.toEqual({
+      ok: false,
+      error: {
+        code: 'invalid_json',
+        message: 'Malformed JSON in request body',
+      },
+    });
+  });
+
   it('returns invalid_json for malformed group DM request bodies', async () => {
     const ws = await createWorkspace(stack.app, 'malformed-group-dm-ws');
     const agent = await registerAgent(stack.app, ws.workspaceKey, 'group-dm-agent');

--- a/packages/engine/src/__tests__/conformance/httpResponse.test.ts
+++ b/packages/engine/src/__tests__/conformance/httpResponse.test.ts
@@ -446,4 +446,27 @@ describe('route response helpers', () => {
       },
     });
   });
+
+  it('returns invalid_json for malformed optional action invocation bodies', async () => {
+    const ws = await createWorkspace(stack.app, 'malformed-action-ws');
+    const agent = await registerAgent(stack.app, ws.workspaceKey, 'action-agent');
+
+    const res = await stack.app.request('/v1/actions/missing/invoke', {
+      method: 'POST',
+      headers: {
+        authorization: `Bearer ${agent.token}`,
+        'content-type': 'application/json',
+      },
+      body: '{',
+    });
+
+    expect(res.status).toBe(400);
+    await expect(res.json()).resolves.toEqual({
+      ok: false,
+      error: {
+        code: 'invalid_json',
+        message: 'Malformed JSON in request body',
+      },
+    });
+  });
 });

--- a/packages/engine/src/__tests__/conformance/httpResponse.test.ts
+++ b/packages/engine/src/__tests__/conformance/httpResponse.test.ts
@@ -357,6 +357,164 @@ describe('route response helpers', () => {
         message: 'Invalid console message query',
       },
     });
+
+    const emptyLimit = await stack.app.request('/v1/console/messages?limit=', {
+      headers: {
+        authorization: `Bearer ${ws.workspaceKey}`,
+      },
+    });
+
+    expect(emptyLimit.status).toBe(200);
+    await expect(emptyLimit.json()).resolves.toMatchObject({ ok: true });
+  });
+
+  it('uses schema-backed validation messages for search query parameters', async () => {
+    const ws = await createWorkspace(stack.app, 'search-query-validation-ws');
+
+    const missingQ = await stack.app.request('/v1/search?q=   ', {
+      headers: {
+        authorization: `Bearer ${ws.workspaceKey}`,
+      },
+    });
+    expect(missingQ.status).toBe(400);
+    await expect(missingQ.json()).resolves.toEqual({
+      ok: false,
+      error: {
+        code: 'invalid_request',
+        message: 'q (search query) is required',
+      },
+    });
+
+    const invalidLimit = await stack.app.request('/v1/search?q=hello&limit=not-a-number', {
+      headers: {
+        authorization: `Bearer ${ws.workspaceKey}`,
+      },
+    });
+    expect(invalidLimit.status).toBe(400);
+    await expect(invalidLimit.json()).resolves.toEqual({
+      ok: false,
+      error: {
+        code: 'invalid_request',
+        message: 'Invalid search query',
+      },
+    });
+  });
+
+  it('keeps success envelopes consistent for command-style routes', async () => {
+    const ws = await createWorkspace(stack.app, 'presence-success-envelope-ws');
+    const agent = await registerAgent(stack.app, ws.workspaceKey, 'presence-success-agent');
+
+    const res = await stack.app.request('/v1/agents/heartbeat', {
+      method: 'POST',
+      headers: { authorization: `Bearer ${agent.token}` },
+    });
+
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toEqual({ ok: true, data: null });
+  });
+
+  it('enforces schema-level handler requirements for action registration', async () => {
+    const ws = await createWorkspace(stack.app, 'action-handler-validation-ws');
+
+    const res = await stack.app.request('/v1/actions', {
+      method: 'POST',
+      headers: {
+        authorization: `Bearer ${ws.workspaceKey}`,
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({ name: 'missing-handler', description: 'no handler' }),
+    });
+
+    expect(res.status).toBe(400);
+    await expect(res.json()).resolves.toEqual({
+      ok: false,
+      error: {
+        code: 'invalid_request',
+        message: 'handler_agent or handler_node is required',
+      },
+    });
+  });
+
+  it('reports field-specific message validation failures', async () => {
+    const ws = await createWorkspace(stack.app, 'message-validation-ws');
+    const agent = await registerAgent(stack.app, ws.workspaceKey, 'message-validation-agent');
+
+    const res = await stack.app.request('/v1/channels/general/messages', {
+      method: 'POST',
+      headers: {
+        authorization: `Bearer ${agent.token}`,
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({ text: 'hello', mode: 'invalid' }),
+    });
+
+    expect(res.status).toBe(400);
+    await expect(res.json()).resolves.toEqual({
+      ok: false,
+      error: {
+        code: 'invalid_request',
+        message: 'mode must be "wait" or "steer"',
+      },
+    });
+  });
+
+  it('uses a generic validation message for invalid thread reply bodies', async () => {
+    const ws = await createWorkspace(stack.app, 'thread-validation-ws');
+    const agent = await registerAgent(stack.app, ws.workspaceKey, 'thread-validation-agent');
+
+    const res = await stack.app.request('/v1/messages/missing/replies', {
+      method: 'POST',
+      headers: {
+        authorization: `Bearer ${agent.token}`,
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({ text: 'reply', blocks: 'not-array' }),
+    });
+
+    expect(res.status).toBe(400);
+    await expect(res.json()).resolves.toEqual({
+      ok: false,
+      error: {
+        code: 'invalid_request',
+        message: 'invalid reply body',
+      },
+    });
+  });
+
+  it('rejects mixed workspace feature override payloads and caps activity limits', async () => {
+    const ws = await createWorkspace(stack.app, 'workspace-feature-validation-ws');
+
+    for (const path of ['/v1/workspace/stream', '/v1/workspace/fleet-nodes']) {
+      const mixed = await stack.app.request(path, {
+        method: 'PUT',
+        headers: {
+          authorization: `Bearer ${ws.workspaceKey}`,
+          'content-type': 'application/json',
+        },
+        body: JSON.stringify({ enabled: true, mode: 'inherit' }),
+      });
+      expect(mixed.status).toBe(400);
+      await expect(mixed.json()).resolves.toEqual({
+        ok: false,
+        error: {
+          code: 'invalid_request',
+          message: 'Provide { enabled: boolean } or { mode: "inherit" }',
+        },
+      });
+    }
+
+    const tooLarge = await stack.app.request('/v1/activity?limit=501', {
+      headers: { authorization: `Bearer ${ws.workspaceKey}` },
+    });
+
+    expect(tooLarge.status).toBe(400);
+    await expect(tooLarge.json()).resolves.toEqual({
+      ok: false,
+      error: {
+        code: 'invalid_request',
+        message: 'Invalid activity query',
+      },
+    });
   });
 
   it('supports optional delivery fail bodies through the shared parser', async () => {

--- a/packages/engine/src/__tests__/conformance/httpResponse.test.ts
+++ b/packages/engine/src/__tests__/conformance/httpResponse.test.ts
@@ -211,6 +211,57 @@ describe('route response helpers', () => {
     });
   });
 
+  it('returns invalid_json for malformed thread reply request bodies', async () => {
+    const ws = await createWorkspace(stack.app, 'malformed-thread-ws');
+    const agent = await registerAgent(stack.app, ws.workspaceKey, 'thread-agent');
+
+    const createChannel = await stack.app.request('/v1/channels', {
+      method: 'POST',
+      headers: {
+        authorization: `Bearer ${ws.workspaceKey}`,
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({ name: 'thread-helper-channel' }),
+    });
+    expect(createChannel.status).toBe(201);
+
+    const join = await stack.app.request('/v1/channels/thread-helper-channel/join', {
+      method: 'POST',
+      headers: { authorization: `Bearer ${agent.token}` },
+    });
+    expect(join.status).toBe(200);
+
+    const post = await stack.app.request('/v1/channels/thread-helper-channel/messages', {
+      method: 'POST',
+      headers: {
+        authorization: `Bearer ${agent.token}`,
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({ text: 'parent message' }),
+    });
+    expect(post.status).toBe(201);
+    const postBody = await post.json() as { data?: { id?: string } };
+    expect(postBody.data?.id).toBeTruthy();
+
+    const res = await stack.app.request(`/v1/messages/${postBody.data!.id}/replies`, {
+      method: 'POST',
+      headers: {
+        authorization: `Bearer ${agent.token}`,
+        'content-type': 'application/json',
+      },
+      body: '{',
+    });
+
+    expect(res.status).toBe(400);
+    await expect(res.json()).resolves.toEqual({
+      ok: false,
+      error: {
+        code: 'invalid_json',
+        message: 'Malformed JSON in request body',
+      },
+    });
+  });
+
   it('uses the shared invalid_request envelope for query validation', async () => {
     const ws = await createWorkspace(stack.app, 'invalid-console-query-ws');
 

--- a/packages/engine/src/__tests__/conformance/httpResponse.test.ts
+++ b/packages/engine/src/__tests__/conformance/httpResponse.test.ts
@@ -10,6 +10,49 @@ describe('route response helpers', () => {
 
   afterEach(() => stack.close());
 
+  async function createDeliveryForAgent(workspaceName: string, channelName: string) {
+    const ws = await createWorkspace(stack.app, workspaceName);
+    const alice = await registerAgent(stack.app, ws.workspaceKey, `${channelName}-alice`);
+    const bob = await registerAgent(stack.app, ws.workspaceKey, `${channelName}-bob`);
+
+    const createChannel = await stack.app.request('/v1/channels', {
+      method: 'POST',
+      headers: {
+        authorization: `Bearer ${ws.workspaceKey}`,
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({ name: channelName }),
+    });
+    expect(createChannel.status).toBe(201);
+
+    for (const token of [alice.token, bob.token]) {
+      const join = await stack.app.request(`/v1/channels/${channelName}/join`, {
+        method: 'POST',
+        headers: { authorization: `Bearer ${token}` },
+      });
+      expect(join.status).toBe(200);
+    }
+
+    const post = await stack.app.request(`/v1/channels/${channelName}/messages`, {
+      method: 'POST',
+      headers: {
+        authorization: `Bearer ${alice.token}`,
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({ text: 'delivery helper test' }),
+    });
+    expect(post.status).toBe(201);
+
+    const list = await stack.app.request('/v1/deliveries', {
+      headers: { authorization: `Bearer ${bob.token}` },
+    });
+    expect(list.status).toBe(200);
+    const body = await list.json() as { data?: Array<{ id: string }> };
+    expect(body.data?.length).toBeGreaterThan(0);
+
+    return { deliveryId: body.data![0]!.id, token: bob.token };
+  }
+
   it('returns invalid_json for malformed bodies handled by the shared parser', async () => {
     const ws = await createWorkspace(stack.app, 'malformed-trigger-ws');
     const agent = await registerAgent(stack.app, ws.workspaceKey, 'parser-agent');
@@ -162,6 +205,37 @@ describe('route response helpers', () => {
         message: 'Invalid console message query',
       },
     });
+  });
+
+  it('supports optional delivery fail bodies through the shared parser', async () => {
+    const delivery = await createDeliveryForAgent('delivery-parser-ws', 'delivery-parser-channel');
+
+    const malformed = await stack.app.request(`/v1/deliveries/${delivery.deliveryId}/fail`, {
+      method: 'POST',
+      headers: {
+        authorization: `Bearer ${delivery.token}`,
+        'content-type': 'application/json',
+      },
+      body: '{',
+    });
+
+    expect(malformed.status).toBe(400);
+    await expect(malformed.json()).resolves.toEqual({
+      ok: false,
+      error: {
+        code: 'invalid_request',
+        message: 'Invalid JSON body',
+      },
+    });
+
+    const empty = await stack.app.request(`/v1/deliveries/${delivery.deliveryId}/fail`, {
+      method: 'POST',
+      headers: { authorization: `Bearer ${delivery.token}` },
+    });
+
+    expect(empty.status).toBe(200);
+    const emptyBody = await empty.json() as { data?: { status?: string } };
+    expect(emptyBody.data?.status).toBe('failed');
   });
 
   it('returns invalid_json for malformed routing request bodies', async () => {

--- a/packages/engine/src/__tests__/conformance/httpResponse.test.ts
+++ b/packages/engine/src/__tests__/conformance/httpResponse.test.ts
@@ -144,4 +144,23 @@ describe('route response helpers', () => {
       },
     });
   });
+
+  it('uses the shared invalid_request envelope for query validation', async () => {
+    const ws = await createWorkspace(stack.app, 'invalid-console-query-ws');
+
+    const res = await stack.app.request('/v1/console/messages?limit=not-a-number', {
+      headers: {
+        authorization: `Bearer ${ws.workspaceKey}`,
+      },
+    });
+
+    expect(res.status).toBe(400);
+    await expect(res.json()).resolves.toEqual({
+      ok: false,
+      error: {
+        code: 'invalid_request',
+        message: 'Invalid console message query',
+      },
+    });
+  });
 });

--- a/packages/engine/src/__tests__/conformance/httpResponse.test.ts
+++ b/packages/engine/src/__tests__/conformance/httpResponse.test.ts
@@ -163,4 +163,26 @@ describe('route response helpers', () => {
       },
     });
   });
+
+  it('returns invalid_json for malformed routing request bodies', async () => {
+    const ws = await createWorkspace(stack.app, 'malformed-routing-ws');
+
+    const res = await stack.app.request('/v1/route', {
+      method: 'POST',
+      headers: {
+        authorization: `Bearer ${ws.workspaceKey}`,
+        'content-type': 'application/json',
+      },
+      body: '{',
+    });
+
+    expect(res.status).toBe(400);
+    await expect(res.json()).resolves.toEqual({
+      ok: false,
+      error: {
+        code: 'invalid_json',
+        message: 'Malformed JSON in request body',
+      },
+    });
+  });
 });

--- a/packages/engine/src/__tests__/conformance/httpResponse.test.ts
+++ b/packages/engine/src/__tests__/conformance/httpResponse.test.ts
@@ -99,6 +99,38 @@ describe('route response helpers', () => {
     });
   });
 
+  it('returns invalid_json for malformed channel update request bodies', async () => {
+    const ws = await createWorkspace(stack.app, 'malformed-channel-update-ws');
+
+    const create = await stack.app.request('/v1/channels', {
+      method: 'POST',
+      headers: {
+        authorization: `Bearer ${ws.workspaceKey}`,
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({ name: 'malformed-update-channel' }),
+    });
+    expect(create.status).toBe(201);
+
+    const res = await stack.app.request('/v1/channels/malformed-update-channel', {
+      method: 'PATCH',
+      headers: {
+        authorization: `Bearer ${ws.workspaceKey}`,
+        'content-type': 'application/json',
+      },
+      body: '{',
+    });
+
+    expect(res.status).toBe(400);
+    await expect(res.json()).resolves.toEqual({
+      ok: false,
+      error: {
+        code: 'invalid_json',
+        message: 'Malformed JSON in request body',
+      },
+    });
+  });
+
   it('keeps custom validation messages when routes use the shared parser', async () => {
     const ws = await createWorkspace(stack.app, 'subscription-validation-ws');
 

--- a/packages/engine/src/__tests__/conformance/httpResponse.test.ts
+++ b/packages/engine/src/__tests__/conformance/httpResponse.test.ts
@@ -185,4 +185,27 @@ describe('route response helpers', () => {
       },
     });
   });
+
+  it('returns invalid_json for malformed reaction request bodies', async () => {
+    const ws = await createWorkspace(stack.app, 'malformed-reaction-ws');
+    const agent = await registerAgent(stack.app, ws.workspaceKey, 'reaction-agent');
+
+    const res = await stack.app.request('/v1/messages/missing/reactions', {
+      method: 'POST',
+      headers: {
+        authorization: `Bearer ${agent.token}`,
+        'content-type': 'application/json',
+      },
+      body: '{',
+    });
+
+    expect(res.status).toBe(400);
+    await expect(res.json()).resolves.toEqual({
+      ok: false,
+      error: {
+        code: 'invalid_json',
+        message: 'Malformed JSON in request body',
+      },
+    });
+  });
 });

--- a/packages/engine/src/__tests__/conformance/httpResponse.test.ts
+++ b/packages/engine/src/__tests__/conformance/httpResponse.test.ts
@@ -121,4 +121,27 @@ describe('route response helpers', () => {
       },
     });
   });
+
+  it('returns invalid_json for malformed file upload request bodies', async () => {
+    const ws = await createWorkspace(stack.app, 'malformed-file-ws');
+    const agent = await registerAgent(stack.app, ws.workspaceKey, 'file-agent');
+
+    const res = await stack.app.request('/v1/files/upload', {
+      method: 'POST',
+      headers: {
+        authorization: `Bearer ${agent.token}`,
+        'content-type': 'application/json',
+      },
+      body: '{',
+    });
+
+    expect(res.status).toBe(400);
+    await expect(res.json()).resolves.toEqual({
+      ok: false,
+      error: {
+        code: 'invalid_json',
+        message: 'Malformed JSON in request body',
+      },
+    });
+  });
 });

--- a/packages/engine/src/__tests__/conformance/httpResponse.test.ts
+++ b/packages/engine/src/__tests__/conformance/httpResponse.test.ts
@@ -188,6 +188,29 @@ describe('route response helpers', () => {
     });
   });
 
+  it('returns invalid_json for malformed direct message request bodies', async () => {
+    const ws = await createWorkspace(stack.app, 'malformed-dm-ws');
+    const agent = await registerAgent(stack.app, ws.workspaceKey, 'dm-agent');
+
+    const res = await stack.app.request('/v1/dm', {
+      method: 'POST',
+      headers: {
+        authorization: `Bearer ${agent.token}`,
+        'content-type': 'application/json',
+      },
+      body: '{',
+    });
+
+    expect(res.status).toBe(400);
+    await expect(res.json()).resolves.toEqual({
+      ok: false,
+      error: {
+        code: 'invalid_json',
+        message: 'Malformed JSON in request body',
+      },
+    });
+  });
+
   it('uses the shared invalid_request envelope for query validation', async () => {
     const ws = await createWorkspace(stack.app, 'invalid-console-query-ws');
 

--- a/packages/engine/src/__tests__/conformance/httpResponse.test.ts
+++ b/packages/engine/src/__tests__/conformance/httpResponse.test.ts
@@ -501,4 +501,27 @@ describe('route response helpers', () => {
       },
     });
   });
+
+  it('returns invalid_json for malformed agent update request bodies', async () => {
+    const ws = await createWorkspace(stack.app, 'malformed-agent-update-ws');
+    await registerAgent(stack.app, ws.workspaceKey, 'updatable-agent');
+
+    const res = await stack.app.request('/v1/agents/updatable-agent', {
+      method: 'PATCH',
+      headers: {
+        authorization: `Bearer ${ws.workspaceKey}`,
+        'content-type': 'application/json',
+      },
+      body: '{',
+    });
+
+    expect(res.status).toBe(400);
+    await expect(res.json()).resolves.toEqual({
+      ok: false,
+      error: {
+        code: 'invalid_json',
+        message: 'Malformed JSON in request body',
+      },
+    });
+  });
 });

--- a/packages/engine/src/__tests__/conformance/httpResponse.test.ts
+++ b/packages/engine/src/__tests__/conformance/httpResponse.test.ts
@@ -208,4 +208,26 @@ describe('route response helpers', () => {
       },
     });
   });
+
+  it('returns invalid_json for malformed inbound webhook request bodies', async () => {
+    const ws = await createWorkspace(stack.app, 'malformed-inbound-webhook-ws');
+
+    const res = await stack.app.request('/v1/webhooks', {
+      method: 'POST',
+      headers: {
+        authorization: `Bearer ${ws.workspaceKey}`,
+        'content-type': 'application/json',
+      },
+      body: '{',
+    });
+
+    expect(res.status).toBe(400);
+    await expect(res.json()).resolves.toEqual({
+      ok: false,
+      error: {
+        code: 'invalid_json',
+        message: 'Malformed JSON in request body',
+      },
+    });
+  });
 });

--- a/packages/engine/src/__tests__/conformance/httpResponse.test.ts
+++ b/packages/engine/src/__tests__/conformance/httpResponse.test.ts
@@ -211,6 +211,29 @@ describe('route response helpers', () => {
     });
   });
 
+  it('returns invalid_json for malformed group DM request bodies', async () => {
+    const ws = await createWorkspace(stack.app, 'malformed-group-dm-ws');
+    const agent = await registerAgent(stack.app, ws.workspaceKey, 'group-dm-agent');
+
+    const res = await stack.app.request('/v1/dm/group', {
+      method: 'POST',
+      headers: {
+        authorization: `Bearer ${agent.token}`,
+        'content-type': 'application/json',
+      },
+      body: '{',
+    });
+
+    expect(res.status).toBe(400);
+    await expect(res.json()).resolves.toEqual({
+      ok: false,
+      error: {
+        code: 'invalid_json',
+        message: 'Malformed JSON in request body',
+      },
+    });
+  });
+
   it('returns invalid_json for malformed thread reply request bodies', async () => {
     const ws = await createWorkspace(stack.app, 'malformed-thread-ws');
     const agent = await registerAgent(stack.app, ws.workspaceKey, 'thread-agent');

--- a/packages/engine/src/__tests__/conformance/httpResponse.test.ts
+++ b/packages/engine/src/__tests__/conformance/httpResponse.test.ts
@@ -99,4 +99,26 @@ describe('route response helpers', () => {
       },
     });
   });
+
+  it('returns invalid_json for malformed directory request bodies', async () => {
+    const ws = await createWorkspace(stack.app, 'malformed-directory-ws');
+
+    const res = await stack.app.request('/v1/directory/agents', {
+      method: 'POST',
+      headers: {
+        authorization: `Bearer ${ws.workspaceKey}`,
+        'content-type': 'application/json',
+      },
+      body: '{',
+    });
+
+    expect(res.status).toBe(400);
+    await expect(res.json()).resolves.toEqual({
+      ok: false,
+      error: {
+        code: 'invalid_json',
+        message: 'Malformed JSON in request body',
+      },
+    });
+  });
 });

--- a/packages/engine/src/__tests__/nodeUpgradeAuth.test.ts
+++ b/packages/engine/src/__tests__/nodeUpgradeAuth.test.ts
@@ -44,9 +44,9 @@ describe('node control WS upgrade auth (self-host)', () => {
   }
 
   /** Resolve to the HTTP status code of the upgrade response (101 on success). */
-  function tryUpgrade(headers: Record<string, string>, query = ''): Promise<number> {
+  function tryUpgrade(headers: Record<string, string>, query = '', path = '/v1/node/ws'): Promise<number> {
     return new Promise((resolve) => {
-      const ws = new WebSocket(`${wsBase}/v1/node/ws${query}`, { headers });
+      const ws = new WebSocket(`${wsBase}${path}${query}`, { headers });
       ws.on('open', () => { ws.close(); resolve(101); });
       ws.on('unexpected-response', (_req, res) => { resolve(res.statusCode ?? 0); });
       ws.on('error', () => { /* handled by unexpected-response */ });
@@ -82,8 +82,38 @@ describe('node control WS upgrade auth (self-host)', () => {
 
     // Broker transport: Authorization: Bearer header, no query param.
     expect(await tryUpgrade({ authorization: `Bearer ${token}` })).toBe(101);
+    // Empty query params must not shadow a valid Authorization header.
+    expect(await tryUpgrade({ authorization: `Bearer ${token}` }, '?token=')).toBe(101);
     // SDK/Pear transport: ?token= query param, no header.
     expect(await tryUpgrade({}, `?token=${token}`)).toBe(101);
+  });
+
+  it('gates agent realtime upgrades when workspace streams are disabled', async () => {
+    const ws = await api('/v1/workspaces', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ name: 'stream-off' }),
+    });
+    const workspaceKey = ws.body.data.api_key as string;
+
+    const agent = await api('/v1/agents', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', authorization: `Bearer ${workspaceKey}` },
+      body: JSON.stringify({ name: 'stream-agent' }),
+    });
+    expect(agent.status).toBe(201);
+    const token = agent.body.data.token as string;
+
+    expect(await tryUpgrade({}, `?token=${token}`, '/v1/ws')).toBe(404);
+
+    const enabled = await api('/v1/workspace/stream', {
+      method: 'PUT',
+      headers: { 'content-type': 'application/json', authorization: `Bearer ${workspaceKey}` },
+      body: JSON.stringify({ enabled: true }),
+    });
+    expect(enabled.status).toBe(200);
+    expect(enabled.body.data.enabled).toBe(true);
+    expect(await tryUpgrade({}, `?token=${token}`, '/v1/ws')).toBe(101);
   });
 
   it('rejects the upgrade while the workspace fleet flag is off (404)', async () => {

--- a/packages/engine/src/engine.ts
+++ b/packages/engine/src/engine.ts
@@ -2,19 +2,21 @@ import { Hono } from 'hono';
 import type { ContentfulStatusCode } from 'hono/utils/http-status';
 import { cors } from 'hono/cors';
 import { secureHeaders } from 'hono/secure-headers';
-import { eq } from 'drizzle-orm';
 import type { AppEnv, EngineRuntime } from './env.js';
 import type { EngineDeps } from './ports/index.js';
 import { engineContext } from './middleware/engine-context.js';
 import { loggerMiddleware } from './middleware/logger.js';
-import { agents, nodes, workspaces } from './db/schema.js';
-import { isWorkspaceStreamEnabled } from './lib/workspaceStream.js';
-import { isFleetNodesEnabled } from './lib/fleetNodes.js';
 import { getRequestLogger, toErrorDetails } from './lib/logger.js';
 import { asCodedError } from './lib/httpError.js';
 import { jsonError, jsonMalformedBody, jsonNotFound } from './lib/httpResponse.js';
 import { requiredOriginInfo } from './lib/origin.js';
 import { emitServerEvent } from './lib/serverTelemetry.js';
+import {
+  authenticateNodeWs,
+  authenticateRealtimeWs,
+  missingWsToken,
+  queryOrBearerToken,
+} from './engine/wsAuth.js';
 
 // Route imports
 import { healthRoutes } from './routes/health.js';
@@ -101,69 +103,55 @@ export function createEngine(deps: EngineDeps): Hono<AppEnv> {
       return jsonError(c, 'unauthorized', 'Missing token', 401);
     }
 
-    const { auth, connections, kv, config } = c.get('engine');
+    const { auth, connections, kv, config, presence } = c.get('engine');
     const db = c.get('db');
-    const hash = await auth.hashToken(token);
     const originInfo = requiredOriginInfo(c.req.raw);
     const origin = {
       client: originInfo.origin_client,
       version: originInfo.origin_version,
     };
     const originActor = c.get('originActor') ?? 'unknown';
+    const authResult = await authenticateRealtimeWs({ auth, db, kv, config }, token);
 
-    if (token.startsWith('at_live_')) {
-      const [agent] = await db.select().from(agents).where(eq(agents.tokenHash, hash));
-      if (!agent) {
-        return jsonError(c, 'invalid_token', 'Invalid agent token', 401);
-      }
-      const workspaceId = agent.workspaceId;
+    if (!authResult.ok) {
+      return jsonError(c, authResult.code, authResult.message, authResult.status);
+    }
 
+    if (authResult.scope === 'agent') {
       // Register the agent online (fire-and-forget)
-      c.get('engine').presence.heartbeat(workspaceId, agent.id, agent.name).catch(() => {});
+      presence.heartbeat(authResult.workspace.id, authResult.agent.id, authResult.agent.name).catch(() => {});
 
       const response = await connections.upgrade({
         request: c.req.raw,
         scope: 'agent',
-        workspaceId,
-        agentId: agent.id,
-        agentName: agent.name,
+        workspaceId: authResult.workspace.id,
+        agentId: authResult.agent.id,
+        agentName: authResult.agent.name,
         origin,
         originActor,
       });
       if (response.status === 101) {
-        emitServerEvent(c, workspaceId, 'relaycast_server_ws_session_started', {
-          agent_id: agent.id,
+        emitServerEvent(c, authResult.workspace.id, 'relaycast_server_ws_session_started', {
+          agent_id: authResult.agent.id,
           session_scope: 'agent',
         });
       }
       return response;
     }
 
-    if (token.startsWith('rk_live_')) {
-      const [workspace] = await db.select().from(workspaces).where(eq(workspaces.apiKeyHash, hash));
-      if (!workspace) {
-        return jsonError(c, 'invalid_token', 'Invalid workspace key', 401);
-      }
-      if (!(await isWorkspaceStreamEnabled(kv, workspace.id, config.workspaceStreamEnabled ?? false))) {
-        return jsonNotFound(c, 'not_found', 'Workspace stream is disabled');
-      }
-
-      const response = await connections.upgrade({
-        request: c.req.raw,
-        scope: 'workspace',
-        workspaceId: workspace.id,
-        origin,
-        originActor,
+    const response = await connections.upgrade({
+      request: c.req.raw,
+      scope: 'workspace',
+      workspaceId: authResult.workspace.id,
+      origin,
+      originActor,
+    });
+    if (response.status === 101) {
+      emitServerEvent(c, authResult.workspace.id, 'relaycast_server_ws_session_started', {
+        session_scope: 'workspace',
       });
-      if (response.status === 101) {
-        emitServerEvent(c, workspace.id, 'relaycast_server_ws_session_started', {
-          session_scope: 'workspace',
-        });
-      }
-      return response;
     }
-
-    return jsonError(c, 'invalid_token', 'Invalid token format', 401);
+    return response;
   });
 
   app.get('/v1/node/ws', async (c) => {
@@ -176,30 +164,17 @@ export function createEngine(deps: EngineDeps): Hono<AppEnv> {
     // OR an `Authorization: Bearer <token>` header (the relay Rust broker's
     // node_control client sends it this way). Supporting both keeps the engine
     // compatible with every node client without changing the shipped broker.
-    const authHeader = c.req.header('Authorization') ?? c.req.header('authorization');
-    const bearer = authHeader && /^bearer\s+/i.test(authHeader)
-      ? authHeader.replace(/^bearer\s+/i, '').trim()
-      : undefined;
-    const token = c.req.query('token') ?? bearer;
+    const token = queryOrBearerToken(c.req.query('token'), c.req.header('Authorization') ?? c.req.header('authorization'));
     if (!token) {
-      return jsonError(c, 'unauthorized', 'Missing token', 401);
-    }
-    if (!token.startsWith('nt_live_')) {
-      return jsonError(c, 'invalid_token', 'Invalid node token format', 401);
+      const error = missingWsToken();
+      return jsonError(c, error.code, error.message, error.status);
     }
 
     const { auth, nodeConnections, kv, config } = c.get('engine');
     const db = c.get('db');
-    const hash = await auth.hashToken(token);
-    const [node] = await db.select().from(nodes).where(eq(nodes.tokenHash, hash));
-    if (!node) {
-      return jsonError(c, 'invalid_token', 'Invalid node token', 401);
-    }
-
-    // Phase 6 rollout flag: the node control surface is inert until a workspace
-    // opts in. A node with a valid token still cannot attach while the flag is off.
-    if (!(await isFleetNodesEnabled(kv, node.workspaceId, config.fleetNodesEnabled ?? false))) {
-      return jsonNotFound(c, 'fleet_nodes_disabled', 'Fleet nodes are disabled for this workspace');
+    const authResult = await authenticateNodeWs({ auth, db, kv, config }, token);
+    if (!authResult.ok) {
+      return jsonError(c, authResult.code, authResult.message, authResult.status);
     }
 
     const originInfo = requiredOriginInfo(c.req.raw);
@@ -210,15 +185,15 @@ export function createEngine(deps: EngineDeps): Hono<AppEnv> {
     const originActor = c.get('originActor') ?? 'unknown';
     const response = await nodeConnections.upgradeNode({
       request: c.req.raw,
-      workspaceId: node.workspaceId,
-      nodeId: node.id,
-      nodeName: node.name,
+      workspaceId: authResult.node.workspaceId,
+      nodeId: authResult.node.id,
+      nodeName: authResult.node.name,
       origin,
       originActor,
     });
     if (response.status === 101) {
-      emitServerEvent(c, node.workspaceId, 'relaycast_server_ws_session_started', {
-        node_id: node.id,
+      emitServerEvent(c, authResult.node.workspaceId, 'relaycast_server_ws_session_started', {
+        node_id: authResult.node.id,
         session_scope: 'node',
       });
     }

--- a/packages/engine/src/engine.ts
+++ b/packages/engine/src/engine.ts
@@ -164,7 +164,7 @@ export function createEngine(deps: EngineDeps): Hono<AppEnv> {
     // OR an `Authorization: Bearer <token>` header (the relay Rust broker's
     // node_control client sends it this way). Supporting both keeps the engine
     // compatible with every node client without changing the shipped broker.
-    const token = queryOrBearerToken(c.req.query('token'), c.req.header('Authorization') ?? c.req.header('authorization'));
+    const token = queryOrBearerToken(c.req.query('token'), c.req.header('Authorization'));
     if (!token) {
       const error = missingWsToken();
       return jsonError(c, error.code, error.message, error.status);
@@ -257,7 +257,7 @@ export function createEngine(deps: EngineDeps): Hono<AppEnv> {
       });
     }
 
-    if (error.message?.includes('JSON')) {
+    if (error.code === 'invalid_json' || err instanceof SyntaxError) {
       return jsonMalformedBody(c);
     }
     return jsonError(

--- a/packages/engine/src/engine.ts
+++ b/packages/engine/src/engine.ts
@@ -12,6 +12,7 @@ import { isWorkspaceStreamEnabled } from './lib/workspaceStream.js';
 import { isFleetNodesEnabled } from './lib/fleetNodes.js';
 import { getRequestLogger, toErrorDetails } from './lib/logger.js';
 import { asCodedError } from './lib/httpError.js';
+import { jsonError, jsonMalformedBody, jsonNotFound } from './lib/httpResponse.js';
 import { requiredOriginInfo } from './lib/origin.js';
 import { emitServerEvent } from './lib/serverTelemetry.js';
 
@@ -97,7 +98,7 @@ export function createEngine(deps: EngineDeps): Hono<AppEnv> {
 
     const token = c.req.query('token');
     if (!token) {
-      return c.json({ ok: false, error: { code: 'unauthorized', message: 'Missing token' } }, 401);
+      return jsonError(c, 'unauthorized', 'Missing token', 401);
     }
 
     const { auth, connections, kv, config } = c.get('engine');
@@ -113,7 +114,7 @@ export function createEngine(deps: EngineDeps): Hono<AppEnv> {
     if (token.startsWith('at_live_')) {
       const [agent] = await db.select().from(agents).where(eq(agents.tokenHash, hash));
       if (!agent) {
-        return c.json({ ok: false, error: { code: 'invalid_token', message: 'Invalid agent token' } }, 401);
+        return jsonError(c, 'invalid_token', 'Invalid agent token', 401);
       }
       const workspaceId = agent.workspaceId;
 
@@ -141,13 +142,10 @@ export function createEngine(deps: EngineDeps): Hono<AppEnv> {
     if (token.startsWith('rk_live_')) {
       const [workspace] = await db.select().from(workspaces).where(eq(workspaces.apiKeyHash, hash));
       if (!workspace) {
-        return c.json({ ok: false, error: { code: 'invalid_token', message: 'Invalid workspace key' } }, 401);
+        return jsonError(c, 'invalid_token', 'Invalid workspace key', 401);
       }
       if (!(await isWorkspaceStreamEnabled(kv, workspace.id, config.workspaceStreamEnabled ?? false))) {
-        return c.json(
-          { ok: false, error: { code: 'not_found', message: 'Workspace stream is disabled' } },
-          404,
-        );
+        return jsonNotFound(c, 'not_found', 'Workspace stream is disabled');
       }
 
       const response = await connections.upgrade({
@@ -165,7 +163,7 @@ export function createEngine(deps: EngineDeps): Hono<AppEnv> {
       return response;
     }
 
-    return c.json({ ok: false, error: { code: 'invalid_token', message: 'Invalid token format' } }, 401);
+    return jsonError(c, 'invalid_token', 'Invalid token format', 401);
   });
 
   app.get('/v1/node/ws', async (c) => {
@@ -184,10 +182,10 @@ export function createEngine(deps: EngineDeps): Hono<AppEnv> {
       : undefined;
     const token = c.req.query('token') ?? bearer;
     if (!token) {
-      return c.json({ ok: false, error: { code: 'unauthorized', message: 'Missing token' } }, 401);
+      return jsonError(c, 'unauthorized', 'Missing token', 401);
     }
     if (!token.startsWith('nt_live_')) {
-      return c.json({ ok: false, error: { code: 'invalid_token', message: 'Invalid node token format' } }, 401);
+      return jsonError(c, 'invalid_token', 'Invalid node token format', 401);
     }
 
     const { auth, nodeConnections, kv, config } = c.get('engine');
@@ -195,16 +193,13 @@ export function createEngine(deps: EngineDeps): Hono<AppEnv> {
     const hash = await auth.hashToken(token);
     const [node] = await db.select().from(nodes).where(eq(nodes.tokenHash, hash));
     if (!node) {
-      return c.json({ ok: false, error: { code: 'invalid_token', message: 'Invalid node token' } }, 401);
+      return jsonError(c, 'invalid_token', 'Invalid node token', 401);
     }
 
     // Phase 6 rollout flag: the node control surface is inert until a workspace
     // opts in. A node with a valid token still cannot attach while the flag is off.
     if (!(await isFleetNodesEnabled(kv, node.workspaceId, config.fleetNodesEnabled ?? false))) {
-      return c.json(
-        { ok: false, error: { code: 'fleet_nodes_disabled', message: 'Fleet nodes are disabled for this workspace' } },
-        404,
-      );
+      return jsonNotFound(c, 'fleet_nodes_disabled', 'Fleet nodes are disabled for this workspace');
     }
 
     const originInfo = requiredOriginInfo(c.req.raw);
@@ -261,7 +256,7 @@ export function createEngine(deps: EngineDeps): Hono<AppEnv> {
 
   // 404 handler
   app.notFound((c) => {
-    return c.json({ ok: false, error: { code: 'not_found', message: 'Route not found' } }, 404);
+    return jsonNotFound(c, 'not_found', 'Route not found');
   });
 
   // Global error handler
@@ -288,15 +283,14 @@ export function createEngine(deps: EngineDeps): Hono<AppEnv> {
     }
 
     if (error.message?.includes('JSON')) {
-      return c.json({ ok: false, error: { code: 'invalid_json', message: 'Malformed JSON in request body' } }, 400);
+      return jsonMalformedBody(c);
     }
-    return c.json({
-      ok: false,
-      error: {
-        code: error.code || 'internal_error',
-        message: error.message || 'Internal server error',
-      },
-    }, status as ContentfulStatusCode);
+    return jsonError(
+      c,
+      error.code || 'internal_error',
+      error.message || 'Internal server error',
+      status as ContentfulStatusCode,
+    );
   });
 
   return app;

--- a/packages/engine/src/engine/wsAuth.ts
+++ b/packages/engine/src/engine/wsAuth.ts
@@ -24,7 +24,7 @@ export type RealtimeWsAuthResult =
 export type NodeWsAuthResult =
   | {
       ok: true;
-      node: Awaited<ReturnType<typeof getNodeByTokenHash>>;
+      node: NonNullable<Awaited<ReturnType<typeof getNodeByTokenHash>>>;
     }
   | WsAuthError;
 
@@ -42,7 +42,8 @@ export function extractBearerToken(authHeader: string | undefined): string | und
 }
 
 export function queryOrBearerToken(queryToken: string | null | undefined, authHeader: string | undefined): string | undefined {
-  return queryToken ?? extractBearerToken(authHeader);
+  const tokenFromQuery = queryToken?.trim();
+  return tokenFromQuery || extractBearerToken(authHeader);
 }
 
 export function missingWsToken(): WsAuthError {
@@ -80,6 +81,9 @@ export async function authenticateRealtimeWs(deps: WsAuthDeps, token: string): P
     const result = await deps.auth.authenticate({ token, require: 'agent', db: deps.db });
     if (!result.ok || !result.agent) {
       return invalidWsToken('Invalid agent token');
+    }
+    if (!(await isWorkspaceStreamEnabled(deps.kv, result.workspace.id, deps.config?.workspaceStreamEnabled ?? false))) {
+      return notFoundWsToken('not_found', 'Workspace stream is disabled');
     }
     return { ok: true, scope: 'agent', workspace: result.workspace, agent: result.agent };
   }

--- a/packages/engine/src/engine/wsAuth.ts
+++ b/packages/engine/src/engine/wsAuth.ts
@@ -1,0 +1,117 @@
+import type { EngineConfig } from '../ports/index.js';
+import type { AuthProvider, Agent, Workspace } from '../ports/auth.js';
+import type { EngineDb } from '../ports/database.js';
+import type { KeyValueStore } from '../ports/kv.js';
+import { getNodeByTokenHash } from './node.js';
+import { isFleetNodesEnabled } from '../lib/fleetNodes.js';
+import { isWorkspaceStreamEnabled } from '../lib/workspaceStream.js';
+
+type WsAuthErrorCode = 'unauthorized' | 'invalid_token' | 'not_found' | 'fleet_nodes_disabled';
+
+export interface WsAuthError {
+  ok: false;
+  status: 401 | 404;
+  code: WsAuthErrorCode;
+  message: string;
+  upgradeMessage: 'Unauthorized' | 'Not Found';
+}
+
+export type RealtimeWsAuthResult =
+  | { ok: true; scope: 'agent'; workspace: Workspace; agent: Agent }
+  | { ok: true; scope: 'workspace'; workspace: Workspace }
+  | WsAuthError;
+
+export type NodeWsAuthResult =
+  | {
+      ok: true;
+      node: Awaited<ReturnType<typeof getNodeByTokenHash>>;
+    }
+  | WsAuthError;
+
+interface WsAuthDeps {
+  auth: AuthProvider;
+  db: EngineDb;
+  kv: KeyValueStore;
+  config?: EngineConfig;
+}
+
+export function extractBearerToken(authHeader: string | undefined): string | undefined {
+  return authHeader && /^bearer\s+/i.test(authHeader)
+    ? authHeader.replace(/^bearer\s+/i, '').trim()
+    : undefined;
+}
+
+export function queryOrBearerToken(queryToken: string | null | undefined, authHeader: string | undefined): string | undefined {
+  return queryToken ?? extractBearerToken(authHeader);
+}
+
+export function missingWsToken(): WsAuthError {
+  return {
+    ok: false,
+    status: 401,
+    code: 'unauthorized',
+    message: 'Missing token',
+    upgradeMessage: 'Unauthorized',
+  };
+}
+
+function invalidWsToken(message: string): WsAuthError {
+  return {
+    ok: false,
+    status: 401,
+    code: 'invalid_token',
+    message,
+    upgradeMessage: 'Unauthorized',
+  };
+}
+
+function notFoundWsToken(code: WsAuthErrorCode, message: string): WsAuthError {
+  return {
+    ok: false,
+    status: 404,
+    code,
+    message,
+    upgradeMessage: 'Not Found',
+  };
+}
+
+export async function authenticateRealtimeWs(deps: WsAuthDeps, token: string): Promise<RealtimeWsAuthResult> {
+  if (token.startsWith('at_live_')) {
+    const result = await deps.auth.authenticate({ token, require: 'agent', db: deps.db });
+    if (!result.ok || !result.agent) {
+      return invalidWsToken('Invalid agent token');
+    }
+    return { ok: true, scope: 'agent', workspace: result.workspace, agent: result.agent };
+  }
+
+  if (token.startsWith('rk_live_')) {
+    const result = await deps.auth.authenticate({ token, require: 'workspace', db: deps.db });
+    if (!result.ok) {
+      return invalidWsToken('Invalid workspace key');
+    }
+    if (!(await isWorkspaceStreamEnabled(deps.kv, result.workspace.id, deps.config?.workspaceStreamEnabled ?? false))) {
+      return notFoundWsToken('not_found', 'Workspace stream is disabled');
+    }
+    return { ok: true, scope: 'workspace', workspace: result.workspace };
+  }
+
+  return invalidWsToken('Invalid token format');
+}
+
+export async function authenticateNodeWs(deps: WsAuthDeps, token: string): Promise<NodeWsAuthResult> {
+  if (!token.startsWith('nt_live_')) {
+    return invalidWsToken('Invalid node token format');
+  }
+
+  const hash = await deps.auth.hashToken(token);
+  const node = await getNodeByTokenHash(deps.db, hash);
+  if (!node) {
+    return invalidWsToken('Invalid node token');
+  }
+
+  if (!(await isFleetNodesEnabled(deps.kv, node.workspaceId, deps.config?.fleetNodesEnabled ?? false))) {
+    return notFoundWsToken('fleet_nodes_disabled', 'Fleet nodes are disabled for this workspace');
+  }
+
+  return { ok: true, node };
+}

--- a/packages/engine/src/entrypoints/node.ts
+++ b/packages/engine/src/entrypoints/node.ts
@@ -7,6 +7,7 @@ import { WebSocketServer, type WebSocket as WsSocket } from 'ws';
 import { createEngine } from '../engine.js';
 import { isWorkspaceStreamEnabled } from '../lib/workspaceStream.js';
 import { isFleetNodesEnabled } from '../lib/fleetNodes.js';
+import { jsonNotFound } from '../lib/httpResponse.js';
 import type { AppEnv } from '../env.js';
 import type { EngineConfig } from '../ports/index.js';
 import type { AuthProvider } from '../ports/auth.js';
@@ -87,6 +88,7 @@ export function startServer(options: StartServerOptions): RunningServer {
   const app = new Hono<AppEnv>();
   app.all(FILE_ROUTE_PREFIX, (c) => runtime.fileHandler(c.req.raw));
   app.route('/', engine);
+  app.notFound((c) => jsonNotFound(c, 'not_found', 'Route not found'));
 
   const server = serve({ fetch: app.fetch, port: options.port });
 

--- a/packages/engine/src/entrypoints/node.ts
+++ b/packages/engine/src/entrypoints/node.ts
@@ -5,8 +5,6 @@ import { Hono } from 'hono';
 import { serve, type ServerType } from '@hono/node-server';
 import { WebSocketServer, type WebSocket as WsSocket } from 'ws';
 import { createEngine } from '../engine.js';
-import { isWorkspaceStreamEnabled } from '../lib/workspaceStream.js';
-import { isFleetNodesEnabled } from '../lib/fleetNodes.js';
 import { jsonNotFound } from '../lib/httpResponse.js';
 import type { AppEnv } from '../env.js';
 import type { EngineConfig } from '../ports/index.js';
@@ -20,7 +18,12 @@ import {
   type InProcessPresenceOptions,
   type NodeRuntime,
 } from '../adapters/node/index.js';
-import { getNodeByTokenHash } from '../engine/node.js';
+import {
+  authenticateNodeWs,
+  authenticateRealtimeWs,
+  missingWsToken,
+  queryOrBearerToken,
+} from '../engine/wsAuth.js';
 
 export interface StartServerOptions {
   dbPath: string;
@@ -95,6 +98,7 @@ export function startServer(options: StartServerOptions): RunningServer {
   // WebSocket upgrades (Node owns these at the socket level).
   const wss = new WebSocketServer({ noServer: true });
   const { auth, db, kv, config } = runtime.deps;
+  const wsAuthDeps = { auth, db, kv, config };
 
   (server as unknown as Server).on(
     'upgrade',
@@ -109,78 +113,61 @@ export function startServer(options: StartServerOptions): RunningServer {
       // node_control client authenticates the node control connection with the
       // header form, so the self-host upgrade path must honour both.
       const authHeader = req.headers['authorization'];
-      const bearer = typeof authHeader === 'string' && /^bearer\s+/i.test(authHeader)
-        ? authHeader.replace(/^bearer\s+/i, '').trim()
-        : undefined;
-      const token = url.searchParams.get('token') ?? bearer;
+      const token = queryOrBearerToken(url.searchParams.get('token'), typeof authHeader === 'string' ? authHeader : undefined);
       if (!token) {
-        rejectUpgrade(socket, 401, 'Unauthorized');
+        const error = missingWsToken();
+        rejectUpgrade(socket, error.status, error.upgradeMessage);
         return;
       }
 
       void (async () => {
         if (url.pathname === '/v1/node/ws') {
-          if (!token.startsWith('nt_live_')) {
-            rejectUpgrade(socket, 401, 'Unauthorized');
-            return;
-          }
-          const hash = await auth.hashToken(token);
-          const node = await getNodeByTokenHash(db, hash);
-          if (!node) {
-            rejectUpgrade(socket, 401, 'Unauthorized');
-            return;
-          }
-          // Phase 6 rollout flag: the node control surface is inert until the
-          // workspace opts in (mirrors the rk_live stream gate below).
-          if (!(await isFleetNodesEnabled(kv, node.workspaceId, config?.fleetNodesEnabled ?? false))) {
-            rejectUpgrade(socket, 404, 'Not Found');
+          const authResult = await authenticateNodeWs(wsAuthDeps, token);
+          if (!authResult.ok) {
+            rejectUpgrade(socket, authResult.status, authResult.upgradeMessage);
             return;
           }
           wss.handleUpgrade(req, socket, head, (ws) => {
-            const handle = runtime.realtime.attachNodeSocket(node.workspaceId, node.id, toEngineSocket(ws));
+            const handle = runtime.realtime.attachNodeSocket(
+              authResult.node.workspaceId,
+              authResult.node.id,
+              toEngineSocket(ws),
+            );
             ws.on('message', (data) => { void handle.handleMessage(data.toString()); });
             ws.on('close', () => { void handle.handleClose(); });
           });
           return;
         }
 
-        if (token.startsWith('at_live_')) {
-          const res = await auth.authenticate({ token, require: 'agent', db });
-          if (!res.ok || !res.agent) {
-            rejectUpgrade(socket, 401, 'Unauthorized');
-            return;
-          }
-          const { workspace, agent } = res;
+        const authResult = await authenticateRealtimeWs(wsAuthDeps, token);
+        if (!authResult.ok) {
+          rejectUpgrade(socket, authResult.status, authResult.upgradeMessage);
+          return;
+        }
+
+        if (authResult.scope === 'agent') {
           wss.handleUpgrade(req, socket, head, (ws) => {
-            const handle = runtime.realtime.attachAgentSocket(workspace.id, agent.id, toEngineSocket(ws));
-            runtime.deps.presence.heartbeat(workspace.id, agent.id, agent.name).catch(() => {});
+            const handle = runtime.realtime.attachAgentSocket(
+              authResult.workspace.id,
+              authResult.agent.id,
+              toEngineSocket(ws),
+            );
+            runtime.deps.presence.heartbeat(
+              authResult.workspace.id,
+              authResult.agent.id,
+              authResult.agent.name,
+            ).catch(() => {});
             ws.on('message', (data) => { void handle.handleMessage(data.toString()); });
             ws.on('close', () => { void handle.handleClose(); });
           });
           return;
         }
 
-        if (token.startsWith('rk_live_')) {
-          const res = await auth.authenticate({ token, require: 'workspace', db });
-          if (!res.ok) {
-            rejectUpgrade(socket, 401, 'Unauthorized');
-            return;
-          }
-          const enabled = await isWorkspaceStreamEnabled(kv, res.workspace.id, config?.workspaceStreamEnabled ?? false);
-          if (!enabled) {
-            rejectUpgrade(socket, 404, 'Not Found');
-            return;
-          }
-          const { workspace } = res;
-          wss.handleUpgrade(req, socket, head, (ws) => {
-            const handle = runtime.realtime.attachWorkspaceSocket(workspace.id, toEngineSocket(ws));
-            ws.on('message', (data) => { void handle.handleMessage(data.toString()); });
-            ws.on('close', () => { void handle.handleClose(); });
-          });
-          return;
-        }
-
-        rejectUpgrade(socket, 401, 'Unauthorized');
+        wss.handleUpgrade(req, socket, head, (ws) => {
+          const handle = runtime.realtime.attachWorkspaceSocket(authResult.workspace.id, toEngineSocket(ws));
+          ws.on('message', (data) => { void handle.handleMessage(data.toString()); });
+          ws.on('close', () => { void handle.handleClose(); });
+        });
       })().catch(() => rejectUpgrade(socket, 500, 'Internal Server Error'));
     },
   );

--- a/packages/engine/src/lib/__tests__/httpError.test.ts
+++ b/packages/engine/src/lib/__tests__/httpError.test.ts
@@ -40,4 +40,20 @@ describe('errorResponse', () => {
       },
     });
   });
+
+  it('can include an error cause when a route opts in', async () => {
+    const error = codedError('Directory write failed', 'internal_error', 500);
+    error.cause = new Error('SQLITE_CONSTRAINT');
+
+    const response = errorResponse(testContext(), error, { includeCause: true });
+
+    expect(response.status).toBe(500);
+    await expect(response.json()).resolves.toEqual({
+      ok: false,
+      error: {
+        code: 'internal_error',
+        message: 'Directory write failed [cause: SQLITE_CONSTRAINT]',
+      },
+    });
+  });
 });

--- a/packages/engine/src/lib/__tests__/httpError.test.ts
+++ b/packages/engine/src/lib/__tests__/httpError.test.ts
@@ -41,7 +41,7 @@ describe('errorResponse', () => {
     });
   });
 
-  it('can include an error cause when a route opts in', async () => {
+  it('does not expose error causes in client responses', async () => {
     const error = codedError('Directory write failed', 'internal_error', 500);
     error.cause = new Error('SQLITE_CONSTRAINT');
 
@@ -52,7 +52,7 @@ describe('errorResponse', () => {
       ok: false,
       error: {
         code: 'internal_error',
-        message: 'Directory write failed [cause: SQLITE_CONSTRAINT]',
+        message: 'Directory write failed',
       },
     });
   });

--- a/packages/engine/src/lib/httpError.ts
+++ b/packages/engine/src/lib/httpError.ts
@@ -35,6 +35,15 @@ export function codedError(message: string, code: string, status: number): Coded
   return Object.assign(new Error(message), { code, status });
 }
 
+interface ErrorResponseOptions {
+  includeCause?: boolean;
+}
+
+function messageWithCause(error: CodedError) {
+  const cause = error.cause instanceof Error ? error.cause.message : (error.cause ? String(error.cause) : '');
+  return cause ? `${error.message} [cause: ${cause}]` : error.message;
+}
+
 /**
  * Render a thrown value as the standard `{ ok: false, error: { code, message } }`
  * envelope with the carried (or default 500) status. Centralizes the single
@@ -42,7 +51,7 @@ export function codedError(message: string, code: string, status: number): Coded
  * real `instanceof` narrowing instead of the unchecked `err as Error & {...}`
  * assertion that was duplicated across every route handler.
  */
-export function errorResponse(c: Context, err: unknown) {
+export function errorResponse(c: Context, err: unknown, options: ErrorResponseOptions = {}) {
   const error = asCodedError(err);
   if (err instanceof SyntaxError) {
     return jsonMalformedBody(c);
@@ -50,7 +59,7 @@ export function errorResponse(c: Context, err: unknown) {
   return jsonError(
     c,
     error.code || 'internal_error',
-    error.message,
+    options.includeCause ? messageWithCause(error) : error.message,
     (error.status || 500) as ContentfulStatusCode,
   );
 }

--- a/packages/engine/src/lib/httpError.ts
+++ b/packages/engine/src/lib/httpError.ts
@@ -40,8 +40,7 @@ interface ErrorResponseOptions {
 }
 
 function messageWithCause(error: CodedError) {
-  const cause = error.cause instanceof Error ? error.cause.message : (error.cause ? String(error.cause) : '');
-  return cause ? `${error.message} [cause: ${cause}]` : error.message;
+  return error.message;
 }
 
 /**

--- a/packages/engine/src/lib/httpQuery.ts
+++ b/packages/engine/src/lib/httpQuery.ts
@@ -1,0 +1,38 @@
+import { z } from 'zod';
+import type { Context } from 'hono';
+import { parseQueryParams } from './httpResponse.js';
+
+interface PositiveIntQueryOptions {
+  defaultValue?: number;
+  max?: number;
+}
+
+export function positiveIntQueryParam(options: PositiveIntQueryOptions = {}) {
+  const numberSchema = options.max === undefined
+    ? z.number().int().positive()
+    : z.number().int().positive().max(options.max);
+  const valueSchema = options.defaultValue === undefined
+    ? numberSchema.optional()
+    : numberSchema.default(options.defaultValue);
+
+  return z.preprocess(
+    (value) => (value === undefined ? undefined : Number(value)),
+    valueSchema,
+  );
+}
+
+const optionalPositiveInt = positiveIntQueryParam();
+
+export const PaginationQuerySchema = z.object({
+  limit: optionalPositiveInt,
+  before: z.string().optional(),
+  after: z.string().optional(),
+});
+
+export const LimitQuerySchema = z.object({
+  limit: optionalPositiveInt,
+});
+
+export function parsePaginationQuery(c: Context, invalidMessage = 'Invalid pagination query') {
+  return parseQueryParams(c, PaginationQuerySchema, invalidMessage);
+}

--- a/packages/engine/src/lib/httpQuery.ts
+++ b/packages/engine/src/lib/httpQuery.ts
@@ -11,12 +11,20 @@ export function positiveIntQueryParam(options: PositiveIntQueryOptions = {}) {
   const numberSchema = options.max === undefined
     ? z.number().int().positive()
     : z.number().int().positive().max(options.max);
+  if (options.defaultValue !== undefined) {
+    numberSchema.parse(options.defaultValue);
+  }
   const valueSchema = options.defaultValue === undefined
     ? numberSchema.optional()
     : numberSchema.default(options.defaultValue);
 
   return z.preprocess(
-    (value) => (value === undefined ? undefined : Number(value)),
+    (value) => {
+      if (value === undefined || (typeof value === 'string' && value.trim() === '')) {
+        return undefined;
+      }
+      return Number(value);
+    },
     valueSchema,
   );
 }

--- a/packages/engine/src/lib/httpResponse.ts
+++ b/packages/engine/src/lib/httpResponse.ts
@@ -22,6 +22,14 @@ type ParsedRequestValue<T> =
   | { ok: true; data: T }
   | { ok: false; response: Response };
 
+interface ParseJsonBodyOptions {
+  emptyBodyValue?: unknown;
+  malformedBodyError?: {
+    code: string;
+    message: string;
+  };
+}
+
 export function jsonOk<T>(c: Context, data: T, status: ContentfulStatusCode = 200) {
   return c.json({ ok: true as const, data }, status);
 }
@@ -54,20 +62,21 @@ export function jsonMalformedBody(c: Context) {
   return jsonError(c, 'invalid_json', 'Malformed JSON in request body', 400);
 }
 
-export async function parseJsonBody<T>(
-  c: Context,
-  schema: SafeParseSchema<T>,
-  invalidMessage: InvalidRequestMessage,
-): Promise<ParsedRequestValue<T>> {
-  let body: unknown;
-
-  try {
-    body = await c.req.json();
-  } catch {
-    return { ok: false, response: jsonMalformedBody(c) };
+function jsonMalformedBodyForOptions(c: Context, options?: ParseJsonBodyOptions) {
+  if (options?.malformedBodyError) {
+    return jsonError(c, options.malformedBodyError.code, options.malformedBodyError.message, 400);
   }
 
-  const parsed = schema.safeParse(body);
+  return jsonMalformedBody(c);
+}
+
+function validateParsedValue<T>(
+  c: Context,
+  schema: SafeParseSchema<T>,
+  value: unknown,
+  invalidMessage: InvalidRequestMessage,
+): ParsedRequestValue<T> {
+  const parsed = schema.safeParse(value);
   if (!parsed.success) {
     const message = typeof invalidMessage === 'function' ? invalidMessage(parsed) : invalidMessage;
     return { ok: false, response: jsonInvalidRequest(c, message) };
@@ -76,16 +85,47 @@ export async function parseJsonBody<T>(
   return { ok: true, data: parsed.data };
 }
 
+export async function parseJsonBody<T>(
+  c: Context,
+  schema: SafeParseSchema<T>,
+  invalidMessage: InvalidRequestMessage,
+  options?: ParseJsonBodyOptions,
+): Promise<ParsedRequestValue<T>> {
+  let body: unknown;
+
+  try {
+    body = await c.req.json();
+  } catch {
+    return { ok: false, response: jsonMalformedBodyForOptions(c, options) };
+  }
+
+  return validateParsedValue(c, schema, body, invalidMessage);
+}
+
+export async function parseOptionalJsonBody<T>(
+  c: Context,
+  schema: SafeParseSchema<T>,
+  invalidMessage: InvalidRequestMessage,
+  options?: ParseJsonBodyOptions,
+): Promise<ParsedRequestValue<T>> {
+  const bodyText = await c.req.text();
+  let body: unknown = options?.emptyBodyValue === undefined ? {} : options.emptyBodyValue;
+
+  if (bodyText.trim().length > 0) {
+    try {
+      body = JSON.parse(bodyText);
+    } catch {
+      return { ok: false, response: jsonMalformedBodyForOptions(c, options) };
+    }
+  }
+
+  return validateParsedValue(c, schema, body, invalidMessage);
+}
+
 export function parseQueryParams<T>(
   c: Context,
   schema: SafeParseSchema<T>,
   invalidMessage: InvalidRequestMessage,
 ): ParsedRequestValue<T> {
-  const parsed = schema.safeParse(c.req.query());
-  if (!parsed.success) {
-    const message = typeof invalidMessage === 'function' ? invalidMessage(parsed) : invalidMessage;
-    return { ok: false, response: jsonInvalidRequest(c, message) };
-  }
-
-  return { ok: true, data: parsed.data };
+  return validateParsedValue(c, schema, c.req.query(), invalidMessage);
 }

--- a/packages/engine/src/lib/httpResponse.ts
+++ b/packages/engine/src/lib/httpResponse.ts
@@ -18,12 +18,16 @@ interface SafeParseFailure {
 
 type InvalidRequestMessage = string | ((failure: SafeParseFailure) => string);
 
-type ParsedJsonBody<T> =
+type ParsedRequestValue<T> =
   | { ok: true; data: T }
   | { ok: false; response: Response };
 
 export function jsonOk<T>(c: Context, data: T, status: ContentfulStatusCode = 200) {
   return c.json({ ok: true as const, data }, status);
+}
+
+export function jsonSuccess(c: Context) {
+  return c.json({ ok: true as const });
 }
 
 export function jsonCreated<T>(c: Context, data: T) {
@@ -54,7 +58,7 @@ export async function parseJsonBody<T>(
   c: Context,
   schema: SafeParseSchema<T>,
   invalidMessage: InvalidRequestMessage,
-): Promise<ParsedJsonBody<T>> {
+): Promise<ParsedRequestValue<T>> {
   let body: unknown;
 
   try {
@@ -64,6 +68,20 @@ export async function parseJsonBody<T>(
   }
 
   const parsed = schema.safeParse(body);
+  if (!parsed.success) {
+    const message = typeof invalidMessage === 'function' ? invalidMessage(parsed) : invalidMessage;
+    return { ok: false, response: jsonInvalidRequest(c, message) };
+  }
+
+  return { ok: true, data: parsed.data };
+}
+
+export function parseQueryParams<T>(
+  c: Context,
+  schema: SafeParseSchema<T>,
+  invalidMessage: InvalidRequestMessage,
+): ParsedRequestValue<T> {
+  const parsed = schema.safeParse(c.req.query());
   if (!parsed.success) {
     const message = typeof invalidMessage === 'function' ? invalidMessage(parsed) : invalidMessage;
     return { ok: false, response: jsonInvalidRequest(c, message) };

--- a/packages/engine/src/lib/httpResponse.ts
+++ b/packages/engine/src/lib/httpResponse.ts
@@ -35,7 +35,7 @@ export function jsonOk<T>(c: Context, data: T, status: ContentfulStatusCode = 20
 }
 
 export function jsonSuccess(c: Context) {
-  return c.json({ ok: true as const });
+  return c.json({ ok: true as const, data: null });
 }
 
 export function jsonCreated<T>(c: Context, data: T) {

--- a/packages/engine/src/middleware/auth.ts
+++ b/packages/engine/src/middleware/auth.ts
@@ -3,6 +3,7 @@ import type { ContentfulStatusCode } from 'hono/utils/http-status';
 import { touchLastSeen } from '../engine/agent.js';
 import type { AppEnv } from '../env.js';
 import type { AuthRequire } from '../ports/auth.js';
+import { jsonError } from '../lib/httpResponse.js';
 
 // Re-exported for the WS upgrade, which looks tokens up
 // directly. The active provider's `hashToken` is preferred at those call sites.
@@ -19,19 +20,13 @@ function makeAuthMiddleware(require: AuthRequire) {
   return createMiddleware<AppEnv>(async (c, next) => {
     const token = extractToken(c.req.header('Authorization'));
     if (!token) {
-      return c.json(
-        { ok: false, error: { code: 'unauthorized', message: 'Missing or invalid Authorization header' } },
-        401,
-      );
+      return jsonError(c, 'unauthorized', 'Missing or invalid Authorization header', 401);
     }
 
     const db = c.get('db');
     const result = await c.get('engine').auth.authenticate({ token, require, db });
     if (!result.ok) {
-      return c.json(
-        { ok: false, error: { code: result.code, message: result.message } },
-        result.status as ContentfulStatusCode,
-      );
+      return jsonError(c, result.code, result.message, result.status as ContentfulStatusCode);
     }
 
     c.set('workspace', result.workspace);

--- a/packages/engine/src/middleware/fleetNodes.ts
+++ b/packages/engine/src/middleware/fleetNodes.ts
@@ -1,6 +1,7 @@
 import { createMiddleware } from 'hono/factory';
 import type { AppEnv } from '../env.js';
 import { isFleetNodesEnabled } from '../lib/fleetNodes.js';
+import { jsonError } from '../lib/httpResponse.js';
 
 /**
  * Gate the fleet node control surface behind the per-workspace rollout flag
@@ -13,10 +14,7 @@ export const requireFleetNodes = createMiddleware<AppEnv>(async (c, next) => {
   const workspace = c.get('workspace');
   const { kv, config } = c.get('engine');
   if (!workspace || !(await isFleetNodesEnabled(kv, workspace.id, config.fleetNodesEnabled ?? false))) {
-    return c.json(
-      { ok: false, error: { code: 'fleet_nodes_disabled', message: 'Fleet nodes are disabled for this workspace' } },
-      404,
-    );
+    return jsonError(c, 'fleet_nodes_disabled', 'Fleet nodes are disabled for this workspace', 404);
   }
   await next();
 });

--- a/packages/engine/src/middleware/idempotency.ts
+++ b/packages/engine/src/middleware/idempotency.ts
@@ -1,5 +1,8 @@
+import type { Context } from 'hono';
+import type { ContentfulStatusCode } from 'hono/utils/http-status';
 import type { KeyValueStore } from '../ports/kv.js';
 import { sha256Hex } from '../lib/crypto.js';
+import { jsonOk } from '../lib/httpResponse.js';
 
 const IDEMPOTENCY_TTL_SECONDS = 24 * 60 * 60;
 const IDEMPOTENCY_LOCK_TTL_SECONDS = 30;
@@ -16,6 +19,12 @@ export interface IdempotentResult<T> {
   data: T;
   replayed: boolean;
 }
+
+type DeliveryInternals = {
+  _delivery?: unknown;
+  _deliveries?: unknown;
+  _delivery_rejections?: unknown;
+};
 
 interface RunIdempotentOptions<T> {
   workspaceId: string;
@@ -67,6 +76,27 @@ export function parseIdempotencyKey(headerValue: string | undefined): { key?: st
   }
 
   return { key };
+}
+
+export function applyIdempotencyReplayHeader<T>(c: Context, result: IdempotentResult<T>) {
+  if (result.replayed) {
+    c.header('Idempotency-Replayed', 'true');
+  }
+}
+
+export function stripDeliveryInternals<T extends object>(data: T) {
+  const {
+    _delivery: _dropDelivery,
+    _deliveries: _dropDeliveries,
+    _delivery_rejections: _dropRejections,
+    ...publicData
+  } = data as T & DeliveryInternals;
+  return publicData;
+}
+
+export function jsonIdempotentOk<T extends object>(c: Context, result: IdempotentResult<T>) {
+  applyIdempotencyReplayHeader(c, result);
+  return jsonOk(c, stripDeliveryInternals(result.data), result.status as ContentfulStatusCode);
 }
 
 export async function runIdempotent<T>(

--- a/packages/engine/src/middleware/planLimits.ts
+++ b/packages/engine/src/middleware/planLimits.ts
@@ -1,6 +1,7 @@
 import { createMiddleware } from 'hono/factory';
 import type { AppEnv } from '../env.js';
 import type { UsageMetric } from '../ports/entitlements.js';
+import { jsonError } from '../lib/httpResponse.js';
 
 // Re-exported for back-compat with callers/tests that imported the table here.
 export { PLAN_LIMITS } from '../providers/static-entitlements.js';
@@ -19,16 +20,7 @@ export function checkPlanLimit(metric: UsageMetric) {
       const current = await entitlements.getUsage(workspace.id, metric);
       if (current >= limit) {
         const plan = workspace.plan || 'free';
-        return c.json(
-          {
-            ok: false,
-            error: {
-              code: 'plan_limit_exceeded',
-              message: `Plan limit exceeded for ${metric}. Current plan: ${plan}. Limit: ${limit}. Current usage: ${current}. Upgrade your plan to increase limits.`,
-            },
-          },
-          429,
-        );
+        return jsonError(c, 'plan_limit_exceeded', `Plan limit exceeded for ${metric}. Current plan: ${plan}. Limit: ${limit}. Current usage: ${current}. Upgrade your plan to increase limits.`, 429);
       }
     } catch { /* fail open */ }
 

--- a/packages/engine/src/middleware/rateLimit.ts
+++ b/packages/engine/src/middleware/rateLimit.ts
@@ -1,5 +1,6 @@
 import { createMiddleware } from 'hono/factory';
 import type { AppEnv } from '../env.js';
+import { jsonError } from '../lib/httpResponse.js';
 
 // Conservative per-minute ceiling applied when the entitlements lookup fails,
 // so an entitlements outage degrades to a safe default rather than no limit.
@@ -60,16 +61,7 @@ export const rateLimit = createMiddleware<AppEnv>(async (c, next) => {
     c.header('X-RateLimit-Remaining', String(remaining ?? Math.max(0, limit - count)));
 
     if (!allowed) {
-      return c.json(
-        {
-          ok: false,
-          error: {
-            code: 'rate_limit_exceeded',
-            message: `Rate limit exceeded. ${limit} requests per minute allowed for ${workspace.plan} plan.`,
-          },
-        },
-        429,
-      );
+      return jsonError(c, 'rate_limit_exceeded', `Rate limit exceeded. ${limit} requests per minute allowed for ${workspace.plan} plan.`, 429);
     }
   } catch {
     // Only the limiter backend failing is fail-open — a transient infra hiccup

--- a/packages/engine/src/routes/a2a.ts
+++ b/packages/engine/src/routes/a2a.ts
@@ -1,5 +1,6 @@
 import { Hono } from 'hono';
 import type { Context } from 'hono';
+import type { ContentfulStatusCode } from 'hono/utils/http-status';
 import { and, eq } from 'drizzle-orm';
 import { z } from 'zod';
 import type { AppEnv } from '../env.js';
@@ -9,6 +10,13 @@ import { asCodedError, type CodedError } from '../lib/httpError.js';
 import { rateLimit } from '../middleware/rateLimit.js';
 import * as a2aEngine from '../engine/a2a.js';
 import * as dmEngine from '../engine/dm.js';
+import {
+  jsonCreated,
+  jsonError,
+  jsonNotFound,
+  jsonOk,
+  parseJsonBody,
+} from '../lib/httpResponse.js';
 
 export const a2aRoutes = new Hono<AppEnv>();
 
@@ -36,6 +44,15 @@ function jsonResponse(c: Context<AppEnv>, body: unknown, status = 200): Response
       'Content-Type': 'application/json',
     },
   });
+}
+
+function codedJsonError(c: Context<AppEnv>, err: unknown) {
+  const error = asCodedError(err);
+  return jsonError(c, error.code || 'internal_error', error.message, (error.status || 500) as ContentfulStatusCode);
+}
+
+function a2aAgentNotFound(c: Context<AppEnv>) {
+  return jsonNotFound(c, 'a2a_agent_not_found', 'A2A agent not found');
 }
 
 function buildAbsoluteUrl(c: Context<AppEnv>, path: string): string {
@@ -121,12 +138,9 @@ a2aRoutes.post('/v1/a2a/register', requireAuth, rateLimit, async (c) => {
   try {
     const db = c.get('db');
     const workspace = c.get('workspace');
-    const parsed = registerA2aSchema.safeParse(await c.req.json());
-    if (!parsed.success) {
-      return c.json({
-        ok: false,
-        error: { code: 'invalid_request', message: 'agent_card_url or agent_card is required' },
-      }, 400);
+    const parsed = await parseJsonBody(c, registerA2aSchema, 'agent_card_url or agent_card is required');
+    if (!parsed.ok) {
+      return parsed.response;
     }
 
     const result = await a2aEngine.registerA2aAgent(db, workspace.id, {
@@ -136,21 +150,14 @@ a2aRoutes.post('/v1/a2a/register', requireAuth, rateLimit, async (c) => {
       authCredential: parsed.data.auth_credential,
     });
 
-    return c.json({
-      ok: true,
-      data: {
-        relay_name: result.relayName,
-        relay_token: result.relayToken,
-        webhook_url: buildAbsoluteUrl(c, result.webhookUrl),
-        certification: result.certification,
-      },
-    }, 201);
+    return jsonCreated(c, {
+      relay_name: result.relayName,
+      relay_token: result.relayToken,
+      webhook_url: buildAbsoluteUrl(c, result.webhookUrl),
+      certification: result.certification,
+    });
   } catch (err: unknown) {
-    const error = asCodedError(err);
-    return jsonResponse(c, {
-      ok: false,
-      error: { code: error.code || 'internal_error', message: error.message },
-    }, error.status || 500);
+    return codedJsonError(c, err);
   }
 });
 
@@ -159,19 +166,12 @@ a2aRoutes.delete('/v1/a2a/agents/:name', requireAuth, rateLimit, async (c) => {
   try {
     const deleted = await a2aEngine.removeA2aAgent(c.get('db'), c.get('workspace').id, c.req.param('name'));
     if (!deleted) {
-      return c.json({
-        ok: false,
-        error: { code: 'a2a_agent_not_found', message: 'A2A agent not found' },
-      }, 404);
+      return a2aAgentNotFound(c);
     }
 
-    return c.json({ ok: true, data: { name: c.req.param('name'), removed: true } });
+    return jsonOk(c, { name: c.req.param('name'), removed: true });
   } catch (err: unknown) {
-    const error = asCodedError(err);
-    return jsonResponse(c, {
-      ok: false,
-      error: { code: error.code || 'internal_error', message: error.message },
-    }, error.status || 500);
+    return codedJsonError(c, err);
   }
 });
 
@@ -179,13 +179,9 @@ a2aRoutes.delete('/v1/a2a/agents/:name', requireAuth, rateLimit, async (c) => {
 a2aRoutes.get('/v1/a2a/agents', requireAuth, rateLimit, async (c) => {
   try {
     const agentsList = await a2aEngine.listA2aAgents(c.get('db'), c.get('workspace').id);
-    return c.json({ ok: true, data: agentsList });
+    return jsonOk(c, agentsList);
   } catch (err: unknown) {
-    const error = asCodedError(err);
-    return jsonResponse(c, {
-      ok: false,
-      error: { code: error.code || 'internal_error', message: error.message },
-    }, error.status || 500);
+    return codedJsonError(c, err);
   }
 });
 
@@ -194,19 +190,12 @@ a2aRoutes.get('/v1/a2a/agents/:name/card', requireAuth, rateLimit, async (c) => 
   try {
     const record = await a2aEngine.getA2aAgentByRelayName(c.get('db'), c.get('workspace').id, c.req.param('name'));
     if (!record) {
-      return c.json({
-        ok: false,
-        error: { code: 'a2a_agent_not_found', message: 'A2A agent not found' },
-      }, 404);
+      return a2aAgentNotFound(c);
     }
 
-    return c.json({ ok: true, data: record.agent_card });
+    return jsonOk(c, record.agent_card);
   } catch (err: unknown) {
-    const error = asCodedError(err);
-    return jsonResponse(c, {
-      ok: false,
-      error: { code: error.code || 'internal_error', message: error.message },
-    }, error.status || 500);
+    return codedJsonError(c, err);
   }
 });
 
@@ -252,20 +241,13 @@ async function handleWorkspaceAgentCard(c: Context<AppEnv>) {
     }
 
     if (!workspace) {
-      return c.json({
-        ok: false,
-        error: { code: 'workspace_not_found', message: 'Workspace could not be inferred from request. Provide an Authorization header or ?workspace= query param.' },
-      }, 404);
+      return jsonNotFound(c, 'workspace_not_found', 'Workspace could not be inferred from request. Provide an Authorization header or ?workspace= query param.');
     }
 
     const card = await a2aEngine.getWorkspaceAgentCard(db, workspace.id, workspace.name, new URL(c.req.url).origin);
-    return c.json(card);
+    return jsonResponse(c, card);
   } catch (err: unknown) {
-    const error = asCodedError(err);
-    return jsonResponse(c, {
-      ok: false,
-      error: { code: error.code || 'internal_error', message: error.message },
-    }, error.status || 500);
+    return codedJsonError(c, err);
   }
 }
 
@@ -280,7 +262,7 @@ a2aRoutes.post('/a2a/rpc', requireAuth, rateLimit, async (c) => {
     const workspace = c.get('workspace');
     const parsed = rpcRequestSchema.safeParse(await c.req.json());
     if (!parsed.success) {
-      return c.json(a2aEngine.jsonRpcError(undefined, -32600, 'Invalid Request'), 400);
+      return jsonResponse(c, a2aEngine.jsonRpcError(undefined, -32600, 'Invalid Request'), 400);
     }
 
     const request = parsed.data;
@@ -310,7 +292,7 @@ a2aRoutes.post('/a2a/rpc', requireAuth, rateLimit, async (c) => {
           credential: target.auth_credential,
         });
         await a2aEngine.incrementA2aMessagesSent(db, target.id);
-        return c.json(upstream.response ?? a2aEngine.jsonRpcSuccess(request.id, {}));
+        return jsonResponse(c, upstream.response ?? a2aEngine.jsonRpcSuccess(request.id, {}));
       }
       default: {
         const response = a2aEngine.jsonRpcError(request.id, -32601, `Unsupported method "${request.method}"`);
@@ -336,10 +318,7 @@ a2aRoutes.post('/a2a/webhook/:workspace_id/:agent_name', async (c) => {
     const relayAgent = await findWebhookAgentByName(db, relayName, workspaceId);
 
     if (!relayAgent) {
-      return c.json({
-        ok: false,
-        error: { code: 'a2a_agent_not_found', message: 'A2A agent not found' },
-      }, 404);
+      return a2aAgentNotFound(c);
     }
 
     const token = c.req.header('Authorization')?.startsWith('Bearer ')
@@ -347,15 +326,12 @@ a2aRoutes.post('/a2a/webhook/:workspace_id/:agent_name', async (c) => {
       : null;
     const tokenHash = token ? await hashToken(token) : null;
     if (!tokenHash || tokenHash !== relayAgent.tokenHash) {
-      return c.json({
-        ok: false,
-        error: { code: 'unauthorized', message: 'Missing or invalid bearer token' },
-      }, 401);
+      return jsonError(c, 'unauthorized', 'Missing or invalid bearer token', 401);
     }
 
     const parsed = rpcWebhookSchema.safeParse(await c.req.json());
     if (!parsed.success) {
-      return c.json(a2aEngine.jsonRpcError(undefined, -32600, 'Invalid Request'), 400);
+      return jsonResponse(c, a2aEngine.jsonRpcError(undefined, -32600, 'Invalid Request'), 400);
     }
 
     const payload = parsed.data;
@@ -424,7 +400,7 @@ a2aRoutes.post('/a2a/webhook/:workspace_id/:agent_name', async (c) => {
       },
     });
 
-    return c.json(response);
+    return jsonResponse(c, response);
   } catch (err: unknown) {
     const error = asCodedError(err) as CodedError & { data?: unknown };
     return jsonResponse(

--- a/packages/engine/src/routes/a2a.ts
+++ b/packages/engine/src/routes/a2a.ts
@@ -1,12 +1,11 @@
 import { Hono } from 'hono';
 import type { Context } from 'hono';
-import type { ContentfulStatusCode } from 'hono/utils/http-status';
 import { and, eq } from 'drizzle-orm';
 import { z } from 'zod';
 import type { AppEnv } from '../env.js';
 import { a2aAgents, agents, messages, workspaces } from '../db/schema.js';
 import { requireAuth, hashToken } from '../middleware/auth.js';
-import { asCodedError, type CodedError } from '../lib/httpError.js';
+import { asCodedError, errorResponse, type CodedError } from '../lib/httpError.js';
 import { rateLimit } from '../middleware/rateLimit.js';
 import * as a2aEngine from '../engine/a2a.js';
 import * as dmEngine from '../engine/dm.js';
@@ -47,8 +46,7 @@ function jsonResponse(c: Context<AppEnv>, body: unknown, status = 200): Response
 }
 
 function codedJsonError(c: Context<AppEnv>, err: unknown) {
-  const error = asCodedError(err);
-  return jsonError(c, error.code || 'internal_error', error.message, (error.status || 500) as ContentfulStatusCode);
+  return errorResponse(c, err);
 }
 
 function a2aAgentNotFound(c: Context<AppEnv>) {

--- a/packages/engine/src/routes/a2a.ts
+++ b/packages/engine/src/routes/a2a.ts
@@ -202,22 +202,12 @@ async function resolveWorkspaceFromAuth(c: Context<AppEnv>): Promise<{ id: strin
   if (!authHeader?.startsWith('Bearer ')) return null;
 
   const token = authHeader.slice(7);
-  const hash = await hashToken(token);
-  const db = c.get('db');
-
-  if (token.startsWith('rk_live_')) {
-    const [ws] = await db.select().from(workspaces).where(eq(workspaces.apiKeyHash, hash));
-    return ws ?? null;
-  }
-
-  if (token.startsWith('at_live_')) {
-    const [agent] = await db.select().from(agents).where(eq(agents.tokenHash, hash));
-    if (!agent) return null;
-    const [ws] = await db.select().from(workspaces).where(eq(workspaces.id, agent.workspaceId));
-    return ws ?? null;
-  }
-
-  return null;
+  const result = await c.get('engine').auth.authenticate({
+    token,
+    require: 'any',
+    db: c.get('db'),
+  });
+  return result.ok ? result.workspace : null;
 }
 
 async function handleWorkspaceAgentCard(c: Context<AppEnv>) {

--- a/packages/engine/src/routes/action.ts
+++ b/packages/engine/src/routes/action.ts
@@ -33,7 +33,13 @@ const registerActionSchema = z.object({
   input_schema: z.record(z.string(), z.unknown()).optional(),
   output_schema: z.record(z.string(), z.unknown()).optional(),
   available_to: z.array(z.string().min(1)).optional(),
-});
+}).refine(
+  ({ handler_agent, handler_node }) => Boolean(handler_agent || handler_node),
+  {
+    path: ['handler_agent'],
+    message: 'handler_agent or handler_node is required',
+  },
+);
 
 const invokeActionSchema = z.object({
   input: z.record(z.string(), z.unknown()).optional(),

--- a/packages/engine/src/routes/action.ts
+++ b/packages/engine/src/routes/action.ts
@@ -13,6 +13,15 @@ import { runInBackground } from './background.js';
 import { sendWebhookEvent } from './webhookOutbox.js';
 import { emitServerEvent } from '../lib/serverTelemetry.js';
 import { asCodedError } from '../lib/httpError.js';
+import {
+  jsonCreated,
+  jsonError,
+  jsonNoContent,
+  jsonNotFound,
+  jsonOk,
+  parseJsonBody,
+  parseOptionalJsonBody,
+} from '../lib/httpResponse.js';
 
 export const actionRoutes = new Hono<AppEnv>();
 
@@ -41,28 +50,26 @@ actionRoutes.post('/actions', requireAuth, rateLimit, async (c) => {
   try {
     const db = c.get('db');
     const workspace = c.get('workspace');
-    const parsed = registerActionSchema.safeParse(await c.req.json());
-    if (!parsed.success) {
-      const hasNameIssue = parsed.error.issues.some((i) => i.path[0] === 'name');
-      const hasDescIssue = parsed.error.issues.some((i) => i.path[0] === 'description');
-      const hasHandlerIssue = parsed.error.issues.some((i) => i.path[0] === 'handler_agent' || i.path[0] === 'handler_node');
-      const message = hasNameIssue
+    const parsed = await parseJsonBody(c, registerActionSchema, (failure) => {
+      const hasNameIssue = failure.error.issues.some((i) => i.path[0] === 'name');
+      const hasDescIssue = failure.error.issues.some((i) => i.path[0] === 'description');
+      const hasHandlerIssue = failure.error.issues.some((i) => i.path[0] === 'handler_agent' || i.path[0] === 'handler_node');
+      return hasNameIssue
         ? 'name is required'
         : hasDescIssue
           ? 'description is required'
           : hasHandlerIssue
             ? 'handler_agent or handler_node is required'
             : 'invalid action registration body';
-      return c.json({ ok: false, error: { code: 'invalid_request', message } }, 400);
+    });
+    if (!parsed.ok) {
+      return parsed.response;
     }
 
     // If called with an agent token, handler_agent must match the calling agent
     const callerAgent = c.get('agent');
     if (callerAgent && parsed.data.handler_agent !== callerAgent.name) {
-      return c.json(
-        { ok: false, error: { code: 'forbidden', message: `Agent "${callerAgent.name}" may only register actions it will handle itself` } },
-        403,
-      );
+      return jsonError(c, 'forbidden', `Agent "${callerAgent.name}" may only register actions it will handle itself`, 403);
     }
 
     const result = await actionEngine.registerAction(db, workspace.id, parsed.data);
@@ -78,7 +85,7 @@ actionRoutes.post('/actions', requireAuth, rateLimit, async (c) => {
       'fanout action.registered',
     );
 
-    return c.json({ ok: true, data: result }, 201);
+    return jsonCreated(c, result);
   } catch (err: unknown) {
     return errorResponse(c, err);
   }
@@ -91,7 +98,7 @@ actionRoutes.get('/actions', requireAuth, rateLimit, async (c) => {
     const workspace = c.get('workspace');
     const agent = c.get('agent');
     const result = await actionEngine.listActions(db, workspace.id, agent?.name);
-    return c.json({ ok: true, data: result });
+    return jsonOk(c, result);
   } catch (err: unknown) {
     return errorResponse(c, err);
   }
@@ -105,12 +112,9 @@ actionRoutes.get('/actions/:name', requireAuth, rateLimit, async (c) => {
     const agent = c.get('agent');
     const result = await actionEngine.getAction(db, workspace.id, c.req.param('name'), agent?.name);
     if (!result) {
-      return c.json(
-        { ok: false, error: { code: 'action_not_found', message: 'Action not found' } },
-        404,
-      );
+      return jsonNotFound(c, 'action_not_found', 'Action not found');
     }
-    return c.json({ ok: true, data: result });
+    return jsonOk(c, result);
   } catch (err: unknown) {
     return errorResponse(c, err);
   }
@@ -123,15 +127,12 @@ actionRoutes.delete('/actions/:name', requireAuth, rateLimit, async (c) => {
     const workspace = c.get('workspace');
     const deleted = await actionEngine.deleteAction(db, workspace.id, c.req.param('name'));
     if (!deleted) {
-      return c.json(
-        { ok: false, error: { code: 'action_not_found', message: 'Action not found' } },
-        404,
-      );
+      return jsonNotFound(c, 'action_not_found', 'Action not found');
     }
     emitServerEvent(c, workspace.id, 'relaycast_server_action_deleted', {
       action_name: c.req.param('name'),
     });
-    return c.body(null, 204);
+    return jsonNoContent(c);
   } catch (err: unknown) {
     return errorResponse(c, err);
   }
@@ -145,24 +146,12 @@ actionRoutes.post('/actions/:name/invoke', requireAuth, rateLimit, async (c) => 
     const agent = c.get('agent');
 
     if (!agent) {
-      return c.json(
-        {
-          ok: false,
-          error: {
-            code: 'agent_token_required',
-            message: 'Agent token required to invoke actions',
-          },
-        },
-        403,
-      );
+      return jsonError(c, 'agent_token_required', 'Agent token required to invoke actions', 403);
     }
 
-    const parsed = invokeActionSchema.safeParse(await c.req.json().catch(() => ({})));
-    if (!parsed.success) {
-      return c.json(
-        { ok: false, error: { code: 'invalid_request', message: 'invalid invocation body' } },
-        400,
-      );
+    const parsed = await parseOptionalJsonBody(c, invokeActionSchema, 'invalid invocation body');
+    if (!parsed.ok) {
+      return parsed.response;
     }
 
     const { nodeConnections, kv, config } = c.get('engine');
@@ -209,7 +198,7 @@ actionRoutes.post('/actions/:name/invoke', requireAuth, rateLimit, async (c) => 
       caller_agent_id: agent.id,
     });
 
-    return c.json({ ok: true, data: result }, 201);
+    return jsonCreated(c, result);
   } catch (err: unknown) {
     const error = asCodedError(err);
     if (error.code === 'action_denied') {
@@ -236,12 +225,9 @@ actionRoutes.post('/actions/:name/invocations/:id/complete', requireAuth, rateLi
   try {
     const db = c.get('db');
     const workspace = c.get('workspace');
-    const parsed = completeInvocationSchema.safeParse(await c.req.json().catch(() => ({})));
-    if (!parsed.success) {
-      return c.json(
-        { ok: false, error: { code: 'invalid_request', message: 'invalid completion body' } },
-        400,
-      );
+    const parsed = await parseOptionalJsonBody(c, completeInvocationSchema, 'invalid completion body');
+    if (!parsed.ok) {
+      return parsed.response;
     }
 
     const agent = c.get('agent');
@@ -254,17 +240,14 @@ actionRoutes.post('/actions/:name/invocations/:id/complete', requireAuth, rateLi
     );
 
     if (!result) {
-      return c.json(
-        { ok: false, error: { code: 'invocation_not_found', message: 'Invocation not found' } },
-        404,
-      );
+      return jsonNotFound(c, 'invocation_not_found', 'Invocation not found');
     }
 
     await emitInvocationCompletionEffects(c.get('engine'), workspace.id, result);
 
     // Strip caller_id from client response (internal routing detail)
     const { caller_id: _drop, ...publicResult } = result;
-    return c.json({ ok: true, data: publicResult });
+    return jsonOk(c, publicResult);
   } catch (err: unknown) {
     return errorResponse(c, err);
   }
@@ -277,12 +260,9 @@ actionRoutes.get('/actions/:name/invocations/:id', requireAuth, rateLimit, async
     const workspace = c.get('workspace');
     const result = await actionEngine.getInvocation(db, workspace.id, c.req.param('name'), c.req.param('id'));
     if (!result) {
-      return c.json(
-        { ok: false, error: { code: 'invocation_not_found', message: 'Invocation not found' } },
-        404,
-      );
+      return jsonNotFound(c, 'invocation_not_found', 'Invocation not found');
     }
-    return c.json({ ok: true, data: result });
+    return jsonOk(c, result);
   } catch (err: unknown) {
     return errorResponse(c, err);
   }

--- a/packages/engine/src/routes/agent.ts
+++ b/packages/engine/src/routes/agent.ts
@@ -19,7 +19,9 @@ import {
   jsonNotFound,
   jsonOk,
   parseJsonBody,
+  parseQueryParams,
 } from '../lib/httpResponse.js';
+import { positiveIntQueryParam } from '../lib/httpQuery.js';
 
 export const agentRoutes = new Hono<AppEnv>();
 
@@ -71,6 +73,11 @@ const releaseAgentSchema = z.object({
   name: z.string().min(1),
   reason: z.string().nullable().optional(),
   delete_agent: z.boolean().optional(),
+});
+
+const listSessionEventsQuerySchema = z.object({
+  type: z.string().optional(),
+  limit: positiveIntQueryParam({ defaultValue: 100, max: 500 }),
 });
 
 function canonicalStatus(status: string): 'active' | 'idle' | 'blocked' | 'waiting' | 'offline' | null {
@@ -462,8 +469,11 @@ agentRoutes.get(
       const db = c.get('db');
       const workspace = c.get('workspace');
       const name = c.req.param('name');
-      const type = c.req.query('type');
-      const limit = Math.min(parseInt(c.req.query('limit') ?? '100', 10), 500);
+      const parsed = parseQueryParams(c, listSessionEventsQuerySchema, 'Invalid agent event query');
+      if (!parsed.ok) {
+        return parsed.response;
+      }
+      const { type, limit } = parsed.data;
 
       const agent = await agentEngine.getAgentByName(db, workspace.id, name);
       if (!agent) {

--- a/packages/engine/src/routes/agent.ts
+++ b/packages/engine/src/routes/agent.ts
@@ -1,5 +1,4 @@
 import { Hono } from 'hono';
-import type { ContentfulStatusCode } from 'hono/utils/http-status';
 import { z } from 'zod';
 import { AgentTypeSchema, CliTypeSchema } from '@relaycast/types';
 import type { AppEnv } from '../env.js';
@@ -13,6 +12,14 @@ import { runInBackground } from './background.js';
 import { sendWebhookEvent } from './webhookOutbox.js';
 import { emitServerEvent } from '../lib/serverTelemetry.js';
 import { errorResponse } from '../lib/httpError.js';
+import {
+  jsonCreated,
+  jsonError,
+  jsonNoContent,
+  jsonNotFound,
+  jsonOk,
+  parseJsonBody,
+} from '../lib/httpResponse.js';
 
 export const agentRoutes = new Hono<AppEnv>();
 
@@ -74,6 +81,10 @@ function canonicalStatus(status: string): 'active' | 'idle' | 'blocked' | 'waiti
   return null;
 }
 
+function agentNotFound(c: Parameters<typeof jsonNotFound>[0], name: string) {
+  return jsonNotFound(c, 'agent_not_found', `Agent "${name}" not found`);
+}
+
 async function fanoutAgentStatus(c: Parameters<typeof runInBackground>[0], agent: { id: string; name: string }, status: string, eventId?: string): Promise<void> {
   const nextStatus = canonicalStatus(status);
   if (!nextStatus) return;
@@ -104,12 +115,9 @@ agentRoutes.get(
       const authAgent = c.get('agent');
       const agent = await agentEngine.getAgentByName(db, workspace.id, authAgent!.name);
       if (!agent) {
-        return c.json({
-          ok: false,
-          error: { code: 'agent_not_found', message: 'Authenticated agent not found' },
-        }, 404);
+        return jsonNotFound(c, 'agent_not_found', 'Authenticated agent not found');
       }
-      return c.json({ ok: true, data: agent });
+      return jsonOk(c, agent);
     } catch (err: unknown) {
       return errorResponse(c, err);
     }
@@ -125,12 +133,9 @@ agentRoutes.post(
     try {
       const db = c.get('db');
       const workspace = c.get('workspace');
-      const parsed = registerAgentSchema.safeParse(await c.req.json());
-      if (!parsed.success) {
-        return c.json({
-          ok: false,
-          error: { code: 'invalid_request', message: 'name is required' },
-        }, 400);
+      const parsed = await parseJsonBody(c, registerAgentSchema, 'name is required');
+      if (!parsed.ok) {
+        return parsed.response;
       }
       const { name, type, persona, metadata, skills, capabilities } = parsed.data;
       const nextMetadata = {
@@ -158,7 +163,7 @@ agentRoutes.post(
         agent_name: result.name,
         agent_type: type ?? 'agent',
       });
-      return c.json({ ok: true, data: result }, 201);
+      return jsonCreated(c, result);
     } catch (err: unknown) {
       return errorResponse(c, err);
     }
@@ -176,7 +181,7 @@ agentRoutes.get(
       const workspace = c.get('workspace');
       const status = c.req.query('status');
       const agents = await agentEngine.listAgents(db, workspace.id, status);
-      return c.json({ ok: true, data: agents });
+      return jsonOk(c, agents);
     } catch (err: unknown) {
       return errorResponse(c, err);
     }
@@ -195,12 +200,9 @@ agentRoutes.get(
       const name = c.req.param('name');
       const agent = await agentEngine.getAgentByName(db, workspace.id, name);
       if (!agent) {
-        return c.json({
-          ok: false,
-          error: { code: 'agent_not_found', message: `Agent "${name}" not found` },
-        }, 404);
+        return agentNotFound(c, name);
       }
-      return c.json({ ok: true, data: agent });
+      return jsonOk(c, agent);
     } catch (err: unknown) {
       return errorResponse(c, err);
     }
@@ -217,19 +219,13 @@ agentRoutes.patch(
       const db = c.get('db');
       const workspace = c.get('workspace');
       const name = c.req.param('name');
-      const parsed = updateAgentSchema.safeParse(await c.req.json());
-      if (!parsed.success) {
-        return c.json({
-          ok: false,
-          error: { code: 'invalid_request', message: 'invalid agent update body' },
-        }, 400);
+      const parsed = await parseJsonBody(c, updateAgentSchema, 'invalid agent update body');
+      if (!parsed.ok) {
+        return parsed.response;
       }
       const existing = await agentEngine.getAgentByName(db, workspace.id, name);
       if (!existing) {
-        return c.json({
-          ok: false,
-          error: { code: 'agent_not_found', message: `Agent "${name}" not found` },
-        }, 404);
+        return agentNotFound(c, name);
       }
 
       const body = parsed.data;
@@ -248,10 +244,7 @@ agentRoutes.patch(
         capabilities: body.capabilities,
       });
       if (!updated) {
-        return c.json({
-          ok: false,
-          error: { code: 'agent_not_found', message: `Agent "${name}" not found` },
-        }, 404);
+        return agentNotFound(c, name);
       }
       if (body.metadata !== undefined || body.skills !== undefined || body.status !== undefined) {
         await directoryEngine.syncSourceAgentDirectoryEntry(db, workspace.id, {
@@ -269,7 +262,7 @@ agentRoutes.patch(
         changed_status: typeof body?.status === 'string',
         changed_persona: typeof body?.persona === 'string',
       });
-      return c.json({ ok: true, data: updated });
+      return jsonOk(c, updated);
     } catch (err: unknown) {
       return errorResponse(c, err);
     }
@@ -288,15 +281,12 @@ agentRoutes.delete(
       const name = c.req.param('name');
       const deleted = await agentEngine.deleteAgent(db, workspace.id, name);
       if (!deleted) {
-        return c.json({
-          ok: false,
-          error: { code: 'agent_not_found', message: `Agent "${name}" not found` },
-        }, 404);
+        return agentNotFound(c, name);
       }
       emitServerEvent(c, workspace.id, 'relaycast_server_agent_deleted', {
         agent_name: name,
       });
-      return c.body(null, 204);
+      return jsonNoContent(c);
     } catch (err: unknown) {
       return errorResponse(c, err);
     }
@@ -312,22 +302,20 @@ agentRoutes.post(
     try {
       const db = c.get('db');
       const workspace = c.get('workspace');
-      const parsed = spawnAgentSchema.safeParse(await c.req.json());
-      if (!parsed.success) {
-        const hasNameIssue = parsed.error.issues.some((issue) => issue.path[0] === 'name');
-        const hasCliIssue = parsed.error.issues.some((issue) => issue.path[0] === 'cli');
-        const hasTaskIssue = parsed.error.issues.some((issue) => issue.path[0] === 'task');
-        const message = hasNameIssue
+      const parsed = await parseJsonBody(c, spawnAgentSchema, (failure) => {
+        const hasNameIssue = failure.error.issues.some((issue) => issue.path[0] === 'name');
+        const hasCliIssue = failure.error.issues.some((issue) => issue.path[0] === 'cli');
+        const hasTaskIssue = failure.error.issues.some((issue) => issue.path[0] === 'task');
+        return hasNameIssue
           ? 'name is required'
           : hasCliIssue
             ? `cli must be one of: ${CliTypeSchema.options.join(', ')}`
             : hasTaskIssue
               ? 'task is required'
               : 'invalid spawn request';
-        return c.json({
-          ok: false,
-          error: { code: 'invalid_request', message },
-        }, 400);
+      });
+      if (!parsed.ok) {
+        return parsed.response;
       }
       const { name, cli, task, channel, persona, model, metadata } = parsed.data;
 
@@ -365,7 +353,7 @@ agentRoutes.post(
         already_existed: result.already_existed,
       });
 
-      return c.json({ ok: true, data: result }, (result.already_existed ? 200 : 201) as ContentfulStatusCode);
+      return result.already_existed ? jsonOk(c, result) : jsonCreated(c, result);
     } catch (err: unknown) {
       return errorResponse(c, err);
     }
@@ -383,38 +371,26 @@ agentRoutes.post(
       const workspace = c.get('workspace');
       const name = c.req.param('name');
 
-      const parsed = sessionEventSchema.safeParse(await c.req.json());
-      if (!parsed.success) {
-        return c.json(
-          { ok: false, error: { code: 'invalid_request', message: 'type is required' } },
-          400,
-        );
+      const parsed = await parseJsonBody(c, sessionEventSchema, 'type is required');
+      if (!parsed.ok) {
+        return parsed.response;
       }
 
       const { type, payload } = parsed.data;
 
       if (!sessionEventEngine.isValidEventType(type)) {
-        return c.json(
-          { ok: false, error: { code: 'invalid_event_type', message: `Unknown event type: ${type}` } },
-          400,
-        );
+        return jsonError(c, 'invalid_event_type', `Unknown event type: ${type}`, 400);
       }
 
       const agentRecord = await agentEngine.getAgentByName(db, workspace.id, name);
       if (!agentRecord) {
-        return c.json(
-          { ok: false, error: { code: 'agent_not_found', message: `Agent "${name}" not found` } },
-          404,
-        );
+        return agentNotFound(c, name);
       }
 
       // Agent tokens may only post events for themselves
       const callerAgent = c.get('agent');
       if (callerAgent && callerAgent.id !== agentRecord.id) {
-        return c.json(
-          { ok: false, error: { code: 'forbidden', message: 'Agent token can only post events for itself' } },
-          403,
-        );
+        return jsonError(c, 'forbidden', 'Agent token can only post events for itself', 403);
       }
 
       // Validate status events before writing — reject early so no orphan row is created
@@ -425,16 +401,10 @@ agentRoutes.post(
         const newStatus = resolved ?? fromPayload;
 
         if (!newStatus) {
-          return c.json(
-            { ok: false, error: { code: 'invalid_request', message: 'status.changed event requires payload.status' } },
-            400,
-          );
+          return jsonError(c, 'invalid_request', 'status.changed event requires payload.status', 400);
         }
         if (!VALID_STATUSES.has(newStatus)) {
-          return c.json(
-            { ok: false, error: { code: 'invalid_request', message: `Invalid status value: "${newStatus}". Must be one of: ${[...VALID_STATUSES].join(', ')}` } },
-            400,
-          );
+          return jsonError(c, 'invalid_request', `Invalid status value: "${newStatus}". Must be one of: ${[...VALID_STATUSES].join(', ')}`, 400);
         }
       }
 
@@ -475,7 +445,7 @@ agentRoutes.post(
         });
       }
 
-      return c.json({ ok: true, data: event }, 201);
+      return jsonCreated(c, event);
     } catch (err: unknown) {
       return errorResponse(c, err);
     }
@@ -497,10 +467,7 @@ agentRoutes.get(
 
       const agent = await agentEngine.getAgentByName(db, workspace.id, name);
       if (!agent) {
-        return c.json(
-          { ok: false, error: { code: 'agent_not_found', message: `Agent "${name}" not found` } },
-          404,
-        );
+        return agentNotFound(c, name);
       }
 
       const events = await sessionEventEngine.listSessionEvents(db, workspace.id, agent.id, {
@@ -508,7 +475,7 @@ agentRoutes.get(
         limit,
       });
 
-      return c.json({ ok: true, data: events });
+      return jsonOk(c, events);
     } catch (err: unknown) {
       return errorResponse(c, err);
     }
@@ -524,12 +491,9 @@ agentRoutes.post(
     try {
       const db = c.get('db');
       const workspace = c.get('workspace');
-      const parsed = releaseAgentSchema.safeParse(await c.req.json());
-      if (!parsed.success) {
-        return c.json({
-          ok: false,
-          error: { code: 'invalid_request', message: 'name is required' },
-        }, 400);
+      const parsed = await parseJsonBody(c, releaseAgentSchema, 'name is required');
+      if (!parsed.ok) {
+        return parsed.response;
       }
       const { name, reason, delete_agent } = parsed.data;
 
@@ -540,10 +504,7 @@ agentRoutes.post(
       });
 
       if (!result) {
-        return c.json({
-          ok: false,
-          error: { code: 'agent_not_found', message: `Agent "${name}" not found` },
-        }, 404);
+        return agentNotFound(c, name);
       }
 
       const releaseEventData = {
@@ -563,7 +524,7 @@ agentRoutes.post(
         deleted: result.deleted,
       });
 
-      return c.json({ ok: true, data: result });
+      return jsonOk(c, result);
     } catch (err: unknown) {
       return errorResponse(c, err);
     }

--- a/packages/engine/src/routes/certify.ts
+++ b/packages/engine/src/routes/certify.ts
@@ -5,6 +5,12 @@ import { requireAuth } from '../middleware/auth.js';
 import { rateLimit } from '../middleware/rateLimit.js';
 import * as certifyEngine from '../engine/certify.js';
 import { errorResponse } from '../lib/httpError.js';
+import {
+  jsonCreated,
+  jsonNotFound,
+  jsonOk,
+  parseJsonBody,
+} from '../lib/httpResponse.js';
 
 export const certifyRoutes = new Hono<AppEnv>();
 
@@ -21,12 +27,13 @@ const monitorCertificationSchema = z.object({
 
 certifyRoutes.post('/certify', requireAuth, rateLimit, async (c) => {
   try {
-    const parsed = submitCertificationSchema.safeParse(await c.req.json());
-    if (!parsed.success) {
-      return c.json({
-        ok: false,
-        error: { code: 'invalid_request', message: 'agent_url and a valid level are required' },
-      }, 400);
+    const parsed = await parseJsonBody(
+      c,
+      submitCertificationSchema,
+      'agent_url and a valid level are required',
+    );
+    if (!parsed.ok) {
+      return parsed.response;
     }
 
     const result = await certifyEngine.createAndRunCertification(c.get('db'), c.get('workspace').id, {
@@ -35,20 +42,17 @@ certifyRoutes.post('/certify', requireAuth, rateLimit, async (c) => {
       source: 'manual',
     });
 
-    return c.json({
-      ok: true,
-      data: {
-        id: result.id,
-        agent_url: result.agent_url,
-        level: result.level,
-        passed: result.passed,
-        passed_tests: result.passed_tests,
-        total_tests: result.total_tests,
-        started_at: result.started_at,
-        completed_at: result.completed_at,
-        tests: result.tests,
-      },
-    }, 201);
+    return jsonCreated(c, {
+      id: result.id,
+      agent_url: result.agent_url,
+      level: result.level,
+      passed: result.passed,
+      passed_tests: result.passed_tests,
+      total_tests: result.total_tests,
+      started_at: result.started_at,
+      completed_at: result.completed_at,
+      tests: result.tests,
+    });
   } catch (err: unknown) {
     return errorResponse(c, err);
   }
@@ -58,13 +62,10 @@ certifyRoutes.get('/certify/:id', requireAuth, rateLimit, async (c) => {
   try {
     const result = await certifyEngine.getCertificationRun(c.get('db'), c.get('workspace').id, c.req.param('id'));
     if (!result) {
-      return c.json({
-        ok: false,
-        error: { code: 'certification_not_found', message: 'Certification run not found' },
-      }, 404);
+      return jsonNotFound(c, 'certification_not_found', 'Certification run not found');
     }
 
-    return c.json({ ok: true, data: result });
+    return jsonOk(c, result);
   } catch (err: unknown) {
     return errorResponse(c, err);
   }
@@ -100,12 +101,13 @@ certifyRoutes.get('/certify/:id/badge.svg', requireAuth, rateLimit, async (c) =>
 
 certifyRoutes.post('/certify/monitor', requireAuth, rateLimit, async (c) => {
   try {
-    const parsed = monitorCertificationSchema.safeParse(await c.req.json());
-    if (!parsed.success) {
-      return c.json({
-        ok: false,
-        error: { code: 'invalid_request', message: 'agent_url and a valid monitoring configuration are required' },
-      }, 400);
+    const parsed = await parseJsonBody(
+      c,
+      monitorCertificationSchema,
+      'agent_url and a valid monitoring configuration are required',
+    );
+    if (!parsed.ok) {
+      return parsed.response;
     }
 
     const result = await certifyEngine.enableCertificationMonitoring(
@@ -116,10 +118,7 @@ certifyRoutes.post('/certify/monitor', requireAuth, rateLimit, async (c) => {
       parsed.data.interval_minutes,
     );
 
-    return c.json({
-      ok: true,
-      data: result,
-    }, 201);
+    return jsonCreated(c, result);
   } catch (err: unknown) {
     return errorResponse(c, err);
   }

--- a/packages/engine/src/routes/channel.ts
+++ b/packages/engine/src/routes/channel.ts
@@ -9,6 +9,14 @@ import { runInBackground } from './background.js';
 import { sendWebhookEvent } from './webhookOutbox.js';
 import { emitServerEvent } from '../lib/serverTelemetry.js';
 import { errorResponse } from '../lib/httpError.js';
+import {
+  jsonCreated,
+  jsonError,
+  jsonNoContent,
+  jsonNotFound,
+  jsonOk,
+  parseJsonBody,
+} from '../lib/httpResponse.js';
 
 export const channelRoutes = new Hono<AppEnv>();
 
@@ -31,6 +39,10 @@ const inviteChannelSchema = z.object({
   agent_name: z.string().min(1),
 });
 
+function channelNotFound(c: Parameters<typeof jsonNotFound>[0], name: string) {
+  return jsonNotFound(c, 'channel_not_found', `Channel "${name}" not found`);
+}
+
 // POST /v1/channels - create channel
 channelRoutes.post(
   '/channels',
@@ -41,12 +53,9 @@ channelRoutes.post(
       const db = c.get('db');
       const workspace = c.get('workspace');
       const agent = c.get('agent');
-      const parsed = createChannelSchema.safeParse(await c.req.json());
-      if (!parsed.success) {
-        return c.json({
-          ok: false,
-          error: { code: 'invalid_request', message: 'name is required' },
-        }, 400);
+      const parsed = await parseJsonBody(c, createChannelSchema, 'name is required');
+      if (!parsed.ok) {
+        return parsed.response;
       }
       const { name, topic, metadata } = parsed.data;
 
@@ -78,7 +87,7 @@ channelRoutes.post(
         channel_name: result.name,
       });
 
-      return c.json({ ok: true, data: result }, 201);
+      return jsonCreated(c, result);
     } catch (err: unknown) {
       return errorResponse(c, err);
     }
@@ -100,7 +109,7 @@ channelRoutes.get(
         workspace.id,
         includeArchived,
       );
-      return c.json({ ok: true, data: channels });
+      return jsonOk(c, channels);
     } catch (err: unknown) {
       return errorResponse(c, err);
     }
@@ -119,15 +128,9 @@ channelRoutes.get(
       const name = c.req.param('name');
       const channel = await channelEngine.getChannel(db, workspace.id, name);
       if (!channel) {
-        return c.json({
-          ok: false,
-          error: {
-            code: 'channel_not_found',
-            message: `Channel "${name}" not found`,
-          },
-        }, 404);
+        return channelNotFound(c, name);
       }
-      return c.json({ ok: true, data: channel });
+      return jsonOk(c, channel);
     } catch (err: unknown) {
       return errorResponse(c, err);
     }
@@ -144,12 +147,9 @@ channelRoutes.patch(
       const db = c.get('db');
       const workspace = c.get('workspace');
       const name = c.req.param('name');
-      const parsed = updateChannelSchema.safeParse(await c.req.json());
-      if (!parsed.success) {
-        return c.json({
-          ok: false,
-          error: { code: 'invalid_request', message: 'invalid channel update body' },
-        }, 400);
+      const parsed = await parseJsonBody(c, updateChannelSchema, 'invalid channel update body');
+      if (!parsed.ok) {
+        return parsed.response;
       }
       const body = parsed.data;
       const updated = await channelEngine.updateChannel(
@@ -159,13 +159,7 @@ channelRoutes.patch(
         body,
       );
       if (!updated) {
-        return c.json({
-          ok: false,
-          error: {
-            code: 'channel_not_found',
-            message: `Channel "${name}" not found`,
-          },
-        }, 404);
+        return channelNotFound(c, name);
       }
 
       const eventData = { ...updated, channel_name: updated.name };
@@ -180,7 +174,7 @@ channelRoutes.patch(
         channel_name: updated.name,
       });
 
-      return c.json({ ok: true, data: updated });
+      return jsonOk(c, updated);
     } catch (err: unknown) {
       return errorResponse(c, err);
     }
@@ -198,12 +192,9 @@ channelRoutes.patch(
       const db = c.get('db');
       const workspace = c.get('workspace');
       const name = c.req.param('name');
-      const parsed = updateChannelTopicSchema.safeParse(await c.req.json());
-      if (!parsed.success) {
-        return c.json({
-          ok: false,
-          error: { code: 'invalid_request', message: 'topic is required' },
-        }, 400);
+      const parsed = await parseJsonBody(c, updateChannelTopicSchema, 'topic is required');
+      if (!parsed.ok) {
+        return parsed.response;
       }
       const { topic } = parsed.data;
 
@@ -214,13 +205,7 @@ channelRoutes.patch(
         { topic },
       );
       if (!updated) {
-        return c.json({
-          ok: false,
-          error: {
-            code: 'channel_not_found',
-            message: `Channel "${name}" not found`,
-          },
-        }, 404);
+        return channelNotFound(c, name);
       }
 
       const eventData = { ...updated, channel_name: name };
@@ -235,7 +220,7 @@ channelRoutes.patch(
         channel_name: updated.name,
       });
 
-      return c.json({ ok: true, data: updated });
+      return jsonOk(c, updated);
     } catch (err: unknown) {
       return errorResponse(c, err);
     }
@@ -258,13 +243,7 @@ channelRoutes.delete(
         name,
       );
       if (!archived) {
-        return c.json({
-          ok: false,
-          error: {
-            code: 'channel_not_found',
-            message: `Channel "${name}" not found`,
-          },
-        }, 404);
+        return channelNotFound(c, name);
       }
 
       const channel = await channelEngine.getChannel(db, workspace.id, name);
@@ -281,7 +260,7 @@ channelRoutes.delete(
         channel_name: name,
       });
 
-      return c.body(null, 204);
+      return jsonNoContent(c);
     } catch (err: unknown) {
       return errorResponse(c, err);
     }
@@ -329,7 +308,7 @@ channelRoutes.post(
         agent_id: agent!.id,
       });
 
-      return c.json({ ok: true, data: result });
+      return jsonOk(c, result);
     } catch (err: unknown) {
       return errorResponse(c, err);
     }
@@ -389,7 +368,7 @@ channelRoutes.post(
         agent_id: agent!.id,
       });
 
-      return c.body(null, 204);
+      return jsonNoContent(c);
     } catch (err: unknown) {
       return errorResponse(c, err);
     }
@@ -411,7 +390,7 @@ channelRoutes.get(
         workspace.id,
         name,
       );
-      return c.json({ ok: true, data: members });
+      return jsonOk(c, members);
     } catch (err: unknown) {
       return errorResponse(c, err);
     }
@@ -429,25 +408,16 @@ channelRoutes.post(
       const workspace = c.get('workspace');
       const agent = c.get('agent');
       const name = c.req.param('name');
-      const parsed = inviteChannelSchema.safeParse(await c.req.json());
-      if (!parsed.success) {
-        return c.json({
-          ok: false,
-          error: { code: 'invalid_request', message: 'agent_name is required' },
-        }, 400);
+      const parsed = await parseJsonBody(c, inviteChannelSchema, 'agent_name is required');
+      if (!parsed.ok) {
+        return parsed.response;
       }
       const { agent_name: agentName } = parsed.data;
 
       // For invite, we need to know who's doing the inviting
       const inviterAgentId = agent?.id;
       if (!inviterAgentId) {
-        return c.json({
-          ok: false,
-          error: {
-            code: 'agent_token_required',
-            message: 'Agent token required to invite others',
-          },
-        }, 403);
+        return jsonError(c, 'agent_token_required', 'Agent token required to invite others', 403);
       }
 
       const result = await channelEngine.inviteAgent(
@@ -481,7 +451,7 @@ channelRoutes.post(
         invited_agent_name: agentName,
       });
 
-      return c.json({ ok: true, data: result });
+      return jsonOk(c, result);
     } catch (err: unknown) {
       return errorResponse(c, err);
     }
@@ -529,7 +499,7 @@ channelRoutes.post(
         agent_id: agent!.id,
       });
 
-      return c.json({ ok: true, data: result });
+      return jsonOk(c, result);
     } catch (err: unknown) {
       return errorResponse(c, err);
     }
@@ -577,7 +547,7 @@ channelRoutes.post(
         agent_id: agent!.id,
       });
 
-      return c.json({ ok: true, data: result });
+      return jsonOk(c, result);
     } catch (err: unknown) {
       return errorResponse(c, err);
     }

--- a/packages/engine/src/routes/console.ts
+++ b/packages/engine/src/routes/console.ts
@@ -6,11 +6,12 @@ import { rateLimit } from '../middleware/rateLimit.js';
 import * as consoleEngine from '../engine/console.js';
 import { errorResponse } from '../lib/httpError.js';
 import { jsonOk, parseQueryParams } from '../lib/httpResponse.js';
+import { positiveIntQueryParam } from '../lib/httpQuery.js';
 
 export const consoleRoutes = new Hono<AppEnv>();
 
 const listLogsQuerySchema = z.object({
-  limit: z.coerce.number().int().min(1).max(100).optional(),
+  limit: positiveIntQueryParam({ max: 100 }),
   before: z.string().min(1).optional(),
   agent_id: z.string().min(1).optional(),
   channel_id: z.string().min(1).optional(),
@@ -19,12 +20,12 @@ const listLogsQuerySchema = z.object({
 });
 
 const windowQuerySchema = z.object({
-  days: z.coerce.number().int().min(1).max(30).default(7),
+  days: positiveIntQueryParam({ defaultValue: 7, max: 30 }),
 });
 
 const agentStatsQuerySchema = z.object({
-  days: z.coerce.number().int().min(1).max(30).default(7),
-  limit: z.coerce.number().int().min(1).max(100).default(20),
+  days: positiveIntQueryParam({ defaultValue: 7, max: 30 }),
+  limit: positiveIntQueryParam({ defaultValue: 20, max: 100 }),
 });
 
 consoleRoutes.get('/console/messages', requireAuth, rateLimit, async (c) => {

--- a/packages/engine/src/routes/console.ts
+++ b/packages/engine/src/routes/console.ts
@@ -5,6 +5,7 @@ import { requireAuth } from '../middleware/auth.js';
 import { rateLimit } from '../middleware/rateLimit.js';
 import * as consoleEngine from '../engine/console.js';
 import { errorResponse } from '../lib/httpError.js';
+import { jsonOk, parseQueryParams } from '../lib/httpResponse.js';
 
 export const consoleRoutes = new Hono<AppEnv>();
 
@@ -30,12 +31,9 @@ consoleRoutes.get('/console/messages', requireAuth, rateLimit, async (c) => {
   try {
     const workspace = c.get('workspace');
     const db = c.get('db');
-    const parsed = listLogsQuerySchema.safeParse(c.req.query());
-    if (!parsed.success) {
-      return c.json({
-        ok: false,
-        error: { code: 'invalid_request', message: 'Invalid console message query' },
-      }, 400);
+    const parsed = parseQueryParams(c, listLogsQuerySchema, 'Invalid console message query');
+    if (!parsed.ok) {
+      return parsed.response;
     }
 
     const data = await consoleEngine.listMessageLogs(db, workspace.id, {
@@ -47,7 +45,7 @@ consoleRoutes.get('/console/messages', requireAuth, rateLimit, async (c) => {
       deliveryKind: parsed.data.delivery_kind,
     });
 
-    return c.json({ ok: true, data });
+    return jsonOk(c, data);
   } catch (err: unknown) {
     return errorResponse(c, err);
   }
@@ -57,16 +55,13 @@ consoleRoutes.get('/console/stats', requireAuth, rateLimit, async (c) => {
   try {
     const workspace = c.get('workspace');
     const db = c.get('db');
-    const parsed = windowQuerySchema.safeParse(c.req.query());
-    if (!parsed.success) {
-      return c.json({
-        ok: false,
-        error: { code: 'invalid_request', message: 'Invalid console stats query' },
-      }, 400);
+    const parsed = parseQueryParams(c, windowQuerySchema, 'Invalid console stats query');
+    if (!parsed.ok) {
+      return parsed.response;
     }
 
     const data = await consoleEngine.getConsoleOverview(db, workspace.id, parsed.data.days);
-    return c.json({ ok: true, data });
+    return jsonOk(c, data);
   } catch (err: unknown) {
     return errorResponse(c, err);
   }
@@ -76,12 +71,9 @@ consoleRoutes.get('/console/agents', requireAuth, rateLimit, async (c) => {
   try {
     const workspace = c.get('workspace');
     const db = c.get('db');
-    const parsed = agentStatsQuerySchema.safeParse(c.req.query());
-    if (!parsed.success) {
-      return c.json({
-        ok: false,
-        error: { code: 'invalid_request', message: 'Invalid console agent query' },
-      }, 400);
+    const parsed = parseQueryParams(c, agentStatsQuerySchema, 'Invalid console agent query');
+    if (!parsed.ok) {
+      return parsed.response;
     }
 
     const data = await consoleEngine.getAgentStats(
@@ -90,7 +82,7 @@ consoleRoutes.get('/console/agents', requireAuth, rateLimit, async (c) => {
       parsed.data.days,
       parsed.data.limit,
     );
-    return c.json({ ok: true, data });
+    return jsonOk(c, data);
   } catch (err: unknown) {
     return errorResponse(c, err);
   }
@@ -100,16 +92,13 @@ consoleRoutes.get('/console/costs', requireAuth, rateLimit, async (c) => {
   try {
     const workspace = c.get('workspace');
     const db = c.get('db');
-    const parsed = windowQuerySchema.safeParse(c.req.query());
-    if (!parsed.success) {
-      return c.json({
-        ok: false,
-        error: { code: 'invalid_request', message: 'Invalid console cost query' },
-      }, 400);
+    const parsed = parseQueryParams(c, windowQuerySchema, 'Invalid console cost query');
+    if (!parsed.ok) {
+      return parsed.response;
     }
 
     const data = await consoleEngine.getCostStats(db, workspace.id, parsed.data.days);
-    return c.json({ ok: true, data });
+    return jsonOk(c, data);
   } catch (err: unknown) {
     return errorResponse(c, err);
   }

--- a/packages/engine/src/routes/delivery.ts
+++ b/packages/engine/src/routes/delivery.ts
@@ -7,6 +7,13 @@ import { fanoutToAgents } from './fanout.js';
 import { notifyDeliveryFailures } from './deliveryRouting.js';
 import { runInBackground } from './background.js';
 import { errorResponse } from '../lib/httpError.js';
+import {
+  jsonNotFound,
+  jsonOk,
+  parseJsonBody,
+  parseOptionalJsonBody,
+  parseQueryParams,
+} from '../lib/httpResponse.js';
 import { ListDeliveriesQuerySchema, FailDeliveryRequestSchema, DeferDeliveryRequestSchema } from '@relaycast/types';
 
 export const deliveryRoutes = new Hono<AppEnv>();
@@ -20,15 +27,9 @@ deliveryRoutes.get(
   rateLimit,
   async (c) => {
     try {
-      const parsed = ListDeliveriesQuerySchema.safeParse({
-        status: c.req.query('status'),
-        limit: c.req.query('limit'),
-      });
-      if (!parsed.success) {
-        return c.json({
-          ok: false,
-          error: { code: 'invalid_request', message: 'Invalid status or limit' },
-        }, 400);
+      const parsed = parseQueryParams(c, ListDeliveriesQuerySchema, 'Invalid status or limit');
+      if (!parsed.ok) {
+        return parsed.response;
       }
       const db = c.get('db');
       const workspace = c.get('workspace');
@@ -38,7 +39,7 @@ deliveryRoutes.get(
         runInBackground(c, notifyDeliveryFailures(c, expired), 'fanout delivery expired');
       }
       const result = await deliveryEngine.listDeliveries(db, workspace.id, agent!.id, parsed.data);
-      return c.json({ ok: true, data: result });
+      return jsonOk(c, result);
     } catch (err: unknown) {
       return errorResponse(c, err);
     }
@@ -58,10 +59,7 @@ deliveryRoutes.post(
       const id = c.req.param('id');
       const result = await deliveryEngine.ackDelivery(db, workspace.id, agent!.id, id);
       if (!result) {
-        return c.json({
-          ok: false,
-          error: { code: 'delivery_not_found', message: 'Delivery not found' },
-        }, 404);
+        return jsonNotFound(c, 'delivery_not_found', 'Delivery not found');
       }
       // Only fan out when this call actually transitioned the delivery, so
       // idempotent retries don't emit duplicate notifications.
@@ -75,7 +73,7 @@ deliveryRoutes.post(
           'fanout delivery.delivered',
         );
       }
-      return c.json({ ok: true, data: result.delivery });
+      return jsonOk(c, result.delivery);
     } catch (err: unknown) {
       return errorResponse(c, err);
     }
@@ -89,27 +87,14 @@ deliveryRoutes.post(
   rateLimit,
   async (c) => {
     try {
-      // The fail body is optional (error/retryable), so an empty body is valid
-      // and defaults to {}. But a non-empty malformed JSON body is a client
-      // error and must 400 — don't silently coerce it and mutate state.
-      const bodyText = await c.req.text();
-      let raw: unknown = {};
-      if (bodyText.trim().length > 0) {
-        try {
-          raw = JSON.parse(bodyText);
-        } catch {
-          return c.json({
-            ok: false,
-            error: { code: 'invalid_request', message: 'Invalid JSON body' },
-          }, 400);
-        }
-      }
-      const parsed = FailDeliveryRequestSchema.safeParse(raw);
-      if (!parsed.success) {
-        return c.json({
-          ok: false,
-          error: { code: 'invalid_request', message: 'Invalid fail payload' },
-        }, 400);
+      const parsed = await parseOptionalJsonBody(
+        c,
+        FailDeliveryRequestSchema,
+        'Invalid fail payload',
+        { malformedBodyError: { code: 'invalid_request', message: 'Invalid JSON body' } },
+      );
+      if (!parsed.ok) {
+        return parsed.response;
       }
       const db = c.get('db');
       const workspace = c.get('workspace');
@@ -117,10 +102,7 @@ deliveryRoutes.post(
       const id = c.req.param('id');
       const result = await deliveryEngine.failDelivery(db, workspace.id, agent!.id, id, parsed.data);
       if (!result) {
-        return c.json({
-          ok: false,
-          error: { code: 'delivery_not_found', message: 'Delivery not found' },
-        }, 404);
+        return jsonNotFound(c, 'delivery_not_found', 'Delivery not found');
       }
       if (result.changed) {
         runInBackground(
@@ -134,7 +116,7 @@ deliveryRoutes.post(
           'fanout delivery.failed',
         );
       }
-      return c.json({ ok: true, data: result.delivery });
+      return jsonOk(c, result.delivery);
     } catch (err: unknown) {
       return errorResponse(c, err);
     }
@@ -148,13 +130,19 @@ deliveryRoutes.post(
   rateLimit,
   async (c) => {
     try {
-      const raw = await c.req.json().catch(() => null);
-      const parsed = DeferDeliveryRequestSchema.safeParse(raw);
-      if (!parsed.success) {
-        return c.json({
-          ok: false,
-          error: { code: 'invalid_request', message: 'available_at must be an ISO-8601 timestamp' },
-        }, 400);
+      const parsed = await parseJsonBody(
+        c,
+        DeferDeliveryRequestSchema,
+        'available_at must be an ISO-8601 timestamp',
+        {
+          malformedBodyError: {
+            code: 'invalid_request',
+            message: 'available_at must be an ISO-8601 timestamp',
+          },
+        },
+      );
+      if (!parsed.ok) {
+        return parsed.response;
       }
       const db = c.get('db');
       const workspace = c.get('workspace');
@@ -165,10 +153,7 @@ deliveryRoutes.post(
         reason: parsed.data.reason,
       });
       if (!result) {
-        return c.json({
-          ok: false,
-          error: { code: 'delivery_not_found', message: 'Delivery not found' },
-        }, 404);
+        return jsonNotFound(c, 'delivery_not_found', 'Delivery not found');
       }
       if (result.changed) {
         runInBackground(
@@ -182,7 +167,7 @@ deliveryRoutes.post(
           'fanout delivery.deferred',
         );
       }
-      return c.json({ ok: true, data: result.delivery });
+      return jsonOk(c, result.delivery);
     } catch (err: unknown) {
       return errorResponse(c, err);
     }

--- a/packages/engine/src/routes/directory.ts
+++ b/packages/engine/src/routes/directory.ts
@@ -82,7 +82,7 @@ function parseTagsParam(value: string | undefined): string[] | undefined {
 }
 
 function handleError(c: Context<AppEnv>, err: unknown) {
-  return errorResponse(c, err, { includeCause: true });
+  return errorResponse(c, err);
 }
 
 directoryRoutes.post('/directory/agents', requireWorkspaceKey, rateLimit, async (c) => {

--- a/packages/engine/src/routes/directory.ts
+++ b/packages/engine/src/routes/directory.ts
@@ -14,7 +14,9 @@ import {
   jsonNotFound,
   jsonOk,
   parseJsonBody,
+  parseQueryParams,
 } from '../lib/httpResponse.js';
+import { LimitQuerySchema } from '../lib/httpQuery.js';
 
 export const directoryRoutes = new Hono<AppEnv>();
 
@@ -63,6 +65,16 @@ const ratingSchema = z.object({
   review: z.string().max(4000).optional(),
 });
 
+const listDirectoryAgentsQuerySchema = LimitQuerySchema.extend({
+  status: z.string().optional(),
+});
+
+const searchDirectoryQuerySchema = LimitQuerySchema.extend({
+  q: z.string().optional(),
+  tags: z.string().optional(),
+  status: z.string().optional(),
+});
+
 function parseTagsParam(value: string | undefined): string[] | undefined {
   if (!value) return undefined;
   const tags = value.split(',').map((tag) => tag.trim()).filter(Boolean);
@@ -95,9 +107,13 @@ directoryRoutes.post('/directory/agents', requireWorkspaceKey, rateLimit, async 
 directoryRoutes.get('/directory/agents', requireAuth, rateLimit, async (c) => {
   try {
     const workspace = c.get('workspace');
-    const limit = c.req.query('limit') ? parseInt(c.req.query('limit')!, 10) : undefined;
+    const parsed = parseQueryParams(c, listDirectoryAgentsQuerySchema, 'Invalid directory agent query');
+    if (!parsed.ok) {
+      return parsed.response;
+    }
+    const { status, limit } = parsed.data;
     const result = await directoryEngine.listDirectoryAgents(c.get('db'), workspace.id, {
-      status: c.req.query('status') || undefined,
+      status: status || undefined,
       limit,
     });
     return jsonOk(c, result);
@@ -109,17 +125,20 @@ directoryRoutes.get('/directory/agents', requireAuth, rateLimit, async (c) => {
 directoryRoutes.get('/directory/search', requireAuth, rateLimit, async (c) => {
   try {
     const workspace = c.get('workspace');
-    const q = c.req.query('q') || undefined;
-    const tags = parseTagsParam(c.req.query('tags'));
+    const parsed = parseQueryParams(c, searchDirectoryQuerySchema, 'Invalid directory search query');
+    if (!parsed.ok) {
+      return parsed.response;
+    }
+    const { q, tags: tagsParam, status, limit } = parsed.data;
+    const tags = parseTagsParam(tagsParam);
     if ((!q || !q.trim()) && (!tags || tags.length === 0)) {
       return jsonInvalidRequest(c, 'q or tags is required');
     }
 
-    const limit = c.req.query('limit') ? parseInt(c.req.query('limit')!, 10) : undefined;
     const result = await directoryEngine.searchDirectory(c.get('db'), workspace.id, {
       q,
       tags,
-      status: c.req.query('status') || undefined,
+      status: status || undefined,
       limit,
     });
     emitServerEvent(c, workspace.id, 'relaycast_server_directory_search_executed', {

--- a/packages/engine/src/routes/directory.ts
+++ b/packages/engine/src/routes/directory.ts
@@ -1,12 +1,20 @@
 import { Hono, type Context } from 'hono';
-import type { ContentfulStatusCode } from 'hono/utils/http-status';
 import { z } from 'zod';
 import type { AppEnv } from '../env.js';
 import * as directoryEngine from '../engine/directory.js';
 import { requireAuth, requireWorkspaceKey } from '../middleware/auth.js';
 import { rateLimit } from '../middleware/rateLimit.js';
 import { emitServerEvent } from '../lib/serverTelemetry.js';
-import { asCodedError } from '../lib/httpError.js';
+import { errorResponse } from '../lib/httpError.js';
+import {
+  jsonCreated,
+  jsonError,
+  jsonInvalidRequest,
+  jsonNoContent,
+  jsonNotFound,
+  jsonOk,
+  parseJsonBody,
+} from '../lib/httpResponse.js';
 
 export const directoryRoutes = new Hono<AppEnv>();
 
@@ -62,23 +70,14 @@ function parseTagsParam(value: string | undefined): string[] | undefined {
 }
 
 function handleError(c: Context<AppEnv>, err: unknown) {
-  const error = asCodedError(err);
-  const cause = error.cause instanceof Error ? error.cause.message : (error.cause ? String(error.cause) : '');
-  const message = cause ? `${error.message} [cause: ${cause}]` : error.message;
-  return c.json({
-    ok: false,
-    error: { code: error.code || 'internal_error', message },
-  }, (error.status || 500) as ContentfulStatusCode);
+  return errorResponse(c, err, { includeCause: true });
 }
 
 directoryRoutes.post('/directory/agents', requireWorkspaceKey, rateLimit, async (c) => {
   try {
-    const parsed = createDirectoryAgentSchema.safeParse(await c.req.json());
-    if (!parsed.success) {
-      return c.json({
-        ok: false,
-        error: { code: 'invalid_request', message: 'name is required' },
-      }, 400);
+    const parsed = await parseJsonBody(c, createDirectoryAgentSchema, 'name is required');
+    if (!parsed.ok) {
+      return parsed.response;
     }
 
     const workspace = c.get('workspace');
@@ -87,7 +86,7 @@ directoryRoutes.post('/directory/agents', requireWorkspaceKey, rateLimit, async 
       slug: result?.slug,
       skill_count: result?.skills.length ?? 0,
     });
-    return c.json({ ok: true, data: result }, 201);
+    return jsonCreated(c, result);
   } catch (err: unknown) {
     return handleError(c, err);
   }
@@ -101,7 +100,7 @@ directoryRoutes.get('/directory/agents', requireAuth, rateLimit, async (c) => {
       status: c.req.query('status') || undefined,
       limit,
     });
-    return c.json({ ok: true, data: result });
+    return jsonOk(c, result);
   } catch (err: unknown) {
     return handleError(c, err);
   }
@@ -113,10 +112,7 @@ directoryRoutes.get('/directory/search', requireAuth, rateLimit, async (c) => {
     const q = c.req.query('q') || undefined;
     const tags = parseTagsParam(c.req.query('tags'));
     if ((!q || !q.trim()) && (!tags || tags.length === 0)) {
-      return c.json({
-        ok: false,
-        error: { code: 'invalid_request', message: 'q or tags is required' },
-      }, 400);
+      return jsonInvalidRequest(c, 'q or tags is required');
     }
 
     const limit = c.req.query('limit') ? parseInt(c.req.query('limit')!, 10) : undefined;
@@ -131,7 +127,7 @@ directoryRoutes.get('/directory/search', requireAuth, rateLimit, async (c) => {
       tag_count: tags?.length || 0,
       result_count: result.length,
     });
-    return c.json({ ok: true, data: result });
+    return jsonOk(c, result);
   } catch (err: unknown) {
     return handleError(c, err);
   }
@@ -142,12 +138,9 @@ directoryRoutes.get('/directory/agents/:slug', requireAuth, rateLimit, async (c)
     const workspace = c.get('workspace');
     const result = await directoryEngine.getDirectoryAgent(c.get('db'), workspace.id, c.req.param('slug'));
     if (!result) {
-      return c.json({
-        ok: false,
-        error: { code: 'directory_agent_not_found', message: 'Directory agent not found' },
-      }, 404);
+      return jsonNotFound(c, 'directory_agent_not_found', 'Directory agent not found');
     }
-    return c.json({ ok: true, data: result });
+    return jsonOk(c, result);
   } catch (err: unknown) {
     return handleError(c, err);
   }
@@ -155,12 +148,9 @@ directoryRoutes.get('/directory/agents/:slug', requireAuth, rateLimit, async (c)
 
 directoryRoutes.patch('/directory/agents/:slug', requireWorkspaceKey, rateLimit, async (c) => {
   try {
-    const parsed = updateDirectoryAgentSchema.safeParse(await c.req.json());
-    if (!parsed.success) {
-      return c.json({
-        ok: false,
-        error: { code: 'invalid_request', message: 'invalid directory agent update body' },
-      }, 400);
+    const parsed = await parseJsonBody(c, updateDirectoryAgentSchema, 'invalid directory agent update body');
+    if (!parsed.ok) {
+      return parsed.response;
     }
 
     const workspace = c.get('workspace');
@@ -172,17 +162,14 @@ directoryRoutes.patch('/directory/agents/:slug', requireWorkspaceKey, rateLimit,
     );
 
     if (!result) {
-      return c.json({
-        ok: false,
-        error: { code: 'directory_agent_not_found', message: 'Directory agent not found' },
-      }, 404);
+      return jsonNotFound(c, 'directory_agent_not_found', 'Directory agent not found');
     }
 
     emitServerEvent(c, workspace.id, 'relaycast_server_directory_agent_updated', {
       slug: result.slug,
       status: result.status,
     });
-    return c.json({ ok: true, data: result });
+    return jsonOk(c, result);
   } catch (err: unknown) {
     return handleError(c, err);
   }
@@ -193,16 +180,13 @@ directoryRoutes.delete('/directory/agents/:slug', requireWorkspaceKey, rateLimit
     const workspace = c.get('workspace');
     const deleted = await directoryEngine.deleteDirectoryAgent(c.get('db'), workspace.id, c.req.param('slug'));
     if (!deleted) {
-      return c.json({
-        ok: false,
-        error: { code: 'directory_agent_not_found', message: 'Directory agent not found' },
-      }, 404);
+      return jsonNotFound(c, 'directory_agent_not_found', 'Directory agent not found');
     }
 
     emitServerEvent(c, workspace.id, 'relaycast_server_directory_agent_deleted', {
       slug: c.req.param('slug'),
     });
-    return c.body(null, 204);
+    return jsonNoContent(c);
   } catch (err: unknown) {
     return handleError(c, err);
   }
@@ -212,7 +196,7 @@ directoryRoutes.get('/directory/agents/:slug/ratings', requireAuth, rateLimit, a
   try {
     const workspace = c.get('workspace');
     const result = await directoryEngine.listDirectoryRatings(c.get('db'), workspace.id, c.req.param('slug'));
-    return c.json({ ok: true, data: result });
+    return jsonOk(c, result);
   } catch (err: unknown) {
     return handleError(c, err);
   }
@@ -220,23 +204,14 @@ directoryRoutes.get('/directory/agents/:slug/ratings', requireAuth, rateLimit, a
 
 directoryRoutes.post('/directory/agents/:slug/ratings', requireAuth, rateLimit, async (c) => {
   try {
-    const parsed = ratingSchema.safeParse(await c.req.json());
-    if (!parsed.success) {
-      return c.json({
-        ok: false,
-        error: { code: 'invalid_request', message: 'score must be an integer between 1 and 5' },
-      }, 400);
+    const parsed = await parseJsonBody(c, ratingSchema, 'score must be an integer between 1 and 5');
+    if (!parsed.ok) {
+      return parsed.response;
     }
 
     const agent = c.get('agent');
     if (!agent?.id) {
-      return c.json({
-        ok: false,
-        error: {
-          code: 'agent_token_required',
-          message: 'Agent token required to submit ratings',
-        },
-      }, 403);
+      return jsonError(c, 'agent_token_required', 'Agent token required to submit ratings', 403);
     }
 
     const workspace = c.get('workspace');
@@ -251,7 +226,7 @@ directoryRoutes.post('/directory/agents/:slug/ratings', requireAuth, rateLimit, 
       score: result.score,
       rater_agent_id: agent.id,
     });
-    return c.json({ ok: true, data: result }, 201);
+    return jsonCreated(c, result);
   } catch (err: unknown) {
     return handleError(c, err);
   }

--- a/packages/engine/src/routes/dm.ts
+++ b/packages/engine/src/routes/dm.ts
@@ -1,10 +1,9 @@
 import { Hono } from 'hono';
-import type { ContentfulStatusCode } from 'hono/utils/http-status';
 import { z } from 'zod';
 import type { AppEnv } from '../env.js';
 import { requireAgentToken } from '../middleware/auth.js';
 import { rateLimit } from '../middleware/rateLimit.js';
-import { parseIdempotencyKey, runIdempotent } from '../middleware/idempotency.js';
+import { jsonIdempotentOk, parseIdempotencyKey, runIdempotent } from '../middleware/idempotency.js';
 import * as dmEngine from '../engine/dm.js';
 import { resolveMailboxConfig } from '../engine/mailboxConfig.js';
 import { and, eq, isNull } from 'drizzle-orm';
@@ -89,10 +88,6 @@ dmRoutes.post(
         },
       });
 
-      if (idempotent.replayed) {
-        c.header('Idempotency-Replayed', 'true');
-      }
-
       if (!idempotent.replayed) {
         const {
           _delivery,
@@ -141,15 +136,7 @@ dmRoutes.post(
         });
       }
 
-      const {
-        _delivery: _dropDelivery,
-        _delivery_rejections: _dropRejections,
-        ...responseData
-      } = idempotent.data as typeof idempotent.data & {
-        _delivery?: unknown;
-        _delivery_rejections?: unknown;
-      };
-      return jsonOk(c, responseData, idempotent.status as ContentfulStatusCode);
+      return jsonIdempotentOk(c, idempotent);
     } catch (err: unknown) {
       return errorResponse(c, err);
     }

--- a/packages/engine/src/routes/dm.ts
+++ b/packages/engine/src/routes/dm.ts
@@ -16,6 +16,7 @@ import { sendWebhookEvent } from './webhookOutbox.js';
 import { emitServerEvent } from '../lib/serverTelemetry.js';
 import { errorResponse } from '../lib/httpError.js';
 import { jsonError, jsonOk, parseJsonBody } from '../lib/httpResponse.js';
+import { parsePaginationQuery } from '../lib/httpQuery.js';
 
 export const dmRoutes = new Hono<AppEnv>();
 
@@ -175,11 +176,11 @@ dmRoutes.get(
       const db = c.get('db');
       const workspace = c.get('workspace');
       const agent = c.get('agent');
-      const limit = c.req.query('limit')
-        ? parseInt(c.req.query('limit')!, 10)
-        : undefined;
-      const before = c.req.query('before');
-      const after = c.req.query('after');
+      const query = parsePaginationQuery(c);
+      if (!query.ok) {
+        return query.response;
+      }
+      const { limit, before, after } = query.data;
 
       const conversationId = c.req.param('conversation_id');
       const msgs = await dmEngine.getDmMessages(

--- a/packages/engine/src/routes/dm.ts
+++ b/packages/engine/src/routes/dm.ts
@@ -16,6 +16,7 @@ import { runInBackground } from './background.js';
 import { sendWebhookEvent } from './webhookOutbox.js';
 import { emitServerEvent } from '../lib/serverTelemetry.js';
 import { errorResponse } from '../lib/httpError.js';
+import { jsonError, jsonOk, parseJsonBody } from '../lib/httpResponse.js';
 
 export const dmRoutes = new Hono<AppEnv>();
 
@@ -36,32 +37,24 @@ dmRoutes.post(
       const db = c.get('db');
       const workspace = c.get('workspace');
       const agent = c.get('agent');
-      const parsed = sendDmSchema.safeParse(await c.req.json());
-      if (!parsed.success) {
-        const hasToIssue = parsed.error.issues.some((issue) => issue.path[0] === 'to');
-        const hasTextIssue = parsed.error.issues.some((issue) => issue.path[0] === 'text');
-        const message = hasToIssue
+      const parsed = await parseJsonBody(c, sendDmSchema, (failure) => {
+        const hasToIssue = failure.error.issues.some((issue) => issue.path[0] === 'to');
+        const hasTextIssue = failure.error.issues.some((issue) => issue.path[0] === 'text');
+        return hasToIssue
           ? '"to" agent name is required'
           : hasTextIssue
             ? 'text is required'
             : 'invalid dm body';
-        return c.json({
-          ok: false,
-          error: {
-            code: 'invalid_request',
-            message,
-          },
-        }, 400);
+      });
+      if (!parsed.ok) {
+        return parsed.response;
       }
       const { to, text, attachments, mode } = parsed.data;
       const normalizedAttachments = attachments && attachments.length > 0 ? attachments : undefined;
 
       const { key: idempotencyKey, error: idempotencyError } = parseIdempotencyKey(c.req.header('Idempotency-Key'));
       if (idempotencyError) {
-        return c.json({
-          ok: false,
-          error: { code: 'invalid_idempotency_key', message: idempotencyError },
-        }, 400);
+        return jsonError(c, 'invalid_idempotency_key', idempotencyError, 400);
       }
 
       const mailbox = resolveMailboxConfig(c.get('engine').config, workspace.id);
@@ -156,7 +149,7 @@ dmRoutes.post(
         _delivery?: unknown;
         _delivery_rejections?: unknown;
       };
-      return c.json({ ok: true, data: responseData }, idempotent.status as ContentfulStatusCode);
+      return jsonOk(c, responseData, idempotent.status as ContentfulStatusCode);
     } catch (err: unknown) {
       return errorResponse(c, err);
     }
@@ -178,7 +171,7 @@ dmRoutes.get(
         workspace.id,
         agent!.id,
       );
-      return c.json({ ok: true, data: conversations });
+      return jsonOk(c, conversations);
     } catch (err: unknown) {
       return errorResponse(c, err);
     }
@@ -209,7 +202,7 @@ dmRoutes.get(
         agent!.id,
         { limit, before, after },
       );
-      return c.json({ ok: true, data: msgs });
+      return jsonOk(c, msgs);
     } catch (err: unknown) {
       return errorResponse(c, err);
     }

--- a/packages/engine/src/routes/file.ts
+++ b/packages/engine/src/routes/file.ts
@@ -9,7 +9,9 @@ import {
   jsonNotFound,
   jsonOk,
   parseJsonBody,
+  parseQueryParams,
 } from '../lib/httpResponse.js';
+import { LimitQuerySchema } from '../lib/httpQuery.js';
 import { requireAuth, requireAgentToken } from '../middleware/auth.js';
 import { rateLimit } from '../middleware/rateLimit.js';
 import * as fileEngine from '../engine/file.js';
@@ -24,6 +26,10 @@ const fileUploadSchema = z.object({
   filename: z.string().min(1),
   content_type: z.string().min(1),
   size_bytes: z.number().finite().refine((value) => value !== 0),
+});
+
+const listFilesQuerySchema = LimitQuerySchema.extend({
+  uploaded_by: z.string().optional(),
 });
 
 type ValidationFailure = { error: { issues: Array<{ path: PropertyKey[] }> } };
@@ -167,9 +173,11 @@ fileRoutes.get('/files', requireAuth, rateLimit, async (c) => {
     const db = c.get('db');
     const workspace = c.get('workspace');
 
-    const uploaded_by = c.req.query('uploaded_by');
-    const limitStr = c.req.query('limit');
-    const limit = limitStr ? parseInt(limitStr, 10) : undefined;
+    const parsed = parseQueryParams(c, listFilesQuerySchema, 'Invalid file list query');
+    if (!parsed.ok) {
+      return parsed.response;
+    }
+    const { uploaded_by, limit } = parsed.data;
 
     const result = await fileEngine.listFiles(db, workspace.id, {
       uploaded_by,

--- a/packages/engine/src/routes/file.ts
+++ b/packages/engine/src/routes/file.ts
@@ -2,6 +2,14 @@ import { Hono } from 'hono';
 import { z } from 'zod';
 import type { AppEnv } from '../env.js';
 import { errorResponse } from '../lib/httpError.js';
+import {
+  jsonCreated,
+  jsonError,
+  jsonNoContent,
+  jsonNotFound,
+  jsonOk,
+  parseJsonBody,
+} from '../lib/httpResponse.js';
 import { requireAuth, requireAgentToken } from '../middleware/auth.js';
 import { rateLimit } from '../middleware/rateLimit.js';
 import * as fileEngine from '../engine/file.js';
@@ -18,6 +26,21 @@ const fileUploadSchema = z.object({
   size_bytes: z.number().finite().refine((value) => value !== 0),
 });
 
+type ValidationFailure = { error: { issues: Array<{ path: PropertyKey[] }> } };
+
+function uploadInvalidMessage(failure: ValidationFailure) {
+  const hasFilenameIssue = failure.error.issues.some((issue) => issue.path[0] === 'filename');
+  const hasContentTypeIssue = failure.error.issues.some((issue) => issue.path[0] === 'content_type');
+  const hasSizeBytesIssue = failure.error.issues.some((issue) => issue.path[0] === 'size_bytes');
+  return hasFilenameIssue
+    ? 'filename is required'
+    : hasContentTypeIssue
+      ? 'content_type is required'
+      : hasSizeBytesIssue
+        ? 'size_bytes is required'
+        : 'invalid upload body';
+}
+
 // POST /v1/files/upload — Returns presigned PUT URL
 fileRoutes.post('/files/upload', requireAgentToken, rateLimit, async (c) => {
   try {
@@ -25,22 +48,9 @@ fileRoutes.post('/files/upload', requireAgentToken, rateLimit, async (c) => {
     const workspace = c.get('workspace');
     const agent = c.get('agent')!;
     const storage = c.get('engine').files;
-    const parsed = fileUploadSchema.safeParse(await c.req.json());
-    if (!parsed.success) {
-      const hasFilenameIssue = parsed.error.issues.some((issue) => issue.path[0] === 'filename');
-      const hasContentTypeIssue = parsed.error.issues.some((issue) => issue.path[0] === 'content_type');
-      const hasSizeBytesIssue = parsed.error.issues.some((issue) => issue.path[0] === 'size_bytes');
-      const message = hasFilenameIssue
-        ? 'filename is required'
-        : hasContentTypeIssue
-          ? 'content_type is required'
-          : hasSizeBytesIssue
-            ? 'size_bytes is required'
-            : 'invalid upload body';
-      return c.json({
-        ok: false,
-        error: { code: 'invalid_request', message },
-      }, 400);
+    const parsed = await parseJsonBody(c, fileUploadSchema, uploadInvalidMessage);
+    if (!parsed.ok) {
+      return parsed.response;
     }
     const { filename, content_type, size_bytes } = parsed.data;
 
@@ -58,7 +68,7 @@ fileRoutes.post('/files/upload', requireAgentToken, rateLimit, async (c) => {
       content_type,
     });
 
-    return c.json({ ok: true, data: result }, 201);
+    return jsonCreated(c, result);
   } catch (err: unknown) {
     return errorResponse(c, err);
   }
@@ -80,10 +90,7 @@ fileRoutes.post('/files/:id/complete', requireAgentToken, rateLimit, async (c) =
       agent.id,
     );
     if (!result) {
-      return c.json({
-        ok: false,
-        error: { code: 'file_not_found', message: 'File not found or not owned by you' },
-      }, 404);
+      return jsonNotFound(c, 'file_not_found', 'File not found or not owned by you');
     }
 
     const eventData = { ...result, agent_id: agent.id };
@@ -99,7 +106,7 @@ fileRoutes.post('/files/:id/complete', requireAgentToken, rateLimit, async (c) =
       content_type: result.content_type,
     });
 
-    return c.json({ ok: true, data: result });
+    return jsonOk(c, result);
   } catch (err: unknown) {
     return errorResponse(c, err);
   }
@@ -119,13 +126,10 @@ fileRoutes.get('/files/:id', requireAuth, rateLimit, async (c) => {
       c.req.param('id'),
     );
     if (!result) {
-      return c.json({
-        ok: false,
-        error: { code: 'file_not_found', message: 'File not found' },
-      }, 404);
+      return jsonNotFound(c, 'file_not_found', 'File not found');
     }
 
-    return c.json({ ok: true, data: result });
+    return jsonOk(c, result);
   } catch (err: unknown) {
     return errorResponse(c, err);
   }
@@ -145,19 +149,13 @@ fileRoutes.delete('/files/:id', requireAgentToken, rateLimit, async (c) => {
       agent.id,
     );
     if (result === null) {
-      return c.json({
-        ok: false,
-        error: { code: 'file_not_found', message: 'File not found' },
-      }, 404);
+      return jsonNotFound(c, 'file_not_found', 'File not found');
     }
     if (result === 'forbidden') {
-      return c.json({
-        ok: false,
-        error: { code: 'forbidden', message: 'Not the file owner' },
-      }, 403);
+      return jsonError(c, 'forbidden', 'Not the file owner', 403);
     }
 
-    return c.body(null, 204);
+    return jsonNoContent(c);
   } catch (err: unknown) {
     return errorResponse(c, err);
   }
@@ -178,7 +176,7 @@ fileRoutes.get('/files', requireAuth, rateLimit, async (c) => {
       limit,
     });
 
-    return c.json({ ok: true, data: result });
+    return jsonOk(c, result);
   } catch (err: unknown) {
     return errorResponse(c, err);
   }

--- a/packages/engine/src/routes/groupDm.ts
+++ b/packages/engine/src/routes/groupDm.ts
@@ -16,6 +16,13 @@ import { buildGroupDmReceivedEventData } from '../engine/deliveryWire.js';
 import { runInBackground } from './background.js';
 import { sendWebhookEvent } from './webhookOutbox.js';
 import { emitServerEvent } from '../lib/serverTelemetry.js';
+import {
+  jsonCreated,
+  jsonError,
+  jsonNoContent,
+  jsonOk,
+  parseJsonBody,
+} from '../lib/httpResponse.js';
 
 export const groupDmRoutes = new Hono<AppEnv>();
 
@@ -44,12 +51,13 @@ groupDmRoutes.post(
       const db = c.get('db');
       const workspace = c.get('workspace');
       const agent = c.get('agent');
-      const parsed = createGroupDmSchema.safeParse(await c.req.json());
-      if (!parsed.success) {
-        return c.json({
-          ok: false,
-          error: { code: 'invalid_request', message: 'participants array is required with at least 1 member' },
-        }, 400);
+      const parsed = await parseJsonBody(
+        c,
+        createGroupDmSchema,
+        'participants array is required with at least 1 member',
+      );
+      if (!parsed.ok) {
+        return parsed.response;
       }
       const { participants, name } = parsed.data;
 
@@ -63,7 +71,7 @@ groupDmRoutes.post(
         conversation_id: result.id,
         participant_count: result.participants.length,
       });
-      return c.json({ ok: true, data: result }, 201);
+      return jsonCreated(c, result);
     } catch (err: unknown) {
       return errorResponse(c, err);
     }
@@ -80,32 +88,27 @@ groupDmRoutes.post(
       const db = c.get('db');
       const workspace = c.get('workspace');
       const agent = c.get('agent');
-      const parsed = postGroupDmMessageSchema.safeParse(await c.req.json());
-      if (!parsed.success) {
-        const hasTextIssue = parsed.error.issues.some((issue) => issue.path[0] === 'text');
-        const hasModeIssue = parsed.error.issues.some((issue) => issue.path[0] === 'mode');
-        const hasAttachmentsIssue = parsed.error.issues.some((issue) => issue.path[0] === 'attachments');
-        const message = hasTextIssue
+      const parsed = await parseJsonBody(c, postGroupDmMessageSchema, (failure) => {
+        const hasTextIssue = failure.error.issues.some((issue) => issue.path[0] === 'text');
+        const hasModeIssue = failure.error.issues.some((issue) => issue.path[0] === 'mode');
+        const hasAttachmentsIssue = failure.error.issues.some((issue) => issue.path[0] === 'attachments');
+        return hasTextIssue
           ? 'text is required'
           : hasModeIssue
             ? 'mode must be one of: wait, steer'
             : hasAttachmentsIssue
               ? 'attachments must be an array of file ids'
               : 'invalid group dm body';
-        return c.json({
-          ok: false,
-          error: { code: 'invalid_request', message },
-        }, 400);
+      });
+      if (!parsed.ok) {
+        return parsed.response;
       }
       const { text, attachments, mode } = parsed.data;
       const normalizedAttachments = attachments && attachments.length > 0 ? attachments : undefined;
 
       const { key: idempotencyKey, error: idempotencyError } = parseIdempotencyKey(c.req.header('Idempotency-Key'));
       if (idempotencyError) {
-        return c.json({
-          ok: false,
-          error: { code: 'invalid_idempotency_key', message: idempotencyError },
-        }, 400);
+        return jsonError(c, 'invalid_idempotency_key', idempotencyError, 400);
       }
 
       const conversationId = c.req.param('conversation_id');
@@ -209,7 +212,7 @@ groupDmRoutes.post(
         _deliveries?: unknown;
         _delivery_rejections?: unknown;
       };
-      return c.json({ ok: true, data: responseData }, idempotent.status as ContentfulStatusCode);
+      return jsonOk(c, responseData, idempotent.status as ContentfulStatusCode);
     } catch (err: unknown) {
       return errorResponse(c, err);
     }
@@ -226,12 +229,9 @@ groupDmRoutes.post(
       const db = c.get('db');
       const workspace = c.get('workspace');
       const agentCtx = c.get('agent');
-      const parsed = addGroupDmParticipantSchema.safeParse(await c.req.json());
-      if (!parsed.success) {
-        return c.json({
-          ok: false,
-          error: { code: 'invalid_request', message: 'agent_name is required' },
-        }, 400);
+      const parsed = await parseJsonBody(c, addGroupDmParticipantSchema, 'agent_name is required');
+      if (!parsed.ok) {
+        return parsed.response;
       }
       const { agent_name: agentName } = parsed.data;
 
@@ -248,7 +248,7 @@ groupDmRoutes.post(
         agent_name: agentName,
         invited_by_agent_id: agentCtx!.id,
       });
-      return c.json({ ok: true, data: result });
+      return jsonOk(c, result);
     } catch (err: unknown) {
       return errorResponse(c, err);
     }
@@ -276,7 +276,7 @@ groupDmRoutes.delete(
         conversation_id: conversationId,
         agent_id: agent!.id,
       });
-      return c.body(null, 204);
+      return jsonNoContent(c);
     } catch (err: unknown) {
       return errorResponse(c, err);
     }

--- a/packages/engine/src/routes/groupDm.ts
+++ b/packages/engine/src/routes/groupDm.ts
@@ -1,11 +1,10 @@
 import { Hono } from 'hono';
-import type { ContentfulStatusCode } from 'hono/utils/http-status';
 import { z } from 'zod';
 import type { AppEnv } from '../env.js';
 import { errorResponse } from '../lib/httpError.js';
 import { requireAgentToken } from '../middleware/auth.js';
 import { rateLimit } from '../middleware/rateLimit.js';
-import { parseIdempotencyKey, runIdempotent } from '../middleware/idempotency.js';
+import { jsonIdempotentOk, parseIdempotencyKey, runIdempotent } from '../middleware/idempotency.js';
 import * as groupDmEngine from '../engine/groupDm.js';
 import { resolveMailboxConfig } from '../engine/mailboxConfig.js';
 import { and, eq, isNull } from 'drizzle-orm';
@@ -149,10 +148,6 @@ groupDmRoutes.post(
         },
       });
 
-      if (idempotent.replayed) {
-        c.header('Idempotency-Replayed', 'true');
-      }
-
       if (!idempotent.replayed) {
         const {
           _deliveries,
@@ -204,15 +199,7 @@ groupDmRoutes.post(
         });
       }
 
-      const {
-        _deliveries: _dropDeliveries,
-        _delivery_rejections: _dropRejections,
-        ...responseData
-      } = idempotent.data as typeof idempotent.data & {
-        _deliveries?: unknown;
-        _delivery_rejections?: unknown;
-      };
-      return jsonOk(c, responseData, idempotent.status as ContentfulStatusCode);
+      return jsonIdempotentOk(c, idempotent);
     } catch (err: unknown) {
       return errorResponse(c, err);
     }

--- a/packages/engine/src/routes/inboundWebhook.ts
+++ b/packages/engine/src/routes/inboundWebhook.ts
@@ -10,6 +10,13 @@ import { fanoutToChannel } from './fanout.js';
 import { runInBackground } from './background.js';
 import { sendWebhookEvent } from './webhookOutbox.js';
 import { emitServerEvent } from '../lib/serverTelemetry.js';
+import {
+  jsonCreated,
+  jsonNoContent,
+  jsonNotFound,
+  jsonOk,
+  parseJsonBody,
+} from '../lib/httpResponse.js';
 
 export const inboundWebhookRoutes = new Hono<AppEnv>();
 
@@ -40,26 +47,19 @@ inboundWebhookRoutes.post('/webhooks', requireWorkspaceKey, rateLimit, async (c)
   try {
     const db = c.get('db');
     const workspace = c.get('workspace');
-    const parsed = createInboundWebhookSchema.safeParse(await c.req.json());
-    if (!parsed.success) {
-      const hasChannelIssue = parsed.error.issues.some((issue) => issue.path[0] === 'channel');
-      const message = hasChannelIssue
-          ? 'channel is required'
-          : 'invalid webhook body';
-      return c.json({
-        ok: false,
-        error: { code: 'invalid_request', message },
-      }, 400);
+    const parsed = await parseJsonBody(c, createInboundWebhookSchema, (failure) => {
+      const hasChannelIssue = failure.error.issues.some((issue) => issue.path[0] === 'channel');
+      return hasChannelIssue ? 'channel is required' : 'invalid webhook body';
+    });
+    if (!parsed.ok) {
+      return parsed.response;
     }
     const { name, channel } = parsed.data;
 
     // Resolve channel name to ID
     const ch = await channelEngine.getChannel(db, workspace.id, channel);
     if (!ch) {
-      return c.json({
-        ok: false,
-        error: { code: 'channel_not_found', message: `Channel "${channel}" not found` },
-      }, 404);
+      return jsonNotFound(c, 'channel_not_found', `Channel "${channel}" not found`);
     }
 
     const result = await inboundWebhookEngine.createWebhook(
@@ -72,7 +72,7 @@ inboundWebhookRoutes.post('/webhooks', requireWorkspaceKey, rateLimit, async (c)
       webhook_id: result.webhook_id,
       channel_name: channel,
     });
-    return c.json({ ok: true, data: { ...result, url: hookUrl(c.req.url, result.webhook_id) } }, 201);
+    return jsonCreated(c, { ...result, url: hookUrl(c.req.url, result.webhook_id) });
   } catch (err: unknown) {
     return errorResponse(c, err);
   }
@@ -84,10 +84,7 @@ inboundWebhookRoutes.get('/webhooks', requireWorkspaceKey, rateLimit, async (c) 
     const db = c.get('db');
     const workspace = c.get('workspace');
     const result = await inboundWebhookEngine.listWebhooks(db, workspace.id);
-    return c.json({
-      ok: true,
-      data: result.map((webhook) => ({ ...webhook, url: hookUrl(c.req.url, webhook.id) })),
-    });
+    return jsonOk(c, result.map((webhook) => ({ ...webhook, url: hookUrl(c.req.url, webhook.id) })));
   } catch (err: unknown) {
     return errorResponse(c, err);
   }
@@ -104,15 +101,12 @@ inboundWebhookRoutes.delete('/webhooks/:id', requireWorkspaceKey, rateLimit, asy
       c.req.param('id'),
     );
     if (!deleted) {
-      return c.json({
-        ok: false,
-        error: { code: 'webhook_not_found', message: 'Webhook not found' },
-      }, 404);
+      return jsonNotFound(c, 'webhook_not_found', 'Webhook not found');
     }
     emitServerEvent(c, workspace.id, 'relaycast_server_inbound_webhook_deleted', {
       webhook_id: c.req.param('id'),
     });
-    return c.body(null, 204);
+    return jsonNoContent(c);
   } catch (err: unknown) {
     return errorResponse(c, err);
   }
@@ -123,12 +117,9 @@ inboundWebhookRoutes.post('/hooks/:webhookId', async (c) => {
   try {
     const db = c.get('db');
     const token = extractBearerToken(c.req.header('Authorization'));
-    const parsed = triggerInboundWebhookSchema.safeParse(await c.req.json());
-    if (!parsed.success) {
-      return c.json({
-        ok: false,
-        error: { code: 'invalid_request', message: 'invalid webhook payload' },
-      }, 400);
+    const parsed = await parseJsonBody(c, triggerInboundWebhookSchema, 'invalid webhook payload');
+    if (!parsed.ok) {
+      return parsed.response;
     }
     const { text, message, source, author, payload } = parsed.data;
     const result = await inboundWebhookEngine.triggerWebhook(
@@ -143,10 +134,7 @@ inboundWebhookRoutes.post('/hooks/:webhookId', async (c) => {
       },
     );
     if (!result) {
-      return c.json({
-        ok: false,
-        error: { code: 'webhook_not_found', message: 'Webhook not found or inactive' },
-      }, 404);
+      return jsonNotFound(c, 'webhook_not_found', 'Webhook not found or inactive');
     }
     const { workspace_id, channel_id, ...responseData } = result;
 
@@ -171,7 +159,7 @@ inboundWebhookRoutes.post('/hooks/:webhookId', async (c) => {
       author: result.author ?? null,
     });
 
-    return c.json({ ok: true, data: responseData }, 201);
+    return jsonCreated(c, responseData);
   } catch (err: unknown) {
     return errorResponse(c, err);
   }

--- a/packages/engine/src/routes/inbox.ts
+++ b/packages/engine/src/routes/inbox.ts
@@ -7,6 +7,7 @@ import * as deliveryEngine from '../engine/delivery.js';
 import { notifyDeliveryFailures } from './deliveryRouting.js';
 import { runInBackground } from './background.js';
 import { errorResponse } from '../lib/httpError.js';
+import { jsonOk } from '../lib/httpResponse.js';
 
 export const inboxRoutes = new Hono<AppEnv>();
 
@@ -25,7 +26,7 @@ inboxRoutes.get(
         runInBackground(c, notifyDeliveryFailures(c, expired), 'fanout delivery expired');
       }
       const result = await inboxEngine.getInbox(db, workspace.id, agent!.id);
-      return c.json({ ok: true, data: result });
+      return jsonOk(c, result);
     } catch (err: unknown) {
       return errorResponse(c, err);
     }

--- a/packages/engine/src/routes/message.ts
+++ b/packages/engine/src/routes/message.ts
@@ -1,10 +1,9 @@
 import { Hono } from 'hono';
-import type { ContentfulStatusCode } from 'hono/utils/http-status';
 import { z } from 'zod';
 import type { AppEnv } from '../env.js';
 import { requireAuth } from '../middleware/auth.js';
 import { rateLimit } from '../middleware/rateLimit.js';
-import { parseIdempotencyKey, runIdempotent } from '../middleware/idempotency.js';
+import { jsonIdempotentOk, parseIdempotencyKey, runIdempotent } from '../middleware/idempotency.js';
 import * as messageEngine from '../engine/message.js';
 import * as channelEngine from '../engine/channel.js';
 import * as triggerEngine from '../engine/trigger.js';
@@ -103,10 +102,6 @@ messageRoutes.post(
         },
       });
 
-      if (idempotent.replayed) {
-        c.header('Idempotency-Replayed', 'true');
-      }
-
       // Durable event queue for webhook delivery; real-time pub/sub still fire-and-forget.
       // Only publish for fresh writes, not idempotent replays.
       if (!idempotent.replayed) {
@@ -173,16 +168,7 @@ messageRoutes.post(
         );
       }
 
-      // Strip internal _deliveries field before returning to client
-      const {
-        _deliveries: _dropDeliveries,
-        _delivery_rejections: _dropRejections,
-        ...responseData
-      } = idempotent.data as typeof idempotent.data & {
-        _deliveries?: unknown;
-        _delivery_rejections?: unknown;
-      };
-      return jsonOk(c, responseData, idempotent.status as ContentfulStatusCode);
+      return jsonIdempotentOk(c, idempotent);
     } catch (err: unknown) {
       return errorResponse(c, err);
     }

--- a/packages/engine/src/routes/message.ts
+++ b/packages/engine/src/routes/message.ts
@@ -22,6 +22,7 @@ import {
   jsonOk,
   parseJsonBody,
 } from '../lib/httpResponse.js';
+import { parsePaginationQuery } from '../lib/httpQuery.js';
 
 export const messageRoutes = new Hono<AppEnv>();
 
@@ -190,9 +191,11 @@ messageRoutes.get(
         return jsonNotFound(c, 'channel_not_found', `Channel "${channelName}" not found`);
       }
 
-      const limit = c.req.query('limit') ? parseInt(c.req.query('limit')!, 10) : undefined;
-      const before = c.req.query('before');
-      const after = c.req.query('after');
+      const query = parsePaginationQuery(c);
+      if (!query.ok) {
+        return query.response;
+      }
+      const { limit, before, after } = query.data;
 
       const messages = await messageEngine.getMessages(
         db,

--- a/packages/engine/src/routes/message.ts
+++ b/packages/engine/src/routes/message.ts
@@ -17,6 +17,12 @@ import { isFleetNodesEnabled } from '../lib/fleetNodes.js';
 import { sendWebhookEvent } from './webhookOutbox.js';
 import { emitServerEvent } from '../lib/serverTelemetry.js';
 import { errorResponse } from '../lib/httpError.js';
+import {
+  jsonError,
+  jsonNotFound,
+  jsonOk,
+  parseJsonBody,
+} from '../lib/httpResponse.js';
 
 export const messageRoutes = new Hono<AppEnv>();
 
@@ -39,21 +45,15 @@ messageRoutes.post(
       const db = c.get('db');
       const workspace = c.get('workspace');
       const agent = c.get('agent');
-      const parsed = postMessageSchema.safeParse(await c.req.json());
-      if (!parsed.success) {
-        return c.json({
-          ok: false,
-          error: { code: 'invalid_request', message: 'text is required' },
-        }, 400);
+      const parsed = await parseJsonBody(c, postMessageSchema, 'text is required');
+      if (!parsed.ok) {
+        return parsed.response;
       }
       const { text, blocks, attachments, data, content_type, mode } = parsed.data;
 
       const { key: idempotencyKey, error: idempotencyError } = parseIdempotencyKey(c.req.header('Idempotency-Key'));
       if (idempotencyError) {
-        return c.json({
-          ok: false,
-          error: { code: 'invalid_idempotency_key', message: idempotencyError },
-        }, 400);
+        return jsonError(c, 'invalid_idempotency_key', idempotencyError, 400);
       }
 
       const channelName = c.req.param('name');
@@ -61,19 +61,13 @@ messageRoutes.post(
       // Resolve channel name to ID
       const channel = await channelEngine.getChannel(db, workspace.id, channelName);
       if (!channel) {
-        return c.json({
-          ok: false,
-          error: { code: 'channel_not_found', message: `Channel "${channelName}" not found` },
-        }, 404);
+        return jsonNotFound(c, 'channel_not_found', `Channel "${channelName}" not found`);
       }
 
       // Determine agent ID (from agent token or body)
       const agentId = agent?.id;
       if (!agentId) {
-        return c.json({
-          ok: false,
-          error: { code: 'agent_token_required', message: 'Agent token required to post messages' },
-        }, 403);
+        return jsonError(c, 'agent_token_required', 'Agent token required to post messages', 403);
       }
 
       const mailbox = resolveMailboxConfig(c.get('engine').config, workspace.id);
@@ -188,7 +182,7 @@ messageRoutes.post(
         _deliveries?: unknown;
         _delivery_rejections?: unknown;
       };
-      return c.json({ ok: true, data: responseData }, idempotent.status as ContentfulStatusCode);
+      return jsonOk(c, responseData, idempotent.status as ContentfulStatusCode);
     } catch (err: unknown) {
       return errorResponse(c, err);
     }
@@ -207,10 +201,7 @@ messageRoutes.get(
       const channelName = c.req.param('name');
       const channel = await channelEngine.getChannel(db, workspace.id, channelName);
       if (!channel) {
-        return c.json({
-          ok: false,
-          error: { code: 'channel_not_found', message: `Channel "${channelName}" not found` },
-        }, 404);
+        return jsonNotFound(c, 'channel_not_found', `Channel "${channelName}" not found`);
       }
 
       const limit = c.req.query('limit') ? parseInt(c.req.query('limit')!, 10) : undefined;
@@ -223,7 +214,7 @@ messageRoutes.get(
         channel.id,
         { limit, before, after },
       );
-      return c.json({ ok: true, data: messages });
+      return jsonOk(c, messages);
     } catch (err: unknown) {
       return errorResponse(c, err);
     }
@@ -242,12 +233,9 @@ messageRoutes.get(
       const messageId = c.req.param('id');
       const message = await messageEngine.getMessage(db, workspace.id, messageId);
       if (!message) {
-        return c.json({
-          ok: false,
-          error: { code: 'message_not_found', message: 'Message not found' },
-        }, 404);
+        return jsonNotFound(c, 'message_not_found', 'Message not found');
       }
-      return c.json({ ok: true, data: message });
+      return jsonOk(c, message);
     } catch (err: unknown) {
       return errorResponse(c, err);
     }

--- a/packages/engine/src/routes/message.ts
+++ b/packages/engine/src/routes/message.ts
@@ -35,6 +35,19 @@ const postMessageSchema = z.object({
   mode: z.enum(['wait', 'steer']).default('wait'),
 });
 
+type ValidationFailure = { error: { issues: Array<{ path: PropertyKey[] }> } };
+
+function postMessageInvalidMessage(failure: ValidationFailure) {
+  const field = failure.error.issues[0]?.path[0];
+  if (field === 'text') return 'text is required';
+  if (field === 'mode') return 'mode must be "wait" or "steer"';
+  if (field === 'attachments') return 'attachments must be an array of strings';
+  if (field === 'blocks') return 'blocks must be an array';
+  if (field === 'data') return 'data must be an object';
+  if (field === 'content_type') return 'content_type must be a string';
+  return 'invalid message body';
+}
+
 // POST /v1/channels/:name/messages - post a message
 messageRoutes.post(
   '/channels/:name/messages',
@@ -45,7 +58,7 @@ messageRoutes.post(
       const db = c.get('db');
       const workspace = c.get('workspace');
       const agent = c.get('agent');
-      const parsed = await parseJsonBody(c, postMessageSchema, 'text is required');
+      const parsed = await parseJsonBody(c, postMessageSchema, postMessageInvalidMessage);
       if (!parsed.ok) {
         return parsed.response;
       }

--- a/packages/engine/src/routes/presence.ts
+++ b/packages/engine/src/routes/presence.ts
@@ -5,6 +5,7 @@ import { rateLimit } from '../middleware/rateLimit.js';
 import * as presenceEngine from '../engine/presence.js';
 import { emitServerEvent } from '../lib/serverTelemetry.js';
 import { errorResponse } from '../lib/httpError.js';
+import { jsonOk, jsonSuccess } from '../lib/httpResponse.js';
 
 export const presenceRoutes = new Hono<AppEnv>();
 
@@ -13,7 +14,7 @@ presenceRoutes.get('/agents/presence', requireAuth, rateLimit, async (c) => {
     const db = c.get('db');
     const workspace = c.get('workspace');
     const result = await presenceEngine.getPresence(db, c.get('engine').presence, workspace.id);
-    return c.json({ ok: true, data: result });
+    return jsonOk(c, result);
   } catch (err: unknown) {
     return errorResponse(c, err);
   }
@@ -29,7 +30,7 @@ presenceRoutes.post('/agents/heartbeat', requireAgentToken, rateLimit, async (c)
       agent_id: agent.id,
       agent_name: agent.name,
     });
-    return c.json({ ok: true });
+    return jsonSuccess(c);
   } catch (err: unknown) {
     return errorResponse(c, err);
   }
@@ -56,7 +57,7 @@ presenceRoutes.post('/agents/disconnect', requireAgentToken, rateLimit, async (c
       agent_id: agent.id,
       agent_name: agent.name,
     });
-    return c.json({ ok: true });
+    return jsonSuccess(c);
   } catch (err: unknown) {
     return errorResponse(c, err);
   }

--- a/packages/engine/src/routes/reaction.ts
+++ b/packages/engine/src/routes/reaction.ts
@@ -11,6 +11,13 @@ import { runInBackground } from './background.js';
 import { sendWebhookEvent } from './webhookOutbox.js';
 import { emitServerEvent } from '../lib/serverTelemetry.js';
 import { errorResponse } from '../lib/httpError.js';
+import {
+  jsonCreated,
+  jsonNoContent,
+  jsonNotFound,
+  jsonOk,
+  parseJsonBody,
+} from '../lib/httpResponse.js';
 
 export const reactionRoutes = new Hono<AppEnv>();
 
@@ -28,12 +35,9 @@ reactionRoutes.post(
       const db = c.get('db');
       const workspace = c.get('workspace');
       const agent = c.get('agent');
-      const parsed = addReactionSchema.safeParse(await c.req.json());
-      if (!parsed.success) {
-        return c.json({
-          ok: false,
-          error: { code: 'invalid_request', message: 'emoji is required' },
-        }, 400);
+      const parsed = await parseJsonBody(c, addReactionSchema, 'emoji is required');
+      if (!parsed.ok) {
+        return parsed.response;
       }
       const { emoji } = parsed.data;
 
@@ -45,10 +49,7 @@ reactionRoutes.post(
         emoji,
       );
       if (!result) {
-        return c.json({
-          ok: false,
-          error: { code: 'message_not_found', message: 'Message not found' },
-        }, 404);
+        return jsonNotFound(c, 'message_not_found', 'Message not found');
       }
 
       // Strip internal channel_id/channel_name before sending to client
@@ -80,7 +81,7 @@ reactionRoutes.post(
         channel_id: channel_id ?? null,
       });
 
-      return c.json({ ok: true, data: reactionData }, 201);
+      return jsonCreated(c, reactionData);
     } catch (err: unknown) {
       return errorResponse(c, err);
     }
@@ -105,10 +106,7 @@ reactionRoutes.delete(
         c.req.param('emoji'),
       );
       if (result === null) {
-        return c.json({
-          ok: false,
-          error: { code: 'message_not_found', message: 'Message not found' },
-        }, 404);
+        return jsonNotFound(c, 'message_not_found', 'Message not found');
       }
 
       const eventData = {
@@ -153,7 +151,7 @@ reactionRoutes.delete(
         emoji: c.req.param('emoji'),
       });
 
-      return c.body(null, 204);
+      return jsonNoContent(c);
     } catch (err: unknown) {
       return errorResponse(c, err);
     }
@@ -175,13 +173,10 @@ reactionRoutes.get(
         c.req.param('id'),
       );
       if (result === null) {
-        return c.json({
-          ok: false,
-          error: { code: 'message_not_found', message: 'Message not found' },
-        }, 404);
+        return jsonNotFound(c, 'message_not_found', 'Message not found');
       }
 
-      return c.json({ ok: true, data: result });
+      return jsonOk(c, result);
     } catch (err: unknown) {
       return errorResponse(c, err);
     }

--- a/packages/engine/src/routes/routing.ts
+++ b/packages/engine/src/routes/routing.ts
@@ -13,7 +13,9 @@ import {
   jsonNotFound,
   jsonOk,
   parseJsonBody,
+  parseQueryParams,
 } from '../lib/httpResponse.js';
+import { LimitQuerySchema } from '../lib/httpQuery.js';
 
 export const routingRoutes = new Hono<AppEnv>();
 
@@ -53,6 +55,10 @@ const syncAgentSkillsSchema = z.object({
   metadata: z.record(z.string(), z.unknown()).optional(),
   status: z.string().min(1).optional(),
   skills: z.array(skillSchema).optional(),
+});
+
+const searchSkillsQuerySchema = LimitQuerySchema.extend({
+  q: z.string().optional(),
 });
 
 routingRoutes.post('/route', requireAuth, rateLimit, async (c) => {
@@ -118,8 +124,11 @@ routingRoutes.post('/route/feedback', requireAuth, rateLimit, async (c) => {
 routingRoutes.get('/skills/search', requireAuth, rateLimit, async (c) => {
   try {
     const workspace = c.get('workspace');
-    const q = c.req.query('q') || undefined;
-    const limit = c.req.query('limit') ? parseInt(c.req.query('limit')!, 10) : undefined;
+    const parsed = parseQueryParams(c, searchSkillsQuerySchema, 'Invalid skill search query');
+    if (!parsed.ok) {
+      return parsed.response;
+    }
+    const { q, limit } = parsed.data;
     const result = await routingEngine.searchSkills(c.get('db'), workspace.id, { q, limit });
     return jsonOk(c, result);
   } catch (err: unknown) {

--- a/packages/engine/src/routes/routing.ts
+++ b/packages/engine/src/routes/routing.ts
@@ -1,4 +1,4 @@
-import { Hono, type Context } from 'hono';
+import { Hono } from 'hono';
 import { z } from 'zod';
 import { and, eq } from 'drizzle-orm';
 import type { AppEnv } from '../env.js';
@@ -9,6 +9,11 @@ import { requireAuth, requireWorkspaceKey } from '../middleware/auth.js';
 import { rateLimit } from '../middleware/rateLimit.js';
 import { emitServerEvent } from '../lib/serverTelemetry.js';
 import { errorResponse } from '../lib/httpError.js';
+import {
+  jsonNotFound,
+  jsonOk,
+  parseJsonBody,
+} from '../lib/httpResponse.js';
 
 export const routingRoutes = new Hono<AppEnv>();
 
@@ -50,18 +55,11 @@ const syncAgentSkillsSchema = z.object({
   skills: z.array(skillSchema).optional(),
 });
 
-function handleError(c: Context<AppEnv>, err: unknown) {
-  return errorResponse(c, err);
-}
-
 routingRoutes.post('/route', requireAuth, rateLimit, async (c) => {
   try {
-    const parsed = routeRequestSchema.safeParse(await c.req.json());
-    if (!parsed.success) {
-      return c.json({
-        ok: false,
-        error: { code: 'invalid_request', message: 'skill is required' },
-      }, 400);
+    const parsed = await parseJsonBody(c, routeRequestSchema, 'skill is required');
+    if (!parsed.ok) {
+      return parsed.response;
     }
 
     const workspace = c.get('workspace');
@@ -79,27 +77,21 @@ routingRoutes.post('/route', requireAuth, rateLimit, async (c) => {
       score: result.score,
     });
 
-    return c.json({
-      ok: true,
-      data: {
-        agent_name: result.agentName,
-        score: result.score,
-        fallback: result.fallback,
-      },
+    return jsonOk(c, {
+      agent_name: result.agentName,
+      score: result.score,
+      fallback: result.fallback,
     });
   } catch (err: unknown) {
-    return handleError(c, err);
+    return errorResponse(c, err);
   }
 });
 
 routingRoutes.post('/route/feedback', requireAuth, rateLimit, async (c) => {
   try {
-    const parsed = routeFeedbackSchema.safeParse(await c.req.json());
-    if (!parsed.success) {
-      return c.json({
-        ok: false,
-        error: { code: 'invalid_request', message: 'agent_name and success are required' },
-      }, 400);
+    const parsed = await parseJsonBody(c, routeFeedbackSchema, 'agent_name and success are required');
+    if (!parsed.ok) {
+      return parsed.response;
     }
 
     const workspace = c.get('workspace');
@@ -117,9 +109,9 @@ routingRoutes.post('/route/feedback', requireAuth, rateLimit, async (c) => {
       success: parsed.data.success,
     });
 
-    return c.json({ ok: true, data: result });
+    return jsonOk(c, result);
   } catch (err: unknown) {
-    return handleError(c, err);
+    return errorResponse(c, err);
   }
 });
 
@@ -129,20 +121,17 @@ routingRoutes.get('/skills/search', requireAuth, rateLimit, async (c) => {
     const q = c.req.query('q') || undefined;
     const limit = c.req.query('limit') ? parseInt(c.req.query('limit')!, 10) : undefined;
     const result = await routingEngine.searchSkills(c.get('db'), workspace.id, { q, limit });
-    return c.json({ ok: true, data: result });
+    return jsonOk(c, result);
   } catch (err: unknown) {
-    return handleError(c, err);
+    return errorResponse(c, err);
   }
 });
 
 routingRoutes.post('/skills/sync', requireWorkspaceKey, rateLimit, async (c) => {
   try {
-    const parsed = syncAgentSkillsSchema.safeParse(await c.req.json());
-    if (!parsed.success) {
-      return c.json({
-        ok: false,
-        error: { code: 'invalid_request', message: 'agent_name is required' },
-      }, 400);
+    const parsed = await parseJsonBody(c, syncAgentSkillsSchema, 'agent_name is required');
+    if (!parsed.ok) {
+      return parsed.response;
     }
 
     const workspace = c.get('workspace');
@@ -154,10 +143,7 @@ routingRoutes.post('/skills/sync', requireWorkspaceKey, rateLimit, async (c) => 
 
     const row = agent[0];
     if (!row) {
-      return c.json({
-        ok: false,
-        error: { code: 'agent_not_found', message: `Agent "${parsed.data.agent_name}" not found` },
-      }, 404);
+      return jsonNotFound(c, 'agent_not_found', `Agent "${parsed.data.agent_name}" not found`);
     }
 
     const metadata = {
@@ -173,9 +159,9 @@ routingRoutes.post('/skills/sync', requireWorkspaceKey, rateLimit, async (c) => 
       metadata,
     });
 
-    return c.json({ ok: true, data: result });
+    return jsonOk(c, result);
   } catch (err: unknown) {
-    return handleError(c, err);
+    return errorResponse(c, err);
   }
 });
 
@@ -183,20 +169,17 @@ routingRoutes.get('/routing/config', requireAuth, rateLimit, async (c) => {
   try {
     const workspace = c.get('workspace');
     const result = await routingEngine.getRoutingConfig(c.get('db'), workspace.id);
-    return c.json({ ok: true, data: result });
+    return jsonOk(c, result);
   } catch (err: unknown) {
-    return handleError(c, err);
+    return errorResponse(c, err);
   }
 });
 
 routingRoutes.put('/routing/config', requireWorkspaceKey, rateLimit, async (c) => {
   try {
-    const parsed = routingConfigSchema.safeParse(await c.req.json());
-    if (!parsed.success) {
-      return c.json({
-        ok: false,
-        error: { code: 'invalid_request', message: 'invalid routing config body' },
-      }, 400);
+    const parsed = await parseJsonBody(c, routingConfigSchema, 'invalid routing config body');
+    if (!parsed.ok) {
+      return parsed.response;
     }
 
     const workspace = c.get('workspace');
@@ -205,8 +188,8 @@ routingRoutes.put('/routing/config', requireWorkspaceKey, rateLimit, async (c) =
       circuit_breaker_threshold: result.circuit_breaker_threshold,
       circuit_breaker_cooldown_seconds: result.circuit_breaker_cooldown_seconds,
     });
-    return c.json({ ok: true, data: result });
+    return jsonOk(c, result);
   } catch (err: unknown) {
-    return handleError(c, err);
+    return errorResponse(c, err);
   }
 });

--- a/packages/engine/src/routes/search.ts
+++ b/packages/engine/src/routes/search.ts
@@ -1,13 +1,21 @@
 import { Hono } from 'hono';
+import { z } from 'zod';
 import type { AppEnv } from '../env.js';
 import { requireAuth } from '../middleware/auth.js';
 import { rateLimit } from '../middleware/rateLimit.js';
 import * as searchEngine from '../engine/search.js';
 import { emitServerEvent } from '../lib/serverTelemetry.js';
 import { errorResponse } from '../lib/httpError.js';
-import { jsonInvalidRequest, jsonOk } from '../lib/httpResponse.js';
+import { jsonInvalidRequest, jsonOk, parseQueryParams } from '../lib/httpResponse.js';
+import { PaginationQuerySchema } from '../lib/httpQuery.js';
 
 export const searchRoutes = new Hono<AppEnv>();
+
+const searchQuerySchema = PaginationQuerySchema.extend({
+  q: z.string().optional(),
+  channel: z.string().optional(),
+  from: z.string().optional(),
+});
 
 // GET /v1/search?q=...&channel=...&from=...&limit=...&before=...&after=...
 searchRoutes.get(
@@ -18,16 +26,14 @@ searchRoutes.get(
     try {
       const db = c.get('db');
       const workspace = c.get('workspace');
-      const q = c.req.query('q');
-      if (!q || typeof q !== 'string' || !q.trim()) {
+      const parsed = parseQueryParams(c, searchQuerySchema, 'Invalid search query');
+      if (!parsed.ok) {
+        return parsed.response;
+      }
+      const { q, channel, from, limit, before, after } = parsed.data;
+      if (!q || !q.trim()) {
         return jsonInvalidRequest(c, 'q (search query) is required');
       }
-
-      const channel = c.req.query('channel');
-      const from = c.req.query('from');
-      const limit = c.req.query('limit') ? parseInt(c.req.query('limit')!, 10) : undefined;
-      const before = c.req.query('before');
-      const after = c.req.query('after');
 
       const results = await searchEngine.searchMessages(db, workspace.id, {
         q,

--- a/packages/engine/src/routes/search.ts
+++ b/packages/engine/src/routes/search.ts
@@ -6,13 +6,13 @@ import { rateLimit } from '../middleware/rateLimit.js';
 import * as searchEngine from '../engine/search.js';
 import { emitServerEvent } from '../lib/serverTelemetry.js';
 import { errorResponse } from '../lib/httpError.js';
-import { jsonInvalidRequest, jsonOk, parseQueryParams } from '../lib/httpResponse.js';
+import { jsonOk, parseQueryParams } from '../lib/httpResponse.js';
 import { PaginationQuerySchema } from '../lib/httpQuery.js';
 
 export const searchRoutes = new Hono<AppEnv>();
 
 const searchQuerySchema = PaginationQuerySchema.extend({
-  q: z.string().optional(),
+  q: z.string().trim().min(1),
   channel: z.string().optional(),
   from: z.string().optional(),
 });
@@ -26,14 +26,15 @@ searchRoutes.get(
     try {
       const db = c.get('db');
       const workspace = c.get('workspace');
-      const parsed = parseQueryParams(c, searchQuerySchema, 'Invalid search query');
+      const parsed = parseQueryParams(c, searchQuerySchema, (failure) =>
+        failure.error.issues.some((issue) => issue.path[0] === 'q')
+          ? 'q (search query) is required'
+          : 'Invalid search query',
+      );
       if (!parsed.ok) {
         return parsed.response;
       }
       const { q, channel, from, limit, before, after } = parsed.data;
-      if (!q || !q.trim()) {
-        return jsonInvalidRequest(c, 'q (search query) is required');
-      }
 
       const results = await searchEngine.searchMessages(db, workspace.id, {
         q,

--- a/packages/engine/src/routes/search.ts
+++ b/packages/engine/src/routes/search.ts
@@ -5,6 +5,7 @@ import { rateLimit } from '../middleware/rateLimit.js';
 import * as searchEngine from '../engine/search.js';
 import { emitServerEvent } from '../lib/serverTelemetry.js';
 import { errorResponse } from '../lib/httpError.js';
+import { jsonInvalidRequest, jsonOk } from '../lib/httpResponse.js';
 
 export const searchRoutes = new Hono<AppEnv>();
 
@@ -19,10 +20,7 @@ searchRoutes.get(
       const workspace = c.get('workspace');
       const q = c.req.query('q');
       if (!q || typeof q !== 'string' || !q.trim()) {
-        return c.json({
-          ok: false,
-          error: { code: 'invalid_request', message: 'q (search query) is required' },
-        }, 400);
+        return jsonInvalidRequest(c, 'q (search query) is required');
       }
 
       const channel = c.req.query('channel');
@@ -47,7 +45,7 @@ searchRoutes.get(
         has_from_filter: Boolean(from),
       });
 
-      return c.json({ ok: true, data: results });
+      return jsonOk(c, results);
     } catch (err: unknown) {
       return errorResponse(c, err);
     }

--- a/packages/engine/src/routes/thread.ts
+++ b/packages/engine/src/routes/thread.ts
@@ -14,6 +14,7 @@ import { runInBackground } from './background.js';
 import { sendWebhookEvent } from './webhookOutbox.js';
 import { emitServerEvent } from '../lib/serverTelemetry.js';
 import { errorResponse } from '../lib/httpError.js';
+import { jsonError, jsonOk, parseJsonBody } from '../lib/httpResponse.js';
 
 export const threadRoutes = new Hono<AppEnv>();
 
@@ -33,29 +34,20 @@ threadRoutes.post(
       const db = c.get('db');
       const workspace = c.get('workspace');
       const agent = c.get('agent');
-      const parsed = postReplySchema.safeParse(await c.req.json());
-      if (!parsed.success) {
-        return c.json({
-          ok: false,
-          error: { code: 'invalid_request', message: 'text is required' },
-        }, 400);
+      const parsed = await parseJsonBody(c, postReplySchema, 'text is required');
+      if (!parsed.ok) {
+        return parsed.response;
       }
       const { text, blocks, data } = parsed.data;
 
       const { key: idempotencyKey, error: idempotencyError } = parseIdempotencyKey(c.req.header('Idempotency-Key'));
       if (idempotencyError) {
-        return c.json({
-          ok: false,
-          error: { code: 'invalid_idempotency_key', message: idempotencyError },
-        }, 400);
+        return jsonError(c, 'invalid_idempotency_key', idempotencyError, 400);
       }
 
       const agentId = agent?.id;
       if (!agentId) {
-        return c.json({
-          ok: false,
-          error: { code: 'agent_token_required', message: 'Agent token required to post replies' },
-        }, 403);
+        return jsonError(c, 'agent_token_required', 'Agent token required to post replies', 403);
       }
 
       const parentId = c.req.param('id');
@@ -151,7 +143,7 @@ threadRoutes.post(
         _deliveries?: unknown;
         _delivery_rejections?: unknown;
       };
-      return c.json({ ok: true, data: responseData }, idempotent.status as ContentfulStatusCode);
+      return jsonOk(c, responseData, idempotent.status as ContentfulStatusCode);
     } catch (err: unknown) {
       return errorResponse(c, err);
     }
@@ -178,7 +170,7 @@ threadRoutes.get(
         parentId,
         { limit, before, after },
       );
-      return c.json({ ok: true, data: result });
+      return jsonOk(c, result);
     } catch (err: unknown) {
       return errorResponse(c, err);
     }

--- a/packages/engine/src/routes/thread.ts
+++ b/packages/engine/src/routes/thread.ts
@@ -1,10 +1,9 @@
 import { Hono } from 'hono';
-import type { ContentfulStatusCode } from 'hono/utils/http-status';
 import { z } from 'zod';
 import type { AppEnv } from '../env.js';
 import { requireAuth } from '../middleware/auth.js';
 import { rateLimit } from '../middleware/rateLimit.js';
-import { parseIdempotencyKey, runIdempotent } from '../middleware/idempotency.js';
+import { jsonIdempotentOk, parseIdempotencyKey, runIdempotent } from '../middleware/idempotency.js';
 import * as threadEngine from '../engine/thread.js';
 import { resolveMailboxConfig } from '../engine/mailboxConfig.js';
 import { fanoutToChannel, fanoutToAgents, getDmParticipantAgentIds } from './fanout.js';
@@ -83,10 +82,6 @@ threadRoutes.post(
         },
       });
 
-      if (idempotent.replayed) {
-        c.header('Idempotency-Replayed', 'true');
-      }
-
       if (!idempotent.replayed) {
         const {
           _deliveries,
@@ -135,15 +130,7 @@ threadRoutes.post(
         });
       }
 
-      const {
-        _deliveries: _dropDeliveries,
-        _delivery_rejections: _dropRejections,
-        ...responseData
-      } = idempotent.data as typeof idempotent.data & {
-        _deliveries?: unknown;
-        _delivery_rejections?: unknown;
-      };
-      return jsonOk(c, responseData, idempotent.status as ContentfulStatusCode);
+      return jsonIdempotentOk(c, idempotent);
     } catch (err: unknown) {
       return errorResponse(c, err);
     }

--- a/packages/engine/src/routes/thread.ts
+++ b/packages/engine/src/routes/thread.ts
@@ -14,6 +14,7 @@ import { sendWebhookEvent } from './webhookOutbox.js';
 import { emitServerEvent } from '../lib/serverTelemetry.js';
 import { errorResponse } from '../lib/httpError.js';
 import { jsonError, jsonOk, parseJsonBody } from '../lib/httpResponse.js';
+import { parsePaginationQuery } from '../lib/httpQuery.js';
 
 export const threadRoutes = new Hono<AppEnv>();
 
@@ -146,9 +147,11 @@ threadRoutes.get(
     try {
       const db = c.get('db');
       const workspace = c.get('workspace');
-      const limit = c.req.query('limit') ? parseInt(c.req.query('limit')!, 10) : undefined;
-      const before = c.req.query('before');
-      const after = c.req.query('after');
+      const query = parsePaginationQuery(c);
+      if (!query.ok) {
+        return query.response;
+      }
+      const { limit, before, after } = query.data;
 
       const parentId = c.req.param('id');
       const result = await threadEngine.getThread(

--- a/packages/engine/src/routes/thread.ts
+++ b/packages/engine/src/routes/thread.ts
@@ -34,7 +34,7 @@ threadRoutes.post(
       const db = c.get('db');
       const workspace = c.get('workspace');
       const agent = c.get('agent');
-      const parsed = await parseJsonBody(c, postReplySchema, 'text is required');
+      const parsed = await parseJsonBody(c, postReplySchema, 'invalid reply body');
       if (!parsed.ok) {
         return parsed.response;
       }

--- a/packages/engine/src/routes/workspace.ts
+++ b/packages/engine/src/routes/workspace.ts
@@ -1,5 +1,4 @@
 import { Hono } from 'hono';
-import type { ContentfulStatusCode } from 'hono/utils/http-status';
 import type { Context } from 'hono';
 import { createMiddleware } from 'hono/factory';
 import { z } from 'zod';
@@ -316,7 +315,7 @@ workspaceRoutes.get('/workspace/stream', requireWorkspaceKey, rateLimit, async (
       status: error.status,
       ...toErrorDetails(error),
     });
-    return jsonError(c, error.code || 'internal_error', error.message, (error.status || 500) as ContentfulStatusCode);
+    return errorResponse(c, error);
   }
 });
 
@@ -356,7 +355,7 @@ workspaceRoutes.put('/workspace/stream', requireWorkspaceKey, rateLimit, async (
       status: error.status,
       ...toErrorDetails(error),
     });
-    return jsonError(c, error.code || 'internal_error', error.message, (error.status || 500) as ContentfulStatusCode);
+    return errorResponse(c, error);
   }
 });
 
@@ -376,7 +375,7 @@ workspaceRoutes.get('/workspace/fleet-nodes', requireWorkspaceKey, rateLimit, as
       status: error.status,
       ...toErrorDetails(error),
     });
-    return jsonError(c, error.code || 'internal_error', error.message, (error.status || 500) as ContentfulStatusCode);
+    return errorResponse(c, error);
   }
 });
 
@@ -416,6 +415,6 @@ workspaceRoutes.put('/workspace/fleet-nodes', requireWorkspaceKey, rateLimit, as
       status: error.status,
       ...toErrorDetails(error),
     });
-    return jsonError(c, error.code || 'internal_error', error.message, (error.status || 500) as ContentfulStatusCode);
+    return errorResponse(c, error);
   }
 });

--- a/packages/engine/src/routes/workspace.ts
+++ b/packages/engine/src/routes/workspace.ts
@@ -21,6 +21,14 @@ import {
 import { getRequestLogger, toErrorDetails } from '../lib/logger.js';
 import { emitServerEvent } from '../lib/serverTelemetry.js';
 import { errorResponse, asCodedError } from '../lib/httpError.js';
+import {
+  jsonCreated,
+  jsonError,
+  jsonNoContent,
+  jsonNotFound,
+  jsonOk,
+  parseJsonBody,
+} from '../lib/httpResponse.js';
 
 export const workspaceRoutes = new Hono<AppEnv>();
 
@@ -42,6 +50,20 @@ const updateFleetNodesSchema = z.object({
   enabled: z.boolean().optional(),
   mode: z.string().optional(),
 }).passthrough();
+
+const WORKSPACE_OVERRIDE_MESSAGE = 'Provide { enabled: boolean } or { mode: "inherit" }';
+
+function workspaceNotFound(c: Context<AppEnv>) {
+  return jsonNotFound(c, 'workspace_not_found', 'Workspace not found');
+}
+
+function featureConfigData(config: { enabled: boolean; defaultEnabled: boolean; override: boolean | null }) {
+  return {
+    enabled: config.enabled,
+    default_enabled: config.defaultEnabled,
+    override: config.override,
+  };
+}
 
 const PUBLIC_WORKSPACE_LOOKUP_LIMIT = 30;
 const publicWorkspaceLookupBuckets = new Map<string, { count: number; lastSeen: number }>();
@@ -104,13 +126,7 @@ const publicWorkspaceLookupRateLimit = createMiddleware<AppEnv>(async (c, next) 
     c.header('X-RateLimit-Remaining', String(remaining));
 
     if (!allowed) {
-      return c.json({
-        ok: false,
-        error: {
-          code: 'rate_limit_exceeded',
-          message: `Rate limit exceeded. ${limit} requests per minute allowed for public workspace lookups.`,
-        },
-      }, 429);
+      return jsonError(c, 'rate_limit_exceeded', `Rate limit exceeded. ${limit} requests per minute allowed for public workspace lookups.`, 429);
     }
   } catch {
     const { allowed, remaining } = inMemoryPublicLookupRateCheck(clientId, limit);
@@ -118,13 +134,7 @@ const publicWorkspaceLookupRateLimit = createMiddleware<AppEnv>(async (c, next) 
     c.header('X-RateLimit-Remaining', String(remaining));
 
     if (!allowed) {
-      return c.json({
-        ok: false,
-        error: {
-          code: 'rate_limit_exceeded',
-          message: `Rate limit exceeded. ${limit} requests per minute allowed for public workspace lookups.`,
-        },
-      }, 429);
+      return jsonError(c, 'rate_limit_exceeded', `Rate limit exceeded. ${limit} requests per minute allowed for public workspace lookups.`, 429);
     }
   }
 
@@ -134,9 +144,9 @@ const publicWorkspaceLookupRateLimit = createMiddleware<AppEnv>(async (c, next) 
 // POST /workspaces - create workspace (no auth required, workspace key optional)
 workspaceRoutes.post('/workspaces', async (c) => {
   try {
-    const parsed = createWorkspaceSchema.safeParse(await c.req.json());
-    if (!parsed.success) {
-      return c.json({ ok: false, error: { code: 'invalid_request', message: 'name is required' } }, 400);
+    const parsed = await parseJsonBody(c, createWorkspaceSchema, 'name is required');
+    if (!parsed.ok) {
+      return parsed.response;
     }
     const { name } = parsed.data;
     const db = c.get('db');
@@ -151,7 +161,7 @@ workspaceRoutes.post('/workspaces', async (c) => {
         created_via: 'api',
       });
     }
-    return c.json({ ok: true, data: result.workspace }, result.created ? 201 : 200);
+    return result.created ? jsonCreated(c, result.workspace) : jsonOk(c, result.workspace);
   } catch (err: unknown) {
     return errorResponse(c, err);
   }
@@ -163,9 +173,9 @@ workspaceRoutes.get('/workspaces/by-name/:name', publicWorkspaceLookupRateLimit,
     const db = c.get('db');
     const workspace = await workspaceEngine.getWorkspaceByName(db, c.req.param('name'));
     if (!workspace) {
-      return c.json({ ok: false, error: { code: 'workspace_not_found', message: 'Workspace not found' } }, 404);
+      return workspaceNotFound(c);
     }
-    return c.json({ ok: true, data: workspace });
+    return jsonOk(c, workspace);
   } catch (err: unknown) {
     return errorResponse(c, err);
   }
@@ -177,9 +187,9 @@ workspaceRoutes.get('/workspace', requireWorkspaceKey, rateLimit, async (c) => {
     const db = c.get('db');
     const workspace = await workspaceEngine.getWorkspace(db, c.get('workspace').id);
     if (!workspace) {
-      return c.json({ ok: false, error: { code: 'workspace_not_found', message: 'Workspace not found' } }, 404);
+      return workspaceNotFound(c);
     }
-    return c.json({ ok: true, data: workspace });
+    return jsonOk(c, workspace);
   } catch (err: unknown) {
     return errorResponse(c, err);
   }
@@ -190,20 +200,20 @@ workspaceRoutes.patch('/workspace', requireWorkspaceKey, rateLimit, async (c) =>
   try {
     const db = c.get('db');
     const workspace = c.get('workspace');
-    const parsed = updateWorkspaceSchema.safeParse(await c.req.json());
-    if (!parsed.success) {
-      return c.json({ ok: false, error: { code: 'invalid_request', message: 'invalid workspace update body' } }, 400);
+    const parsed = await parseJsonBody(c, updateWorkspaceSchema, 'invalid workspace update body');
+    if (!parsed.ok) {
+      return parsed.response;
     }
     const body = parsed.data;
     const updated = await workspaceEngine.updateWorkspace(db, workspace.id, body);
     if (!updated) {
-      return c.json({ ok: false, error: { code: 'workspace_not_found', message: 'Workspace not found' } }, 404);
+      return workspaceNotFound(c);
     }
     emitServerEvent(c, workspace.id, 'relaycast_server_workspace_updated', {
       changed_name: typeof body?.name === 'string',
       changed_system_prompt: typeof body?.system_prompt === 'string',
     });
-    return c.json({ ok: true, data: updated });
+    return jsonOk(c, updated);
   } catch (err: unknown) {
     return errorResponse(c, err);
   }
@@ -218,7 +228,7 @@ workspaceRoutes.delete('/workspace', requireWorkspaceKey, rateLimit, async (c) =
     emitServerEvent(c, workspace.id, 'relaycast_server_workspace_deleted', {
       deleted_via: 'api',
     });
-    return c.body(null, 204);
+    return jsonNoContent(c);
   } catch (err: unknown) {
     return errorResponse(c, err);
   }
@@ -233,7 +243,7 @@ workspaceRoutes.get('/activity', requireWorkspaceKey, rateLimit, async (c) => {
     const limit = limitStr ? parseInt(limitStr, 10) : 20;
 
     const items = await activityEngine.getActivityFeed(db, workspace.id, limit);
-    return c.json({ ok: true, data: items });
+    return jsonOk(c, items);
   } catch (err: unknown) {
     return errorResponse(c, err);
   }
@@ -245,7 +255,7 @@ workspaceRoutes.get('/dm/conversations/all', requireWorkspaceKey, rateLimit, asy
     const db = c.get('db');
     const workspace = c.get('workspace');
     const conversations = await dmAllEngine.listAllDmConversations(db, workspace.id);
-    return c.json({ ok: true, data: conversations });
+    return jsonOk(c, conversations);
   } catch (err: unknown) {
     return errorResponse(c, err);
   }
@@ -265,7 +275,7 @@ workspaceRoutes.get('/dm/conversations/:conversation_id/messages', requireWorksp
     const msgs = await dmAllEngine.getDmMessagesForWorkspace(
       db, workspace.id, conversationId, { limit, before, after },
     );
-    return c.json({ ok: true, data: msgs });
+    return jsonOk(c, msgs);
   } catch (err: unknown) {
     return errorResponse(c, err);
   }
@@ -284,7 +294,7 @@ workspaceRoutes.post('/agents/:name/rotate-token', requireWorkspaceKey, rateLimi
     emitServerEvent(c, workspace.id, 'relaycast_server_agent_token_rotated', {
       agent_name: c.req.param('name'),
     });
-    return c.json({ ok: true, data: result });
+    return jsonOk(c, result);
   } catch (err: unknown) {
     return errorResponse(c, err);
   }
@@ -297,14 +307,7 @@ workspaceRoutes.get('/workspace/stream', requireWorkspaceKey, rateLimit, async (
   try {
     const { kv, config: engineConfig } = c.get('engine');
     const config = await getWorkspaceStreamConfig(kv, workspaceId, engineConfig.workspaceStreamEnabled ?? false);
-    return c.json({
-      ok: true,
-      data: {
-        enabled: config.enabled,
-        default_enabled: config.defaultEnabled,
-        override: config.override,
-      },
-    });
+    return jsonOk(c, featureConfigData(config));
   } catch (err: unknown) {
     const error = asCodedError(err);
     logger.error('Failed to get stream config', {
@@ -313,10 +316,7 @@ workspaceRoutes.get('/workspace/stream', requireWorkspaceKey, rateLimit, async (
       status: error.status,
       ...toErrorDetails(error),
     });
-    return c.json({
-      ok: false,
-      error: { code: error.code || 'internal_error', message: error.message },
-    }, (error.status || 500) as ContentfulStatusCode);
+    return jsonError(c, error.code || 'internal_error', error.message, (error.status || 500) as ContentfulStatusCode);
   }
 });
 
@@ -325,12 +325,9 @@ workspaceRoutes.put('/workspace/stream', requireWorkspaceKey, rateLimit, async (
   const logger = getRequestLogger(c, 'workspace.stream.put');
   const workspaceId = c.get('workspace').id;
   try {
-    const parsed = updateWorkspaceStreamSchema.safeParse(await c.req.json());
-    if (!parsed.success) {
-      return c.json({
-        ok: false,
-        error: { code: 'invalid_request', message: 'Provide { enabled: boolean } or { mode: "inherit" }' },
-      }, 400);
+    const parsed = await parseJsonBody(c, updateWorkspaceStreamSchema, WORKSPACE_OVERRIDE_MESSAGE);
+    if (!parsed.ok) {
+      return parsed.response;
     }
     const body = parsed.data;
 
@@ -340,10 +337,7 @@ workspaceRoutes.put('/workspace/stream', requireWorkspaceKey, rateLimit, async (
     } else if (typeof body?.enabled === 'boolean') {
       override = body.enabled;
     } else {
-      return c.json({
-        ok: false,
-        error: { code: 'invalid_request', message: 'Provide { enabled: boolean } or { mode: "inherit" }' },
-      }, 400);
+      return jsonError(c, 'invalid_request', WORKSPACE_OVERRIDE_MESSAGE, 400);
     }
 
     const { kv, config: engineConfig } = c.get('engine');
@@ -353,14 +347,7 @@ workspaceRoutes.put('/workspace/stream', requireWorkspaceKey, rateLimit, async (
       stream_mode: override === null ? 'inherit' : (override ? 'enabled' : 'disabled'),
     });
 
-    return c.json({
-      ok: true,
-      data: {
-        enabled: config.enabled,
-        default_enabled: config.defaultEnabled,
-        override: config.override,
-      },
-    });
+    return jsonOk(c, featureConfigData(config));
   } catch (err: unknown) {
     const error = asCodedError(err);
     logger.error('Failed to update stream config', {
@@ -369,10 +356,7 @@ workspaceRoutes.put('/workspace/stream', requireWorkspaceKey, rateLimit, async (
       status: error.status,
       ...toErrorDetails(error),
     });
-    return c.json({
-      ok: false,
-      error: { code: error.code || 'internal_error', message: error.message },
-    }, (error.status || 500) as ContentfulStatusCode);
+    return jsonError(c, error.code || 'internal_error', error.message, (error.status || 500) as ContentfulStatusCode);
   }
 });
 
@@ -383,14 +367,7 @@ workspaceRoutes.get('/workspace/fleet-nodes', requireWorkspaceKey, rateLimit, as
   try {
     const { kv, config: engineConfig } = c.get('engine');
     const config = await getFleetNodesConfig(kv, workspaceId, engineConfig.fleetNodesEnabled ?? false);
-    return c.json({
-      ok: true,
-      data: {
-        enabled: config.enabled,
-        default_enabled: config.defaultEnabled,
-        override: config.override,
-      },
-    });
+    return jsonOk(c, featureConfigData(config));
   } catch (err: unknown) {
     const error = asCodedError(err);
     logger.error('Failed to get fleet nodes config', {
@@ -399,10 +376,7 @@ workspaceRoutes.get('/workspace/fleet-nodes', requireWorkspaceKey, rateLimit, as
       status: error.status,
       ...toErrorDetails(error),
     });
-    return c.json({
-      ok: false,
-      error: { code: error.code || 'internal_error', message: error.message },
-    }, (error.status || 500) as ContentfulStatusCode);
+    return jsonError(c, error.code || 'internal_error', error.message, (error.status || 500) as ContentfulStatusCode);
   }
 });
 
@@ -411,12 +385,9 @@ workspaceRoutes.put('/workspace/fleet-nodes', requireWorkspaceKey, rateLimit, as
   const logger = getRequestLogger(c, 'workspace.fleet_nodes.put');
   const workspaceId = c.get('workspace').id;
   try {
-    const parsed = updateFleetNodesSchema.safeParse(await c.req.json());
-    if (!parsed.success) {
-      return c.json({
-        ok: false,
-        error: { code: 'invalid_request', message: 'Provide { enabled: boolean } or { mode: "inherit" }' },
-      }, 400);
+    const parsed = await parseJsonBody(c, updateFleetNodesSchema, WORKSPACE_OVERRIDE_MESSAGE);
+    if (!parsed.ok) {
+      return parsed.response;
     }
     const body = parsed.data;
 
@@ -426,10 +397,7 @@ workspaceRoutes.put('/workspace/fleet-nodes', requireWorkspaceKey, rateLimit, as
     } else if (typeof body?.enabled === 'boolean') {
       override = body.enabled;
     } else {
-      return c.json({
-        ok: false,
-        error: { code: 'invalid_request', message: 'Provide { enabled: boolean } or { mode: "inherit" }' },
-      }, 400);
+      return jsonError(c, 'invalid_request', WORKSPACE_OVERRIDE_MESSAGE, 400);
     }
 
     const { kv, config: engineConfig } = c.get('engine');
@@ -439,14 +407,7 @@ workspaceRoutes.put('/workspace/fleet-nodes', requireWorkspaceKey, rateLimit, as
       fleet_nodes_mode: override === null ? 'inherit' : (override ? 'enabled' : 'disabled'),
     });
 
-    return c.json({
-      ok: true,
-      data: {
-        enabled: config.enabled,
-        default_enabled: config.defaultEnabled,
-        override: config.override,
-      },
-    });
+    return jsonOk(c, featureConfigData(config));
   } catch (err: unknown) {
     const error = asCodedError(err);
     logger.error('Failed to update fleet nodes config', {
@@ -455,9 +416,6 @@ workspaceRoutes.put('/workspace/fleet-nodes', requireWorkspaceKey, rateLimit, as
       status: error.status,
       ...toErrorDetails(error),
     });
-    return c.json({
-      ok: false,
-      error: { code: error.code || 'internal_error', message: error.message },
-    }, (error.status || 500) as ContentfulStatusCode);
+    return jsonError(c, error.code || 'internal_error', error.message, (error.status || 500) as ContentfulStatusCode);
   }
 });

--- a/packages/engine/src/routes/workspace.ts
+++ b/packages/engine/src/routes/workspace.ts
@@ -42,19 +42,18 @@ const updateWorkspaceSchema = z.object({
   system_prompt: z.string().nullable().optional(),
 });
 
-const updateWorkspaceStreamSchema = z.object({
-  enabled: z.boolean().optional(),
-  mode: z.string().optional(),
-}).passthrough();
+const featureOverrideSchema = z.union([
+  z.object({ enabled: z.boolean() }).strict(),
+  z.object({ mode: z.literal('inherit') }).strict(),
+]);
+
+const updateWorkspaceStreamSchema = featureOverrideSchema;
 
 const activityQuerySchema = z.object({
-  limit: positiveIntQueryParam({ defaultValue: 20 }),
+  limit: positiveIntQueryParam({ defaultValue: 20, max: 500 }),
 });
 
-const updateFleetNodesSchema = z.object({
-  enabled: z.boolean().optional(),
-  mode: z.string().optional(),
-}).passthrough();
+const updateFleetNodesSchema = featureOverrideSchema;
 
 const WORKSPACE_OVERRIDE_MESSAGE = 'Provide { enabled: boolean } or { mode: "inherit" }';
 
@@ -68,6 +67,10 @@ function featureConfigData(config: { enabled: boolean; defaultEnabled: boolean; 
     default_enabled: config.defaultEnabled,
     override: config.override,
   };
+}
+
+function featureOverrideValue(body: z.infer<typeof featureOverrideSchema>) {
+  return 'mode' in body ? null : body.enabled;
 }
 
 const PUBLIC_WORKSPACE_LOOKUP_LIMIT = 30;
@@ -340,14 +343,7 @@ workspaceRoutes.put('/workspace/stream', requireWorkspaceKey, rateLimit, async (
     }
     const body = parsed.data;
 
-    let override: boolean | null;
-    if (body?.mode === 'inherit') {
-      override = null;
-    } else if (typeof body?.enabled === 'boolean') {
-      override = body.enabled;
-    } else {
-      return jsonError(c, 'invalid_request', WORKSPACE_OVERRIDE_MESSAGE, 400);
-    }
+    const override = featureOverrideValue(body);
 
     const { kv, config: engineConfig } = c.get('engine');
     await setWorkspaceStreamOverride(kv, workspaceId, override);
@@ -400,14 +396,7 @@ workspaceRoutes.put('/workspace/fleet-nodes', requireWorkspaceKey, rateLimit, as
     }
     const body = parsed.data;
 
-    let override: boolean | null;
-    if (body?.mode === 'inherit') {
-      override = null;
-    } else if (typeof body?.enabled === 'boolean') {
-      override = body.enabled;
-    } else {
-      return jsonError(c, 'invalid_request', WORKSPACE_OVERRIDE_MESSAGE, 400);
-    }
+    const override = featureOverrideValue(body);
 
     const { kv, config: engineConfig } = c.get('engine');
     await setFleetNodesOverride(kv, workspaceId, override);

--- a/packages/engine/src/routes/workspace.ts
+++ b/packages/engine/src/routes/workspace.ts
@@ -27,7 +27,9 @@ import {
   jsonNotFound,
   jsonOk,
   parseJsonBody,
+  parseQueryParams,
 } from '../lib/httpResponse.js';
+import { parsePaginationQuery, positiveIntQueryParam } from '../lib/httpQuery.js';
 
 export const workspaceRoutes = new Hono<AppEnv>();
 
@@ -44,6 +46,10 @@ const updateWorkspaceStreamSchema = z.object({
   enabled: z.boolean().optional(),
   mode: z.string().optional(),
 }).passthrough();
+
+const activityQuerySchema = z.object({
+  limit: positiveIntQueryParam({ defaultValue: 20 }),
+});
 
 const updateFleetNodesSchema = z.object({
   enabled: z.boolean().optional(),
@@ -238,8 +244,11 @@ workspaceRoutes.get('/activity', requireWorkspaceKey, rateLimit, async (c) => {
   try {
     const db = c.get('db');
     const workspace = c.get('workspace');
-    const limitStr = c.req.query('limit');
-    const limit = limitStr ? parseInt(limitStr, 10) : 20;
+    const parsed = parseQueryParams(c, activityQuerySchema, 'Invalid activity query');
+    if (!parsed.ok) {
+      return parsed.response;
+    }
+    const { limit } = parsed.data;
 
     const items = await activityEngine.getActivityFeed(db, workspace.id, limit);
     return jsonOk(c, items);
@@ -266,10 +275,11 @@ workspaceRoutes.get('/dm/conversations/:conversation_id/messages', requireWorksp
     const db = c.get('db');
     const workspace = c.get('workspace');
     const conversationId = c.req.param('conversation_id');
-    const limitStr = c.req.query('limit');
-    const limit = limitStr ? parseInt(limitStr, 10) : undefined;
-    const before = c.req.query('before') || undefined;
-    const after = c.req.query('after') || undefined;
+    const query = parsePaginationQuery(c);
+    if (!query.ok) {
+      return query.response;
+    }
+    const { limit, before, after } = query.data;
 
     const msgs = await dmAllEngine.getDmMessagesForWorkspace(
       db, workspace.id, conversationId, { limit, before, after },


### PR DESCRIPTION
## Summary

This continues the engine architecture refactor after the already-merged response-helper PR.

- Migrates the remaining route modules to shared response/body/query helpers
- Centralizes coded error rendering, idempotent replay response shaping, and WebSocket upgrade authentication
- Adds zod-backed HTTP query helpers for route numeric query parsing
- Keeps intentional protocol exceptions intact: `/health` raw JSON and A2A JSON-RPC request parsing

## Impact

The HTTP wire shape stays consistent with the existing success/error envelopes while reducing repeated route-local parsing and rendering code. WebSocket auth and idempotent replay behavior now have single implementation points, which should make future API and auth changes easier to audit.

## Validation

- `git diff --check`
- `npm --workspace @relaycast/engine run typecheck`
- `npm --workspace @relaycast/engine run lint`
- `npm --workspace @relaycast/engine run build`
- `npm --workspace @relaycast/engine test`
- Final scans:
  - raw response/body handling remains only in `/health` and A2A JSON-RPC protocol paths
  - numeric query preprocessing remains centralized in `packages/engine/src/lib/httpQuery.ts`

## Notes

This branch was recreated from current `origin/main` because the prior local branch name belonged to merged PR #207 and was based before newer release/SDK commits. Recreating the branch avoids unrelated reversions in the PR diff.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/AgentWorkforce/relaycast/pull/209?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

