### PR TITLE
refactor: cast-only engine; SDK owns the base-URL default

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -3002,6 +3002,33 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
 
+  /node/ws:
+    get:
+      summary: Fleet node control WebSocket
+      description: >
+        Upgrade to the fleet node-control realtime stream. A fleet node
+        connects here to receive spawn/node-action placement and to report
+        status. Gated by the per-workspace fleet node rollout flag; inert when
+        disabled.
+      tags:
+        - Nodes
+      parameters:
+        - name: token
+          in: query
+          required: true
+          schema:
+            type: string
+          description: Fleet node token
+      responses:
+        '101':
+          description: Switching Protocols (WebSocket)
+        '401':
+          description: Invalid token
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
   /triggers:
     post:
       summary: Create message trigger

--- a/packages/observer-dashboard/src/lib/relay-server.test.ts
+++ b/packages/observer-dashboard/src/lib/relay-server.test.ts
@@ -42,10 +42,15 @@ describe('relay server resolution', () => {
     ]);
   });
 
-  it('resolves the per-environment gateway/api candidates for preview observers', () => {
+  it('resolves the hosted engine for preview observers', () => {
     expect(resolveRelayServerCandidatesFromHost('pr23-observer.relaycast.dev')).toEqual([
-      'https://pr23-gateway.relaycast.dev',
-      'https://pr23-api.relaycast.dev',
+      'https://cast.agentrelay.com',
+    ]);
+  });
+
+  it('resolves the hosted engine for the staging observer', () => {
+    expect(resolveRelayServerCandidatesFromHost('staging-observer.relaycast.dev')).toEqual([
+      'https://cast.agentrelay.com',
     ]);
   });
 
@@ -59,12 +64,12 @@ describe('relay server resolution', () => {
 
   it('only accepts remembered engines from the current host candidates', () => {
     const candidates = [
-      'https://pr23-gateway.relaycast.dev',
-      'https://pr23-api.relaycast.dev',
+      'https://cast.agentrelay.com',
+      'https://relay.example.com',
     ];
 
-    expect(pickRememberedEngine('https://pr23-api.relaycast.dev', candidates)).toBe(
-      'https://pr23-api.relaycast.dev'
+    expect(pickRememberedEngine('https://relay.example.com', candidates)).toBe(
+      'https://relay.example.com'
     );
     expect(
       pickRememberedEngine('https://attacker.example.com', candidates)
@@ -74,10 +79,10 @@ describe('relay server resolution', () => {
   it('orders remembered engine first without duplicating candidates', () => {
     expect(
       orderByRemembered(
-        ['https://pr23-gateway.relaycast.dev', 'https://pr23-api.relaycast.dev'],
-        'https://pr23-api.relaycast.dev'
+        ['https://cast.agentrelay.com', 'https://relay.example.com'],
+        'https://relay.example.com'
       )
-    ).toEqual(['https://pr23-api.relaycast.dev', 'https://pr23-gateway.relaycast.dev']);
+    ).toEqual(['https://relay.example.com', 'https://cast.agentrelay.com']);
   });
 });
 
@@ -86,7 +91,7 @@ describe('selectEngineForKey', () => {
     vi.unstubAllGlobals();
   });
 
-  it('falls back to the -api engine when the gateway rejects the key', async () => {
+  it('falls back to the next engine when the first rejects the key', async () => {
     const fetchMock = mockFetch(
       new Response(null, { status: 401 }),
       new Response(null, { status: 200 })
@@ -94,11 +99,11 @@ describe('selectEngineForKey', () => {
 
     await expect(
       selectEngineForKey(
-        ['https://pr23-gateway.relaycast.dev', 'https://pr23-api.relaycast.dev'],
+        ['https://cast.agentrelay.com', 'https://relay.example.com'],
         'rk_live_test'
       )
     ).resolves.toEqual({
-      baseUrl: 'https://pr23-api.relaycast.dev',
+      baseUrl: 'https://relay.example.com',
       reachedAny: true,
       rejectedAny: true,
       inconclusiveAny: false,
@@ -106,12 +111,12 @@ describe('selectEngineForKey', () => {
 
     expect(fetchMock).toHaveBeenNthCalledWith(
       1,
-      'https://pr23-gateway.relaycast.dev/v1/workspace',
+      'https://cast.agentrelay.com/v1/workspace',
       expect.objectContaining({ cache: 'no-store' })
     );
     expect(fetchMock).toHaveBeenNthCalledWith(
       2,
-      'https://pr23-api.relaycast.dev/v1/workspace',
+      'https://relay.example.com/v1/workspace',
       expect.objectContaining({ cache: 'no-store' })
     );
   });
@@ -124,7 +129,7 @@ describe('selectEngineForKey', () => {
 
     await expect(
       selectEngineForKey(
-        ['https://pr23-gateway.relaycast.dev', 'https://pr23-api.relaycast.dev'],
+        ['https://cast.agentrelay.com', 'https://relay.example.com'],
         'rk_live_test'
       )
     ).resolves.toEqual({
@@ -143,7 +148,7 @@ describe('selectEngineForKey', () => {
 
     await expect(
       selectEngineForKey(
-        ['https://pr23-gateway.relaycast.dev', 'https://pr23-api.relaycast.dev'],
+        ['https://cast.agentrelay.com', 'https://relay.example.com'],
         'rk_live_test'
       )
     ).resolves.toEqual({
@@ -159,7 +164,7 @@ describe('selectEngineForKey', () => {
 
     await expect(
       selectEngineForKey(
-        ['https://pr23-gateway.relaycast.dev', 'https://pr23-api.relaycast.dev'],
+        ['https://cast.agentrelay.com', 'https://relay.example.com'],
         'rk_live_test'
       )
     ).resolves.toEqual({

--- a/packages/observer-dashboard/src/lib/relay-server.ts
+++ b/packages/observer-dashboard/src/lib/relay-server.ts
@@ -20,19 +20,14 @@ function isLocalHost(host: string): boolean {
 /**
  * Resolve the ordered list of Relay engine base URLs to try for an observer host.
  *
- * Production resolves to the hosted engine (`cast.agentrelay.com`); the legacy
- * `gateway.relaycast.dev` / `api.relaycast.dev` engines have been decommissioned
- * and are no longer probed. Callers probe the candidates in order and keep the
- * first one that accepts the workspace key.
+ * Every hosted observer host resolves to the single hosted engine
+ * (`cast.agentrelay.com`). A self-hosted or local engine is pinned with the
+ * `RELAY_SERVER_URL` override. Callers probe the candidates in order and keep
+ * the first one that accepts the workspace key.
  *
  * Examples:
  * - observer.relaycast.dev -> [cast.agentrelay.com]
- * - pr23-observer.relaycast.dev -> [pr23-gateway.relaycast.dev, pr23-api.relaycast.dev]
- *
- * Per-environment gateway hostnames (`staging-gateway`, `prNN-gateway`) are
- * assumed to mirror the `-api` naming. If a gateway host does not exist for an
- * environment, the probe simply fails over to its `-api` counterpart, so the
- * assumption carries no risk.
+ * - RELAY_SERVER_URL=http://localhost:8787 -> [http://localhost:8787]
  */
 export function resolveRelayServerCandidatesFromHost(
   host: string | null | undefined
@@ -47,23 +42,6 @@ export function resolveRelayServerCandidatesFromHost(
 
   if (!normalized || isLocalHost(normalized)) {
     return ['http://localhost:3890'];
-  }
-
-  // Accept both custom domains and workers/pages preview hostnames that begin with prNN-observer.
-  const prMatch = normalized.match(/^pr(\d+)-observer(?:[.-]|$)/);
-  if (prMatch) {
-    const n = prMatch[1];
-    return [
-      `https://pr${n}-gateway.relaycast.dev`,
-      `https://pr${n}-api.relaycast.dev`,
-    ];
-  }
-
-  if (normalized === 'staging-observer.relaycast.dev') {
-    return [
-      'https://staging-gateway.relaycast.dev',
-      'https://staging-api.relaycast.dev',
-    ];
   }
 
   return ['https://cast.agentrelay.com'];

--- a/packages/observer-router/src/worker.ts
+++ b/packages/observer-router/src/worker.ts
@@ -21,8 +21,8 @@ export default {
     upstream.pathname = incoming.pathname;
     upstream.search = incoming.search;
 
-    // Preserve original observer host so dashboard API routes can map:
-    // prNN-observer.relaycast.dev -> prNN-api.relaycast.dev
+    // Preserve the original observer host so dashboard API routes can resolve
+    // the hosted engine (cast.agentrelay.com) for the request.
     // Use both a custom header and x-forwarded-host for compatibility.
     const headers = new Headers(request.headers);
     headers.set('x-relaycast-observer-host', incoming.host);

--- a/packages/sdk-rust/CHANGELOG.md
+++ b/packages/sdk-rust/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
 ## [Unreleased]
 
 ### Added
+- Added `node_control_ws_url(base_url: Option<&str>)`, which builds the fleet node-control WebSocket URL (`{ws_base}/v1/node/ws`), applying the hosted default and `https`→`wss` rewrite when no base is given. Lets callers reach the node-control endpoint without knowing the hosted host or scheme.
 - Added optional `harness` identifier on `RelayCastOptions`/`ClientOptions` and `WsClientOptions` via `with_harness(...)`, plus `sanitize_harness(...)` and the `HARNESS_HEADER` constant. A User-Agent-style identifier for the harness driving requests (e.g. `"claude-code/2.3 (model=opus-4.8)"`, `"codex"`, `"human"`); sent as the `X-Relaycast-Harness` HTTP header and forwarded as the `harness` WS query param so server-side telemetry can attribute traffic. Invalid values (empty, control characters) are dropped; the header/param is omitted entirely when unset, and the value survives `HttpClient::with_api_key(...)`. Brings the Rust SDK to parity with `@relaycast/sdk`.
 - Added raw WebSocket event subscriptions with `WsClient::subscribe_raw_events()` and `RawEventReceiver`.
 - Added SDK-owned raw event normalization helpers:

--- a/packages/sdk-rust/Cargo.toml
+++ b/packages/sdk-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "relaycast"
-version = "4.1.1"
+version = "4.1.2"
 edition = "2021"
 authors = ["Agent Workforce <team@agentrelay.dev>"]
 description = "Rust SDK for RelayCast - multi-agent coordination platform"

--- a/packages/sdk-rust/src/client.rs
+++ b/packages/sdk-rust/src/client.rs
@@ -11,8 +11,9 @@ use crate::origin_actor::{
 };
 use crate::types::ApiResponse;
 
+use crate::DEFAULT_BASE_URL;
+
 const SDK_VERSION: &str = env!("CARGO_PKG_VERSION");
-const DEFAULT_BASE_URL: &str = "https://cast.agentrelay.com";
 const DEFAULT_ORIGIN_CLIENT: &str = "@relaycast/sdk-rust";
 const RETRY_BACKOFFS_MS: [u64; 3] = [200, 400, 800];
 

--- a/packages/sdk-rust/src/lib.rs
+++ b/packages/sdk-rust/src/lib.rs
@@ -337,3 +337,62 @@ pub use types::{
 
 /// SDK version.
 pub const SDK_VERSION: &str = env!("CARGO_PKG_VERSION");
+
+/// Default base URL for the hosted RelayCast engine. Applied whenever a client
+/// is created without an explicit `base_url`. Crate-internal: callers express
+/// "use the hosted default" by passing `None` rather than naming this value.
+pub(crate) const DEFAULT_BASE_URL: &str = "https://cast.agentrelay.com";
+
+/// Rewrite an HTTP(S) base URL to its WebSocket form, mirroring the rewrite the
+/// SDK applies internally when opening a socket.
+fn ws_base_from_http(base: &str) -> String {
+    let trimmed = base.trim().trim_end_matches('/');
+    if let Some(rest) = trimmed.strip_prefix("https://") {
+        format!("wss://{rest}")
+    } else if let Some(rest) = trimmed.strip_prefix("http://") {
+        format!("ws://{rest}")
+    } else {
+        trimmed.to_string()
+    }
+}
+
+/// Build the fleet node-control WebSocket URL (`{ws_base}/v1/node/ws`) for the
+/// given engine base URL, applying the hosted default when `base_url` is `None`
+/// or blank. Lets callers (e.g. the broker's node-control client) reach the
+/// node-control endpoint without knowing the hosted host or the URL scheme.
+pub fn node_control_ws_url(base_url: Option<&str>) -> String {
+    let base = base_url
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .unwrap_or(DEFAULT_BASE_URL);
+    format!("{}/v1/node/ws", ws_base_from_http(base))
+}
+
+#[cfg(test)]
+mod base_url_tests {
+    use super::*;
+
+    #[test]
+    fn node_control_ws_url_defaults_to_hosted_engine() {
+        assert_eq!(
+            node_control_ws_url(None),
+            "wss://cast.agentrelay.com/v1/node/ws"
+        );
+        assert_eq!(
+            node_control_ws_url(Some("   ")),
+            "wss://cast.agentrelay.com/v1/node/ws"
+        );
+    }
+
+    #[test]
+    fn node_control_ws_url_uses_override_and_rewrites_scheme() {
+        assert_eq!(
+            node_control_ws_url(Some("https://self.hosted.example/")),
+            "wss://self.hosted.example/v1/node/ws"
+        );
+        assert_eq!(
+            node_control_ws_url(Some("http://localhost:8787")),
+            "ws://localhost:8787/v1/node/ws"
+        );
+    }
+}

--- a/packages/sdk-rust/src/relay.rs
+++ b/packages/sdk-rust/src/relay.rs
@@ -5,8 +5,9 @@ use crate::client::{ClientOptions, HttpClient};
 use crate::error::{RelayError, Result};
 use crate::types::*;
 
+use crate::DEFAULT_BASE_URL;
+
 const SDK_VERSION: &str = env!("CARGO_PKG_VERSION");
-const DEFAULT_BASE_URL: &str = "https://cast.agentrelay.com";
 const DEFAULT_ORIGIN_CLIENT: &str = "@relaycast/sdk-rust";
 
 fn strip_hash(channel: &str) -> &str {

--- a/packages/sdk-rust/src/ws.rs
+++ b/packages/sdk-rust/src/ws.rs
@@ -14,7 +14,7 @@ use crate::origin_actor::{
     sanitize_agent_relay_distinct_id, sanitize_origin_actor, AGENT_RELAY_DISTINCT_ID_QUERY,
 };
 use crate::types::WsEvent;
-use crate::DEFAULT_BASE_URL;
+use crate::{ws_base_from_http, DEFAULT_BASE_URL};
 
 const SDK_VERSION: &str = env!("CARGO_PKG_VERSION");
 const DEFAULT_ORIGIN_CLIENT: &str = "@relaycast/sdk-rust";
@@ -154,11 +154,10 @@ enum WsCommand {
 impl WsClient {
     /// Create a new WebSocket client with the given options.
     pub fn new(options: WsClientOptions) -> Self {
-        let base_url = options
-            .base_url
-            .unwrap_or_else(|| DEFAULT_BASE_URL.to_string())
-            .replace("https://", "wss://")
-            .replace("http://", "ws://");
+        // Single source of truth for HTTP(S)->WS(S) normalization (trims
+        // whitespace + trailing slashes); see `ws_base_from_http` in lib.rs.
+        let base_url =
+            ws_base_from_http(options.base_url.as_deref().unwrap_or(DEFAULT_BASE_URL));
 
         let (event_tx, _) = broadcast::channel(1024);
         let (raw_event_tx, _) = broadcast::channel(1024);
@@ -166,7 +165,7 @@ impl WsClient {
 
         Self {
             token: Arc::new(Mutex::new(options.token)),
-            base_url: base_url.trim_end_matches('/').to_string(),
+            base_url,
             debug: options.debug,
             origin_client: options
                 .origin_client

--- a/packages/sdk-rust/src/ws.rs
+++ b/packages/sdk-rust/src/ws.rs
@@ -14,8 +14,8 @@ use crate::origin_actor::{
     sanitize_agent_relay_distinct_id, sanitize_origin_actor, AGENT_RELAY_DISTINCT_ID_QUERY,
 };
 use crate::types::WsEvent;
+use crate::DEFAULT_BASE_URL;
 
-const DEFAULT_BASE_URL: &str = "https://cast.agentrelay.com";
 const SDK_VERSION: &str = env!("CARGO_PKG_VERSION");
 const DEFAULT_ORIGIN_CLIENT: &str = "@relaycast/sdk-rust";
 const PING_INTERVAL_SECS: u64 = 30;

--- a/packages/sdk-typescript/src/__tests__/agent-ws.test.ts
+++ b/packages/sdk-typescript/src/__tests__/agent-ws.test.ts
@@ -97,13 +97,13 @@ describe('AgentClient WebSocket integration', () => {
   it('connect() normalizes trailing slash base URL', () => {
     const client = new HttpClient({
       apiKey: 'at_live_test',
-      baseUrl: 'https://pr28-gateway.relaycast.dev/',
+      baseUrl: 'https://relay.example.com/',
     });
     const agent = new AgentClient(client);
     agent.connect();
 
     const url = new URL(MockWebSocket.instances[0]!.url);
-    expect(url.origin).toBe('wss://pr28-gateway.relaycast.dev');
+    expect(url.origin).toBe('wss://relay.example.com');
     expect(url.pathname).toBe('/v1/ws');
     expect(url.searchParams.get('token')).toBe('at_live_test');
     expect(url.searchParams.get('origin_client')).toBe('@relaycast/sdk');

--- a/packages/sdk-typescript/src/__tests__/ws.test.ts
+++ b/packages/sdk-typescript/src/__tests__/ws.test.ts
@@ -80,12 +80,12 @@ describe('WsClient', () => {
   it('normalizes trailing slash in baseUrl', () => {
     const client = new WsClient({
       token: 'at_live_test',
-      baseUrl: 'https://pr28-gateway.relaycast.dev/',
+      baseUrl: 'https://relay.example.com/',
     });
     client.connect();
 
     const url = new URL(MockWebSocket.instances[0]!.url);
-    expect(url.origin).toBe('wss://pr28-gateway.relaycast.dev');
+    expect(url.origin).toBe('wss://relay.example.com');
     expect(url.pathname).toBe('/v1/ws');
     expect(url.searchParams.get('token')).toBe('at_live_test');
     expect(url.searchParams.get('origin_client')).toBe('@relaycast/sdk');

--- a/scripts/e2e.ts
+++ b/scripts/e2e.ts
@@ -43,15 +43,6 @@ function resolveDashboardUrl(baseUrl: string): string {
     return 'http://localhost:3100';
   }
 
-  const prMatch = host.match(/^pr(\d+)-api(?:[.-]|$)/);
-  if (prMatch) {
-    return `https://pr${prMatch[1]}-observer.relaycast.dev`;
-  }
-
-  if (host === 'staging-api.relaycast.dev') {
-    return 'https://staging-observer.relaycast.dev';
-  }
-
   return 'https://observer.relaycast.dev';
 }
 


### PR DESCRIPTION
## What

Make `cast.agentrelay.com` the **single hosted engine** and the **single source of the base-URL default**, and remove the strangled `gateway.relaycast.dev` / `api.relaycast.dev` engine domains from this repo.

This is the relaycast half of a two-repo change. After this is published (4.1.2) the relay repo bumps to it and drops its own base-URL literals (separate PR, pending this publish).

## Changes

**sdk-rust (`relaycast` crate) — 4.1.1 → 4.1.2**
- Consolidated the three per-module `DEFAULT_BASE_URL` copies into one **crate-private** const (callers express "use the hosted default" by passing `None`, not by naming the value).
- Added `pub fn node_control_ws_url(base_url: Option<&str>) -> String` — builds the fleet node-control WS URL (`{ws_base}/v1/node/ws`), applying the hosted default + `https`→`wss` rewrite when no base is given. Lets the broker reach node-control without knowing the host/scheme/default.

**observer-dashboard / e2e / observer-router**
- Every hosted observer host now resolves to `cast.agentrelay.com`; dropped the PR-preview/staging `gateway`/`api` engine candidates and their multi-candidate probe fixtures.

**sdk-typescript**
- Neutralized two incidental `gateway.relaycast.dev` test fixtures (trailing-slash normalization cases) to a neutral host.

## Verification
- `cargo test` (sdk-rust): green, incl. new `node_control_ws_url` tests.
- observer-dashboard `relay-server.test.ts`: 11 passed; touched sdk-typescript ws tests: 68 passed.
- Repo grep: zero `gateway.relaycast.dev` / `api.relaycast.dev` outside changelog history.

## Follow-up (after you publish 4.1.2)
relay bumps `relaycast = "=4.1.2"`, drops its temporary `[patch.crates-io]`, and relies on `node_control_ws_url` + `None` pass-through so it holds no base-URL literal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/AgentWorkforce/relaycast/pull/211?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

