### PR TITLE
[codex] Add Python SDK node event parity

### DIFF
--- a/packages/sdk-python/src/relay_sdk/models.py
+++ b/packages/sdk-python/src/relay_sdk/models.py
@@ -898,6 +898,14 @@ class MessageReadEvent(BaseModel):
     read_at: str
 
 
+class DeliveryAcceptedEvent(BaseModel):
+    type: Literal["delivery.accepted"]
+    delivery_id: str
+    message_id: str
+    channel_id: str | None = None
+    reason: str | None = None
+
+
 class DeliveryDeliveredEvent(BaseModel):
     type: Literal["delivery.delivered"]
     delivery_id: str
@@ -941,6 +949,7 @@ ServerEvent = (
     | ChannelCreatedEvent
     | ChannelArchivedEvent
     | MessageReadEvent
+    | DeliveryAcceptedEvent
     | DeliveryDeliveredEvent
     | DeliveryDeferredEvent
     | DeliveryFailedEvent
@@ -964,6 +973,7 @@ ServerEventType = Literal[
     "channel.created",
     "channel.archived",
     "message.read",
+    "delivery.accepted",
     "delivery.delivered",
     "delivery.deferred",
     "delivery.failed",

--- a/packages/sdk-python/src/relay_sdk/models.py
+++ b/packages/sdk-python/src/relay_sdk/models.py
@@ -898,6 +898,29 @@ class MessageReadEvent(BaseModel):
     read_at: str
 
 
+class DeliveryDeliveredEvent(BaseModel):
+    type: Literal["delivery.delivered"]
+    delivery_id: str
+    message_id: str
+
+
+class DeliveryDeferredEvent(BaseModel):
+    type: Literal["delivery.deferred"]
+    delivery_id: str
+    message_id: str
+    available_at: str | None
+    reason: str | None = None
+
+
+class DeliveryFailedEvent(BaseModel):
+    type: Literal["delivery.failed"]
+    delivery_id: str | None
+    message_id: str
+    error: str | None = None
+    reason: str | None = None
+    retryable: bool | None = None
+
+
 class FileUploadedEvent(BaseModel):
     type: Literal["file.uploaded"]
     file: FileEventPayload
@@ -918,6 +941,9 @@ ServerEvent = (
     | ChannelCreatedEvent
     | ChannelArchivedEvent
     | MessageReadEvent
+    | DeliveryDeliveredEvent
+    | DeliveryDeferredEvent
+    | DeliveryFailedEvent
     | FileUploadedEvent
     | PongEvent
 )
@@ -938,6 +964,9 @@ ServerEventType = Literal[
     "channel.created",
     "channel.archived",
     "message.read",
+    "delivery.delivered",
+    "delivery.deferred",
+    "delivery.failed",
     "file.uploaded",
     "pong",
 ]

--- a/packages/sdk-python/tests/test_models.py
+++ b/packages/sdk-python/tests/test_models.py
@@ -12,6 +12,7 @@ from relay_sdk.models import (
     ChannelCreatedEvent,
     CreateAgentRequest,
     CreateAgentResponse,
+    DeliveryAcceptedEvent,
     DeliveryDeferredEvent,
     DeliveryDeliveredEvent,
     DeliveryFailedEvent,
@@ -445,6 +446,19 @@ def test_ws_message_read_event_model():
 
 
 def test_ws_delivery_event_models():
+    accepted = DeliveryAcceptedEvent.model_validate(
+        {
+            "type": "delivery.accepted",
+            "delivery_id": "del_1",
+            "message_id": "m_1",
+            "channel_id": "ch_1",
+            "reason": "queued",
+        }
+    )
+    assert accepted.delivery_id == "del_1"
+    assert accepted.channel_id == "ch_1"
+    assert accepted.reason == "queued"
+
     delivered = DeliveryDeliveredEvent.model_validate(
         {"type": "delivery.delivered", "delivery_id": "del_1", "message_id": "m_1"}
     )

--- a/packages/sdk-python/tests/test_models.py
+++ b/packages/sdk-python/tests/test_models.py
@@ -12,6 +12,9 @@ from relay_sdk.models import (
     ChannelCreatedEvent,
     CreateAgentRequest,
     CreateAgentResponse,
+    DeliveryDeferredEvent,
+    DeliveryDeliveredEvent,
+    DeliveryFailedEvent,
     DmConversationSummary,
     DmReceivedEvent,
     FileAttachment,
@@ -439,6 +442,37 @@ def test_ws_message_read_event_model():
     )
     assert ev.type == "message.read"
     assert ev.read_at.endswith("Z")
+
+
+def test_ws_delivery_event_models():
+    delivered = DeliveryDeliveredEvent.model_validate(
+        {"type": "delivery.delivered", "delivery_id": "del_1", "message_id": "m_1"}
+    )
+    assert delivered.delivery_id == "del_1"
+
+    deferred = DeliveryDeferredEvent.model_validate(
+        {
+            "type": "delivery.deferred",
+            "delivery_id": "del_1",
+            "message_id": "m_1",
+            "available_at": "2026-02-08T00:00:00Z",
+            "reason": "busy",
+        }
+    )
+    assert deferred.reason == "busy"
+
+    failed = DeliveryFailedEvent.model_validate(
+        {
+            "type": "delivery.failed",
+            "delivery_id": None,
+            "message_id": "m_1",
+            "reason": "depth_cap",
+            "retryable": False,
+        }
+    )
+    assert failed.delivery_id is None
+    assert failed.reason == "depth_cap"
+    assert failed.retryable is False
 
 
 def test_ws_file_uploaded_event_model():

--- a/packages/sdk-python/tests/test_ws.py
+++ b/packages/sdk-python/tests/test_ws.py
@@ -260,6 +260,40 @@ class TestWsClientOriginParams:
 
 class TestWsClientNodeTransport:
     @pytest.mark.asyncio
+    async def test_node_context_update_emits_delivery_failed(self):
+        ws = WsClient(token="nt_xxx")
+        handler = MagicMock()
+        ws.on("delivery.failed", handler)
+
+        handled = await ws._handle_node_frame(
+            {
+                "v": 1,
+                "type": "context.update",
+                "topic": "agent",
+                "event": "delivery.failed",
+                "agent_ids": ["agent_1"],
+                "data": {
+                    "delivery_id": None,
+                    "message_id": "m_1",
+                    "reason": "depth_cap",
+                    "retryable": False,
+                },
+            },
+            False,
+        )
+
+        assert handled is True
+        handler.assert_called_once_with(
+            {
+                "type": "delivery.failed",
+                "delivery_id": None,
+                "message_id": "m_1",
+                "reason": "depth_cap",
+                "retryable": False,
+            }
+        )
+
+    @pytest.mark.asyncio
     @respx.mock
     async def test_agent_token_uses_direct_node_transport_and_acks_deliveries(self):
         respx.post(f"{BASE}/v1/agent/node-token").mock(


### PR DESCRIPTION
## Summary
- add Python SDK typed models for `delivery.accepted`, `delivery.delivered`, `delivery.deferred`, and `delivery.failed`
- allow `delivery.failed.delivery_id` to be `None` for rejection/status fanout events
- add a Python WebSocket regression test proving node `context.update` frames emit `delivery.failed` to local handlers

## Validation
- `.venv/bin/python -m pytest` from `packages/sdk-python` (`200 passed`)

## Notes
- `WsClient` already forwarded node `context.update` frames at runtime; this closes the Python SDK typing/test parity gap after the node fanout work.
