### PR TITLE
[codex] Export node control handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -442,9 +442,16 @@ securely hold that token.
 Queue/cron-backed deployments must call `sweepDueHttpPushDeliveries` from a scheduled
 handler to retry queued HTTP push deliveries whose `next_attempt_at` is due; the Node
 self-host adapter runs that sweep on its local maintenance timer.
-Adapters that terminate `/v1/node/ws` outside the engine request handler should call
-`handleNodeReconnect(db, nodeConnections, workspaceId, nodeId)` from `@relaycast/engine`
-after `node.register` succeeds so queued node deliveries replay on reconnect.
+Adapters that terminate `/v1/node/ws` outside the engine request handler should delegate
+node control frames to `handleNodeControlMessage` from `@relaycast/engine/node-control`:
+the handler only needs `{ db, registry, workspaceId, nodeId, socket, raw }`, where
+`socket` is any object with `send(data: string): void`. It is self-contained and does
+not read Hono context. Pass `completionDeps` (`db`, `realtime`, `webhookQueue`, and
+`nodeConnections`) if `action.result` should emit completion fan-out and webhook effects;
+without it, the invocation state is still completed in the database. The handler already
+drains queued node invocations and replays pending node deliveries after
+`node.register`, `agent.register`, and `inventory.sync`, so adapters using it should not
+also call `handleNodeReconnect` for those same frames.
 
 Actions are async fire-and-forget: invoking an action returns an ack with
 `invocation_id` and dispatches an `action.invoke` frame to the handler's node. Agent

--- a/packages/engine/package.json
+++ b/packages/engine/package.json
@@ -34,6 +34,10 @@
     "./node-reconnect": {
       "types": "./dist/node-reconnect.d.ts",
       "import": "./dist/node-reconnect.js"
+    },
+    "./node-control": {
+      "types": "./dist/node-control.d.ts",
+      "import": "./dist/node-control.js"
     }
   },
   "files": [

--- a/packages/engine/src/__tests__/conformance/node.test.ts
+++ b/packages/engine/src/__tests__/conformance/node.test.ts
@@ -10,8 +10,9 @@ import {
   deliverFramesOfType,
   type TestStack,
 } from './harness.js';
-import { actionInvocations, agents, deliveries, nodes } from '../../db/schema.js';
+import { actionInvocations, agentNodeBindings, agents, deliveries, nodes } from '../../db/schema.js';
 import { sweepTimedOutInvocations } from '../../engine/action.js';
+import { handleNodeControlMessage } from '../../node-control.js';
 
 function capability(name: string, kind?: string, metadata?: Record<string, unknown>) {
   return { name, ...(kind ? { kind } : {}), ...(metadata ? { metadata } : {}) };
@@ -501,6 +502,195 @@ describe('node adapter conformance', () => {
       }));
       return { sock, handle };
     }
+
+    it('drives node control directly without the websocket route wrapper', async () => {
+      const ws = await createWorkspace(stack.app, 'node-control-direct-dispatch');
+      const db = stack.runtime.handle.db;
+
+      const createBroker = await stack.app.request('/v1/nodes', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json', authorization: `Bearer ${ws.workspaceKey}` },
+        body: JSON.stringify({
+          node_id: 'node_control_broker',
+          name: 'control-broker',
+          role: 'broker',
+          capabilities: [],
+          max_agents: 4,
+          tags: ['control'],
+          version: 'control-v0',
+        }),
+      });
+      expect(createBroker.status).toBe(201);
+
+      const brokerSock = new FakeSocket();
+      const sendBroker = (frame: Record<string, unknown>) => handleNodeControlMessage({
+        db,
+        registry: stack.runtime.realtime,
+        completionDeps: stack.runtime.deps,
+        workspaceId: ws.workspaceId,
+        nodeId: 'node_control_broker',
+        socket: brokerSock,
+        raw: JSON.stringify(frame),
+      });
+
+      await sendBroker({
+        v: 1,
+        id: 'control-broker-register',
+        type: 'node.register',
+        name: 'control-broker',
+        node_id: 'node_control_broker',
+        capabilities: [capability('echo', 'tool')],
+        max_agents: 4,
+        tags: ['control'],
+        version: 'control-v1',
+        resume_cursor: null,
+      });
+      expect(brokerSock.ofType('reply').at(-1)).toMatchObject({
+        id: 'control-broker-register',
+        ok: true,
+      });
+
+      await sendBroker({
+        v: 1,
+        id: 'control-agent-register',
+        type: 'agent.register',
+        name: 'control-worker',
+        session_ref: 'pty://control/worker',
+        resumable: true,
+      });
+      const agentReply = brokerSock.ofType('reply').at(-1) as { data?: { agent_id?: string } };
+      const controlAgentId = agentReply.data?.agent_id ?? '';
+      expect(controlAgentId.length).toBeGreaterThan(0);
+
+      const [activeBinding] = await db
+        .select({
+          nodeId: agentNodeBindings.nodeId,
+          status: agentNodeBindings.status,
+          sessionRef: agentNodeBindings.sessionRef,
+        })
+        .from(agentNodeBindings)
+        .where(and(
+          eq(agentNodeBindings.workspaceId, ws.workspaceId),
+          eq(agentNodeBindings.agentId, controlAgentId),
+          eq(agentNodeBindings.status, 'active'),
+        ));
+      expect(activeBinding).toMatchObject({
+        nodeId: 'node_control_broker',
+        status: 'active',
+        sessionRef: 'pty://control/worker',
+      });
+
+      await sendBroker({
+        v: 1,
+        id: 'control-broker-heartbeat',
+        type: 'node.heartbeat',
+        load: 0.25,
+        active_agents: 1,
+        handlers_live: true,
+        node_id: 'node_control_broker',
+        name: 'control-broker-renamed',
+        capabilities: [capability('echo', 'tool'), capability('spawn:claude', 'spawn')],
+        max_agents: 6,
+        version: 'control-v2',
+      });
+      const [brokerNode] = await db
+        .select()
+        .from(nodes)
+        .where(and(eq(nodes.workspaceId, ws.workspaceId), eq(nodes.id, 'node_control_broker')));
+      expect(brokerNode).toMatchObject({
+        name: 'control-broker-renamed',
+        maxAgents: 6,
+        activeAgents: 1,
+        handlersLive: true,
+        version: 'control-v2',
+      });
+      expect(brokerNode.capabilities.map((cap) => cap.name).sort()).toEqual(['echo', 'spawn:claude']);
+
+      await sendBroker({
+        v: 1,
+        id: 'control-agent-deregister',
+        type: 'agent.deregister',
+        agent_id: controlAgentId,
+      });
+      const activeBindingsAfterDeregister = await db
+        .select({ id: agentNodeBindings.id })
+        .from(agentNodeBindings)
+        .where(and(
+          eq(agentNodeBindings.workspaceId, ws.workspaceId),
+          eq(agentNodeBindings.agentId, controlAgentId),
+          eq(agentNodeBindings.nodeId, 'node_control_broker'),
+          eq(agentNodeBindings.status, 'active'),
+        ));
+      expect(activeBindingsAfterDeregister).toHaveLength(0);
+
+      const createDirect = await stack.app.request('/v1/nodes', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json', authorization: `Bearer ${ws.workspaceKey}` },
+        body: JSON.stringify({
+          node_id: 'node_control_direct',
+          name: 'control-direct',
+          role: 'direct',
+          capabilities: ['echo'],
+          max_agents: 1,
+          tags: ['direct'],
+          version: 'direct-v0',
+        }),
+      });
+      expect(createDirect.status).toBe(201);
+
+      const directSock = new FakeSocket();
+      const sendDirect = (frame: Record<string, unknown>) => handleNodeControlMessage({
+        db,
+        registry: stack.runtime.realtime,
+        workspaceId: ws.workspaceId,
+        nodeId: 'node_control_direct',
+        socket: directSock,
+        raw: JSON.stringify(frame),
+      });
+
+      await sendDirect({
+        v: 1,
+        id: 'control-direct-register',
+        type: 'node.register',
+        name: 'control-direct-live',
+        node_id: 'node_control_direct',
+        capabilities: [capability('echo', 'tool'), capability('spawn:claude', 'spawn')],
+        max_agents: 99,
+        tags: ['attempted-broker'],
+        version: 'direct-v1',
+        resume_cursor: null,
+      });
+      expect(directSock.ofType('reply').at(-1)).toMatchObject({
+        id: 'control-direct-register',
+        ok: true,
+      });
+
+      await sendDirect({
+        v: 1,
+        id: 'control-direct-heartbeat',
+        type: 'node.heartbeat',
+        load: 0.5,
+        active_agents: 7,
+        handlers_live: true,
+        node_id: 'node_control_direct',
+        name: 'control-direct-live',
+        capabilities: [capability('echo', 'tool')],
+        max_agents: 99,
+        version: 'direct-v2',
+      });
+      const [directNode] = await db
+        .select()
+        .from(nodes)
+        .where(and(eq(nodes.workspaceId, ws.workspaceId), eq(nodes.id, 'node_control_direct')));
+      expect(directNode).toMatchObject({
+        role: 'direct',
+        maxAgents: 1,
+        activeAgents: 1,
+        handlersLive: false,
+        version: 'direct-v2',
+      });
+      expect(directNode.capabilities).toEqual([]);
+    });
 
     it('enforces node capacity for agents registered over node control', async () => {
       const ws = await createWorkspace(stack.app, 'fleet-agent-register-capacity');

--- a/packages/engine/src/engine/node.ts
+++ b/packages/engine/src/engine/node.ts
@@ -14,6 +14,7 @@ import { actionInvocations, actions, agents, agentNodeBindings, channelMembers, 
 import { randomHex, sha256Hex } from '../lib/crypto.js';
 import { codedError } from '../lib/httpError.js';
 import { runAtomic } from '../ports/database.js';
+import type { EngineDb } from '../ports/database.js';
 import type { NodeConnectionRegistry } from '../ports/realtime.js';
 import { generateId } from './snowflake.js';
 import { isNodeLive, nodeHasCapability } from './placement.js';
@@ -28,8 +29,19 @@ type AgentRow = typeof agents.$inferSelect;
 type NodeKind = 'ws' | 'http_push' | 'poll';
 type NodeRole = 'direct' | 'broker';
 
-interface NodeSocketLike {
+/** Minimal socket surface used by node-control dispatchers to send reply frames. */
+export interface NodeSocketLike {
   send(data: string): void;
+}
+
+export interface HandleNodeControlMessageArgs {
+  db: EngineDb;
+  registry: NodeConnectionRegistry;
+  completionDeps?: InvocationCompletionDeps;
+  workspaceId: string;
+  nodeId: string;
+  socket?: NodeSocketLike;
+  raw: string;
 }
 
 type CapabilityLike = string | FleetCapability;
@@ -345,23 +357,20 @@ export async function heartbeatNode(
     throw codedError('node_id does not match the authenticated node token', 'node_id_mismatch', 403);
   }
 
+  const [nodeState] = await db
+    .select({ role: nodes.role })
+    .from(nodes)
+    .where(and(eq(nodes.workspaceId, workspaceId), eq(nodes.id, nodeId)));
+  const role: NodeRole = nodeState?.role === 'direct' ? 'direct' : 'broker';
   const rosterUpdate: Partial<typeof nodes.$inferInsert> = {};
   if (message.name !== undefined) rosterUpdate.name = message.name;
   if (message.capabilities !== undefined) {
-    const [node] = await db
-      .select({ role: nodes.role })
-      .from(nodes)
-      .where(and(eq(nodes.workspaceId, workspaceId), eq(nodes.id, nodeId)));
-    if (node?.role !== 'direct') {
+    if (role !== 'direct') {
       rosterUpdate.capabilities = normalizeCapabilities(message.capabilities);
     }
   }
   if (message.max_agents !== undefined) {
-    const [node] = await db
-      .select({ role: nodes.role })
-      .from(nodes)
-      .where(and(eq(nodes.workspaceId, workspaceId), eq(nodes.id, nodeId)));
-    rosterUpdate.maxAgents = node?.role === 'direct' ? 1 : message.max_agents;
+    rosterUpdate.maxAgents = role === 'direct' ? 1 : message.max_agents;
   }
   if (message.version !== undefined) rosterUpdate.version = message.version;
 
@@ -371,8 +380,8 @@ export async function heartbeatNode(
       ...rosterUpdate,
       status: 'online',
       load: message.load,
-      activeAgents: message.active_agents,
-      handlersLive: message.handlers_live,
+      activeAgents: role === 'direct' ? 1 : message.active_agents,
+      handlersLive: role !== 'direct' && message.handlers_live,
       lastHeartbeatAt: new Date(),
     })
     .where(and(eq(nodes.workspaceId, workspaceId), eq(nodes.id, nodeId)))
@@ -1202,15 +1211,7 @@ function sendControl(socket: NodeSocketLike | undefined, payload: Record<string,
   }
 }
 
-export async function handleNodeControlMessage(args: {
-  db: Db;
-  registry: NodeConnectionRegistry;
-  completionDeps?: InvocationCompletionDeps;
-  workspaceId: string;
-  nodeId: string;
-  socket?: NodeSocketLike;
-  raw: string;
-}) {
+export async function handleNodeControlMessage(args: HandleNodeControlMessageArgs) {
   let message: FleetBrokerToRelaycastMessage;
   try {
     message = parseFleetBrokerToRelaycastMessage(JSON.parse(args.raw));

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -55,6 +55,8 @@ export { runA2aHealthChecks } from './engine/a2a-health.js';
 export { sweepDueHttpPushDeliveries } from './routes/deliveryRouting.js';
 export { deliverPendingToNode } from './engine/delivery.js';
 export { handleNodeReconnect } from './node-reconnect.js';
+export { handleNodeControlMessage } from './engine/node.js';
+export type { HandleNodeControlMessageArgs, NodeSocketLike } from './engine/node.js';
 
 // `pending_events` outbox primitives for queue-backed deployments: the queue
 // consumer settles rows (`completeEvent` / `failEvent` / `rescheduleEvent`)

--- a/packages/engine/src/node-control.ts
+++ b/packages/engine/src/node-control.ts
@@ -1,0 +1,6 @@
+export {
+  handleNodeControlMessage,
+  type HandleNodeControlMessageArgs,
+  type NodeSocketLike,
+} from './engine/node.js';
+export type { InvocationCompletionDeps } from './engine/invocationCompletion.js';


### PR DESCRIPTION
## Summary

- export the canonical node-control dispatcher via `@relaycast/engine/node-control` and the root engine entrypoint
- export `NodeSocketLike`, `HandleNodeControlMessageArgs`, and `InvocationCompletionDeps` for DO adapters
- document the DO adapter contract, `completionDeps` behavior, self-containment, and built-in reconnect replay/drain behavior
- constrain direct-node heartbeats so roster refresh cannot advertise broker handler semantics
- add direct conformance coverage for `handleNodeControlMessage` without the websocket route wrapper

## Validation

- `npx vitest run packages/engine/src/__tests__/conformance/node.test.ts`
- `npm run -w @relaycast/engine typecheck`
- `npm run -w @relaycast/engine lint`
- `npm run -w @relaycast/engine build`
- `node --input-type=module -e "const m = await import('@relaycast/engine/node-control'); if (typeof m.handleNodeControlMessage !== 'function') throw new Error('missing node-control handler'); console.log('node-control export ok')"`
- `node --input-type=module -e "const m = await import('@relaycast/engine'); if (typeof m.handleNodeControlMessage !== 'function') throw new Error('missing root handler'); console.log('root export ok')"`
- `npm run -w @relaycast/engine test`
- `npx turbo build`


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/AgentWorkforce/relaycast/pull/218?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

