### PR TITLE
[codex] Export agent disconnect helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -451,7 +451,10 @@ not read Hono context. Pass `completionDeps` (`db`, `realtime`, `webhookQueue`, 
 without it, the invocation state is still completed in the database. The handler already
 drains queued node invocations and replays pending node deliveries after
 `node.register`, `agent.register`, and `inventory.sync`, so adapters using it should not
-also call `handleNodeReconnect` for those same frames.
+also call `handleNodeReconnect` for those same frames. If an adapter owns
+`POST /v1/agents/disconnect` outside the engine router, call `handleAgentDisconnect`
+from `@relaycast/engine/agent-disconnect` before presence cleanup so node-hosted
+agents follow the same deregistration path as an `agent.deregister` frame.
 
 Actions are async fire-and-forget: invoking an action returns an ack with
 `invocation_id` and dispatches an `action.invoke` frame to the handler's node. Agent

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -2679,7 +2679,7 @@ paths:
   /agents/disconnect:
     post:
       summary: Mark agent disconnected
-      description: Explicitly mark the authenticated agent offline
+      description: Explicitly mark the authenticated agent offline and release any node-hosted binding
       tags:
         - Presence
       security:

--- a/packages/engine/package.json
+++ b/packages/engine/package.json
@@ -35,6 +35,10 @@
       "types": "./dist/node-reconnect.d.ts",
       "import": "./dist/node-reconnect.js"
     },
+    "./agent-disconnect": {
+      "types": "./dist/agent-disconnect.d.ts",
+      "import": "./dist/agent-disconnect.js"
+    },
     "./node-control": {
       "types": "./dist/node-control.d.ts",
       "import": "./dist/node-control.js"

--- a/packages/engine/src/__tests__/conformance/node.test.ts
+++ b/packages/engine/src/__tests__/conformance/node.test.ts
@@ -969,6 +969,108 @@ describe('node adapter conformance', () => {
       });
     });
 
+    it('REST disconnect deregisters a node-hosted agent without a node socket', async () => {
+      const ws = await createWorkspace(stack.app, 'agent-disconnect-helper-ws');
+      const db = stack.runtime.handle.db;
+      const alpha = await enrollAndAttachNode(ws, {
+        id: 'node_disconnect_alpha',
+        name: 'disconnect-alpha',
+        capabilities: [],
+        maxAgents: 1,
+      });
+
+      await alpha.handle.handleMessage(JSON.stringify({
+        v: 1,
+        id: 'agent-register-disconnect',
+        type: 'agent.register',
+        name: 'disconnect-worker',
+        session_ref: 'pty://disconnect/worker',
+      }));
+      const reply = alpha.sock.ofType('reply').find((frame) => frame.id === 'agent-register-disconnect') as {
+        data?: { agent_id?: string; token?: string };
+      };
+      const agentId = reply.data?.agent_id ?? '';
+      expect(agentId.length).toBeGreaterThan(0);
+
+      const beforeNode = await db
+        .select({ activeAgents: nodes.activeAgents })
+        .from(nodes)
+        .where(and(eq(nodes.workspaceId, ws.workspaceId), eq(nodes.id, 'node_disconnect_alpha')))
+        .then((rows) => rows[0]);
+      expect(beforeNode?.activeAgents).toBe(1);
+
+      const disconnect = await stack.app.request('/v1/agents/disconnect', {
+        method: 'POST',
+        headers: { authorization: `Bearer ${reply.data?.token ?? ''}` },
+      });
+      expect(disconnect.status).toBe(200);
+
+      const worker = await db
+        .select({
+          status: agents.status,
+          locationType: agents.locationType,
+          locationNodeId: agents.locationNodeId,
+        })
+        .from(agents)
+        .where(and(eq(agents.workspaceId, ws.workspaceId), eq(agents.id, agentId)))
+        .then((rows) => rows[0]);
+      const directNodeId = `node_direct_${agentId}`;
+      expect(worker).toMatchObject({
+        status: 'offline',
+        locationType: 'via_node',
+        locationNodeId: directNodeId,
+      });
+
+      const activeBindings = await db
+        .select({ nodeId: agentNodeBindings.nodeId })
+        .from(agentNodeBindings)
+        .where(and(
+          eq(agentNodeBindings.workspaceId, ws.workspaceId),
+          eq(agentNodeBindings.agentId, agentId),
+          eq(agentNodeBindings.status, 'active'),
+        ));
+      expect(activeBindings).toEqual([{ nodeId: directNodeId }]);
+
+      const inactiveAlphaBindings = await db
+        .select({ id: agentNodeBindings.id })
+        .from(agentNodeBindings)
+        .where(and(
+          eq(agentNodeBindings.workspaceId, ws.workspaceId),
+          eq(agentNodeBindings.agentId, agentId),
+          eq(agentNodeBindings.nodeId, 'node_disconnect_alpha'),
+          eq(agentNodeBindings.status, 'inactive'),
+        ));
+      expect(inactiveAlphaBindings).toHaveLength(1);
+
+      const alphaNode = await db
+        .select({
+          id: nodes.id,
+          activeAgents: nodes.activeAgents,
+        })
+        .from(nodes)
+        .where(and(eq(nodes.workspaceId, ws.workspaceId), eq(nodes.id, 'node_disconnect_alpha')))
+        .then((rows) => rows[0]);
+      expect(alphaNode).toMatchObject({
+        id: 'node_disconnect_alpha',
+        activeAgents: 0,
+      });
+
+      const directNode = await db
+        .select({
+          id: nodes.id,
+          status: nodes.status,
+          activeAgents: nodes.activeAgents,
+        })
+        .from(nodes)
+        .where(and(eq(nodes.workspaceId, ws.workspaceId), eq(nodes.id, directNodeId)))
+        .then((rows) => rows[0]);
+      expect(directNode).toMatchObject({
+        id: directNodeId,
+        status: 'offline',
+        activeAgents: 1,
+      });
+    });
+
     it('drains an offline-queued invoke into dispatched state so the timeout sweep reschedules it', async () => {
       const ws = await createWorkspace(stack.app, 'fleet-drain-ws');
       const caller = await registerAgent(stack.app, ws.workspaceKey, 'caller');

--- a/packages/engine/src/agent-disconnect.ts
+++ b/packages/engine/src/agent-disconnect.ts
@@ -1,5 +1,5 @@
 import { and, eq } from 'drizzle-orm';
-import type { EngineDb, NodeConnectionRegistry } from './ports/index.js';
+import type { EngineDb } from './ports/index.js';
 import { agents } from './db/schema.js';
 import { deregisterAgentViaNode, directNodeIdForAgent } from './engine/node.js';
 
@@ -9,7 +9,6 @@ import { deregisterAgentViaNode, directNodeIdForAgent } from './engine/node.js';
  */
 export async function handleAgentDisconnect(
   db: EngineDb,
-  _registry: NodeConnectionRegistry,
   workspaceId: string,
   agentId: string,
 ): Promise<boolean> {

--- a/packages/engine/src/agent-disconnect.ts
+++ b/packages/engine/src/agent-disconnect.ts
@@ -1,0 +1,40 @@
+import { and, eq } from 'drizzle-orm';
+import type { EngineDb, NodeConnectionRegistry } from './ports/index.js';
+import { agents } from './db/schema.js';
+import { deregisterAgentViaNode, directNodeIdForAgent } from './engine/node.js';
+
+/**
+ * Disconnect an agent currently hosted by an explicit node when the caller has
+ * no node-control socket frame to pass through `handleNodeControlMessage`.
+ */
+export async function handleAgentDisconnect(
+  db: EngineDb,
+  _registry: NodeConnectionRegistry,
+  workspaceId: string,
+  agentId: string,
+): Promise<boolean> {
+  const [agent] = await db
+    .select({
+      locationType: agents.locationType,
+      locationNodeId: agents.locationNodeId,
+    })
+    .from(agents)
+    .where(and(eq(agents.workspaceId, workspaceId), eq(agents.id, agentId)));
+
+  if (
+    !agent
+    || agent.locationType !== 'via_node'
+    || !agent.locationNodeId
+    || agent.locationNodeId === directNodeIdForAgent(agentId)
+  ) {
+    return false;
+  }
+
+  const disconnected = await deregisterAgentViaNode(
+    db,
+    workspaceId,
+    agent.locationNodeId,
+    { agent_id: agentId },
+  );
+  return disconnected !== null;
+}

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -55,6 +55,7 @@ export { runA2aHealthChecks } from './engine/a2a-health.js';
 export { sweepDueHttpPushDeliveries } from './routes/deliveryRouting.js';
 export { deliverPendingToNode } from './engine/delivery.js';
 export { handleNodeReconnect } from './node-reconnect.js';
+export { handleAgentDisconnect } from './agent-disconnect.js';
 export { handleNodeControlMessage } from './engine/node.js';
 export type { HandleNodeControlMessageArgs, NodeSocketLike } from './engine/node.js';
 

--- a/packages/engine/src/routes/presence.ts
+++ b/packages/engine/src/routes/presence.ts
@@ -3,6 +3,7 @@ import type { AppEnv } from '../env.js';
 import { requireWorkspaceRead, requireAgentToken } from '../middleware/auth.js';
 import { rateLimit } from '../middleware/rateLimit.js';
 import * as presenceEngine from '../engine/presence.js';
+import { handleAgentDisconnect } from '../agent-disconnect.js';
 import {
   getObserverTokenFromContext,
   observerAllowsAgent,
@@ -45,10 +46,12 @@ presenceRoutes.post('/agents/heartbeat', requireAgentToken, rateLimit, async (c)
 // POST /agents/disconnect — explicitly mark agent offline.
 presenceRoutes.post('/agents/disconnect', requireAgentToken, rateLimit, async (c) => {
   try {
+    const db = c.get('db');
     const agent = c.get('agent')!;
     const workspace = c.get('workspace');
-    const { presence } = c.get('engine');
+    const { nodeConnections, presence } = c.get('engine');
 
+    await handleAgentDisconnect(db, nodeConnections, workspace.id, agent.id);
     await presence.disconnect(workspace.id, agent.id, agent.name);
 
     emitServerEvent(c, workspace.id, 'relaycast_server_presence_disconnected', {

--- a/packages/engine/src/routes/presence.ts
+++ b/packages/engine/src/routes/presence.ts
@@ -49,9 +49,9 @@ presenceRoutes.post('/agents/disconnect', requireAgentToken, rateLimit, async (c
     const db = c.get('db');
     const agent = c.get('agent')!;
     const workspace = c.get('workspace');
-    const { nodeConnections, presence } = c.get('engine');
+    const { presence } = c.get('engine');
 
-    await handleAgentDisconnect(db, nodeConnections, workspace.id, agent.id);
+    await handleAgentDisconnect(db, workspace.id, agent.id);
     await presence.disconnect(workspace.id, agent.id, agent.name);
 
     emitServerEvent(c, workspace.id, 'relaycast_server_presence_disconnected', {


### PR DESCRIPTION
## What changed

- Added `handleAgentDisconnect(db, registry, workspaceId, agentId)` as a public engine helper and `@relaycast/engine/agent-disconnect` subpath export.
- Wired `POST /v1/agents/disconnect` through the helper before presence cleanup.
- Documented the helper and updated the OpenAPI disconnect description.
- Added conformance coverage for REST disconnecting a node-hosted agent without a node-control socket.

## Why

DO-based adapters can receive REST disconnects without a node socket, so they cannot synthesize an `agent.deregister` control frame through `handleNodeControlMessage`. The new helper resolves the agent's current explicit node and reuses `deregisterAgentViaNode`, preserving offline status, binding deactivation, node slot release, and direct-node rehoming.

## Validation

- `../../node_modules/.bin/vitest run src/__tests__/conformance/node.test.ts`
- `../../node_modules/.bin/tsc --noEmit`
- `../../node_modules/.bin/eslint src/`
- `../../node_modules/.bin/tsc`

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/AgentWorkforce/relaycast/pull/219?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

