### PR TITLE
[codex] Export node invocation helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -455,6 +455,9 @@ also call `handleNodeReconnect` for those same frames. If an adapter owns
 `POST /v1/agents/disconnect` outside the engine router, call `handleAgentDisconnect`
 from `@relaycast/engine/agent-disconnect` before presence cleanup so node-hosted
 agents follow the same deregistration path as an `agent.deregister` frame.
+Queue/cron-backed adapters that own node dispatch outside the Node adapter should call
+`drainNodeInvocations` after node reconnect/register/heartbeat and
+`sweepTimedOutInvocations` from cron via `@relaycast/engine/node-invocations`.
 
 Actions are async fire-and-forget: invoking an action returns an ack with
 `invocation_id` and dispatches an `action.invoke` frame to the handler's node. Agent

--- a/packages/engine/package.json
+++ b/packages/engine/package.json
@@ -39,6 +39,10 @@
       "types": "./dist/agent-disconnect.d.ts",
       "import": "./dist/agent-disconnect.js"
     },
+    "./node-invocations": {
+      "types": "./dist/node-invocations.d.ts",
+      "import": "./dist/node-invocations.js"
+    },
     "./node-control": {
       "types": "./dist/node-control.d.ts",
       "import": "./dist/node-control.js"

--- a/packages/engine/src/__tests__/conformance/node.test.ts
+++ b/packages/engine/src/__tests__/conformance/node.test.ts
@@ -13,6 +13,7 @@ import {
 } from './harness.js';
 import { actionInvocations, actions, agentNodeBindings, agents, deliveries, nodes } from '../../db/schema.js';
 import { handleNodeControlMessage } from '../../node-control.js';
+import type { NodeConnectionRegistry } from '../../ports/realtime.js';
 
 function capability(name: string, kind?: string, metadata?: Record<string, unknown>) {
   return { name, ...(kind ? { kind } : {}), ...(metadata ? { metadata } : {}) };
@@ -1217,7 +1218,134 @@ describe('node adapter conformance', () => {
       expect(updated.attemptedNodeIds).toEqual(['node_alpha']);
     });
 
-    it('drains a queued spawn only once the node is back online, arming a retry backstop meanwhile', async () => {
+    it('exported drain helper preserves spawn-prefixed actions and skips retry-delayed invocations', async () => {
+      const ws = await createWorkspace(stack.app, 'fleet-spawn-prefix-drain-helper-ws');
+      const caller = await registerAgent(stack.app, ws.workspaceKey, 'caller');
+      const alpha = await enrollAndAttachNode(ws, {
+        id: 'node_alpha',
+        name: 'alpha',
+        capabilities: [capability('spawn:python', 'spawn', { agent: 'python' })],
+        load: 0,
+      });
+
+      const db = stack.runtime.handle.db;
+      const retryLater = new Date(Date.now() + 60_000);
+      await db.insert(actionInvocations).values([
+        {
+          id: 'inv_spawn_prefixed_drain',
+          workspaceId: ws.workspaceId,
+          actionName: 'spawn:python',
+          callerId: caller.agentId,
+          callerName: caller.name,
+          input: { cli: 'python', name: 'worker-prefix', task: 'hi' },
+          status: 'pending',
+          dispatchedNodeId: 'node_alpha',
+          attemptedNodeIds: ['node_alpha'],
+          dispatchAttempts: 1,
+        },
+        {
+          id: 'inv_spawn_future_retry',
+          workspaceId: ws.workspaceId,
+          actionName: 'spawn:python',
+          callerId: caller.agentId,
+          callerName: caller.name,
+          input: { cli: 'python', name: 'worker-later', task: 'wait' },
+          status: 'pending',
+          dispatchedNodeId: 'node_alpha',
+          attemptedNodeIds: ['node_alpha'],
+          dispatchAttempts: 1,
+          retryAfterAt: retryLater,
+        },
+      ]);
+
+      alpha.sock.received.length = 0;
+      const drained = await drainNodeInvocations(db, stack.runtime.realtime, ws.workspaceId, 'node_alpha');
+      expect(drained).toBe(1);
+      expect(alpha.sock.ofType('action.invoke')).toEqual([
+        expect.objectContaining({
+          invocation_id: 'inv_spawn_prefixed_drain',
+          action: 'spawn:python',
+          input: expect.objectContaining({ cli: 'python' }),
+        }),
+      ]);
+
+      const prefixed = await db
+        .select()
+        .from(actionInvocations)
+        .where(eq(actionInvocations.id, 'inv_spawn_prefixed_drain'))
+        .then((rows) => rows[0]);
+      expect(prefixed.status).toBe('dispatched');
+      expect(prefixed.dispatchAttempts).toBe(1);
+      expect(prefixed.attemptedNodeIds).toEqual(['node_alpha']);
+
+      const delayed = await db
+        .select()
+        .from(actionInvocations)
+        .where(eq(actionInvocations.id, 'inv_spawn_future_retry'))
+        .then((rows) => rows[0]);
+      expect(delayed.status).toBe('pending');
+      expect(delayed.dispatchedAt).toBeNull();
+      expect(delayed.spawnReservedAt).toBeNull();
+      expect(delayed.retryAfterAt).toBeInstanceOf(Date);
+      expect(delayed.retryAfterAt!.getTime()).toBeGreaterThan(Date.now());
+    });
+
+    it('exported drain helper releases spawn capacity when redispatch is rejected', async () => {
+      const ws = await createWorkspace(stack.app, 'fleet-spawn-drain-reject-ws');
+      const caller = await registerAgent(stack.app, ws.workspaceKey, 'caller');
+      await enrollAndAttachNode(ws, {
+        id: 'node_alpha',
+        name: 'alpha',
+        capabilities: [capability('spawn:python', 'spawn', { agent: 'python' })],
+        load: 0,
+        maxAgents: 1,
+      });
+
+      const db = stack.runtime.handle.db;
+      await db.insert(actionInvocations).values({
+        id: 'inv_spawn_rejected_drain',
+        workspaceId: ws.workspaceId,
+        actionName: 'spawn:python',
+        callerId: caller.agentId,
+        callerName: caller.name,
+        input: { cli: 'python', name: 'worker-rejected', task: 'hi' },
+        status: 'pending',
+        dispatchedNodeId: 'node_alpha',
+        attemptedNodeIds: ['node_alpha'],
+        dispatchAttempts: 1,
+      });
+
+      const rejectingRegistry: NodeConnectionRegistry = {
+        upgradeNode: async () => new Response(null, { status: 501 }),
+        sendToNode: async () => false,
+        isNodeConnected: () => true,
+        disconnectNode: async () => {},
+        drainNode: async () => {},
+      };
+
+      const drained = await drainNodeInvocations(db, rejectingRegistry, ws.workspaceId, 'node_alpha');
+      expect(drained).toBe(0);
+
+      const node = await db
+        .select({ reservedAgents: nodes.reservedAgents })
+        .from(nodes)
+        .where(and(eq(nodes.workspaceId, ws.workspaceId), eq(nodes.id, 'node_alpha')))
+        .then((rows) => rows[0]);
+      expect(node.reservedAgents ?? 0).toBe(0);
+
+      const invocation = await db
+        .select()
+        .from(actionInvocations)
+        .where(eq(actionInvocations.id, 'inv_spawn_rejected_drain'))
+        .then((rows) => rows[0]);
+      expect(invocation.status).toBe('pending');
+      expect(invocation.spawnReservedAt).toBeNull();
+      expect(invocation.dispatchedAt).toBeNull();
+      expect(invocation.dispatchAttempts).toBe(1);
+      expect(invocation.attemptedNodeIds).toEqual(['node_alpha']);
+    });
+
+    it('drains a queued spawn once the node registers without delaying the register-time drain', async () => {
       const ws = await createWorkspace(stack.app, 'fleet-spawn-drain-ws');
       const caller = await registerAgent(stack.app, ws.workspaceKey, 'caller');
 
@@ -1250,19 +1378,19 @@ describe('node adapter conformance', () => {
 
       // Reconnect the socket but DO NOT register yet: the node is still offline,
       // so the drain can't reserve spawn capacity. It must keep the frame queued
-      // and arm a retry_after_at backstop rather than delivering or dropping it.
+      // without arming retry_after_at so node.register can drain immediately.
       const alphaSock = new FakeSocket();
       const alphaHandle = stack.runtime.realtime.attachNodeSocket(ws.workspaceId, 'node_alpha', alphaSock);
       await new Promise((r) => setTimeout(r, 25));
       expect(alphaSock.ofType('action.invoke')).toHaveLength(0);
-      const armed = await db
+      const stillQueued = await db
         .select()
         .from(actionInvocations)
         .where(eq(actionInvocations.id, invocationId))
         .then((rows) => rows[0]);
-      expect(armed.status).toBe('pending');
-      expect(armed.spawnReservedAt).toBeNull();
-      expect(armed.retryAfterAt).toBeInstanceOf(Date); // sweeper backstop armed
+      expect(stillQueued.status).toBe('pending');
+      expect(stillQueued.spawnReservedAt).toBeNull();
+      expect(stillQueued.retryAfterAt).toBeNull();
 
       // Register → node is marked online and the post-register drain reserves
       // capacity and dispatches the queued spawn with the same invocation id.

--- a/packages/engine/src/__tests__/conformance/node.test.ts
+++ b/packages/engine/src/__tests__/conformance/node.test.ts
@@ -1109,6 +1109,8 @@ describe('node adapter conformance', () => {
       // Queued for the offline node: pending, no dispatch timestamp yet.
       expect(queued).toMatchObject({ status: 'pending', dispatchedNodeId: 'node_alpha' });
       expect(queued.dispatchedAt).toBeNull();
+      expect(queued.dispatchAttempts).toBe(1);
+      expect(queued.attemptedNodeIds).toEqual(['node_alpha']);
 
       // alpha reconnects → the queued frame drains and the invocation moves to
       // dispatched via the shared transition (dispatched_at + retry_after_at set).
@@ -1125,6 +1127,8 @@ describe('node adapter conformance', () => {
       expect(drained.status).toBe('dispatched');
       expect(drained.dispatchedAt).toBeInstanceOf(Date);
       expect(drained.retryAfterAt).toBeInstanceOf(Date);
+      expect(drained.dispatchAttempts).toBe(1);
+      expect(drained.attemptedNodeIds).toEqual(['node_alpha']);
 
       // With the invocation now in dispatched state, the dispatch-timeout sweep
       // (timeout 0 ⇒ already overdue) reschedules it onto the live fallback node.

--- a/packages/engine/src/__tests__/conformance/node.test.ts
+++ b/packages/engine/src/__tests__/conformance/node.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { and, eq } from 'drizzle-orm';
+import { drainNodeInvocations, sweepTimedOutInvocations } from '../../index.js';
 import {
   makeNodeStack,
   createWorkspace,
@@ -10,8 +11,7 @@ import {
   deliverFramesOfType,
   type TestStack,
 } from './harness.js';
-import { actionInvocations, agentNodeBindings, agents, deliveries, nodes } from '../../db/schema.js';
-import { sweepTimedOutInvocations } from '../../engine/action.js';
+import { actionInvocations, actions, agentNodeBindings, agents, deliveries, nodes } from '../../db/schema.js';
 import { handleNodeControlMessage } from '../../node-control.js';
 
 function capability(name: string, kind?: string, metadata?: Record<string, unknown>) {
@@ -1129,9 +1129,88 @@ describe('node adapter conformance', () => {
       // With the invocation now in dispatched state, the dispatch-timeout sweep
       // (timeout 0 ⇒ already overdue) reschedules it onto the live fallback node.
       beta.sock.received.length = 0;
-      const rescheduled = await sweepTimedOutInvocations(db, stack.runtime.realtime, 0);
+      const rescheduled = await sweepTimedOutInvocations(db, stack.runtime.realtime, { timeoutMs: 0 });
       expect(rescheduled).toBeGreaterThanOrEqual(1);
       expect(beta.sock.ofType('action.invoke').at(-1)).toMatchObject({ invocation_id: invocationId, action: 'echo' });
+    });
+
+    it('exported drain helper dispatches pending handler-agent invocations with v5 agent fields', async () => {
+      const ws = await createWorkspace(stack.app, 'fleet-agent-drain-helper-ws');
+      const caller = await registerAgent(stack.app, ws.workspaceKey, 'caller');
+      const alpha = await enrollAndAttachNode(ws, {
+        id: 'node_alpha',
+        name: 'alpha',
+        capabilities: [],
+        load: 0,
+      });
+
+      await alpha.handle.handleMessage(JSON.stringify({
+        v: 1,
+        id: 'agent-register-drain-helper',
+        type: 'agent.register',
+        name: 'handler',
+        session_ref: 'pty://alpha/handler',
+      }));
+      const agentReply = alpha.sock.ofType('reply').find((frame) => frame.id === 'agent-register-drain-helper') as {
+        data?: { agent_id?: string };
+      };
+      const handlerAgentId = agentReply.data?.agent_id ?? '';
+      expect(handlerAgentId.length).toBeGreaterThan(0);
+
+      const register = await stack.app.request('/v1/actions', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json', authorization: `Bearer ${ws.workspaceKey}` },
+        body: JSON.stringify({
+          name: 'agent-echo',
+          description: 'handler-agent drain test',
+          handler_agent: 'handler',
+        }),
+      });
+      expect(register.status).toBe(201);
+
+      const db = stack.runtime.handle.db;
+      const action = await db
+        .select({ id: actions.id })
+        .from(actions)
+        .where(and(eq(actions.workspaceId, ws.workspaceId), eq(actions.name, 'agent-echo')))
+        .then((rows) => rows[0]);
+      expect(action?.id).toBeTruthy();
+
+      const invocationId = 'inv_agent_drain_helper';
+      await db.insert(actionInvocations).values({
+        id: invocationId,
+        workspaceId: ws.workspaceId,
+        actionId: action!.id,
+        actionName: 'agent-echo',
+        callerId: caller.agentId,
+        callerName: caller.name,
+        input: { value: 'from-db' },
+        status: 'pending',
+      });
+
+      alpha.sock.received.length = 0;
+      const drained = await drainNodeInvocations(db, stack.runtime.realtime, ws.workspaceId, 'node_alpha');
+      expect(drained).toBe(1);
+      expect(alpha.sock.ofType('action.invoke').at(-1)).toMatchObject({
+        invocation_id: invocationId,
+        action: 'agent-echo',
+        agent_id: handlerAgentId,
+        agent_name: 'handler',
+        input: { value: 'from-db' },
+      });
+
+      const updated = await db
+        .select()
+        .from(actionInvocations)
+        .where(eq(actionInvocations.id, invocationId))
+        .then((rows) => rows[0]);
+      expect(updated).toMatchObject({
+        status: 'dispatched',
+        dispatchedNodeId: 'node_alpha',
+        dispatchAttempts: 1,
+      });
+      expect(updated.dispatchedAt).toBeInstanceOf(Date);
+      expect(updated.attemptedNodeIds).toEqual(['node_alpha']);
     });
 
     it('drains a queued spawn only once the node is back online, arming a retry backstop meanwhile', async () => {

--- a/packages/engine/src/adapters/node/realtime.ts
+++ b/packages/engine/src/adapters/node/realtime.ts
@@ -9,10 +9,9 @@ import type {
 import type { ObserverToken } from '../../ports/auth.js';
 import { and, eq, gt, isNull, or } from 'drizzle-orm';
 import type { EngineDb } from '../../ports/database.js';
-import { actionInvocations, observerTokens } from '../../db/schema.js';
+import { observerTokens } from '../../db/schema.js';
 import { handleNodeControlMessage, markNodeOffline } from '../../engine/node.js';
-import { reserveNodeCapacity } from '../../engine/placement.js';
-import { markDrainedInvocationDispatched } from '../../engine/action.js';
+import { drainNodeInvocations } from '../../engine/action.js';
 import { observerAllowsEvent } from '../../engine/observerToken.js';
 import type { InvocationCompletionDeps } from '../../engine/invocationCompletion.js';
 import type { FleetRelaycastToBrokerMessage } from '@relaycast/types';
@@ -57,9 +56,6 @@ interface QueuedNodeMessage {
   key: string;
   message: Extract<FleetRelaycastToBrokerMessage, { type: 'action.invoke' }>;
 }
-
-/** Backstop delay armed on a queued spawn whose capacity reservation deferred. */
-const NODE_DRAIN_REQUEUE_RETRY_MS = 5_000;
 
 /**
  * Single-process, in-memory implementation of the workspace observer stream and
@@ -287,62 +283,8 @@ export class InProcessRealtime implements RealtimeBus, ConnectionRegistry, NodeC
     const key = this.nodeKey(workspaceId, nodeId);
     const conn = this.nodeSockets.get(key)?.socket;
     if (!conn) return;
-    const queued = this.nodeQueues.get(key);
-    if (!queued || queued.length === 0) return;
-
-    const remaining: QueuedNodeMessage[] = [];
-    for (const item of queued) {
-      try {
-        const [row] = await this.db
-          .select({
-            dispatchedNodeId: actionInvocations.dispatchedNodeId,
-            status: actionInvocations.status,
-            spawnReservedAt: actionInvocations.spawnReservedAt,
-          })
-          .from(actionInvocations)
-          .where(and(eq(actionInvocations.workspaceId, workspaceId), eq(actionInvocations.id, item.message.invocation_id)));
-        if (!row) continue;
-        if (row.dispatchedNodeId !== nodeId || (row.status !== 'dispatched' && row.status !== 'pending')) continue;
-        const isSpawnAction = item.message.action === 'spawn' || item.message.action.startsWith('spawn:');
-        if (isSpawnAction && !row.spawnReservedAt) {
-          const reserved = await reserveNodeCapacity(this.db, workspaceId, nodeId);
-          if (!reserved) {
-            // Node not yet online (drain ran before register) or genuinely at
-            // capacity: keep the frame queued, but arm retry_after_at so the
-            // dispatch sweeper reschedules this pending spawn as a backstop if
-            // no later drain trigger (register/heartbeat) delivers it first.
-            await this.db
-              .update(actionInvocations)
-              .set({ retryAfterAt: new Date(Date.now() + NODE_DRAIN_REQUEUE_RETRY_MS) })
-              .where(and(
-                eq(actionInvocations.workspaceId, workspaceId),
-                eq(actionInvocations.id, item.message.invocation_id),
-                eq(actionInvocations.status, 'pending'),
-              ));
-            remaining.push(item);
-            continue;
-          }
-          await this.db
-            .update(actionInvocations)
-            .set({ spawnReservedAt: new Date() })
-            .where(and(eq(actionInvocations.workspaceId, workspaceId), eq(actionInvocations.id, item.message.invocation_id)));
-        }
-        conn.send(JSON.stringify(item.message));
-        // The frame is now actually on the wire: move the invocation out of the
-        // queued `pending` state into `dispatched` via the shared transition so
-        // the dispatch-timeout sweep/reschedule covers it like a live dispatch.
-        await markDrainedInvocationDispatched(this.db, workspaceId, item.message.invocation_id, nodeId);
-      } catch {
-        remaining.push(item);
-        remaining.push(...queued.slice(queued.indexOf(item) + 1));
-        break;
-      }
-    }
-    if (remaining.length > 0) {
-      this.nodeQueues.set(key, remaining);
-    } else {
-      this.nodeQueues.delete(key);
-    }
+    await drainNodeInvocations(this.db, this, workspaceId, nodeId);
+    this.nodeQueues.delete(key);
   }
 
   private async onWorkspaceMessage(socket: EngineSocket, raw: string): Promise<void> {

--- a/packages/engine/src/engine/action.ts
+++ b/packages/engine/src/engine/action.ts
@@ -641,19 +641,29 @@ async function dispatchNodeAttempt(
   workspaceId: string,
   invocationId: string,
   nodeId: string,
-  opts: { pending?: boolean; retryAfterAt?: Date | null; reservationHeld?: boolean } = {},
+  opts: {
+    pending?: boolean;
+    retryAfterAt?: Date | null;
+    reservationHeld?: boolean;
+    skipIncrementAttempts?: boolean;
+  } = {},
 ) {
   const stateFields = opts.pending
     ? { status: 'pending' as const, dispatchedAt: null, retryAfterAt: opts.retryAfterAt ?? null }
     : dispatchedStateFields({ retryAfterAt: opts.retryAfterAt });
+  const attemptFields = opts.skipIncrementAttempts
+    ? {}
+    : {
+      attemptedNodeIds: sql`json_insert(COALESCE(${actionInvocations.attemptedNodeIds}, '[]'), '$[#]', ${nodeId})`,
+      dispatchAttempts: sql`COALESCE(${actionInvocations.dispatchAttempts}, 0) + 1`,
+    };
   const [updated] = await db
     .update(actionInvocations)
     .set({
       ...stateFields,
       dispatchedNodeId: nodeId,
       spawnReservedAt: opts.reservationHeld ? new Date() : null,
-      attemptedNodeIds: sql`json_insert(COALESCE(${actionInvocations.attemptedNodeIds}, '[]'), '$[#]', ${nodeId})`,
-      dispatchAttempts: sql`COALESCE(${actionInvocations.dispatchAttempts}, 0) + 1`,
+      ...attemptFields,
     })
     .where(and(
       eq(actionInvocations.workspaceId, workspaceId),
@@ -705,6 +715,7 @@ async function dispatchNodeInvocation(args: {
   pending?: boolean;
   retryAfterAt?: Date | null;
   reservationHeld?: boolean;
+  skipIncrementAttempts?: boolean;
 }): Promise<{ accepted: boolean; pending: boolean }> {
   const connectedBefore = args.registry.isNodeConnected(args.workspaceId, args.nodeId);
   const sent = await args.registry.sendToNode(args.workspaceId, args.nodeId, {
@@ -724,7 +735,12 @@ async function dispatchNodeInvocation(args: {
     args.workspaceId,
     args.invocationId,
     args.nodeId,
-    { pending, retryAfterAt: args.retryAfterAt, reservationHeld: args.reservationHeld },
+    {
+      pending,
+      retryAfterAt: args.retryAfterAt,
+      reservationHeld: args.reservationHeld,
+      skipIncrementAttempts: args.skipIncrementAttempts,
+    },
   );
   return { accepted, pending };
 }
@@ -855,6 +871,7 @@ export async function drainNodeInvocations(
         agent: targetAgent ? { id: targetAgent.id, name: targetAgent.name } : null,
         retryAfterAt: new Date(Date.now() + ACTION_DISPATCH_TIMEOUT_MS),
         reservationHeld,
+        skipIncrementAttempts: row.dispatchedNodeId === nodeId,
       });
       if (dispatched.accepted) drained++;
     } catch {
@@ -1141,9 +1158,9 @@ export async function completeNodeInvocation(
 export async function sweepTimedOutInvocations(
   db: Db,
   registry: NodeConnectionRegistry,
-  opts: SweepTimedOutInvocationsOptions | number = {},
+  opts: SweepTimedOutInvocationsOptions | number | null = {},
 ) {
-  const timeoutMs = typeof opts === 'number' ? opts : opts.timeoutMs ?? ACTION_DISPATCH_TIMEOUT_MS;
+  const timeoutMs = typeof opts === 'number' ? opts : opts?.timeoutMs ?? ACTION_DISPATCH_TIMEOUT_MS;
   const now = new Date();
   const cutoff = new Date(Date.now() - timeoutMs);
   const rows = await db

--- a/packages/engine/src/engine/action.ts
+++ b/packages/engine/src/engine/action.ts
@@ -1,11 +1,11 @@
-import { and, asc, eq, inArray, lte, or, sql } from 'drizzle-orm';
+import { and, asc, eq, inArray, isNull, lte, or, sql } from 'drizzle-orm';
 import type { getDb } from '../db/index.js';
 import { actions, actionInvocations, agents, agentNodeBindings, nodes } from '../db/schema.js';
 import { generateId } from './snowflake.js';
 import { codedError } from '../lib/httpError.js';
 import { toFleetWireJson } from './deliveryWire.js';
 import type { NodeConnectionRegistry } from '../ports/realtime.js';
-import { claimSpawnNode, chooseNodeForAction, releaseNodeCapacity, reserveNodeCapacity } from './placement.js';
+import { claimSpawnNode, chooseNodeForAction, isNodeLive, releaseNodeCapacity, reserveNodeCapacity } from './placement.js';
 
 type Db = ReturnType<typeof getDb>;
 type ActionRow = typeof actions.$inferSelect;
@@ -41,9 +41,11 @@ function isReleaseInvocation(actionName: string): boolean {
 function dispatchActionNameForInvocation(actionName: string, input: Record<string, unknown>): string {
   if (!isSpawnInvocation(actionName)) return actionName;
   const raw = input.capability ?? input.cli;
-  if (typeof raw !== 'string' || raw.trim().length === 0) return actionName;
+  if (typeof raw !== 'string' || raw.trim().length === 0) {
+    return actionName.startsWith('spawn:') ? actionName : 'spawn';
+  }
   const value = raw.trim();
-  return value.startsWith('spawn:') ? value : actionName === 'spawn' ? `spawn:${value}` : value;
+  return value.startsWith('spawn:') ? value : `spawn:${value}`;
 }
 
 function normalizeAttemptedNodeIds(value: unknown): string[] {
@@ -802,6 +804,7 @@ export async function drainNodeInvocations(
   workspaceId: string,
   nodeId: string,
 ): Promise<number> {
+  const now = new Date();
   const rows = await db
     .select({
       id: actionInvocations.id,
@@ -822,6 +825,7 @@ export async function drainNodeInvocations(
     .where(and(
       eq(actionInvocations.workspaceId, workspaceId),
       eq(actionInvocations.status, 'pending'),
+      or(isNull(actionInvocations.retryAfterAt), lte(actionInvocations.retryAfterAt, now)),
       or(
         eq(actionInvocations.dispatchedNodeId, nodeId),
         eq(actions.handlerNodeId, nodeId),
@@ -841,23 +845,35 @@ export async function drainNodeInvocations(
     const targetNodeId = targetAgent?.nodeId ?? row.handlerNodeId ?? row.dispatchedNodeId;
     if (targetNodeId !== nodeId) continue;
 
+    let reservedForDrain = false;
     try {
       const input = recordInput(row.input);
       let reservationHeld = isSpawnInvocation(row.actionName) && !!row.spawnReservedAt;
       if (isSpawnInvocation(row.actionName) && !reservationHeld) {
         const reserved = await reserveNodeCapacity(db, workspaceId, nodeId);
         if (!reserved) {
-          await db
-            .update(actionInvocations)
-            .set({ retryAfterAt: new Date(Date.now() + NODE_DRAIN_REQUEUE_RETRY_MS) })
-            .where(and(
-              eq(actionInvocations.workspaceId, workspaceId),
-              eq(actionInvocations.id, row.id),
-              eq(actionInvocations.status, 'pending'),
-            ));
+          const [node] = await db
+            .select({
+              status: nodes.status,
+              handlersLive: nodes.handlersLive,
+              lastHeartbeatAt: nodes.lastHeartbeatAt,
+            })
+            .from(nodes)
+            .where(and(eq(nodes.workspaceId, workspaceId), eq(nodes.id, nodeId)));
+          if (node && isNodeLive(node) && node.handlersLive) {
+            await db
+              .update(actionInvocations)
+              .set({ retryAfterAt: new Date(Date.now() + NODE_DRAIN_REQUEUE_RETRY_MS) })
+              .where(and(
+                eq(actionInvocations.workspaceId, workspaceId),
+                eq(actionInvocations.id, row.id),
+                eq(actionInvocations.status, 'pending'),
+              ));
+          }
           continue;
         }
         reservationHeld = true;
+        reservedForDrain = true;
       }
 
       const dispatched = await dispatchNodeInvocation({
@@ -873,8 +889,15 @@ export async function drainNodeInvocations(
         reservationHeld,
         skipIncrementAttempts: row.dispatchedNodeId === nodeId,
       });
-      if (dispatched.accepted) drained++;
+      if (dispatched.accepted) {
+        drained++;
+      } else if (reservedForDrain) {
+        await releaseNodeCapacity(db, workspaceId, nodeId);
+      }
     } catch {
+      if (reservedForDrain) {
+        await releaseNodeCapacity(db, workspaceId, nodeId).catch(() => {});
+      }
       // Leave the invocation pending; a later drain or timeout sweep can retry.
     }
   }

--- a/packages/engine/src/engine/action.ts
+++ b/packages/engine/src/engine/action.ts
@@ -1,4 +1,4 @@
-import { and, eq, inArray, lte, sql } from 'drizzle-orm';
+import { and, asc, eq, inArray, lte, or, sql } from 'drizzle-orm';
 import type { getDb } from '../db/index.js';
 import { actions, actionInvocations, agents, agentNodeBindings, nodes } from '../db/schema.js';
 import { generateId } from './snowflake.js';
@@ -18,6 +18,11 @@ type RetryableInvocationRow = Pick<
 const OPEN_INVOCATION_STATUSES = ['pending', 'dispatched', 'invoked'];
 export const ACTION_DISPATCH_TIMEOUT_MS = 30_000;
 const ACTION_RETRY_BACKOFF_MS = 5_000;
+const NODE_DRAIN_REQUEUE_RETRY_MS = 5_000;
+
+export interface SweepTimedOutInvocationsOptions {
+  timeoutMs?: number;
+}
 
 function capabilityName(capability: string | { name?: string } | null | undefined): string | null {
   if (typeof capability === 'string') return capability;
@@ -33,6 +38,14 @@ function isReleaseInvocation(actionName: string): boolean {
   return actionName === 'release';
 }
 
+function dispatchActionNameForInvocation(actionName: string, input: Record<string, unknown>): string {
+  if (!isSpawnInvocation(actionName)) return actionName;
+  const raw = input.capability ?? input.cli;
+  if (typeof raw !== 'string' || raw.trim().length === 0) return actionName;
+  const value = raw.trim();
+  return value.startsWith('spawn:') ? value : actionName === 'spawn' ? `spawn:${value}` : value;
+}
+
 function normalizeAttemptedNodeIds(value: unknown): string[] {
   return Array.isArray(value) ? value.filter((item): item is string => typeof item === 'string') : [];
 }
@@ -45,9 +58,9 @@ function nextRetryAfter(attempts: number): Date {
 /**
  * Field set that moves an invocation into the live `dispatched` state once its
  * `action.invoke` frame has actually been delivered to the node. Shared by the
- * live dispatch path (`dispatchNodeAttempt`) and the offline-queue drain path
- * (`markDrainedInvocationDispatched`) so the dispatch-timeout sweep — which keys
- * off `dispatchedAt` — and the reschedule path cover drained invocations too.
+ * live dispatch path (`dispatchNodeAttempt`) and exported offline-queue drain
+ * path (`drainNodeInvocations`) so the dispatch-timeout sweep — which keys off
+ * `dispatchedAt` — and the reschedule path cover drained invocations too.
  */
 function dispatchedStateFields(opts: { retryAfterAt?: Date | null } = {}): {
   status: 'dispatched';
@@ -767,6 +780,90 @@ async function targetAgentForInvocation(
   return { agentId: row.agentId, agentName: row.agentName, nodeId: row.nodeId };
 }
 
+export async function drainNodeInvocations(
+  db: Db,
+  registry: NodeConnectionRegistry,
+  workspaceId: string,
+  nodeId: string,
+): Promise<number> {
+  const rows = await db
+    .select({
+      id: actionInvocations.id,
+      workspaceId: actionInvocations.workspaceId,
+      actionName: actionInvocations.actionName,
+      input: actionInvocations.input,
+      spawnReservedAt: actionInvocations.spawnReservedAt,
+      dispatchedNodeId: actionInvocations.dispatchedNodeId,
+      handlerNodeId: actions.handlerNodeId,
+      handlerAgentId: agents.id,
+      handlerAgentName: agents.name,
+      handlerAgentLocationType: agents.locationType,
+      handlerAgentNodeId: agents.locationNodeId,
+    })
+    .from(actionInvocations)
+    .leftJoin(actions, eq(actionInvocations.actionId, actions.id))
+    .leftJoin(agents, eq(actions.handlerAgentId, agents.id))
+    .where(and(
+      eq(actionInvocations.workspaceId, workspaceId),
+      eq(actionInvocations.status, 'pending'),
+      or(
+        eq(actionInvocations.dispatchedNodeId, nodeId),
+        eq(actions.handlerNodeId, nodeId),
+        and(eq(agents.locationType, 'via_node'), eq(agents.locationNodeId, nodeId)),
+      ),
+    ))
+    .orderBy(asc(actionInvocations.createdAt));
+
+  let drained = 0;
+  for (const row of rows) {
+    const targetAgent = row.handlerAgentId
+      && row.handlerAgentName
+      && row.handlerAgentLocationType === 'via_node'
+      && row.handlerAgentNodeId
+      ? { id: row.handlerAgentId, name: row.handlerAgentName, nodeId: row.handlerAgentNodeId }
+      : null;
+    const targetNodeId = targetAgent?.nodeId ?? row.handlerNodeId ?? row.dispatchedNodeId;
+    if (targetNodeId !== nodeId) continue;
+
+    try {
+      const input = recordInput(row.input);
+      let reservationHeld = isSpawnInvocation(row.actionName) && !!row.spawnReservedAt;
+      if (isSpawnInvocation(row.actionName) && !reservationHeld) {
+        const reserved = await reserveNodeCapacity(db, workspaceId, nodeId);
+        if (!reserved) {
+          await db
+            .update(actionInvocations)
+            .set({ retryAfterAt: new Date(Date.now() + NODE_DRAIN_REQUEUE_RETRY_MS) })
+            .where(and(
+              eq(actionInvocations.workspaceId, workspaceId),
+              eq(actionInvocations.id, row.id),
+              eq(actionInvocations.status, 'pending'),
+            ));
+          continue;
+        }
+        reservationHeld = true;
+      }
+
+      const dispatched = await dispatchNodeInvocation({
+        db,
+        registry,
+        workspaceId,
+        invocationId: row.id,
+        nodeId,
+        action: dispatchActionNameForInvocation(row.actionName, input),
+        input,
+        agent: targetAgent ? { id: targetAgent.id, name: targetAgent.name } : null,
+        retryAfterAt: new Date(Date.now() + ACTION_DISPATCH_TIMEOUT_MS),
+        reservationHeld,
+      });
+      if (dispatched.accepted) drained++;
+    } catch {
+      // Leave the invocation pending; a later drain or timeout sweep can retry.
+    }
+  }
+  return drained;
+}
+
 export async function rescheduleNodeInvocation(
   db: Db,
   registry: NodeConnectionRegistry,
@@ -800,7 +897,7 @@ export async function rescheduleNodeInvocation(
   const attempted = attemptedNodeSet(invocation);
   const current = invocation.dispatchedNodeId ? [invocation.dispatchedNodeId] : [];
   const input = recordInput(invocation.input);
-  const actionToSend = isSpawnInvocation(invocation.actionName) ? 'spawn' : invocation.actionName;
+  const actionToSend = dispatchActionNameForInvocation(invocation.actionName, input);
   const baseExclude = Array.from(new Set([...attempted, ...current]));
   const candidates = opts.allowAttemptedFallback ? [baseExclude, []] : [baseExclude];
 
@@ -1044,8 +1141,9 @@ export async function completeNodeInvocation(
 export async function sweepTimedOutInvocations(
   db: Db,
   registry: NodeConnectionRegistry,
-  timeoutMs = ACTION_DISPATCH_TIMEOUT_MS,
+  opts: SweepTimedOutInvocationsOptions | number = {},
 ) {
+  const timeoutMs = typeof opts === 'number' ? opts : opts.timeoutMs ?? ACTION_DISPATCH_TIMEOUT_MS;
   const now = new Date();
   const cutoff = new Date(Date.now() - timeoutMs);
   const rows = await db

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -56,6 +56,8 @@ export { sweepDueHttpPushDeliveries } from './routes/deliveryRouting.js';
 export { deliverPendingToNode } from './engine/delivery.js';
 export { handleNodeReconnect } from './node-reconnect.js';
 export { handleAgentDisconnect } from './agent-disconnect.js';
+export { drainNodeInvocations, sweepTimedOutInvocations } from './node-invocations.js';
+export type { SweepTimedOutInvocationsOptions } from './node-invocations.js';
 export { handleNodeControlMessage } from './engine/node.js';
 export type { HandleNodeControlMessageArgs, NodeSocketLike } from './engine/node.js';
 

--- a/packages/engine/src/node-invocations.ts
+++ b/packages/engine/src/node-invocations.ts
@@ -1,0 +1,5 @@
+export {
+  drainNodeInvocations,
+  sweepTimedOutInvocations,
+  type SweepTimedOutInvocationsOptions,
+} from './engine/action.js';


### PR DESCRIPTION
## What changed

- Added `drainNodeInvocations(db, registry, workspaceId, nodeId)` and `sweepTimedOutInvocations(db, registry, opts)` to the public engine surface.
- Added `@relaycast/engine/node-invocations` as a dedicated adapter import path.
- Moved the Node adapter drain path onto the shared DB-backed helper.
- Preserved queued spawn capacity reservation/backstop behavior and fixed drained/retried spawn action frames to use the v5 `spawn:<cli>` capability name.
- Added conformance coverage for draining a pending handler-agent invocation with `agent_id` and `agent_name` in the `action.invoke` frame.

## Why

DO-based adapters should delegate invocation drain and timeout retry behavior to the engine instead of reimplementing placement and frame construction. The shared drain now covers both node handlers and handler agents currently located on the node, so worker drains do not miss agent-hosted actions or emit incomplete v5 frames.

## Validation

- `../../node_modules/.bin/vitest run src/__tests__/conformance/node.test.ts`
- `../../node_modules/.bin/tsc --noEmit`
- `../../node_modules/.bin/eslint src/`
- `../../node_modules/.bin/tsc`

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/AgentWorkforce/relaycast/pull/220?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

