### PR TITLE
feat(engine): persist inbound webhook payload into message metadata

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5666,7 +5666,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -5688,7 +5687,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -5710,7 +5708,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -5732,7 +5729,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -5754,7 +5750,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -5776,7 +5771,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -5798,7 +5792,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -5820,7 +5813,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -5842,7 +5834,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -5864,7 +5855,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -5886,7 +5876,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },

--- a/packages/engine/src/engine/__tests__/inboundWebhook.test.ts
+++ b/packages/engine/src/engine/__tests__/inboundWebhook.test.ts
@@ -1,0 +1,99 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { eq } from 'drizzle-orm';
+import { getSqliteDb, runMigrations, type SqliteDbHandle } from '../../adapters/node/database.js';
+import { agents, channels, messages, workspaces } from '../../db/schema.js';
+import { createWebhook, triggerWebhook } from '../inboundWebhook.js';
+import { publicMessageMetadata } from '../messageMetadata.js';
+
+let seq = 0;
+
+function openDb(): SqliteDbHandle {
+  const handle = getSqliteDb(':memory:');
+  runMigrations(handle);
+  return handle;
+}
+
+const handles: SqliteDbHandle[] = [];
+function track(handle: SqliteDbHandle): SqliteDbHandle {
+  handles.push(handle);
+  return handle;
+}
+
+afterEach(() => {
+  for (const handle of handles.splice(0)) {
+    try { handle.sqlite.close(); } catch { /* already closed */ }
+  }
+});
+
+interface Seeded {
+  ws: string;
+  ch: string;
+  agent: string;
+}
+
+type Db = SqliteDbHandle['db'];
+
+async function seedWorkspace(db: Db): Promise<Seeded> {
+  const n = ++seq;
+  const ws = `ws_${n}`;
+  await db.insert(workspaces).values({ id: ws, name: `w${n}`, apiKeyHash: `hash_${n}` });
+
+  const ch = `ch_${n}`;
+  await db.insert(channels).values({ id: ch, workspaceId: ws, name: 'general' });
+
+  const agent = `ag_${n}`;
+  await db.insert(agents).values({ id: agent, workspaceId: ws, name: 'alice', tokenHash: `tok_${n}` });
+
+  return { ws, ch, agent };
+}
+
+async function readMessageMetadata(db: Db, messageId: string): Promise<Record<string, unknown>> {
+  const [row] = await db
+    .select({ metadata: messages.metadata })
+    .from(messages)
+    .where(eq(messages.id, messageId));
+
+  expect(row).toBeDefined();
+  return row!.metadata ?? {};
+}
+
+describe('triggerWebhook payload round-trip', () => {
+  it('persists relayfile metadata into the message row', async () => {
+    const { db } = track(openDb());
+    const base = await seedWorkspace(db);
+    const webhook = await createWebhook(db, base.ws, base.ch, { name: 'relayfile:slack' }, base.agent);
+    const relayfile = { provider: 'slack', path: '/slack/channels/C1', revision: 'r1' };
+
+    const result = await triggerWebhook(db, webhook.webhook_id, webhook.token, {
+      text: 'hello',
+      source: 'relayfile',
+      payload: { relayfile },
+    });
+
+    expect(result).not.toBeNull();
+    const metadata = await readMessageMetadata(db, result!.message_id);
+    expect(publicMessageMetadata(metadata).relayfile).toEqual(relayfile);
+    expect(metadata.__relaycast_origin).toBe('inbound_webhook');
+  });
+
+  it('strips __relaycast_* keys that the caller tries to inject via payload', async () => {
+    const { db } = track(openDb());
+    const base = await seedWorkspace(db);
+    const webhook = await createWebhook(db, base.ws, base.ch, { name: 'relayfile:slack' }, base.agent);
+    const relayfile = { path: '/slack/x' };
+
+    const result = await triggerWebhook(db, webhook.webhook_id, webhook.token, {
+      text: 'hello',
+      source: 'relayfile',
+      payload: {
+        __relaycast_origin: 'hacked',
+        relayfile,
+      },
+    });
+
+    expect(result).not.toBeNull();
+    const metadata = await readMessageMetadata(db, result!.message_id);
+    expect(publicMessageMetadata(metadata)).toEqual({ relayfile });
+    expect(metadata.__relaycast_origin).toBe('inbound_webhook');
+  });
+});

--- a/packages/engine/src/engine/inboundWebhook.ts
+++ b/packages/engine/src/engine/inboundWebhook.ts
@@ -4,7 +4,7 @@ import { webhooks, channels, messages, agents } from '../db/schema.js';
 import { randomHex, sha256Hex } from '../lib/crypto.js';
 import { codedError } from '../lib/httpError.js';
 import { generateId } from './snowflake.js';
-import { inboundWebhookMessageMetadata } from './messageMetadata.js';
+import { inboundWebhookMessageMetadata, sanitizeUserMessageMetadata } from './messageMetadata.js';
 
 type Db = ReturnType<typeof getDb>;
 const WEBHOOK_AGENT_NAME = '__relay_webhook__';
@@ -195,12 +195,15 @@ export async function triggerWebhook(
       channelId: webhook.channelId,
       agentId: webhook.createdBy,
       body: text,
-      metadata: inboundWebhookMessageMetadata({
-        webhookId: webhook.id,
-        webhookName: webhook.name,
-        source: data.source ?? null,
-        author,
-      }),
+      metadata: {
+        ...inboundWebhookMessageMetadata({
+          webhookId: webhook.id,
+          webhookName: webhook.name,
+          source: data.source ?? null,
+          author,
+        }),
+        ...sanitizeUserMessageMetadata(data.payload),
+      },
     })
     .returning();
 


### PR DESCRIPTION
## Summary

- Merges `sanitizeUserMessageMetadata(data.payload)` into `message.metadata` alongside the existing inbound webhook metadata in `triggerWebhook()`
- Enables relayfile `path`, `provider`, and `revision` to round-trip through the channel so outbound subscription delivery can route replies back to the correct provider object
- Adds a test covering the payload round-trip and the `__relaycast_*` key-stripping behavior

## Context

Part of the **integration-bridge** feature ([spec](docs/integration-bridge.md)). This is the load-bearing engine fix (R1) — without it, the canonical relayfile path can't survive the inbound→channel→outbound loop, making provider-agnostic write-back impossible.

## Test plan

- [ ] `packages/engine/src/engine/__tests__/inboundWebhook.test.ts` — payload round-trip + key-stripping
- [ ] Existing engine tests still pass
- [ ] `triggerWebhook` with no `payload` behaves identically to before (metadata spread is a no-op)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/AgentWorkforce/relaycast/pull/221?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

