### PR TITLE
Improve observer: action events, persisted feed, sticky sidenav

### DIFF
--- a/packages/engine/src/__tests__/conformance/node.test.ts
+++ b/packages/engine/src/__tests__/conformance/node.test.ts
@@ -1594,5 +1594,41 @@ describe('node adapter conformance', () => {
       expect(stillNode.version).toBe('test-node-v2');
       expect(stillNode.capabilities.map((cap) => cap.name).sort()).toEqual(['echo', 'spawn:claude']);
     });
+
+    it('publishes action.invoked to the workspace observer stream', async () => {
+      const ws = await createWorkspace(stack.app, 'fleet-action-invoked-observer-ws');
+      const caller = await registerAgent(stack.app, ws.workspaceKey, 'caller');
+      await enrollAndAttachNode(ws, {
+        id: 'node_alpha',
+        name: 'alpha',
+        capabilities: [capability('spawn:claude', 'spawn', { agent: 'claude' })],
+        load: 0,
+      });
+
+      // Observer dashboards watch the workspace stream; they should see the
+      // invocation as it happens, not just its eventual completion.
+      const observerSock = new FakeSocket();
+      stack.runtime.realtime.attachWorkspaceSocket(ws.workspaceId, observerSock);
+
+      const spawn = await stack.app.request('/v1/actions/spawn/invoke', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json', authorization: `Bearer ${caller.token}` },
+        body: JSON.stringify({ input: { cli: 'claude', name: 'observed-worker', task: 'hi', target_node: 'alpha' } }),
+      });
+      expect(spawn.status).toBe(201);
+      const invocationId = (await spawn.json() as { data: { invocation_id: string } }).data.invocation_id;
+
+      // Fanout to the workspace stream runs in the request background lifecycle.
+      await new Promise((r) => setTimeout(r, 25));
+
+      const invoked = observerSock.ofType('action.invoked');
+      expect(invoked).toHaveLength(1);
+      expect(invoked[0]).toMatchObject({
+        type: 'action.invoked',
+        invocation_id: invocationId,
+        action_name: 'spawn',
+        caller_name: 'caller',
+      });
+    });
   });
 });

--- a/packages/engine/src/__tests__/conformance/node.test.ts
+++ b/packages/engine/src/__tests__/conformance/node.test.ts
@@ -1618,10 +1618,13 @@ describe('node adapter conformance', () => {
       expect(spawn.status).toBe(201);
       const invocationId = (await spawn.json() as { data: { invocation_id: string } }).data.invocation_id;
 
-      // Fanout to the workspace stream runs in the request background lifecycle.
-      await new Promise((r) => setTimeout(r, 25));
-
-      const invoked = observerSock.ofType('action.invoked');
+      // Fanout to the workspace stream runs in the request background
+      // lifecycle (best-effort in tests), so poll rather than fixed-sleep.
+      let invoked = observerSock.ofType('action.invoked');
+      for (let i = 0; i < 20 && invoked.length === 0; i += 1) {
+        await new Promise((r) => setTimeout(r, 5));
+        invoked = observerSock.ofType('action.invoked');
+      }
       expect(invoked).toHaveLength(1);
       expect(invoked[0]).toMatchObject({
         type: 'action.invoked',

--- a/packages/engine/src/routes/action.ts
+++ b/packages/engine/src/routes/action.ts
@@ -193,6 +193,14 @@ actionRoutes.post('/actions/:name/invoke', requireAuth, rateLimit, async (c) => 
       invocation_id: result.invocation_id,
       caller_agent_id: agent.id,
     });
+    // Surface the invocation on the workspace observer stream so dashboards see
+    // actions happening (spawns, callbacks) and not just their completions.
+    // The completion side already publishes action.completed / action.failed.
+    runInBackground(
+      c,
+      fanoutToWorkspace(c, 'action.invoked', eventData),
+      'fanout action.invoked',
+    );
 
     return jsonCreated(c, result);
   } catch (err: unknown) {
@@ -228,6 +236,11 @@ actionRoutes.post('/actions/:name/invoke', requireAuth, rateLimit, async (c) => 
         workspaceId: workspace.id,
         data: eventData,
       });
+      runInBackground(
+        c,
+        fanoutToWorkspace(c, 'action.denied', eventData),
+        'fanout action.denied',
+      );
     }
     return errorResponse(c, error);
   }

--- a/packages/observer-dashboard/src/components/ActivityLog.tsx
+++ b/packages/observer-dashboard/src/components/ActivityLog.tsx
@@ -1,8 +1,9 @@
 'use client';
 
-import { Wifi } from 'lucide-react';
+import { Activity, MessageSquare, Radio, Trash2, UserRound, Wifi, Zap } from 'lucide-react';
+import type { ComponentType } from 'react';
 import { useWebSocketFeed } from '../hooks/use-websocket-feed';
-import type { WebSocketFeedEvent } from '../types/dashboard';
+import type { WebSocketFeedCategory, WebSocketFeedEvent } from '../types/dashboard';
 import { cn } from '../lib/utils';
 
 function relativeTime(timestamp: string): string {
@@ -17,12 +18,32 @@ function relativeTime(timestamp: string): string {
   return `${days}d`;
 }
 
+const categoryIcon: Record<WebSocketFeedCategory, ComponentType<{ className?: string }>> = {
+  action: Zap,
+  message: MessageSquare,
+  presence: UserRound,
+  reaction: Activity,
+  channel: Radio,
+  delivery: Radio,
+  system: Wifi,
+};
+
+const categoryAccent: Record<WebSocketFeedCategory, string> = {
+  action: 'text-amber-300',
+  message: 'text-[var(--console-accent)]',
+  presence: 'text-emerald-300',
+  reaction: 'text-fuchsia-300',
+  channel: 'text-sky-300',
+  delivery: 'text-sky-300',
+  system: 'text-[var(--console-muted)]',
+};
+
 interface ActivityLogProps {
   className?: string;
 }
 
 export function ActivityLog({ className }: ActivityLogProps) {
-  const { status, events: wsEvents, latestEventAt } = useWebSocketFeed();
+  const { status, events: wsEvents, latestEventAt, clearEvents } = useWebSocketFeed();
 
   const statusClasses = {
     connected: 'bg-emerald-500/12 text-emerald-300 border-emerald-500/25',
@@ -36,9 +57,22 @@ export function ActivityLog({ className }: ActivityLogProps) {
       <div className="space-y-2 border-b border-[color-mix(in_srgb,var(--console-accent)_14%,transparent)] px-4 py-3">
         <div className="flex items-center justify-between gap-2">
           <h2 className="text-sm font-semibold text-[var(--console-fg)]">Activity</h2>
-          <span className={cn('inline-flex items-center rounded-full border px-2 py-0.5 text-[10px] font-medium uppercase tracking-wide', statusClasses[status])}>
-            WS {status}
-          </span>
+          <div className="flex items-center gap-2">
+            {wsEvents.length > 0 && (
+              <button
+                type="button"
+                onClick={clearEvents}
+                title="Clear activity"
+                className="inline-flex items-center gap-1 rounded-full border border-[color-mix(in_srgb,var(--console-accent)_18%,transparent)] px-2 py-0.5 text-[10px] font-medium text-[var(--console-muted)] transition-colors hover:text-[var(--console-fg)]"
+              >
+                <Trash2 className="h-3 w-3" />
+                Clear
+              </button>
+            )}
+            <span className={cn('inline-flex items-center rounded-full border px-2 py-0.5 text-[10px] font-medium uppercase tracking-wide', statusClasses[status])}>
+              WS {status}
+            </span>
+          </div>
         </div>
         <div className="text-[10px] text-[var(--console-muted)]">
           {latestEventAt ? `Last WS event ${relativeTime(latestEventAt)}` : 'No WS events yet'}
@@ -56,16 +90,20 @@ function Empty() {
 function WebSocketFeed({ events }: { events: WebSocketFeedEvent[] }) {
   return (
     <div className="py-2">
-      {events.map((event) => (
-        <div key={event.id} className="flex items-start gap-2.5 px-4 py-3 text-sm hover:bg-white/2">
-          <Wifi className="mt-0.5 h-3.5 w-3.5 shrink-0 text-[var(--console-accent)]" />
-          <div className="min-w-0 flex-1">
-            <div className="break-all font-mono text-[10px] text-[var(--console-muted)]">{event.eventType}</div>
-            <div className="text-xs leading-relaxed text-[var(--console-fg)]/82">{event.summary}</div>
+      {events.map((event) => {
+        const Icon = categoryIcon[event.category] ?? Wifi;
+        const accent = categoryAccent[event.category] ?? 'text-[var(--console-accent)]';
+        return (
+          <div key={event.id} className="flex items-start gap-2.5 px-4 py-3 text-sm hover:bg-white/2">
+            <Icon className={cn('mt-0.5 h-3.5 w-3.5 shrink-0', accent)} />
+            <div className="min-w-0 flex-1">
+              <div className="break-all font-mono text-[10px] text-[var(--console-muted)]">{event.eventType}</div>
+              <div className="text-xs leading-relaxed text-[var(--console-fg)]/82">{event.summary}</div>
+            </div>
+            <span className="mt-0.5 shrink-0 text-[10px] text-[var(--console-muted)]">{relativeTime(event.timestamp)}</span>
           </div>
-          <span className="mt-0.5 shrink-0 text-[10px] text-[var(--console-muted)]">{relativeTime(event.timestamp)}</span>
-        </div>
-      ))}
+        );
+      })}
     </div>
   );
 }

--- a/packages/observer-dashboard/src/components/DashboardLayout.tsx
+++ b/packages/observer-dashboard/src/components/DashboardLayout.tsx
@@ -175,7 +175,7 @@ export function DashboardLayout() {
           wsStatus={wsStatus}
           onSelectChannel={handleSelectChannel}
           onSelectAgent={handleSelectAgent}
-          className="m-3 mr-0"
+          className="m-3 mr-0 lg:sticky lg:top-3 lg:self-start lg:h-[calc(100vh-1.5rem)]"
         />
 
         <main className="flex min-w-0 flex-1 flex-col py-3 pr-3">

--- a/packages/observer-dashboard/src/components/RelaySessionProvider.tsx
+++ b/packages/observer-dashboard/src/components/RelaySessionProvider.tsx
@@ -4,6 +4,7 @@ import { useEffect, useRef, useState } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { RelayProvider } from '@relaycast/react';
 import { setAuth } from '../lib/auth';
+import { resetActivityIfWorkspaceChanged } from '../lib/activity-store';
 
 interface Session {
   apiKey: string;
@@ -46,6 +47,9 @@ export function RelaySessionProvider({ children }: { children: React.ReactNode }
         if (seq !== requestSeq.current) return;
 
         if (data?.authenticated) {
+          // Drop another workspace's cached activity before this dashboard
+          // mounts, so switching keys never hydrates stale cross-workspace events.
+          resetActivityIfWorkspaceChanged(data.apiKey);
           setSession({
             apiKey: data.apiKey,
             agentToken: data.agentToken,

--- a/packages/observer-dashboard/src/hooks/use-websocket-feed.ts
+++ b/packages/observer-dashboard/src/hooks/use-websocket-feed.ts
@@ -4,9 +4,9 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useEvent, useWebSocket } from '@relaycast/react';
 import type { WsClientEvent } from '@relaycast/sdk';
 import type { WebSocketFeedCategory, WebSocketFeedEvent } from '../types/dashboard';
+import { WS_EVENTS_STORAGE_KEY } from '../lib/activity-store';
 
 const MAX_WS_EVENTS = 300;
-const STORAGE_KEY = 'relaycast-observer-ws-events';
 
 function getString(value: unknown): string | null {
   return typeof value === 'string' && value.length > 0 ? value : null;
@@ -37,7 +37,7 @@ function categorizeEvent(type: string): WebSocketFeedCategory {
 function loadStoredEvents(): WebSocketFeedEvent[] {
   if (typeof window === 'undefined') return [];
   try {
-    const raw = window.localStorage.getItem(STORAGE_KEY);
+    const raw = window.localStorage.getItem(WS_EVENTS_STORAGE_KEY);
     if (!raw) return [];
     const parsed = JSON.parse(raw) as unknown;
     if (!Array.isArray(parsed)) return [];
@@ -47,7 +47,9 @@ function loadStoredEvents(): WebSocketFeedEvent[] {
           !!item &&
           typeof item === 'object' &&
           typeof (item as WebSocketFeedEvent).id === 'string' &&
-          typeof (item as WebSocketFeedEvent).summary === 'string',
+          typeof (item as WebSocketFeedEvent).eventType === 'string' &&
+          typeof (item as WebSocketFeedEvent).summary === 'string' &&
+          typeof (item as WebSocketFeedEvent).timestamp === 'string',
       )
       .map((item) => ({ ...item, category: item.category ?? categorizeEvent(item.eventType) }))
       .slice(-MAX_WS_EVENTS);
@@ -192,7 +194,7 @@ export function useWebSocketFeed() {
   const clearEvents = useCallback(() => {
     setEvents([]);
     try {
-      window.localStorage.removeItem(STORAGE_KEY);
+      window.localStorage.removeItem(WS_EVENTS_STORAGE_KEY);
     } catch {
       // Ignore storage failures (private mode / quota); state is still cleared.
     }
@@ -201,7 +203,7 @@ export function useWebSocketFeed() {
   // Persist the rolling window so a refresh restores recent activity.
   useEffect(() => {
     try {
-      window.localStorage.setItem(STORAGE_KEY, JSON.stringify(events));
+      window.localStorage.setItem(WS_EVENTS_STORAGE_KEY, JSON.stringify(events));
     } catch {
       // Ignore storage failures (private mode / quota).
     }

--- a/packages/observer-dashboard/src/hooks/use-websocket-feed.ts
+++ b/packages/observer-dashboard/src/hooks/use-websocket-feed.ts
@@ -3,9 +3,10 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useEvent, useWebSocket } from '@relaycast/react';
 import type { WsClientEvent } from '@relaycast/sdk';
-import type { WebSocketFeedEvent } from '../types/dashboard';
+import type { WebSocketFeedCategory, WebSocketFeedEvent } from '../types/dashboard';
 
 const MAX_WS_EVENTS = 300;
+const STORAGE_KEY = 'relaycast-observer-ws-events';
 
 function getString(value: unknown): string | null {
   return typeof value === 'string' && value.length > 0 ? value : null;
@@ -13,6 +14,46 @@ function getString(value: unknown): string | null {
 
 function getNumber(value: unknown): number | null {
   return typeof value === 'number' ? value : null;
+}
+
+function categorizeEvent(type: string): WebSocketFeedCategory {
+  if (type.startsWith('action.')) return 'action';
+  if (type.startsWith('agent.status.')) return 'presence';
+  if (type === 'message.reacted') return 'reaction';
+  if (type.startsWith('channel.') || type.startsWith('member.')) return 'channel';
+  if (type.startsWith('delivery.')) return 'delivery';
+  if (
+    type === 'message.created' ||
+    type === 'message.updated' ||
+    type === 'thread.reply' ||
+    type === 'dm.received' ||
+    type === 'group_dm.received'
+  ) {
+    return 'message';
+  }
+  return 'system';
+}
+
+function loadStoredEvents(): WebSocketFeedEvent[] {
+  if (typeof window === 'undefined') return [];
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw) as unknown;
+    if (!Array.isArray(parsed)) return [];
+    return parsed
+      .filter(
+        (item): item is WebSocketFeedEvent =>
+          !!item &&
+          typeof item === 'object' &&
+          typeof (item as WebSocketFeedEvent).id === 'string' &&
+          typeof (item as WebSocketFeedEvent).summary === 'string',
+      )
+      .map((item) => ({ ...item, category: item.category ?? categorizeEvent(item.eventType) }))
+      .slice(-MAX_WS_EVENTS);
+  } catch {
+    return [];
+  }
 }
 
 function summarizeEvent(event: WsClientEvent): string {
@@ -60,6 +101,37 @@ function summarizeEvent(event: WsClientEvent): string {
       const status = getString(record.status) ?? type.replace('agent.status.', '');
       return `${name} ${status}`;
     }
+    case 'action.invoked': {
+      const action = getString(record.actionName) ?? '?';
+      const caller = getString(record.callerName) ?? 'unknown';
+      if (action === 'spawn' || action.startsWith('spawn:')) {
+        const kind = action.includes(':') ? action.slice(action.indexOf(':') + 1) : null;
+        return kind ? `${caller} spawned ${kind}` : `${caller} requested a spawn`;
+      }
+      if (action === 'release' || action.startsWith('release:')) {
+        const kind = action.includes(':') ? action.slice(action.indexOf(':') + 1) : null;
+        return kind ? `${caller} released ${kind}` : `${caller} requested a release`;
+      }
+      return `${caller} called ${action}`;
+    }
+    case 'action.completed': {
+      const action = getString(record.actionName) ?? '?';
+      return `${action} completed`;
+    }
+    case 'action.failed': {
+      const action = getString(record.actionName) ?? '?';
+      const error = getString(record.error);
+      return error ? `${action} failed: ${error}` : `${action} failed`;
+    }
+    case 'action.denied': {
+      const action = getString(record.actionName) ?? '?';
+      const caller = getString(record.callerName) ?? 'unknown';
+      return `${caller} denied calling ${action}`;
+    }
+    case 'action.registered': {
+      const action = getString(record.actionName) ?? '?';
+      return `Action ${action} registered`;
+    }
     case 'dm.received': {
       const message = (record.message as Record<string, unknown> | undefined) ?? {};
       const agent = getString(message.agentName) ?? 'unknown';
@@ -100,7 +172,10 @@ function summarizeEvent(event: WsClientEvent): string {
 
 export function useWebSocketFeed() {
   const { status } = useWebSocket();
-  const [events, setEvents] = useState<WebSocketFeedEvent[]>([]);
+  // Hydrate from localStorage so the live feed survives a page refresh. This
+  // subtree only renders client-side (behind the session gate), so reading
+  // storage in the initializer cannot cause an SSR hydration mismatch.
+  const [events, setEvents] = useState<WebSocketFeedEvent[]>(loadStoredEvents);
   const lastStatusRef = useRef<string | null>(null);
 
   const pushEvent = useCallback((eventType: string, summary: string) => {
@@ -108,10 +183,29 @@ export function useWebSocketFeed() {
       id: `${eventType}-${Date.now()}-${Math.random().toString(36).slice(2, 7)}`,
       eventType,
       summary,
+      category: categorizeEvent(eventType),
       timestamp: new Date().toISOString(),
     };
     setEvents((prev) => [...prev, next].slice(-MAX_WS_EVENTS));
   }, []);
+
+  const clearEvents = useCallback(() => {
+    setEvents([]);
+    try {
+      window.localStorage.removeItem(STORAGE_KEY);
+    } catch {
+      // Ignore storage failures (private mode / quota); state is still cleared.
+    }
+  }, []);
+
+  // Persist the rolling window so a refresh restores recent activity.
+  useEffect(() => {
+    try {
+      window.localStorage.setItem(STORAGE_KEY, JSON.stringify(events));
+    } catch {
+      // Ignore storage failures (private mode / quota).
+    }
+  }, [events]);
 
   useEffect(() => {
     if (lastStatusRef.current === status) return;
@@ -132,5 +226,6 @@ export function useWebSocketFeed() {
     status,
     events: newestFirst,
     latestEventAt: latest?.timestamp ?? null,
+    clearEvents,
   };
 }

--- a/packages/observer-dashboard/src/lib/activity-store.ts
+++ b/packages/observer-dashboard/src/lib/activity-store.ts
@@ -1,0 +1,42 @@
+/**
+ * Shared storage keys + workspace scoping for the persisted Activity feed.
+ *
+ * The live WebSocket feed is cached in localStorage so a refresh restores
+ * recent activity. Because the key is shared across the observer origin, the
+ * cache must be reset whenever the active workspace changes (e.g. logging in
+ * with a different `?key=`), so one workspace's agent/channel/error summaries
+ * never hydrate another workspace's dashboard.
+ */
+export const WS_EVENTS_STORAGE_KEY = 'relaycast-observer-ws-events';
+const WS_WORKSPACE_FINGERPRINT_KEY = 'relaycast-observer-ws-workspace';
+
+/**
+ * Derive a short, non-reversible fingerprint of the workspace key (djb2). Used
+ * only to detect workspace changes — never to reconstruct the key, which is why
+ * the raw key is never written to localStorage.
+ */
+function fingerprintWorkspace(apiKey: string): string {
+  let hash = 5381;
+  for (let i = 0; i < apiKey.length; i += 1) {
+    hash = ((hash << 5) + hash + apiKey.charCodeAt(i)) | 0;
+  }
+  return (hash >>> 0).toString(36);
+}
+
+/**
+ * Clear the persisted activity feed when the active workspace differs from the
+ * one it was captured under. Safe to call on every session resolve; it only
+ * touches storage when the workspace actually changes.
+ */
+export function resetActivityIfWorkspaceChanged(apiKey: string): void {
+  if (typeof window === 'undefined') return;
+  try {
+    const fingerprint = fingerprintWorkspace(apiKey);
+    if (window.localStorage.getItem(WS_WORKSPACE_FINGERPRINT_KEY) !== fingerprint) {
+      window.localStorage.removeItem(WS_EVENTS_STORAGE_KEY);
+      window.localStorage.setItem(WS_WORKSPACE_FINGERPRINT_KEY, fingerprint);
+    }
+  } catch {
+    // Ignore storage failures (private mode / quota).
+  }
+}

--- a/packages/observer-dashboard/src/types/dashboard.ts
+++ b/packages/observer-dashboard/src/types/dashboard.ts
@@ -1,6 +1,16 @@
+export type WebSocketFeedCategory =
+  | 'message'
+  | 'action'
+  | 'presence'
+  | 'reaction'
+  | 'channel'
+  | 'delivery'
+  | 'system';
+
 export interface WebSocketFeedEvent {
   id: string;
   eventType: string;
   summary: string;
+  category: WebSocketFeedCategory;
   timestamp: string;
 }


### PR DESCRIPTION
## Summary

Three improvements to the observer dashboard, addressing the request to see actions (not just messages), keep live events across refreshes, and keep the sidenav in view when scrolling.

### 1. Actions are visible in the Activity feed (spawns, callbacks, denials)
- **Engine** (`routes/action.ts`): publish `action.invoked` and `action.denied` to the workspace observer stream. Completions (`action.completed` / `action.failed`) already published there, so observers now see the full action lifecycle — a spawn fires `action.invoked`, the result comes back as `action.completed`/`failed`.
- **Dashboard** (`use-websocket-feed.ts`): dedicated, readable summaries for action events — e.g. `caller spawned claude`, `caller requested a spawn`, `echo completed`, `deploy failed: …`, `caller denied calling …`. Events are categorized (action / message / presence / reaction / channel / delivery / system) and `ActivityLog.tsx` renders each category with its own icon and accent (actions get a ⚡ in amber).

### 2. Live WebSocket feed persists across refresh
- `use-websocket-feed.ts` hydrates from `localStorage` (key `relaycast-observer-ws-events`) via the `useState` initializer and persists the rolling 300-event window on change. The subtree only renders client-side (behind the session gate), so there's no SSR hydration risk. Added a **Clear** control to reset the feed.

### 3. Sticky sidenav
- The desktop sidebar is now `lg:sticky lg:top-3 lg:self-start lg:h-[calc(100vh-1.5rem)]`, so it stays pinned when the page scrolls. Internal channel/agent scrolling is preserved.

## Notes
- For spawns invoked via the generic `/v1/actions/spawn/invoke` endpoint, the invocation's `action_name` is `"spawn"` (the concrete `spawn:claude` only appears on the node frame, not the invocation result), so the feed reads "requested a spawn." Directly-named `spawn:<cli>` actions render as "spawned `<cli>`."
- The action input payload is intentionally **not** surfaced on the observer stream, to avoid leaking arbitrary invocation input.
- Event names (`action.invoked` / `action.denied`) are already documented as canonical realtime event names in `README.md`, so this aligns observer-stream behavior with the documented vocabulary — no doc changes needed.

## Testing
- New conformance test asserts `action.invoked` reaches the workspace observer stream → engine suite **198 tests pass** (was 197).
- Dashboard **typechecks clean**, **11 tests pass**, and a production `next build` **succeeds**.
- Engine lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QUzDfsdMQx9CVCzMDG393b)_

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/AgentWorkforce/relaycast/pull/222?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

