### PR TITLE
fix(engine): http_push webhook delivery on Cloudflare (redirect:'error' threw on every dispatch)

### DIFF
--- a/packages/engine/src/__tests__/conformance/nodeDeliveryContracts.test.ts
+++ b/packages/engine/src/__tests__/conformance/nodeDeliveryContracts.test.ts
@@ -370,6 +370,60 @@ describe('node delivery contracts', () => {
     });
   });
 
+  it('sweeps never-attempted http_push deliveries (nextAttemptAt IS NULL)', async () => {
+    const fetchMock = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValue(new Response('', { status: 202 }));
+    const ws = await createWorkspace(stack.app, 'http-node-null-next');
+    const alice = await registerAgent(stack.app, ws.workspaceKey, 'alice');
+    const bob = await registerAgent(stack.app, ws.workspaceKey, 'bob');
+    const node = await createHttpNode(ws.workspaceKey, {
+      name: 'null-next-node',
+      ackMode: 'on_2xx',
+    });
+    expect((await bindAgent(ws.workspaceKey, node.data.name, 'bob')).status).toBe(201);
+
+    const post = await stack.app.request('/v1/channels/general/messages', {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        authorization: `Bearer ${alice.token}`,
+      },
+      body: JSON.stringify({ text: 'null next attempt' }),
+    });
+    expect(post.status).toBe(201);
+    // Let the inline send-time dispatch settle first so its async POST can't
+    // bleed into the post-reset sweep count below.
+    await waitForAssertion(() => expect(deliveryPosts(fetchMock)).toHaveLength(1));
+
+    // Reproduce the failure mode where the inline send-time push never ran: the
+    // delivery exists and is queued, but nextAttemptAt was never stamped (only an
+    // inline dispatch attempt sets it). Before the fix the cron sweep skipped
+    // these forever — it required nextAttemptAt IS NOT NULL — so an http_push
+    // agent that never connects would never receive the message.
+    const db = stack.runtime.deps.db;
+    await db
+      .update(deliveries)
+      .set({ status: 'queued', nextAttemptAt: null, dispatchAttempts: 0, deliveredAt: null, ackedAt: null })
+      .where(and(eq(deliveries.workspaceId, ws.workspaceId), eq(deliveries.agentId, bob.agentId)));
+    fetchMock.mockClear();
+
+    const swept = await sweepDueHttpPushDeliveries(stack.runtime.deps, { now: new Date() });
+    expect(swept).toBe(1);
+
+    await waitForAssertion(async () => {
+      // Filter out ephemeral (presence/receipt) POSTs — count only the
+      // message-delivery POST the sweep drove to the webhook.
+      expect(deliveryPosts(fetchMock)).toHaveLength(1);
+      const acked = await stack.app.request('/v1/deliveries?status=acked', {
+        headers: { authorization: `Bearer ${bob.token}` },
+      });
+      expect(
+        ((await acked.json()) as { data: Array<{ status: string }> }).data,
+      ).toEqual([expect.objectContaining({ status: 'acked' })]);
+    });
+  });
+
   it('defaults http_push nodes to one active agent binding', async () => {
     const ws = await createWorkspace(stack.app, 'http-node-capacity');
     await registerAgent(stack.app, ws.workspaceKey, 'bob');

--- a/packages/engine/src/__tests__/conformance/nodeDeliveryContracts.test.ts
+++ b/packages/engine/src/__tests__/conformance/nodeDeliveryContracts.test.ts
@@ -847,6 +847,48 @@ describe('node delivery contracts', () => {
     expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 
+  it('claims a never-attempted http_push delivery only once across overlapping sweeps', async () => {
+    const fetchMock = mockMessageDeliveryFetch([() => new Response('', { status: 202 })]);
+    const ws = await createWorkspace(stack.app, 'http-node-null-claim');
+    const alice = await registerAgent(stack.app, ws.workspaceKey, 'alice');
+    const bob = await registerAgent(stack.app, ws.workspaceKey, 'bob');
+    const node = await createHttpNode(ws.workspaceKey, { name: 'null-claim-http-node' });
+    expect((await bindAgent(ws.workspaceKey, node.data.name, 'bob')).status).toBe(201);
+
+    const post = await stack.app.request('/v1/channels/general/messages', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', authorization: `Bearer ${alice.token}` },
+      body: JSON.stringify({ text: 'never attempted' }),
+    });
+    expect(post.status).toBe(201);
+    await waitForAssertion(() => expect(deliveryPosts(fetchMock)).toHaveLength(1));
+
+    // Reset to the never-attempted state (nextAttemptAt IS NULL). Two overlapping
+    // sweeps must still POST the webhook exactly once — the claim's `IS NULL`
+    // compare-and-swap prevents a duplicate delivery.
+    await stack.runtime.deps.db
+      .update(deliveries)
+      .set({ status: 'queued', nextAttemptAt: null, dispatchAttempts: 0, deliveredAt: null, ackedAt: null })
+      .where(and(eq(deliveries.workspaceId, ws.workspaceId), eq(deliveries.agentId, bob.agentId)));
+
+    let releaseFetch: ((response: Response) => void) | undefined;
+    fetchMock.mockReset();
+    fetchMock.mockImplementation(() => new Promise<Response>((resolve) => {
+      releaseFetch = resolve;
+    }));
+
+    const sweep1 = sweepDueHttpPushDeliveries(stack.runtime.deps, { now: new Date() });
+    const sweep2 = sweepDueHttpPushDeliveries(stack.runtime.deps, { now: new Date() });
+
+    await waitForAssertion(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    releaseFetch?.(new Response('', { status: 202 }));
+    await Promise.all([sweep1, sweep2]);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
   it('does not let a slow http_push receiver block self-connected recipients', async () => {
     // Only the durable message POST hangs; ephemeral event POSTs (presence)
     // resolve immediately so the single hung message delivery stays isolated.

--- a/packages/engine/src/__tests__/conformance/nodeDeliveryContracts.test.ts
+++ b/packages/engine/src/__tests__/conformance/nodeDeliveryContracts.test.ts
@@ -161,7 +161,9 @@ describe('node delivery contracts', () => {
     await waitForAssertion(() => expect(deliveryPosts(fetchMock)).toHaveLength(1));
     const [url, init] = deliveryPosts(fetchMock)[0];
     expect(url).toBe('https://receiver.example.test/relaycast');
-    expect(init.redirect).toBe('error');
+    // Cloudflare Workers rejects redirect:'error'; we use 'manual' and reject
+    // any 3xx ourselves (see dispatchHttpPush) to keep the no-follow SSRF guard.
+    expect(init.redirect).toBe('manual');
     const headers = init.headers as Record<string, string>;
     expect(headers['X-Custom-Timestamp']).toBeTruthy();
     const bodyText = init.body as string;
@@ -367,6 +369,41 @@ describe('node delivery contracts', () => {
           dispatch_attempts: 2,
         }),
       ]);
+    });
+  });
+
+  it('treats a 3xx redirect response as a failed http_push dispatch', async () => {
+    const fetchMock = mockMessageDeliveryFetch([
+      () => new Response(null, { status: 302, headers: { location: 'https://evil.example.test/' } }),
+    ]);
+    const ws = await createWorkspace(stack.app, 'http-node-redirect');
+    const alice = await registerAgent(stack.app, ws.workspaceKey, 'alice');
+    const bob = await registerAgent(stack.app, ws.workspaceKey, 'bob');
+    const node = await createHttpNode(ws.workspaceKey, { name: 'redirect-http-node', ackMode: 'on_2xx' });
+    expect((await bindAgent(ws.workspaceKey, node.data.name, 'bob')).status).toBe(201);
+
+    const post = await stack.app.request('/v1/channels/general/messages', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', authorization: `Bearer ${alice.token}` },
+      body: JSON.stringify({ text: 'redirect me' }),
+    });
+    expect(post.status).toBe(201);
+    await waitForAssertion(() => expect(deliveryPosts(fetchMock)).toHaveLength(1));
+
+    // The request must be made with redirect:'manual' (Workers rejects 'error'),
+    // and a 3xx must be recorded as a failure — not followed — so the delivery
+    // stays queued rather than being marked delivered against a redirect target.
+    const [, init] = deliveryPosts(fetchMock)[0];
+    expect(init.redirect).toBe('manual');
+    await waitForAssertion(async () => {
+      const queued = await stack.app.request('/v1/deliveries', {
+        headers: { authorization: `Bearer ${bob.token}` },
+      });
+      const [item] = ((await queued.json()) as {
+        data: Array<{ status: string; last_dispatch_error: string | null }>;
+      }).data;
+      expect(item).toMatchObject({ status: 'queued' });
+      expect(item.last_dispatch_error).toMatch(/redirect not allowed \(HTTP 302\)/);
     });
   });
 

--- a/packages/engine/src/engine/delivery.ts
+++ b/packages/engine/src/engine/delivery.ts
@@ -1,4 +1,4 @@
-import { eq, and, not, asc, isNull, isNotNull, inArray, notInArray, lte, gt, sql } from 'drizzle-orm';
+import { eq, and, or, not, asc, isNull, inArray, notInArray, lte, gt, sql } from 'drizzle-orm';
 import type { getDb } from '../db/index.js';
 import { deliveries, messages, agents, readReceipts, channelMembers, channels, dmConversations } from '../db/schema.js';
 import type { DeliveryStatus } from '@relaycast/types';
@@ -628,8 +628,15 @@ export async function fetchDueHttpPushDeliveryEvents(
   const conditions = [
     eq(deliveries.status, 'queued'),
     eq(deliveries.routeNodeKind, 'http_push'),
-    isNotNull(deliveries.nextAttemptAt),
-    lte(deliveries.nextAttemptAt, now),
+    // Match deliveries that are EITHER never-attempted (nextAttemptAt IS NULL —
+    // e.g. the inline send-time push never ran or its waitUntil was lost) OR due
+    // for retry (nextAttemptAt <= now). Without the NULL branch the cron could
+    // only ever *retry* deliveries that already had an inline attempt (the inline
+    // dispatch is what first stamps nextAttemptAt); a fresh http_push delivery
+    // whose inline push never fired would sit queued forever and never reach the
+    // webhook — an http_push agent never "comes online" to pull it, so the cron
+    // is its only guaranteed delivery path.
+    or(isNull(deliveries.nextAttemptAt), lte(deliveries.nextAttemptAt, now)),
     sql`(${deliveries.expiresAt} IS NULL OR ${deliveries.expiresAt} > ${nowSeconds})`,
   ];
   if (opts.workspaceId) {

--- a/packages/engine/src/routes/deliveryRouting.ts
+++ b/packages/engine/src/routes/deliveryRouting.ts
@@ -301,9 +301,21 @@ async function dispatchHttpPush(args: {
       method: 'POST',
       headers,
       body,
-      redirect: 'error',
+      // Do NOT follow redirects: a 3xx could point `url` at an internal address
+      // and bypass the SSRF check above. Cloudflare Workers rejects
+      // `redirect: 'error'` outright ("won't be implemented at the edge"), which
+      // would throw on every dispatch and strand every http_push delivery — so
+      // use 'manual' and reject any redirect ourselves below.
+      redirect: 'manual',
       signal: AbortSignal.timeout(10_000),
     });
+
+    // `redirect: 'manual'` surfaces a redirect as a 3xx status (or an
+    // opaqueredirect response with status 0); treat both as a hard failure.
+    if (response.type === 'opaqueredirect' || (response.status >= 300 && response.status < 400)) {
+      await recordHttpPushRetry(args.ctx, args.delivery.id, `redirect not allowed (HTTP ${response.status})`);
+      return 'failed';
+    }
 
     if (!response.ok) {
       await recordHttpPushRetry(args.ctx, args.delivery.id, `HTTP ${response.status}`);

--- a/packages/engine/src/routes/deliveryRouting.ts
+++ b/packages/engine/src/routes/deliveryRouting.ts
@@ -1,5 +1,5 @@
 import type { Context } from 'hono';
-import { and, eq, inArray, sql } from 'drizzle-orm';
+import { and, eq, inArray, isNull, sql } from 'drizzle-orm';
 import type { AppEnv, EngineRuntime } from '../env.js';
 import * as deliveryEngine from '../engine/delivery.js';
 import { buildDeliverFrame, buildDeliverPayload } from '../engine/deliveryWire.js';
@@ -271,6 +271,15 @@ async function dispatchHttpPush(args: {
     ];
     if (args.delivery.nextAttemptAt) {
       claimConditions.push(eq(deliveryRows.nextAttemptAt, args.delivery.nextAttemptAt));
+    } else {
+      // Never-attempted rows (nextAttemptAt IS NULL) are now selectable by the
+      // sweep. status stays 'queued' across the async fetch below, so without a
+      // compare-and-swap token on nextAttemptAt two concurrent dispatchers
+      // (inline vs cron, or two overlapping sweeps) could both match and
+      // double-POST the webhook. Claiming on `nextAttemptAt IS NULL` makes this
+      // atomic: the first claim stamps a non-null retry time, so the second no
+      // longer matches and bails.
+      claimConditions.push(isNull(deliveryRows.nextAttemptAt));
     }
 
     const started = await args.ctx.db


### PR DESCRIPTION
## Root cause (the real one)

Messages to **http_push (webhook) agents** were never delivered on the hosted deployment. Live diagnosis with a probe agent/node pinned it:

`dispatchHttpPush` calls `fetch(url, { redirect: 'error' })`, but **Cloudflare Workers rejects `redirect: 'error'`** — it throws *before the request is sent*:

> Invalid redirect value, must be one of "follow" or "manual" ("error" won't be implemented since it does not make sense at the edge; use "manual" and check the response status code).

So **every** http_push dispatch threw — on the inline send-time attempt **and** every cron retry. `dispatch_attempts` incremented (the claim UPDATE runs first), but the webhook was never actually hit; the delivery sat `queued` forever with `last_dispatch_error` = the redirect message. This affected **all** http_push agents. (A manual `curl` to the same webhook returns `202` — curl has no such limitation, which is what made it look webhook-side.)

## Fixes (all http_push delivery hardening on the edge)

1. **`redirect: 'error'` → `redirect: 'manual'`** *(root cause)* — Workers supports `'manual'`; we then reject any 3xx / opaqueredirect ourselves, preserving the original no-follow SSRF guarantee (a redirect must not repoint `url` at an internal address) while actually running at the edge. **With this, inline dispatch delivers sub-second on the happy path.**

2. **Sweep also selects `nextAttemptAt IS NULL`** *(backstop)* — the cron redrive previously required `nextAttemptAt IS NOT NULL`, so it could only *retry* deliveries that already had an inline attempt, never make a first one. Broadened so a never-attempted queued delivery still gets driven.

3. **Atomic claim CAS for the null case** *(prevents #2 double-send)* — `dispatchHttpPush` now claims on `nextAttemptAt IS NULL` when null, so overlapping dispatchers can't both POST.

## Latency

The inline send-time dispatch runs within ~seconds (verified: `dispatch_attempts` incremented ~16s after send). So the happy path is immediate; the `*/5` cron is purely a backstop for transient failures — no message waits 5 minutes for normal delivery.

## Tests

- 3xx-redirect rejection recorded as `redirect not allowed (HTTP 302)`, delivery stays queued (not followed / not marked delivered)
- never-attempted delivery swept + acked
- never-attempted delivery claimed once across overlapping sweeps (no double-send)
- existing header test updated to expect `redirect: 'manual'`

✅ 17/17 `nodeDeliveryContracts` conformance tests pass · `tsc --noEmit` clean

## Deploy note

Reaches prod via `relaycast-cloud`: publish new `@relaycast/engine`, bump the dep + the `bundled @relaycast/engine:` version-marker comment in `entrypoints/cloudflare.ts` (SST hashes handler source), then deploy. No logic change needed in `relaycast-cloud`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)