### PR TITLE
fix(engine): deliver relayfile inbound integration messages to node agents

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5666,7 +5666,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -5688,7 +5687,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -5710,7 +5708,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -5732,7 +5729,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -5754,7 +5750,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -5776,7 +5771,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -5798,7 +5792,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -5820,7 +5813,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -5842,7 +5834,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -5864,7 +5855,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -5886,7 +5876,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },

--- a/packages/engine/src/engine.ts
+++ b/packages/engine/src/engine.ts
@@ -37,6 +37,7 @@ import { fileRoutes } from './routes/file.js';
 import { presenceRoutes } from './routes/presence.js';
 import { systemPromptRoutes } from './routes/systemPrompt.js';
 import { inboundWebhookRoutes } from './routes/inboundWebhook.js';
+import { relayfileInboundRoutes } from './routes/relayfileInbound.js';
 import { eventSubscriptionRoutes } from './routes/eventSubscription.js';
 import { actionRoutes } from './routes/action.js';
 import { nodeRoutes } from './routes/node.js';
@@ -198,6 +199,7 @@ export function createEngine(deps: EngineDeps): Hono<AppEnv> {
   v1.route('/', deliveryRoutes);
   v1.route('/', fileRoutes);
   v1.route('/', inboundWebhookRoutes);
+  v1.route('/', relayfileInboundRoutes);
   v1.route('/', eventSubscriptionRoutes);
   v1.route('/', actionRoutes);
   v1.route('/', nodeRoutes);

--- a/packages/engine/src/engine/inboundWebhook.ts
+++ b/packages/engine/src/engine/inboundWebhook.ts
@@ -5,6 +5,9 @@ import { randomHex, sha256Hex } from '../lib/crypto.js';
 import { codedError } from '../lib/httpError.js';
 import { generateId } from './snowflake.js';
 import { inboundWebhookMessageMetadata, sanitizeUserMessageMetadata } from './messageMetadata.js';
+import { runAtomicWrites, type AtomicWrite } from '../ports/database.js';
+import { buildChannelDeliveryWrite, fetchChannelDeliveryOutcomes } from './deliveryWrites.js';
+import { DEFAULT_MAILBOX_DEPTH_CAP, DEFAULT_MAILBOX_TTL_MS, type MailboxConfig } from './mailboxConfig.js';
 
 type Db = ReturnType<typeof getDb>;
 const WEBHOOK_AGENT_NAME = '__relay_webhook__';
@@ -224,5 +227,100 @@ export async function triggerWebhook(
     author,
     created_at: message.createdAt.toISOString(),
     metadata: sanitizeUserMessageMetadata(data.payload),
+  };
+}
+
+export async function triggerIntegrationMessage(
+  db: Db,
+  workspaceId: string,
+  channelId: string,
+  data: {
+    text: string;
+    source: string;
+    author: string;
+    payload?: Record<string, unknown>;
+    webhookId?: string;
+    webhookName?: string;
+    mode?: 'wait' | 'steer';
+  },
+  options: { mailbox?: MailboxConfig } = {},
+) {
+  const postingAgentId = await ensureWebhookAgent(db, workspaceId);
+  const messageId = generateId();
+  const webhookId = data.webhookId ?? `relayfile:${data.source}`;
+  const webhookName = data.webhookName ?? data.source;
+  const metadata = {
+    ...inboundWebhookMessageMetadata({
+      webhookId,
+      webhookName,
+      source: data.source,
+      author: data.author,
+    }),
+    ...sanitizeUserMessageMetadata(data.payload),
+  };
+
+  const mailbox = options.mailbox ?? {
+    ttlMs: DEFAULT_MAILBOX_TTL_MS,
+    depthCap: DEFAULT_MAILBOX_DEPTH_CAP,
+  };
+
+  // Insert the message AND compute channel deliveries in one atomic unit — the
+  // delivery rows are what `routeDeliveryOutcomes` dispatches to node-connected
+  // agents. A bare insert (the previous behavior) produced no deliveries, so
+  // broker/node agents never received inbound integration messages.
+  const results = await runAtomicWrites(db, (writeDb) => {
+    const writes: AtomicWrite[] = [
+      writeDb
+        .insert(messages)
+        .values({
+          id: messageId,
+          workspaceId,
+          channelId,
+          agentId: postingAgentId,
+          body: data.text,
+          metadata,
+        })
+        .returning(),
+    ];
+
+    writes.push(
+      buildChannelDeliveryWrite(writeDb, {
+        workspaceId,
+        messageId,
+        channelId,
+        senderAgentId: postingAgentId,
+        mode: data.mode === 'steer' ? 'next-tool-call' : 'immediate',
+        ttlMs: mailbox.ttlMs,
+        depthCap: mailbox.depthCap,
+      }),
+    );
+
+    return writes;
+  });
+  const [message] = results[0] as (typeof messages.$inferSelect)[];
+
+  const [channel] = await db
+    .select({ name: channels.name })
+    .from(channels)
+    .where(eq(channels.id, channelId));
+
+  const outcomes = await fetchChannelDeliveryOutcomes(db, {
+    messageId,
+    channelId,
+    senderAgentId: postingAgentId,
+  });
+
+  return {
+    message_id: message.id,
+    workspace_id: workspaceId,
+    channel_id: channelId,
+    channel: channel?.name || '',
+    text: message.body,
+    source: data.source,
+    author: data.author,
+    created_at: message.createdAt.toISOString(),
+    metadata: sanitizeUserMessageMetadata(data.payload),
+    _deliveries: outcomes.deliveries,
+    _delivery_rejections: outcomes.rejections,
   };
 }

--- a/packages/engine/src/ports/index.ts
+++ b/packages/engine/src/ports/index.ts
@@ -94,6 +94,12 @@ export interface EngineConfig {
   appSemver?: string;
   sdkSemver?: string;
   /**
+   * Master secret used to derive relayfile -> relaycast inbound HMAC secrets.
+   * Hosted adapters wire this from their internal secret; self-host can omit it
+   * to disable the relayfile inbound bridge.
+   */
+  relayfileInboundSecret?: string;
+  /**
    * Optional egress proxy for http_push node delivery. When set, nodes that
    * register with `delivery.use_proxy: true` have their webhook POST routed
    * through this forwarder instead of hitting the destination directly — the

--- a/packages/engine/src/routes/__tests__/relayfileInbound.test.ts
+++ b/packages/engine/src/routes/__tests__/relayfileInbound.test.ts
@@ -1,0 +1,203 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { createHmac } from 'node:crypto';
+import { and, eq } from 'drizzle-orm';
+import { createEngine } from '../../engine.js';
+import { createNodeRuntime, type NodeRuntime } from '../../adapters/node/index.js';
+import { createWorkspace, registerAgent } from '../../__tests__/conformance/harness.js';
+import { deliveries } from '../../db/schema.js';
+import {
+  deriveRelayfileInboundSecret,
+  formatRelayfileEventMessage,
+} from '../relayfileInbound.js';
+
+interface Stack {
+  app: ReturnType<typeof createEngine>;
+  runtime: NodeRuntime;
+}
+
+const stacks: Stack[] = [];
+
+function makeStack(): Stack {
+  const runtime = createNodeRuntime({
+    dbPath: ':memory:',
+    baseUrl: 'http://localhost:0',
+    migrate: true,
+    config: {
+      environment: 'test',
+      relayfileInboundSecret: 'relaycast-master',
+    },
+    presence: { sweepIntervalMs: 0 },
+    eventQueue: { pollIntervalMs: 0 },
+  });
+  runtime.webhookQueue.stop();
+  const stack = { app: createEngine(runtime.deps), runtime };
+  stacks.push(stack);
+  return stack;
+}
+
+afterEach(() => {
+  for (const stack of stacks.splice(0)) stack.runtime.close();
+});
+
+function signedHeaders(secret: string, body: string, timestamp = String(Math.floor(Date.now() / 1000))) {
+  return {
+    'content-type': 'application/json',
+    'X-Relay-Timestamp': timestamp,
+    'X-Relay-Signature': createHmac('sha256', secret).update(`${timestamp}.${body}`).digest('hex'),
+    'X-Relay-Event-Id': 'evt_1',
+  };
+}
+
+describe('relayfile inbound bridge', () => {
+  it('provisions a signed relayfile target for a workspace channel', async () => {
+    const stack = makeStack();
+    const ws = await createWorkspace(stack.app, 'relayfile-target');
+
+    const res = await stack.app.request('/v1/integrations/relayfile/inbound-target', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', authorization: `Bearer ${ws.workspaceKey}` },
+      body: JSON.stringify({ channel: 'general', provider: 'slack', pathGlob: '/slack/channels/C123/messages/**' }),
+    });
+
+    expect(res.status).toBe(201);
+    const body = await res.json() as { data: { url: string; secret: string; channel_id: string } };
+    expect(body.data.url).toContain('/v1/integrations/relayfile/inbound/');
+    expect(body.data.url).toContain('provider=slack');
+    expect(body.data.url).toContain('pathGlob=%2Fslack%2Fchannels%2FC123%2Fmessages%2F**');
+    expect(body.data.secret).toBe(await deriveRelayfileInboundSecret('relaycast-master', {
+      workspaceId: ws.workspaceId,
+      channelId: body.data.channel_id,
+      provider: 'slack',
+      pathGlob: '/slack/channels/C123/messages/**',
+    }));
+  });
+
+  it('accepts a signed relayfile event, injects one message, and dedupes replay', async () => {
+    const stack = makeStack();
+    const ws = await createWorkspace(stack.app, 'relayfile-delivery');
+    const targetRes = await stack.app.request('/v1/integrations/relayfile/inbound-target', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', authorization: `Bearer ${ws.workspaceKey}` },
+      body: JSON.stringify({ channel: 'general', provider: 'slack', pathGlob: '/slack/channels/C123/messages/**' }),
+    });
+    const targetBody = await targetRes.json() as { data: { url: string; secret: string } };
+    const target = targetBody.data;
+    const event = {
+      eventId: 'evt_slack_1',
+      type: 'file.created',
+      path: '/slack/channels/C123/messages/1780607825_485189/meta.json',
+      revision: 'rev_1',
+      origin: 'provider_sync',
+      provider: 'slack',
+      timestamp: new Date().toISOString(),
+      snapshot: {
+        path: '/slack/channels/C123/messages/1780607825_485189/meta.json',
+        contentType: 'application/json',
+        encoding: 'utf-8',
+        content: JSON.stringify({ user_name: 'Ada', text: 'hello from slack' }),
+      },
+    };
+    const payload = JSON.stringify(event);
+    const timestamp = String(Math.floor(Date.now() / 1000));
+
+    const first = await stack.app.request(target.url, {
+      method: 'POST',
+      headers: signedHeaders(target.secret, payload, timestamp),
+      body: payload,
+    });
+    expect(first.status).toBe(201);
+    const replay = await stack.app.request(target.url, {
+      method: 'POST',
+      headers: signedHeaders(target.secret, payload, timestamp),
+      body: payload,
+    });
+    expect(replay.status).toBe(201);
+    expect(await replay.json()).toMatchObject({ data: { replayed: true } });
+
+    const list = await stack.app.request('/v1/channels/general/messages', {
+      headers: { authorization: `Bearer ${ws.workspaceKey}` },
+    });
+    expect(list.status).toBe(200);
+    const messages = await list.json() as { data: Array<{ text: string }> };
+    expect(messages.data.filter((message) => message.text.includes('hello from slack'))).toHaveLength(1);
+  });
+
+  it('creates channel deliveries so node/broker agents receive the message', async () => {
+    // Regression guard for the node-delivery bug: triggerIntegrationMessage used
+    // to insert the message with a bare write (no delivery rows), so fanoutToChannel
+    // (which skips node context for message.created) meant node-connected agents
+    // never received inbound integration messages. A queued delivery row for a
+    // channel member is the proof that routeDeliveryOutcomes has something to dispatch.
+    const stack = makeStack();
+    const ws = await createWorkspace(stack.app, 'relayfile-node-delivery');
+    const bob = await registerAgent(stack.app, ws.workspaceKey, 'bob'); // auto-joins #general
+
+    const targetRes = await stack.app.request('/v1/integrations/relayfile/inbound-target', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', authorization: `Bearer ${ws.workspaceKey}` },
+      body: JSON.stringify({ channel: 'general', provider: 'slack', pathGlob: '/slack/channels/C123/messages/**' }),
+    });
+    const target = (await targetRes.json() as { data: { url: string; secret: string } }).data;
+
+    const event = {
+      eventId: 'evt_node_1',
+      type: 'file.created',
+      path: '/slack/channels/C123/messages/1780607825_999/meta.json',
+      revision: 'rev_1',
+      origin: 'provider_sync',
+      provider: 'slack',
+      timestamp: new Date().toISOString(),
+      snapshot: {
+        path: '/slack/channels/C123/messages/1780607825_999/meta.json',
+        contentType: 'application/json',
+        encoding: 'utf-8',
+        content: JSON.stringify({ user_name: 'Ada', text: 'ping the agents' }),
+      },
+    };
+    const payload = JSON.stringify(event);
+    const res = await stack.app.request(target.url, {
+      method: 'POST',
+      headers: signedHeaders(target.secret, payload),
+      body: payload,
+    });
+    expect(res.status).toBe(201);
+    const messageId = (await res.json() as { data: { message_id: string } }).data.message_id;
+
+    const rows = await stack.runtime.deps.db
+      .select()
+      .from(deliveries)
+      .where(and(eq(deliveries.agentId, bob.agentId), eq(deliveries.messageId, messageId)));
+    expect(rows).toHaveLength(1);
+    expect(rows[0].status).toBe('queued');
+  });
+
+  it('rejects bad signatures', async () => {
+    const stack = makeStack();
+    const ws = await createWorkspace(stack.app, 'relayfile-bad-signature');
+    const targetRes = await stack.app.request('/v1/integrations/relayfile/inbound-target', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', authorization: `Bearer ${ws.workspaceKey}` },
+      body: JSON.stringify({ channel: 'general', provider: 'linear', pathGlob: '/linear/issues/**' }),
+    });
+    const targetBody = await targetRes.json() as { data: { url: string } };
+    const target = targetBody.data;
+    const payload = JSON.stringify({ eventId: 'evt_bad', type: 'file.created', path: '/linear/issues/ENG-1.json', provider: 'linear' });
+    const res = await stack.app.request(target.url, {
+      method: 'POST',
+      headers: signedHeaders('wrong-secret', payload),
+      body: payload,
+    });
+    expect(res.status).toBe(401);
+  });
+
+  it('formats provider records with a path fallback', () => {
+    expect(formatRelayfileEventMessage({
+      type: 'file.created',
+      path: '/github/repos/o/r/issues/1.json',
+      snapshot: { content: JSON.stringify({ title: 'Bug', body: 'Needs fixing', user: { login: 'octo' } }) },
+    }, 'github')).toMatchObject({
+      author: 'octo',
+      text: expect.stringContaining('Bug'),
+    });
+  });
+});

--- a/packages/engine/src/routes/relayfileInbound.ts
+++ b/packages/engine/src/routes/relayfileInbound.ts
@@ -1,0 +1,423 @@
+import { Hono } from 'hono';
+import { z } from 'zod';
+import { and, eq } from 'drizzle-orm';
+import type { AppEnv } from '../env.js';
+import { channels } from '../db/schema.js';
+import { requireWorkspaceKey } from '../middleware/auth.js';
+import { rateLimit } from '../middleware/rateLimit.js';
+import { jsonCreated, jsonError, jsonNotFound, jsonOk, parseJsonBody } from '../lib/httpResponse.js';
+import { getRequestLogger } from '../lib/logger.js';
+import { runIdempotent } from '../middleware/idempotency.js';
+import * as inboundWebhookEngine from '../engine/inboundWebhook.js';
+import { fanoutToChannel } from './fanout.js';
+import { routeDeliveryOutcomes } from './deliveryRouting.js';
+import { resolveMailboxConfig } from '../engine/mailboxConfig.js';
+import { runInBackground } from './background.js';
+import { sendWebhookEvent } from './webhookOutbox.js';
+import { emitServerEvent } from '../lib/serverTelemetry.js';
+
+export const relayfileInboundRoutes = new Hono<AppEnv>();
+
+const MAX_SKEW_MS = 5 * 60 * 1000;
+const SECRET_LABEL = 'relayfile-inbound:v1';
+const IDEMPOTENCY_TTL_SECONDS = 60 * 60 * 24 * 30;
+
+const createTargetSchema = z.object({
+  channel: z.string().min(1),
+  provider: z.string().min(1),
+  pathGlob: z.string().min(1),
+});
+
+interface RelayfileEvent {
+  eventId?: string;
+  type?: string;
+  path?: string;
+  revision?: string;
+  origin?: string;
+  provider?: string;
+  correlationId?: string;
+  timestamp?: string;
+  contentHash?: string;
+  snapshot?: RelayfileSnapshot;
+}
+
+interface RelayfileSnapshot {
+  path?: string;
+  contentType?: string;
+  encoding?: string;
+  content?: string;
+  truncated?: boolean;
+}
+
+relayfileInboundRoutes.post('/integrations/relayfile/inbound-target', requireWorkspaceKey, rateLimit, async (c) => {
+  const parsed = await parseJsonBody(c, createTargetSchema, 'invalid relayfile inbound target body');
+  if (!parsed.ok) return parsed.response;
+
+  const workspace = c.get('workspace');
+  const db = c.get('db');
+  const channel = await getChannelByName(db, workspace.id, parsed.data.channel);
+  if (!channel) {
+    return jsonNotFound(c, 'channel_not_found', `Channel "${parsed.data.channel}" not found`);
+  }
+
+  const master = c.get('engine').config?.relayfileInboundSecret?.trim();
+  if (!master) {
+    return jsonError(c, 'relayfile_inbound_unavailable', 'Relayfile inbound bridge is not configured', 503);
+  }
+
+  const provider = normalizeProvider(parsed.data.provider);
+  const pathGlob = normalizePathGlob(parsed.data.pathGlob);
+  const secret = await deriveRelayfileInboundSecret(master, {
+    workspaceId: workspace.id,
+    channelId: channel.id,
+    provider,
+    pathGlob,
+  });
+  const url = new URL(`/v1/integrations/relayfile/inbound/${encodeURIComponent(workspace.id)}/${encodeURIComponent(channel.id)}`, c.req.url);
+  url.searchParams.set('provider', provider);
+  url.searchParams.set('pathGlob', pathGlob);
+
+  return jsonCreated(c, {
+    url: url.toString(),
+    secret,
+    workspace_id: workspace.id,
+    channel_id: channel.id,
+    channel: channel.name,
+    provider,
+    path_glob: pathGlob,
+  });
+});
+
+relayfileInboundRoutes.post('/integrations/relayfile/inbound/:workspaceId/:channelId', async (c) => {
+  const logger = getRequestLogger(c, 'relayfile.inbound');
+  const workspaceId = c.req.param('workspaceId');
+  const channelId = c.req.param('channelId');
+  const provider = normalizeProvider(c.req.query('provider') ?? '');
+  const pathGlob = normalizePathGlob(c.req.query('pathGlob') ?? '');
+  if (!workspaceId || !channelId || !provider || !pathGlob) {
+    return jsonError(c, 'bad_request', 'missing relayfile inbound route parameters', 400);
+  }
+
+  const master = c.get('engine').config?.relayfileInboundSecret?.trim();
+  if (!master) {
+    return jsonError(c, 'relayfile_inbound_unavailable', 'Relayfile inbound bridge is not configured', 503);
+  }
+
+  const rawBody = await c.req.raw.clone().arrayBuffer();
+  const secret = await deriveRelayfileInboundSecret(master, { workspaceId, channelId, provider, pathGlob });
+  const verified = await verifyRelayfileSignature(c.req.raw.headers, rawBody, secret, Date.now());
+  if (!verified.ok) {
+    logger.warn('relayfile inbound signature rejected', { workspace_id: workspaceId, channel_id: channelId, reason: verified.reason });
+    return jsonError(c, 'unauthorized', 'invalid relayfile signature', 401);
+  }
+
+  let event: RelayfileEvent;
+  try {
+    event = JSON.parse(new TextDecoder().decode(rawBody)) as RelayfileEvent;
+  } catch {
+    return jsonError(c, 'bad_request', 'invalid relayfile event body', 400);
+  }
+  const deliveryEventId = c.req.header('X-Relay-Event-Id')?.trim() || event.eventId;
+
+  if (!event.path || !event.type) {
+    return jsonOk(c, { ok: true, skipped: 'missing_event_fields' });
+  }
+  if (event.provider && normalizeProvider(event.provider) !== provider) {
+    return jsonOk(c, { ok: true, skipped: 'provider_mismatch' });
+  }
+  if (!eventMatchesGlob(event.path, pathGlob)) {
+    return jsonOk(c, { ok: true, skipped: 'path_mismatch' });
+  }
+  if (event.origin === 'agent_write') {
+    return jsonOk(c, { ok: true, skipped: 'agent_write' });
+  }
+  if (event.type !== 'file.created' && event.type !== 'file.updated') {
+    return jsonOk(c, { ok: true, skipped: 'ignored_event_type' });
+  }
+
+  const channel = await getChannelById(c.get('db'), workspaceId, channelId);
+  if (!channel) {
+    return jsonOk(c, { ok: true, skipped: 'channel_not_found' });
+  }
+
+  const message = formatRelayfileEventMessage(event, provider);
+  if (!message) {
+    return jsonOk(c, { ok: true, skipped: 'unformatted_event' });
+  }
+
+  const mailbox = resolveMailboxConfig(c.get('engine').config, workspaceId);
+
+  try {
+    const result = await runIdempotent({
+      workspaceId,
+      actorId: 'relayfile-inbound',
+      scope: `relayfile-inbound:${channelId}`,
+      key: deliveryEventId,
+      fingerprint: JSON.stringify({ path: event.path, revision: event.revision, contentHash: event.contentHash }),
+      kv: c.get('engine').kv,
+      ttlSeconds: IDEMPOTENCY_TTL_SECONDS,
+      operation: () => inboundWebhookEngine.triggerIntegrationMessage(c.get('db'), workspaceId, channelId, {
+        text: message.text,
+        source: `relayfile:${provider}`,
+        author: message.author,
+        webhookId: `relayfile:${provider}`,
+        webhookName: `Relayfile ${provider}`,
+        payload: {
+          relayfile: {
+            workspaceId: eventWorkspaceId(event),
+            path: event.path,
+            revision: event.revision,
+            eventId: deliveryEventId,
+            provider,
+            contentHash: event.contentHash,
+          },
+          provider,
+          path: event.path,
+          event: event.type,
+          record: message.record,
+        },
+      }, { mailbox }),
+    });
+
+    if (!result.replayed) {
+      const eventData = {
+        id: result.data.message_id,
+        channel: result.data.channel,
+        channel_name: result.data.channel,
+        channel_id: result.data.channel_id,
+        text: result.data.text,
+        created_at: result.data.created_at,
+        from_name: result.data.author,
+        metadata: result.data.metadata,
+      };
+      try {
+        await sendWebhookEvent(c, { type: 'message.created', workspaceId, data: eventData });
+      } catch (err) {
+        logger.error('relayfile inbound outbox enqueue failed', {
+          workspace_id: workspaceId,
+          channel_id: channelId,
+          provider,
+          error: err instanceof Error ? err.message : String(err),
+        });
+      }
+      // Fan out to workspace-stream subscribers (dashboard/websocket) and
+      // dispatch the computed mailbox deliveries to node-connected (broker)
+      // agents. Without routeDeliveryOutcomes, fanoutToChannel alone reaches only
+      // workspace-stream subscribers and node agents get nothing. Both run in the
+      // background so a delivery-routing hiccup never fails the ingress — it must
+      // return 2xx fast, since the transport retries (and eventually DLQs) non-2xx.
+      runInBackground(
+        c,
+        fanoutToChannel(c, channelId, 'message.created', eventData, workspaceId),
+        'relayfile inbound fanout',
+      );
+      const deliveries = result.data._deliveries;
+      if (deliveries && deliveries.length > 0) {
+        runInBackground(
+          c,
+          routeDeliveryOutcomes(c, deliveries, 'message.created', eventData),
+          'relayfile inbound deliveries',
+        );
+      }
+      emitServerEvent(c, workspaceId, 'relaycast_server_relayfile_inbound_delivered', {
+        channel_id: channelId,
+        message_id: result.data.message_id,
+        provider,
+      });
+    }
+
+    return jsonCreated(c, { ok: true, replayed: result.replayed, message_id: result.data.message_id });
+  } catch (err) {
+    const code = (err as Error & { code?: string }).code;
+    if (code === 'idempotency_in_progress') {
+      return jsonOk(c, { ok: true, skipped: 'duplicate_in_progress' });
+    }
+    if (code === 'idempotency_key_reused') {
+      logger.warn('relayfile inbound event id reused with different payload', { workspace_id: workspaceId, event_id: deliveryEventId });
+      return jsonOk(c, { ok: true, skipped: 'event_id_reused' });
+    }
+    logger.error('relayfile inbound delivery failed', {
+      workspace_id: workspaceId,
+      channel_id: channelId,
+      provider,
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return jsonOk(c, { ok: true, skipped: 'delivery_failed' });
+  }
+});
+
+async function getChannelByName(db: AppEnv['Variables']['db'], workspaceId: string, name: string) {
+  const [row] = await db
+    .select({ id: channels.id, name: channels.name })
+    .from(channels)
+    .where(and(eq(channels.workspaceId, workspaceId), eq(channels.name, name)));
+  return row ?? null;
+}
+
+async function getChannelById(db: AppEnv['Variables']['db'], workspaceId: string, channelId: string) {
+  const [row] = await db
+    .select({ id: channels.id, name: channels.name })
+    .from(channels)
+    .where(and(eq(channels.workspaceId, workspaceId), eq(channels.id, channelId)));
+  return row ?? null;
+}
+
+export async function deriveRelayfileInboundSecret(
+  master: string,
+  input: { workspaceId: string; channelId: string; provider: string; pathGlob: string },
+): Promise<string> {
+  const label = `${SECRET_LABEL}:${input.workspaceId}:${input.channelId}:${normalizeProvider(input.provider)}:${normalizePathGlob(input.pathGlob)}`;
+  const key = await crypto.subtle.importKey('raw', new TextEncoder().encode(master), { name: 'HMAC', hash: 'SHA-256' }, false, ['sign']);
+  const signed = await crypto.subtle.sign('HMAC', key, new TextEncoder().encode(label));
+  return bytesToHex(new Uint8Array(signed));
+}
+
+export async function verifyRelayfileSignature(
+  headers: Headers,
+  body: ArrayBuffer,
+  secret: string,
+  nowMs = Date.now(),
+): Promise<{ ok: true } | { ok: false; reason: string }> {
+  const timestamp = headers.get('X-Relay-Timestamp')?.trim() ?? '';
+  const signature = headers.get('X-Relay-Signature')?.trim().toLowerCase() ?? '';
+  if (!timestamp || !signature) return { ok: false, reason: 'missing_headers' };
+  const timestampMs = parseRelayTimestamp(timestamp);
+  if (!Number.isFinite(timestampMs)) return { ok: false, reason: 'invalid_timestamp' };
+  if (Math.abs(nowMs - timestampMs) > MAX_SKEW_MS) return { ok: false, reason: 'timestamp_skew' };
+
+  const providedHex = signature.startsWith('sha256=') ? signature.slice('sha256='.length) : signature;
+  const provided = hexToBytes(providedHex);
+  if (!provided) return { ok: false, reason: 'invalid_signature_encoding' };
+  const raw = new TextDecoder().decode(body);
+  const key = await crypto.subtle.importKey('raw', new TextEncoder().encode(secret), { name: 'HMAC', hash: 'SHA-256' }, false, ['sign']);
+  const signed = await crypto.subtle.sign('HMAC', key, new TextEncoder().encode(`${timestamp}.${raw}`));
+  if (!constantTimeEqual(provided, new Uint8Array(signed))) return { ok: false, reason: 'signature_mismatch' };
+  return { ok: true };
+}
+
+export function formatRelayfileEventMessage(event: RelayfileEvent, provider: string): { text: string; author: string; record: unknown } | null {
+  const record = parseSnapshotRecord(event.snapshot);
+  const author = recordAuthor(record) ?? provider;
+  const title = recordTitle(record);
+  const body = recordBody(record);
+  const providerLabel = provider.charAt(0).toUpperCase() + provider.slice(1);
+  const lines = [`${providerLabel} update`];
+  if (title) lines.push(title);
+  if (body && body !== title) lines.push(body);
+  lines.push(`Relayfile path: ${event.path}`);
+  return { text: lines.filter(Boolean).join('\n'), author, record };
+}
+
+function parseSnapshotRecord(snapshot: RelayfileSnapshot | undefined): unknown {
+  if (!snapshot?.content) return null;
+  if (snapshot.encoding === 'base64') return null;
+  const content = snapshot.content.trim();
+  if (!content) return null;
+  try {
+    return JSON.parse(content) as unknown;
+  } catch {
+    return content.slice(0, 500);
+  }
+}
+
+function recordAuthor(record: unknown): string | null {
+  const r = asRecord(record);
+  if (!r) return null;
+  return firstString(
+    r.author,
+    r.author_name,
+    r.user_name,
+    r.username,
+    asRecord(r.user)?.name,
+    asRecord(r.user)?.login,
+    asRecord(r.assignee)?.name,
+  );
+}
+
+function recordTitle(record: unknown): string | null {
+  if (typeof record === 'string') return record;
+  const r = asRecord(record);
+  if (!r) return null;
+  return firstString(r.title, r.name, r.identifier, r.subject, r.text, r.body, r.message);
+}
+
+function recordBody(record: unknown): string | null {
+  const r = asRecord(record);
+  if (!r) return null;
+  const text = firstString(r.text, r.body, r.description, r.message, r.content);
+  if (text && text.length > 1200) return `${text.slice(0, 1200)}...`;
+  return text;
+}
+
+function firstString(...values: unknown[]): string | null {
+  for (const value of values) {
+    if (typeof value === 'string' && value.trim()) return value.trim();
+  }
+  return null;
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === 'object' && !Array.isArray(value) ? value as Record<string, unknown> : null;
+}
+
+function normalizeProvider(provider: string): string {
+  return provider.trim().toLowerCase();
+}
+
+function normalizePathGlob(pathGlob: string): string {
+  const trimmed = pathGlob.trim();
+  if (!trimmed || trimmed === '*') return '/**';
+  return trimmed.startsWith('/') ? trimmed : `/${trimmed}`;
+}
+
+function eventMatchesGlob(path: string, glob: string): boolean {
+  const normalizedPath = normalizePathGlob(path);
+  const normalizedGlob = normalizePathGlob(glob);
+  if (normalizedGlob === '/**' || normalizedGlob === normalizedPath) return true;
+  if (normalizedGlob.endsWith('/**')) {
+    const prefix = normalizedGlob.slice(0, -'/**'.length);
+    return normalizedPath === prefix || normalizedPath.startsWith(`${prefix}/`);
+  }
+  if (normalizedGlob.endsWith('/*')) {
+    const prefix = normalizedGlob.slice(0, -'/*'.length);
+    const rest = normalizedPath.slice(prefix.length + 1);
+    return normalizedPath.startsWith(`${prefix}/`) && !rest.includes('/');
+  }
+  if (normalizedGlob.endsWith('*')) return normalizedPath.startsWith(normalizedGlob.slice(0, -1));
+  return false;
+}
+
+function eventWorkspaceId(event: RelayfileEvent): string | undefined {
+  const correlation = event.correlationId ?? '';
+  return correlation.startsWith('workspace:') ? correlation.slice('workspace:'.length) : undefined;
+}
+
+function parseRelayTimestamp(timestamp: string): number {
+  if (/^\d+$/.test(timestamp)) {
+    const seconds = Number.parseInt(timestamp, 10);
+    return seconds * 1000;
+  }
+  return Date.parse(timestamp);
+}
+
+function constantTimeEqual(a: Uint8Array, b: Uint8Array): boolean {
+  let diff = a.length ^ b.length;
+  const len = Math.max(a.length, b.length);
+  for (let i = 0; i < len; i += 1) {
+    diff |= (a[i] ?? 0) ^ (b[i] ?? 0);
+  }
+  return diff === 0;
+}
+
+function bytesToHex(bytes: Uint8Array): string {
+  let out = '';
+  for (const b of bytes) out += b.toString(16).padStart(2, '0');
+  return out;
+}
+
+function hexToBytes(hex: string): Uint8Array | null {
+  if (!hex || hex.length % 2 !== 0 || /[^0-9a-f]/.test(hex)) return null;
+  const out = new Uint8Array(hex.length / 2);
+  for (let i = 0; i < out.length; i += 1) out[i] = Number.parseInt(hex.slice(i * 2, i * 2 + 2), 16);
+  return out;
+}


### PR DESCRIPTION
## What

Lands the **relayfile inbound bridge** (provider → relay agent) on the engine and fixes the one bug that kept it from working end-to-end: **inbound provider messages never reached node/broker-connected agents.**

This is the server-side mirror of the shipped outbound writeback bridge. A provider event (Slack/GitHub/Linear) written to the relayfile VFS fans out to a `webhook_subscription`, which POSTs a signed delivery to the new route `POST /v1/integrations/relayfile/inbound/:workspaceId/:channelId`. The route verifies the HMAC, dedupes, formats the record, and injects it into the bound relay channel.

## The bug

`triggerIntegrationMessage` inserted the message with a **bare insert** and the route then called `fanoutToChannel(…, 'message.created', …)`. Because `message.created` is a `NODE_DELIVERY_EVENT_TYPE`, `fanoutToChannel` deliberately **skips** `sendNodeContextForChannel` for it (normal messages reach nodes via the mailbox/delivery path). Since the route never computed mailbox deliveries either, **node/broker agents received nothing** — only workspace-stream (dashboard/websocket) subscribers did. Given broker 9.1.x node-only delivery, agents got no inbound integration messages at all.

## The fix

- `triggerIntegrationMessage` now writes the message **and** channel deliveries in one atomic unit (mirroring `postMessage` via `buildChannelDeliveryWrite`) and returns `_deliveries` / `_delivery_rejections`.
- The route dispatches those deliveries via `routeDeliveryOutcomes`, run in the **background** (`runInBackground`) alongside the workspace fanout — so a delivery-routing hiccup never fails the ingress. The ingress must return **2xx fast** because the transport retries then DLQs non-2xx.
- Kept the integration insert (not a wholesale swap to `postMessage`) so the **display-author metadata is preserved** — `postMessage` runs `sanitizeUserMessageMetadata`, which would strip the `__relaycast_*` author markers and make messages render as `__relay_webhook__`.
- Surfaced the previously **swallowed** `delivery_failed` error in logs (it hid the root cause during debugging).

## Tests

- New regression test: asserts a **queued delivery row** is created for a channel-member agent after a signed inbound event (the exact thing the bare insert failed to do).
- Full engine suite green: **213/213**. Typecheck + lint clean.

## Notes / follow-ups (not in this PR)

- Binary / base64 / >64KB snapshots still degrade to a skeleton/sliced message (inline snapshot cap is 64KB). Acceptable for now; noted as a follow-up.
- Residual echo consideration: the injected `message.created` re-fires the same channel's outbound writeback subscription; the inbound side already guards `origin === 'agent_write'`. Worth confirming end-to-end.
- Cross-repo: the relay CLI already provisions this route (`integration subscribe` → inbound-target → `webhook_subscription`); relaycast-cloud must have `RELAYCAST_INTERNAL_SECRET` set and be deployed for the live endpoint. E2E (real Slack message → relay channel, no client) is the next gate and needs a preview deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/AgentWorkforce/relaycast/pull/228?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

