### PR TITLE
feat(engine): relayfile inbound integration ingress + node delivery

### DIFF
--- a/.trajectories/active/traj_qs5trmxsz90l/trajectory.json
+++ b/.trajectories/active/traj_qs5trmxsz90l/trajectory.json
@@ -55,6 +55,42 @@
             "reasoning": "The workflow changes pyproject.toml version before uv sync; uv.lock must be refreshed and committed so release tags do not leave the Python SDK lockfile at the previous version."
           },
           "significance": "high"
+        },
+        {
+          "ts": 1783497752646,
+          "type": "decision",
+          "content": "Validated relayfile-cloud event payload as typed camelCase instead of renaming it: Validated relayfile-cloud event payload as typed camelCase instead of renaming it",
+          "raw": {
+            "question": "Validated relayfile-cloud event payload as typed camelCase instead of renaming it",
+            "chosen": "Validated relayfile-cloud event payload as typed camelCase instead of renaming it",
+            "alternatives": [],
+            "reasoning": "relayfile producer currently emits eventId/contentHash/contentType/correlationId; Relaycast owns the target request and callback URL, so only those new Relaycast wire fields were changed to path_glob."
+          },
+          "significance": "high"
+        },
+        {
+          "ts": 1783497752659,
+          "type": "decision",
+          "content": "Added strict idempotency mode only for relayfile inbound: Added strict idempotency mode only for relayfile inbound",
+          "raw": {
+            "question": "Added strict idempotency mode only for relayfile inbound",
+            "chosen": "Added strict idempotency mode only for relayfile inbound",
+            "alternatives": [],
+            "reasoning": "Provider redelivery with the same X-Relay-Event-Id must not proceed without durable dedupe, while existing user-authenticated routes keep their historical best-effort fallback."
+          },
+          "significance": "high"
+        },
+        {
+          "ts": 1783498123318,
+          "type": "reflection",
+          "content": "Review-clean pass addressed relayfile inbound security, validation, delivery routing, idempotency, OpenAPI, and test-gate issues; focused and root gates now pass under Node 22.",
+          "raw": {
+            "confidence": 0.9
+          },
+          "significance": "high",
+          "tags": [
+            "confidence:0.9"
+          ]
         }
       ]
     }

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -974,6 +974,123 @@ components:
           items:
             $ref: '#/components/schemas/ConsoleCostAgent'
 
+    RelayfileInboundTargetRequest:
+      type: object
+      required:
+        - channel
+        - provider
+        - path_glob
+      properties:
+        channel:
+          type: string
+          description: Relaycast channel name that receives matching relayfile events.
+        provider:
+          type: string
+          description: Relayfile provider namespace, such as `slack`, `linear`, or `github`.
+        path_glob:
+          type: string
+          description: Relayfile path glob to bind to this channel.
+
+    RelayfileInboundTarget:
+      type: object
+      required:
+        - url
+        - secret
+        - workspace_id
+        - channel_id
+        - channel
+        - provider
+        - path_glob
+      properties:
+        url:
+          type: string
+          format: uri
+          description: HMAC-authenticated callback URL for relayfile deliveries.
+        secret:
+          type: string
+          description: Derived HMAC secret for signing callback requests.
+        workspace_id:
+          type: string
+        channel_id:
+          type: string
+        channel:
+          type: string
+        provider:
+          type: string
+        path_glob:
+          type: string
+
+    RelayfileInboundEventSnapshot:
+      type: object
+      properties:
+        path:
+          type: string
+        contentType:
+          type: string
+        encoding:
+          type: string
+        content:
+          type: string
+        truncated:
+          type: boolean
+      additionalProperties: true
+
+    RelayfileInboundEvent:
+      type: object
+      properties:
+        eventId:
+          type: string
+        type:
+          type: string
+          enum: [file.created, file.updated, file.deleted]
+        path:
+          type: string
+        revision:
+          type: string
+        origin:
+          type: string
+        provider:
+          type: string
+        correlationId:
+          type: string
+        timestamp:
+          type: string
+        contentHash:
+          type: string
+        snapshot:
+          $ref: '#/components/schemas/RelayfileInboundEventSnapshot'
+      additionalProperties: true
+
+    RelayfileInboundDeliveryResult:
+      type: object
+      required:
+        - replayed
+        - message_id
+      properties:
+        replayed:
+          type: boolean
+        message_id:
+          type: string
+
+    RelayfileInboundSkipResult:
+      type: object
+      required:
+        - skipped
+      properties:
+        skipped:
+          type: string
+          enum:
+            - missing_event_id
+            - missing_event_fields
+            - provider_mismatch
+            - path_mismatch
+            - agent_write
+            - ignored_event_type
+            - channel_not_found
+            - unformatted_event
+            - duplicate_in_progress
+            - event_id_reused
+
     Error:
       type: object
       properties:
@@ -4072,6 +4189,160 @@ paths:
         '204':
           description: Subscription deleted
 
+  /integrations/relayfile/inbound-target:
+    post:
+      summary: Create relayfile inbound target
+      description: >
+        Provision a relayfile inbound callback URL and derived HMAC secret for a
+        workspace channel/provider/path binding.
+      tags:
+        - Relayfile
+      security:
+        - workspaceKey: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RelayfileInboundTargetRequest'
+      responses:
+        '201':
+          description: Relayfile inbound target created
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/SuccessResponse'
+                  - type: object
+                    properties:
+                      data:
+                        $ref: '#/components/schemas/RelayfileInboundTarget'
+        '400':
+          description: Invalid request body
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '404':
+          description: Channel not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '503':
+          description: Relayfile inbound bridge is not configured
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+  /integrations/relayfile/inbound/{workspaceId}/{channelId}:
+    post:
+      summary: Receive relayfile inbound event
+      description: >
+        HMAC-authenticated callback used by relayfile to inject matching provider
+        file events into a Relaycast channel. The HMAC input is
+        `X-Relay-Timestamp + "." + raw request body`, signed with SHA-256.
+      tags:
+        - Relayfile
+      parameters:
+        - name: workspaceId
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: channelId
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: provider
+          in: query
+          required: true
+          schema:
+            type: string
+        - name: path_glob
+          in: query
+          required: true
+          schema:
+            type: string
+        - name: X-Relay-Timestamp
+          in: header
+          required: true
+          schema:
+            type: string
+        - name: X-Relay-Signature
+          in: header
+          required: true
+          schema:
+            type: string
+          description: Hex HMAC-SHA256 signature, optionally prefixed with `sha256=`.
+        - name: X-Relay-Event-Id
+          in: header
+          required: false
+          schema:
+            type: string
+          description: Stable delivery id used for idempotency. If omitted, `eventId` from the JSON body is used.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RelayfileInboundEvent'
+      responses:
+        '201':
+          description: Event delivered as a Relaycast message
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/SuccessResponse'
+                  - type: object
+                    properties:
+                      data:
+                        $ref: '#/components/schemas/RelayfileInboundDeliveryResult'
+        '200':
+          description: Event accepted but skipped
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/SuccessResponse'
+                  - type: object
+                    properties:
+                      data:
+                        $ref: '#/components/schemas/RelayfileInboundSkipResult'
+        '400':
+          description: Invalid route parameters, JSON, or event body
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          description: Invalid relayfile signature
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '413':
+          description: Event body exceeds the relayfile inbound size limit
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Transient delivery failure; relayfile should retry
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '503':
+          description: Relayfile inbound bridge or idempotency storage is unavailable
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
   /webhooks:
     post:
       summary: Create inbound webhook
@@ -4768,6 +5039,8 @@ tags:
     description: Outbound event subscription management
   - name: Webhooks
     description: Inbound webhook management and trigger endpoints
+  - name: Relayfile
+    description: Relayfile inbound integration bridge
   - name: A2A
     description: Agent-to-Agent protocol gateway
   - name: Certify

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -16,7 +16,7 @@
   },
   "scripts": {
     "build": "tsc",
-    "test": "vitest run",
+    "test": "vitest run --root ../.. packages/cli/src/__tests__/cli.test.ts",
     "lint": "eslint src/"
   },
   "dependencies": {

--- a/packages/engine/src/engine.ts
+++ b/packages/engine/src/engine.ts
@@ -37,6 +37,7 @@ import { fileRoutes } from './routes/file.js';
 import { presenceRoutes } from './routes/presence.js';
 import { systemPromptRoutes } from './routes/systemPrompt.js';
 import { inboundWebhookRoutes } from './routes/inboundWebhook.js';
+import { relayfileInboundRoutes } from './routes/relayfileInbound.js';
 import { eventSubscriptionRoutes } from './routes/eventSubscription.js';
 import { actionRoutes } from './routes/action.js';
 import { nodeRoutes } from './routes/node.js';
@@ -198,6 +199,7 @@ export function createEngine(deps: EngineDeps): Hono<AppEnv> {
   v1.route('/', deliveryRoutes);
   v1.route('/', fileRoutes);
   v1.route('/', inboundWebhookRoutes);
+  v1.route('/', relayfileInboundRoutes);
   v1.route('/', eventSubscriptionRoutes);
   v1.route('/', actionRoutes);
   v1.route('/', nodeRoutes);

--- a/packages/engine/src/engine/inboundWebhook.ts
+++ b/packages/engine/src/engine/inboundWebhook.ts
@@ -5,6 +5,9 @@ import { randomHex, sha256Hex } from '../lib/crypto.js';
 import { codedError } from '../lib/httpError.js';
 import { generateId } from './snowflake.js';
 import { inboundWebhookMessageMetadata, sanitizeUserMessageMetadata } from './messageMetadata.js';
+import { runAtomicWrites, type AtomicWrite } from '../ports/database.js';
+import { buildChannelDeliveryWrite, fetchChannelDeliveryOutcomes } from './deliveryWrites.js';
+import { DEFAULT_MAILBOX_DEPTH_CAP, DEFAULT_MAILBOX_TTL_MS, type MailboxConfig } from './mailboxConfig.js';
 
 type Db = ReturnType<typeof getDb>;
 const WEBHOOK_AGENT_NAME = '__relay_webhook__';
@@ -224,5 +227,100 @@ export async function triggerWebhook(
     author,
     created_at: message.createdAt.toISOString(),
     metadata: sanitizeUserMessageMetadata(data.payload),
+  };
+}
+
+export async function triggerIntegrationMessage(
+  db: Db,
+  workspaceId: string,
+  channelId: string,
+  data: {
+    text: string;
+    source: string;
+    author: string;
+    payload?: Record<string, unknown>;
+    webhookId?: string;
+    webhookName?: string;
+    mode?: 'wait' | 'steer';
+  },
+  options: { mailbox?: MailboxConfig } = {},
+) {
+  const postingAgentId = await ensureWebhookAgent(db, workspaceId);
+  const messageId = generateId();
+  const webhookId = data.webhookId ?? `relayfile:${data.source}`;
+  const webhookName = data.webhookName ?? data.source;
+  const metadata = {
+    ...inboundWebhookMessageMetadata({
+      webhookId,
+      webhookName,
+      source: data.source,
+      author: data.author,
+    }),
+    ...sanitizeUserMessageMetadata(data.payload),
+  };
+
+  const mailbox = options.mailbox ?? {
+    ttlMs: DEFAULT_MAILBOX_TTL_MS,
+    depthCap: DEFAULT_MAILBOX_DEPTH_CAP,
+  };
+
+  // Insert the message AND compute channel deliveries in one atomic unit — the
+  // delivery rows are what `routeDeliveryOutcomes` dispatches to node-connected
+  // agents. A bare insert (the previous behavior) produced no deliveries, so
+  // broker/node agents never received inbound integration messages.
+  const results = await runAtomicWrites(db, (writeDb) => {
+    const writes: AtomicWrite[] = [
+      writeDb
+        .insert(messages)
+        .values({
+          id: messageId,
+          workspaceId,
+          channelId,
+          agentId: postingAgentId,
+          body: data.text,
+          metadata,
+        })
+        .returning(),
+    ];
+
+    writes.push(
+      buildChannelDeliveryWrite(writeDb, {
+        workspaceId,
+        messageId,
+        channelId,
+        senderAgentId: postingAgentId,
+        mode: data.mode === 'steer' ? 'next-tool-call' : 'immediate',
+        ttlMs: mailbox.ttlMs,
+        depthCap: mailbox.depthCap,
+      }),
+    );
+
+    return writes;
+  });
+  const [message] = results[0] as (typeof messages.$inferSelect)[];
+
+  const [channel] = await db
+    .select({ name: channels.name })
+    .from(channels)
+    .where(eq(channels.id, channelId));
+
+  const outcomes = await fetchChannelDeliveryOutcomes(db, {
+    messageId,
+    channelId,
+    senderAgentId: postingAgentId,
+  });
+
+  return {
+    message_id: message.id,
+    workspace_id: workspaceId,
+    channel_id: channelId,
+    channel: channel?.name || '',
+    text: message.body,
+    source: data.source,
+    author: data.author,
+    created_at: message.createdAt.toISOString(),
+    metadata: sanitizeUserMessageMetadata(data.payload),
+    _deliveries: outcomes.deliveries,
+    _delivery_rejections: outcomes.rejections,
   };
 }

--- a/packages/engine/src/middleware/idempotency.ts
+++ b/packages/engine/src/middleware/idempotency.ts
@@ -237,9 +237,9 @@ export async function runIdempotent<T>(
       };
       try {
         await kvStore.put(kvKey, JSON.stringify(record), { expirationTtl: ttlSeconds });
-      } catch {
+      } catch (err) {
         if (requireKv) {
-          throw idempotencyUnavailableError();
+          throw idempotencyUnavailableError(err);
         }
         // KV failure during record storage — proceed without idempotency record.
       } finally {

--- a/packages/engine/src/middleware/idempotency.ts
+++ b/packages/engine/src/middleware/idempotency.ts
@@ -35,6 +35,7 @@ interface RunIdempotentOptions<T> {
   fingerprint?: string;
   ttlSeconds?: number;
   kv?: KeyValueStore;
+  requireKv?: boolean;
   operation: () => Promise<T>;
   /**
    * Fresh-result hook that must complete before the idempotency success record
@@ -42,6 +43,12 @@ interface RunIdempotentOptions<T> {
    * by a later idempotent replay.
    */
   afterOperation?: (data: T) => Promise<void>;
+}
+
+function idempotencyUnavailableError(cause?: unknown): Error {
+  const err = new Error('Idempotency storage is unavailable');
+  Object.assign(err, { code: 'idempotency_unavailable', status: 503, cause });
+  return err;
 }
 
 async function buildKey(workspaceId: string, actorId: string, scope: string, key: string): Promise<string> {
@@ -113,9 +120,15 @@ export async function runIdempotent<T>(
     status = 201,
     ttlSeconds = IDEMPOTENCY_TTL_SECONDS,
     kv,
+    requireKv = false,
   } = options;
 
   if (!key) {
+    if (requireKv) {
+      const err = new Error('Idempotency key is required');
+      Object.assign(err, { code: 'idempotency_key_required', status: 400 });
+      throw err;
+    }
     const data = await operation();
     if (afterOperation) await afterOperation(data);
     return { status, data, replayed: false };
@@ -125,6 +138,10 @@ export async function runIdempotent<T>(
   let kvKey: string | null = null;
   let lockKey: string | null = null;
   let lockAcquired = false;
+
+  if (!kvStore && requireKv) {
+    throw idempotencyUnavailableError();
+  }
 
   if (kvStore) {
     kvKey = await buildKey(workspaceId, actorId, scope, key);
@@ -197,6 +214,9 @@ export async function runIdempotent<T>(
       if (err instanceof Error && ['idempotency_key_reused', 'idempotency_in_progress'].includes((err as Error & { code?: string }).code ?? '')) {
         throw err;
       }
+      if (requireKv) {
+        throw idempotencyUnavailableError(err);
+      }
       // KV unavailable or decode failure: proceed without idempotency.
       kvStore = null;
       kvKey = null;
@@ -218,6 +238,9 @@ export async function runIdempotent<T>(
       try {
         await kvStore.put(kvKey, JSON.stringify(record), { expirationTtl: ttlSeconds });
       } catch {
+        if (requireKv) {
+          throw idempotencyUnavailableError();
+        }
         // KV failure during record storage — proceed without idempotency record.
       } finally {
         if (lockKey) {

--- a/packages/engine/src/ports/index.ts
+++ b/packages/engine/src/ports/index.ts
@@ -94,6 +94,12 @@ export interface EngineConfig {
   appSemver?: string;
   sdkSemver?: string;
   /**
+   * Master secret used to derive relayfile -> relaycast inbound HMAC secrets.
+   * Hosted adapters wire this from their internal secret; self-host can omit it
+   * to disable the relayfile inbound bridge.
+   */
+  relayfileInboundSecret?: string;
+  /**
    * Optional egress proxy for http_push node delivery. When set, nodes that
    * register with `delivery.use_proxy: true` have their webhook POST routed
    * through this forwarder instead of hitting the destination directly — the

--- a/packages/engine/src/routes/__tests__/relayfileInbound.test.ts
+++ b/packages/engine/src/routes/__tests__/relayfileInbound.test.ts
@@ -1,0 +1,203 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { createHmac } from 'node:crypto';
+import { and, eq } from 'drizzle-orm';
+import { createEngine } from '../../engine.js';
+import { createNodeRuntime, type NodeRuntime } from '../../adapters/node/index.js';
+import { createWorkspace, registerAgent } from '../../__tests__/conformance/harness.js';
+import { deliveries } from '../../db/schema.js';
+import {
+  deriveRelayfileInboundSecret,
+  formatRelayfileEventMessage,
+} from '../relayfileInbound.js';
+
+interface Stack {
+  app: ReturnType<typeof createEngine>;
+  runtime: NodeRuntime;
+}
+
+const stacks: Stack[] = [];
+
+function makeStack(): Stack {
+  const runtime = createNodeRuntime({
+    dbPath: ':memory:',
+    baseUrl: 'http://localhost:0',
+    migrate: true,
+    config: {
+      environment: 'test',
+      relayfileInboundSecret: 'relaycast-master',
+    },
+    presence: { sweepIntervalMs: 0 },
+    eventQueue: { pollIntervalMs: 0 },
+  });
+  runtime.webhookQueue.stop();
+  const stack = { app: createEngine(runtime.deps), runtime };
+  stacks.push(stack);
+  return stack;
+}
+
+afterEach(() => {
+  for (const stack of stacks.splice(0)) stack.runtime.close();
+});
+
+function signedHeaders(secret: string, body: string, timestamp = String(Math.floor(Date.now() / 1000))) {
+  return {
+    'content-type': 'application/json',
+    'X-Relay-Timestamp': timestamp,
+    'X-Relay-Signature': createHmac('sha256', secret).update(`${timestamp}.${body}`).digest('hex'),
+    'X-Relay-Event-Id': 'evt_1',
+  };
+}
+
+describe('relayfile inbound bridge', () => {
+  it('provisions a signed relayfile target for a workspace channel', async () => {
+    const stack = makeStack();
+    const ws = await createWorkspace(stack.app, 'relayfile-target');
+
+    const res = await stack.app.request('/v1/integrations/relayfile/inbound-target', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', authorization: `Bearer ${ws.workspaceKey}` },
+      body: JSON.stringify({ channel: 'general', provider: 'slack', pathGlob: '/slack/channels/C123/messages/**' }),
+    });
+
+    expect(res.status).toBe(201);
+    const body = await res.json() as { data: { url: string; secret: string; channel_id: string } };
+    expect(body.data.url).toContain('/v1/integrations/relayfile/inbound/');
+    expect(body.data.url).toContain('provider=slack');
+    expect(body.data.url).toContain('pathGlob=%2Fslack%2Fchannels%2FC123%2Fmessages%2F**');
+    expect(body.data.secret).toBe(await deriveRelayfileInboundSecret('relaycast-master', {
+      workspaceId: ws.workspaceId,
+      channelId: body.data.channel_id,
+      provider: 'slack',
+      pathGlob: '/slack/channels/C123/messages/**',
+    }));
+  });
+
+  it('accepts a signed relayfile event, injects one message, and dedupes replay', async () => {
+    const stack = makeStack();
+    const ws = await createWorkspace(stack.app, 'relayfile-delivery');
+    const targetRes = await stack.app.request('/v1/integrations/relayfile/inbound-target', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', authorization: `Bearer ${ws.workspaceKey}` },
+      body: JSON.stringify({ channel: 'general', provider: 'slack', pathGlob: '/slack/channels/C123/messages/**' }),
+    });
+    const targetBody = await targetRes.json() as { data: { url: string; secret: string } };
+    const target = targetBody.data;
+    const event = {
+      eventId: 'evt_slack_1',
+      type: 'file.created',
+      path: '/slack/channels/C123/messages/1780607825_485189/meta.json',
+      revision: 'rev_1',
+      origin: 'provider_sync',
+      provider: 'slack',
+      timestamp: new Date().toISOString(),
+      snapshot: {
+        path: '/slack/channels/C123/messages/1780607825_485189/meta.json',
+        contentType: 'application/json',
+        encoding: 'utf-8',
+        content: JSON.stringify({ user_name: 'Ada', text: 'hello from slack' }),
+      },
+    };
+    const payload = JSON.stringify(event);
+    const timestamp = String(Math.floor(Date.now() / 1000));
+
+    const first = await stack.app.request(target.url, {
+      method: 'POST',
+      headers: signedHeaders(target.secret, payload, timestamp),
+      body: payload,
+    });
+    expect(first.status).toBe(201);
+    const replay = await stack.app.request(target.url, {
+      method: 'POST',
+      headers: signedHeaders(target.secret, payload, timestamp),
+      body: payload,
+    });
+    expect(replay.status).toBe(201);
+    expect(await replay.json()).toMatchObject({ data: { replayed: true } });
+
+    const list = await stack.app.request('/v1/channels/general/messages', {
+      headers: { authorization: `Bearer ${ws.workspaceKey}` },
+    });
+    expect(list.status).toBe(200);
+    const messages = await list.json() as { data: Array<{ text: string }> };
+    expect(messages.data.filter((message) => message.text.includes('hello from slack'))).toHaveLength(1);
+  });
+
+  it('creates channel deliveries so node/broker agents receive the message', async () => {
+    // Regression guard for the node-delivery bug: triggerIntegrationMessage used
+    // to insert the message with a bare write (no delivery rows), so fanoutToChannel
+    // (which skips node context for message.created) meant node-connected agents
+    // never received inbound integration messages. A queued delivery row for a
+    // channel member is the proof that routeDeliveryOutcomes has something to dispatch.
+    const stack = makeStack();
+    const ws = await createWorkspace(stack.app, 'relayfile-node-delivery');
+    const bob = await registerAgent(stack.app, ws.workspaceKey, 'bob'); // auto-joins #general
+
+    const targetRes = await stack.app.request('/v1/integrations/relayfile/inbound-target', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', authorization: `Bearer ${ws.workspaceKey}` },
+      body: JSON.stringify({ channel: 'general', provider: 'slack', pathGlob: '/slack/channels/C123/messages/**' }),
+    });
+    const target = (await targetRes.json() as { data: { url: string; secret: string } }).data;
+
+    const event = {
+      eventId: 'evt_node_1',
+      type: 'file.created',
+      path: '/slack/channels/C123/messages/1780607825_999/meta.json',
+      revision: 'rev_1',
+      origin: 'provider_sync',
+      provider: 'slack',
+      timestamp: new Date().toISOString(),
+      snapshot: {
+        path: '/slack/channels/C123/messages/1780607825_999/meta.json',
+        contentType: 'application/json',
+        encoding: 'utf-8',
+        content: JSON.stringify({ user_name: 'Ada', text: 'ping the agents' }),
+      },
+    };
+    const payload = JSON.stringify(event);
+    const res = await stack.app.request(target.url, {
+      method: 'POST',
+      headers: signedHeaders(target.secret, payload),
+      body: payload,
+    });
+    expect(res.status).toBe(201);
+    const messageId = (await res.json() as { data: { message_id: string } }).data.message_id;
+
+    const rows = await stack.runtime.deps.db
+      .select()
+      .from(deliveries)
+      .where(and(eq(deliveries.agentId, bob.agentId), eq(deliveries.messageId, messageId)));
+    expect(rows).toHaveLength(1);
+    expect(rows[0].status).toBe('queued');
+  });
+
+  it('rejects bad signatures', async () => {
+    const stack = makeStack();
+    const ws = await createWorkspace(stack.app, 'relayfile-bad-signature');
+    const targetRes = await stack.app.request('/v1/integrations/relayfile/inbound-target', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', authorization: `Bearer ${ws.workspaceKey}` },
+      body: JSON.stringify({ channel: 'general', provider: 'linear', pathGlob: '/linear/issues/**' }),
+    });
+    const targetBody = await targetRes.json() as { data: { url: string } };
+    const target = targetBody.data;
+    const payload = JSON.stringify({ eventId: 'evt_bad', type: 'file.created', path: '/linear/issues/ENG-1.json', provider: 'linear' });
+    const res = await stack.app.request(target.url, {
+      method: 'POST',
+      headers: signedHeaders('wrong-secret', payload),
+      body: payload,
+    });
+    expect(res.status).toBe(401);
+  });
+
+  it('formats provider records with a path fallback', () => {
+    expect(formatRelayfileEventMessage({
+      type: 'file.created',
+      path: '/github/repos/o/r/issues/1.json',
+      snapshot: { content: JSON.stringify({ title: 'Bug', body: 'Needs fixing', user: { login: 'octo' } }) },
+    }, 'github')).toMatchObject({
+      author: 'octo',
+      text: expect.stringContaining('Bug'),
+    });
+  });
+});

--- a/packages/engine/src/routes/__tests__/relayfileInbound.test.ts
+++ b/packages/engine/src/routes/__tests__/relayfileInbound.test.ts
@@ -94,6 +94,73 @@ describe('relayfile inbound bridge', () => {
     }));
   });
 
+  it('rejects whitespace-only relayfile target path globs', async () => {
+    const stack = makeStack();
+    const ws = await createWorkspace(stack.app, 'relayfile-target-blank-glob');
+
+    const res = await stack.app.request('/v1/integrations/relayfile/inbound-target', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', authorization: `Bearer ${ws.workspaceKey}` },
+      body: JSON.stringify({ channel: 'general', provider: 'slack', path_glob: '   ' }),
+    });
+
+    expect(res.status).toBe(400);
+    expect(await res.json()).toMatchObject({
+      ok: false,
+      error: { code: 'invalid_request' },
+    });
+  });
+
+  it('rejects inbound delivery URLs without an explicit path glob', async () => {
+    const stack = makeStack();
+    const ws = await createWorkspace(stack.app, 'relayfile-missing-glob');
+    const targetRes = await stack.app.request('/v1/integrations/relayfile/inbound-target', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', authorization: `Bearer ${ws.workspaceKey}` },
+      body: JSON.stringify({ channel: 'general', provider: 'slack', path_glob: '/slack/channels/C123/messages/**' }),
+    });
+    const target = (await targetRes.json() as { data: { url: string } }).data;
+    const url = new URL(target.url);
+    url.searchParams.delete('path_glob');
+
+    const res = await stack.app.request(url.toString(), {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: '{}',
+    });
+
+    expect(res.status).toBe(400);
+    expect(await res.json()).toMatchObject({
+      ok: false,
+      error: { code: 'bad_request' },
+    });
+  });
+
+  it('rejects inbound delivery URLs with blank path globs', async () => {
+    const stack = makeStack();
+    const ws = await createWorkspace(stack.app, 'relayfile-blank-query-glob');
+    const targetRes = await stack.app.request('/v1/integrations/relayfile/inbound-target', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', authorization: `Bearer ${ws.workspaceKey}` },
+      body: JSON.stringify({ channel: 'general', provider: 'slack', path_glob: '/slack/channels/C123/messages/**' }),
+    });
+    const target = (await targetRes.json() as { data: { url: string } }).data;
+    const url = new URL(target.url);
+    url.searchParams.set('path_glob', '   ');
+
+    const res = await stack.app.request(url.toString(), {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: '{}',
+    });
+
+    expect(res.status).toBe(400);
+    expect(await res.json()).toMatchObject({
+      ok: false,
+      error: { code: 'bad_request' },
+    });
+  });
+
   it('accepts a signed relayfile event, injects one message, and dedupes replay', async () => {
     const stack = makeStack();
     const ws = await createWorkspace(stack.app, 'relayfile-delivery');

--- a/packages/engine/src/routes/__tests__/relayfileInbound.test.ts
+++ b/packages/engine/src/routes/__tests__/relayfileInbound.test.ts
@@ -5,9 +5,11 @@ import { createEngine } from '../../engine.js';
 import { createNodeRuntime, type NodeRuntime } from '../../adapters/node/index.js';
 import { createWorkspace, registerAgent } from '../../__tests__/conformance/harness.js';
 import { deliveries } from '../../db/schema.js';
+import type { KeyValueStore } from '../../ports/kv.js';
 import {
   deriveRelayfileInboundSecret,
   formatRelayfileEventMessage,
+  verifyRelayfileSignature,
 } from '../relayfileInbound.js';
 
 interface Stack {
@@ -17,7 +19,7 @@ interface Stack {
 
 const stacks: Stack[] = [];
 
-function makeStack(): Stack {
+function makeStack(opts: { kv?: KeyValueStore } = {}): Stack {
   const runtime = createNodeRuntime({
     dbPath: ':memory:',
     baseUrl: 'http://localhost:0',
@@ -29,6 +31,7 @@ function makeStack(): Stack {
     presence: { sweepIntervalMs: 0 },
     eventQueue: { pollIntervalMs: 0 },
   });
+  if (opts.kv) runtime.deps.kv = opts.kv;
   runtime.webhookQueue.stop();
   const stack = { app: createEngine(runtime.deps), runtime };
   stacks.push(stack);
@@ -48,6 +51,24 @@ function signedHeaders(secret: string, body: string, timestamp = String(Math.flo
   };
 }
 
+class FailingKeyValueStore implements KeyValueStore {
+  async get(): Promise<string | null> {
+    throw new Error('kv unavailable');
+  }
+
+  async put(): Promise<void> {
+    throw new Error('kv unavailable');
+  }
+
+  async delete(): Promise<void> {
+    throw new Error('kv unavailable');
+  }
+
+  async increment(): Promise<number> {
+    throw new Error('kv unavailable');
+  }
+}
+
 describe('relayfile inbound bridge', () => {
   it('provisions a signed relayfile target for a workspace channel', async () => {
     const stack = makeStack();
@@ -56,14 +77,15 @@ describe('relayfile inbound bridge', () => {
     const res = await stack.app.request('/v1/integrations/relayfile/inbound-target', {
       method: 'POST',
       headers: { 'content-type': 'application/json', authorization: `Bearer ${ws.workspaceKey}` },
-      body: JSON.stringify({ channel: 'general', provider: 'slack', pathGlob: '/slack/channels/C123/messages/**' }),
+      body: JSON.stringify({ channel: 'general', provider: 'slack', path_glob: '/slack/channels/C123/messages/**' }),
     });
 
     expect(res.status).toBe(201);
-    const body = await res.json() as { data: { url: string; secret: string; channel_id: string } };
+    const body = await res.json() as { ok: boolean; data: { url: string; secret: string; channel_id: string } };
+    expect(body.ok).toBe(true);
     expect(body.data.url).toContain('/v1/integrations/relayfile/inbound/');
     expect(body.data.url).toContain('provider=slack');
-    expect(body.data.url).toContain('pathGlob=%2Fslack%2Fchannels%2FC123%2Fmessages%2F**');
+    expect(body.data.url).toContain('path_glob=%2Fslack%2Fchannels%2FC123%2Fmessages%2F**');
     expect(body.data.secret).toBe(await deriveRelayfileInboundSecret('relaycast-master', {
       workspaceId: ws.workspaceId,
       channelId: body.data.channel_id,
@@ -78,7 +100,7 @@ describe('relayfile inbound bridge', () => {
     const targetRes = await stack.app.request('/v1/integrations/relayfile/inbound-target', {
       method: 'POST',
       headers: { 'content-type': 'application/json', authorization: `Bearer ${ws.workspaceKey}` },
-      body: JSON.stringify({ channel: 'general', provider: 'slack', pathGlob: '/slack/channels/C123/messages/**' }),
+      body: JSON.stringify({ channel: 'general', provider: 'slack', path_glob: '/slack/channels/C123/messages/**' }),
     });
     const targetBody = await targetRes.json() as { data: { url: string; secret: string } };
     const target = targetBody.data;
@@ -106,13 +128,14 @@ describe('relayfile inbound bridge', () => {
       body: payload,
     });
     expect(first.status).toBe(201);
+    expect(await first.json()).toMatchObject({ ok: true, data: { replayed: false } });
     const replay = await stack.app.request(target.url, {
       method: 'POST',
       headers: signedHeaders(target.secret, payload, timestamp),
       body: payload,
     });
     expect(replay.status).toBe(201);
-    expect(await replay.json()).toMatchObject({ data: { replayed: true } });
+    expect(await replay.json()).toMatchObject({ ok: true, data: { replayed: true } });
 
     const list = await stack.app.request('/v1/channels/general/messages', {
       headers: { authorization: `Bearer ${ws.workspaceKey}` },
@@ -135,7 +158,7 @@ describe('relayfile inbound bridge', () => {
     const targetRes = await stack.app.request('/v1/integrations/relayfile/inbound-target', {
       method: 'POST',
       headers: { 'content-type': 'application/json', authorization: `Bearer ${ws.workspaceKey}` },
-      body: JSON.stringify({ channel: 'general', provider: 'slack', pathGlob: '/slack/channels/C123/messages/**' }),
+      body: JSON.stringify({ channel: 'general', provider: 'slack', path_glob: '/slack/channels/C123/messages/**' }),
     });
     const target = (await targetRes.json() as { data: { url: string; secret: string } }).data;
 
@@ -177,7 +200,7 @@ describe('relayfile inbound bridge', () => {
     const targetRes = await stack.app.request('/v1/integrations/relayfile/inbound-target', {
       method: 'POST',
       headers: { 'content-type': 'application/json', authorization: `Bearer ${ws.workspaceKey}` },
-      body: JSON.stringify({ channel: 'general', provider: 'linear', pathGlob: '/linear/issues/**' }),
+      body: JSON.stringify({ channel: 'general', provider: 'linear', path_glob: '/linear/issues/**' }),
     });
     const targetBody = await targetRes.json() as { data: { url: string } };
     const target = targetBody.data;
@@ -188,6 +211,110 @@ describe('relayfile inbound bridge', () => {
       body: payload,
     });
     expect(res.status).toBe(401);
+    const body = await res.json() as { ok: boolean; error: { code: string; message: string } };
+    expect(body.ok).toBe(false);
+    expect(body.error.code).toBe('unauthorized');
+    expect(body.error.message).toBeTruthy();
+  });
+
+  it('rejects oversized relayfile event bodies before signature verification', async () => {
+    const stack = makeStack();
+    const ws = await createWorkspace(stack.app, 'relayfile-large-body');
+    const targetRes = await stack.app.request('/v1/integrations/relayfile/inbound-target', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', authorization: `Bearer ${ws.workspaceKey}` },
+      body: JSON.stringify({ channel: 'general', provider: 'linear', path_glob: '/linear/issues/**' }),
+    });
+    const target = (await targetRes.json() as { data: { url: string } }).data;
+    const payload = 'x'.repeat(1024 * 1024 + 1);
+
+    const res = await stack.app.request(target.url, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', 'content-length': String(payload.length) },
+      body: payload,
+    });
+
+    expect(res.status).toBe(413);
+    expect(await res.json()).toMatchObject({
+      ok: false,
+      error: { code: 'payload_too_large' },
+    });
+  });
+
+  it('rejects malformed signed event fields as bad requests', async () => {
+    const stack = makeStack();
+    const ws = await createWorkspace(stack.app, 'relayfile-malformed-event');
+    const targetRes = await stack.app.request('/v1/integrations/relayfile/inbound-target', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', authorization: `Bearer ${ws.workspaceKey}` },
+      body: JSON.stringify({ channel: 'general', provider: 'linear', path_glob: '/linear/issues/**' }),
+    });
+    const target = (await targetRes.json() as { data: { url: string; secret: string } }).data;
+    const payload = JSON.stringify({
+      eventId: 'evt_bad_type',
+      type: 'file.created',
+      path: { not: 'a string' },
+      provider: 'linear',
+      snapshot: { content: 42 },
+    });
+
+    const res = await stack.app.request(target.url, {
+      method: 'POST',
+      headers: signedHeaders(target.secret, payload),
+      body: payload,
+    });
+
+    expect(res.status).toBe(400);
+    expect(await res.json()).toMatchObject({
+      ok: false,
+      error: { code: 'bad_request' },
+    });
+  });
+
+  it('fails closed when idempotency storage is unavailable', async () => {
+    const stack = makeStack({ kv: new FailingKeyValueStore() });
+    const ws = await createWorkspace(stack.app, 'relayfile-kv-failure');
+    const targetRes = await stack.app.request('/v1/integrations/relayfile/inbound-target', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', authorization: `Bearer ${ws.workspaceKey}` },
+      body: JSON.stringify({ channel: 'general', provider: 'linear', path_glob: '/linear/issues/**' }),
+    });
+    const target = (await targetRes.json() as { data: { url: string; secret: string } }).data;
+    const payload = JSON.stringify({
+      eventId: 'evt_kv_failure',
+      type: 'file.created',
+      path: '/linear/issues/ENG-1.json',
+      provider: 'linear',
+      snapshot: { content: JSON.stringify({ title: 'Do not duplicate' }) },
+    });
+
+    const res = await stack.app.request(target.url, {
+      method: 'POST',
+      headers: signedHeaders(target.secret, payload),
+      body: payload,
+    });
+
+    expect(res.status).toBe(503);
+    expect(await res.json()).toMatchObject({
+      ok: false,
+      error: { code: 'idempotency_unavailable' },
+    });
+  });
+
+  it('verifies signatures against the exact request bytes', async () => {
+    const timestamp = String(Math.floor(Date.now() / 1000));
+    const secret = 'binary-secret';
+    const body = new Uint8Array([0xff, 0x00, 0x61]).buffer;
+    const signature = createHmac('sha256', secret)
+      .update(Buffer.concat([Buffer.from(`${timestamp}.`), Buffer.from(body)]))
+      .digest('hex');
+
+    await expect(verifyRelayfileSignature(
+      new Headers({ 'X-Relay-Timestamp': timestamp, 'X-Relay-Signature': signature }),
+      body,
+      secret,
+      Number.parseInt(timestamp, 10) * 1000,
+    )).resolves.toEqual({ ok: true });
   });
 
   it('formats provider records with a path fallback', () => {
@@ -199,5 +326,18 @@ describe('relayfile inbound bridge', () => {
       author: 'octo',
       text: expect.stringContaining('Bug'),
     });
+  });
+
+  it('keeps long provider body fields under the body cap', () => {
+    const longBody = 'x'.repeat(1400);
+
+    const message = formatRelayfileEventMessage({
+      type: 'file.created',
+      path: '/github/repos/o/r/issues/1.json',
+      snapshot: { content: JSON.stringify({ body: longBody }) },
+    }, 'github');
+
+    expect(message?.text).toContain(`${'x'.repeat(1200)}...`);
+    expect(message?.text).not.toContain(longBody);
   });
 });

--- a/packages/engine/src/routes/deliveryRouting.ts
+++ b/packages/engine/src/routes/deliveryRouting.ts
@@ -33,10 +33,14 @@ type DeliveryTarget = {
 
 const HTTP_PUSH_RETRY_DELAY_MS = 30_000;
 
-function routingContextFromHono(c: HonoContext): RoutingContext {
+function routingContextFromHono(c: HonoContext, workspaceIdOverride?: string): RoutingContext {
+  const workspaceId = workspaceIdOverride ?? c.get('workspace')?.id;
+  if (!workspaceId) {
+    throw new Error('Delivery routing requires workspace context');
+  }
   return {
     db: c.get('db'),
-    workspaceId: c.get('workspace').id,
+    workspaceId,
     engine: c.get('engine'),
   };
 }
@@ -449,8 +453,9 @@ export async function routeDeliveryOutcomes(
   deliveries: DeliveryFanoutRecord[],
   eventType: string,
   eventData: Record<string, unknown>,
+  opts: { workspaceId?: string } = {},
 ): Promise<void> {
-  await routeDeliveryOutcomesForContext(routingContextFromHono(c), deliveries, eventType, eventData);
+  await routeDeliveryOutcomesForContext(routingContextFromHono(c, opts.workspaceId), deliveries, eventType, eventData);
 }
 
 export async function sweepDueHttpPushDeliveries(

--- a/packages/engine/src/routes/relayfileInbound.ts
+++ b/packages/engine/src/routes/relayfileInbound.ts
@@ -19,16 +19,48 @@ import { emitServerEvent } from '../lib/serverTelemetry.js';
 export const relayfileInboundRoutes = new Hono<AppEnv>();
 
 const MAX_SKEW_MS = 5 * 60 * 1000;
+const MAX_RELAYFILE_BODY_BYTES = 1024 * 1024;
 const SECRET_LABEL = 'relayfile-inbound:v1';
 const IDEMPOTENCY_TTL_SECONDS = 60 * 60 * 24 * 30;
 
 const createTargetSchema = z.object({
   channel: z.string().min(1),
   provider: z.string().min(1),
-  pathGlob: z.string().min(1),
+  path_glob: z.string().min(1),
 });
 
-interface RelayfileEvent {
+const relayfileSnapshotSchema = z.object({
+  path: z.string().optional(),
+  contentType: z.string().optional(),
+  encoding: z.string().optional(),
+  content: z.string().optional(),
+  truncated: z.boolean().optional(),
+}).passthrough();
+
+const relayfileEventSchema = z.object({
+  eventId: z.string().optional(),
+  type: z.string().optional(),
+  path: z.string().optional(),
+  revision: z.string().optional(),
+  origin: z.string().optional(),
+  provider: z.string().optional(),
+  correlationId: z.string().optional(),
+  timestamp: z.string().optional(),
+  contentHash: z.string().optional(),
+  snapshot: relayfileSnapshotSchema.optional(),
+}).passthrough();
+
+type RelayfileEvent = z.infer<typeof relayfileEventSchema>;
+
+interface RelayfileSnapshot {
+  path?: string;
+  contentType?: string;
+  encoding?: string;
+  content?: string;
+  truncated?: boolean;
+}
+
+interface RelayfileEventPublic {
   eventId?: string;
   type?: string;
   path?: string;
@@ -39,14 +71,6 @@ interface RelayfileEvent {
   timestamp?: string;
   contentHash?: string;
   snapshot?: RelayfileSnapshot;
-}
-
-interface RelayfileSnapshot {
-  path?: string;
-  contentType?: string;
-  encoding?: string;
-  content?: string;
-  truncated?: boolean;
 }
 
 relayfileInboundRoutes.post('/integrations/relayfile/inbound-target', requireWorkspaceKey, rateLimit, async (c) => {
@@ -66,7 +90,7 @@ relayfileInboundRoutes.post('/integrations/relayfile/inbound-target', requireWor
   }
 
   const provider = normalizeProvider(parsed.data.provider);
-  const pathGlob = normalizePathGlob(parsed.data.pathGlob);
+  const pathGlob = normalizePathGlob(parsed.data.path_glob);
   const secret = await deriveRelayfileInboundSecret(master, {
     workspaceId: workspace.id,
     channelId: channel.id,
@@ -75,7 +99,7 @@ relayfileInboundRoutes.post('/integrations/relayfile/inbound-target', requireWor
   });
   const url = new URL(`/v1/integrations/relayfile/inbound/${encodeURIComponent(workspace.id)}/${encodeURIComponent(channel.id)}`, c.req.url);
   url.searchParams.set('provider', provider);
-  url.searchParams.set('pathGlob', pathGlob);
+  url.searchParams.set('path_glob', pathGlob);
 
   return jsonCreated(c, {
     url: url.toString(),
@@ -93,7 +117,7 @@ relayfileInboundRoutes.post('/integrations/relayfile/inbound/:workspaceId/:chann
   const workspaceId = c.req.param('workspaceId');
   const channelId = c.req.param('channelId');
   const provider = normalizeProvider(c.req.query('provider') ?? '');
-  const pathGlob = normalizePathGlob(c.req.query('pathGlob') ?? '');
+  const pathGlob = normalizePathGlob(c.req.query('path_glob') ?? '');
   if (!workspaceId || !channelId || !provider || !pathGlob) {
     return jsonError(c, 'bad_request', 'missing relayfile inbound route parameters', 400);
   }
@@ -103,7 +127,11 @@ relayfileInboundRoutes.post('/integrations/relayfile/inbound/:workspaceId/:chann
     return jsonError(c, 'relayfile_inbound_unavailable', 'Relayfile inbound bridge is not configured', 503);
   }
 
-  const rawBody = await c.req.raw.clone().arrayBuffer();
+  const rawBodyResult = await readRequestBodyWithLimit(c.req.raw, MAX_RELAYFILE_BODY_BYTES);
+  if (!rawBodyResult.ok) {
+    return jsonError(c, 'payload_too_large', 'relayfile event body exceeds maximum size', 413);
+  }
+  const rawBody = rawBodyResult.body;
   const secret = await deriveRelayfileInboundSecret(master, { workspaceId, channelId, provider, pathGlob });
   const verified = await verifyRelayfileSignature(c.req.raw.headers, rawBody, secret, Date.now());
   if (!verified.ok) {
@@ -111,12 +139,17 @@ relayfileInboundRoutes.post('/integrations/relayfile/inbound/:workspaceId/:chann
     return jsonError(c, 'unauthorized', 'invalid relayfile signature', 401);
   }
 
-  let event: RelayfileEvent;
+  let parsedEvent: unknown;
   try {
-    event = JSON.parse(new TextDecoder().decode(rawBody)) as RelayfileEvent;
+    parsedEvent = JSON.parse(new TextDecoder().decode(rawBody)) as unknown;
   } catch {
     return jsonError(c, 'bad_request', 'invalid relayfile event body', 400);
   }
+  const eventResult = relayfileEventSchema.safeParse(parsedEvent);
+  if (!eventResult.success) {
+    return jsonError(c, 'bad_request', 'invalid relayfile event body', 400);
+  }
+  const event = eventResult.data;
   const deliveryEventId = c.req.header('X-Relay-Event-Id')?.trim() || event.eventId;
 
   // Without a stable dedupe key we cannot make delivery idempotent, so a
@@ -125,33 +158,33 @@ relayfileInboundRoutes.post('/integrations/relayfile/inbound/:workspaceId/:chann
   // sends X-Relay-Event-Id, so this only trips on malformed deliveries.
   if (!deliveryEventId) {
     logger.warn('relayfile inbound missing event id', { workspace_id: workspaceId, channel_id: channelId });
-    return jsonOk(c, { ok: true, skipped: 'missing_event_id' });
+    return jsonOk(c, { skipped: 'missing_event_id' });
   }
 
   if (!event.path || !event.type) {
-    return jsonOk(c, { ok: true, skipped: 'missing_event_fields' });
+    return jsonOk(c, { skipped: 'missing_event_fields' });
   }
   if (event.provider && normalizeProvider(event.provider) !== provider) {
-    return jsonOk(c, { ok: true, skipped: 'provider_mismatch' });
+    return jsonOk(c, { skipped: 'provider_mismatch' });
   }
   if (!eventMatchesGlob(event.path, pathGlob)) {
-    return jsonOk(c, { ok: true, skipped: 'path_mismatch' });
+    return jsonOk(c, { skipped: 'path_mismatch' });
   }
   if (event.origin === 'agent_write') {
-    return jsonOk(c, { ok: true, skipped: 'agent_write' });
+    return jsonOk(c, { skipped: 'agent_write' });
   }
   if (event.type !== 'file.created' && event.type !== 'file.updated') {
-    return jsonOk(c, { ok: true, skipped: 'ignored_event_type' });
+    return jsonOk(c, { skipped: 'ignored_event_type' });
   }
 
   const channel = await getChannelById(c.get('db'), workspaceId, channelId);
   if (!channel) {
-    return jsonOk(c, { ok: true, skipped: 'channel_not_found' });
+    return jsonOk(c, { skipped: 'channel_not_found' });
   }
 
   const message = formatRelayfileEventMessage(event, provider);
   if (!message) {
-    return jsonOk(c, { ok: true, skipped: 'unformatted_event' });
+    return jsonOk(c, { skipped: 'unformatted_event' });
   }
 
   const mailbox = resolveMailboxConfig(c.get('engine').config, workspaceId);
@@ -164,6 +197,7 @@ relayfileInboundRoutes.post('/integrations/relayfile/inbound/:workspaceId/:chann
       key: deliveryEventId,
       fingerprint: JSON.stringify({ path: event.path, revision: event.revision, contentHash: event.contentHash }),
       kv: c.get('engine').kv,
+      requireKv: true,
       ttlSeconds: IDEMPOTENCY_TTL_SECONDS,
       operation: () => inboundWebhookEngine.triggerIntegrationMessage(c.get('db'), workspaceId, channelId, {
         text: message.text,
@@ -224,7 +258,7 @@ relayfileInboundRoutes.post('/integrations/relayfile/inbound/:workspaceId/:chann
       if (deliveries && deliveries.length > 0) {
         runInBackground(
           c,
-          routeDeliveryOutcomes(c, deliveries, 'message.created', eventData),
+          routeDeliveryOutcomes(c, deliveries, 'message.created', eventData, { workspaceId }),
           'relayfile inbound deliveries',
         );
       }
@@ -235,15 +269,19 @@ relayfileInboundRoutes.post('/integrations/relayfile/inbound/:workspaceId/:chann
       });
     }
 
-    return jsonCreated(c, { ok: true, replayed: result.replayed, message_id: result.data.message_id });
+    return jsonCreated(c, { replayed: result.replayed, message_id: result.data.message_id });
   } catch (err) {
     const code = (err as Error & { code?: string }).code;
     if (code === 'idempotency_in_progress') {
-      return jsonOk(c, { ok: true, skipped: 'duplicate_in_progress' });
+      return jsonOk(c, { skipped: 'duplicate_in_progress' });
     }
     if (code === 'idempotency_key_reused') {
       logger.warn('relayfile inbound event id reused with different payload', { workspace_id: workspaceId, event_id: deliveryEventId });
-      return jsonOk(c, { ok: true, skipped: 'event_id_reused' });
+      return jsonOk(c, { skipped: 'event_id_reused' });
+    }
+    if (code === 'idempotency_unavailable') {
+      logger.error('relayfile inbound idempotency storage unavailable', { workspace_id: workspaceId, event_id: deliveryEventId });
+      return jsonError(c, 'idempotency_unavailable', 'idempotency storage unavailable', 503);
     }
     logger.error('relayfile inbound delivery failed', {
       workspace_id: workspaceId,
@@ -301,14 +339,17 @@ export async function verifyRelayfileSignature(
   const providedHex = signature.startsWith('sha256=') ? signature.slice('sha256='.length) : signature;
   const provided = hexToBytes(providedHex);
   if (!provided) return { ok: false, reason: 'invalid_signature_encoding' };
-  const raw = new TextDecoder().decode(body);
   const key = await crypto.subtle.importKey('raw', new TextEncoder().encode(secret), { name: 'HMAC', hash: 'SHA-256' }, false, ['sign']);
-  const signed = await crypto.subtle.sign('HMAC', key, new TextEncoder().encode(`${timestamp}.${raw}`));
+  const prefix = new TextEncoder().encode(`${timestamp}.`);
+  const data = new Uint8Array(prefix.length + body.byteLength);
+  data.set(prefix);
+  data.set(new Uint8Array(body), prefix.length);
+  const signed = await crypto.subtle.sign('HMAC', key, data);
   if (!constantTimeEqual(provided, new Uint8Array(signed))) return { ok: false, reason: 'signature_mismatch' };
   return { ok: true };
 }
 
-export function formatRelayfileEventMessage(event: RelayfileEvent, provider: string): { text: string; author: string; record: unknown } | null {
+export function formatRelayfileEventMessage(event: RelayfileEventPublic, provider: string): { text: string; author: string; record: unknown } | null {
   const record = parseSnapshotRecord(event.snapshot);
   const author = recordAuthor(record) ?? provider;
   const title = recordTitle(record);
@@ -351,7 +392,8 @@ function recordTitle(record: unknown): string | null {
   if (typeof record === 'string') return record;
   const r = asRecord(record);
   if (!r) return null;
-  return firstString(r.title, r.name, r.identifier, r.subject, r.text, r.body, r.message);
+  const title = firstString(r.title, r.name, r.identifier, r.subject);
+  return title && title.length > 300 ? `${title.slice(0, 300)}...` : title;
 }
 
 function recordBody(record: unknown): string | null {
@@ -403,6 +445,40 @@ function eventMatchesGlob(path: string, glob: string): boolean {
 function eventWorkspaceId(event: RelayfileEvent): string | undefined {
   const correlation = event.correlationId ?? '';
   return correlation.startsWith('workspace:') ? correlation.slice('workspace:'.length) : undefined;
+}
+
+async function readRequestBodyWithLimit(
+  request: Request,
+  maxBytes: number,
+): Promise<{ ok: true; body: ArrayBuffer } | { ok: false }> {
+  const contentLength = request.headers.get('content-length')?.trim();
+  if (contentLength && /^\d+$/.test(contentLength) && Number.parseInt(contentLength, 10) > maxBytes) {
+    return { ok: false };
+  }
+
+  if (!request.body) return { ok: true, body: new ArrayBuffer(0) };
+
+  const reader = request.body.getReader();
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+  for (;;) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    total += value.byteLength;
+    if (total > maxBytes) {
+      await reader.cancel();
+      return { ok: false };
+    }
+    chunks.push(value);
+  }
+
+  const out = new Uint8Array(total);
+  let offset = 0;
+  for (const chunk of chunks) {
+    out.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return { ok: true, body: out.buffer };
 }
 
 function parseRelayTimestamp(timestamp: string): number {

--- a/packages/engine/src/routes/relayfileInbound.ts
+++ b/packages/engine/src/routes/relayfileInbound.ts
@@ -1,0 +1,423 @@
+import { Hono } from 'hono';
+import { z } from 'zod';
+import { and, eq } from 'drizzle-orm';
+import type { AppEnv } from '../env.js';
+import { channels } from '../db/schema.js';
+import { requireWorkspaceKey } from '../middleware/auth.js';
+import { rateLimit } from '../middleware/rateLimit.js';
+import { jsonCreated, jsonError, jsonNotFound, jsonOk, parseJsonBody } from '../lib/httpResponse.js';
+import { getRequestLogger } from '../lib/logger.js';
+import { runIdempotent } from '../middleware/idempotency.js';
+import * as inboundWebhookEngine from '../engine/inboundWebhook.js';
+import { fanoutToChannel } from './fanout.js';
+import { routeDeliveryOutcomes } from './deliveryRouting.js';
+import { resolveMailboxConfig } from '../engine/mailboxConfig.js';
+import { runInBackground } from './background.js';
+import { sendWebhookEvent } from './webhookOutbox.js';
+import { emitServerEvent } from '../lib/serverTelemetry.js';
+
+export const relayfileInboundRoutes = new Hono<AppEnv>();
+
+const MAX_SKEW_MS = 5 * 60 * 1000;
+const SECRET_LABEL = 'relayfile-inbound:v1';
+const IDEMPOTENCY_TTL_SECONDS = 60 * 60 * 24 * 30;
+
+const createTargetSchema = z.object({
+  channel: z.string().min(1),
+  provider: z.string().min(1),
+  pathGlob: z.string().min(1),
+});
+
+interface RelayfileEvent {
+  eventId?: string;
+  type?: string;
+  path?: string;
+  revision?: string;
+  origin?: string;
+  provider?: string;
+  correlationId?: string;
+  timestamp?: string;
+  contentHash?: string;
+  snapshot?: RelayfileSnapshot;
+}
+
+interface RelayfileSnapshot {
+  path?: string;
+  contentType?: string;
+  encoding?: string;
+  content?: string;
+  truncated?: boolean;
+}
+
+relayfileInboundRoutes.post('/integrations/relayfile/inbound-target', requireWorkspaceKey, rateLimit, async (c) => {
+  const parsed = await parseJsonBody(c, createTargetSchema, 'invalid relayfile inbound target body');
+  if (!parsed.ok) return parsed.response;
+
+  const workspace = c.get('workspace');
+  const db = c.get('db');
+  const channel = await getChannelByName(db, workspace.id, parsed.data.channel);
+  if (!channel) {
+    return jsonNotFound(c, 'channel_not_found', `Channel "${parsed.data.channel}" not found`);
+  }
+
+  const master = c.get('engine').config?.relayfileInboundSecret?.trim();
+  if (!master) {
+    return jsonError(c, 'relayfile_inbound_unavailable', 'Relayfile inbound bridge is not configured', 503);
+  }
+
+  const provider = normalizeProvider(parsed.data.provider);
+  const pathGlob = normalizePathGlob(parsed.data.pathGlob);
+  const secret = await deriveRelayfileInboundSecret(master, {
+    workspaceId: workspace.id,
+    channelId: channel.id,
+    provider,
+    pathGlob,
+  });
+  const url = new URL(`/v1/integrations/relayfile/inbound/${encodeURIComponent(workspace.id)}/${encodeURIComponent(channel.id)}`, c.req.url);
+  url.searchParams.set('provider', provider);
+  url.searchParams.set('pathGlob', pathGlob);
+
+  return jsonCreated(c, {
+    url: url.toString(),
+    secret,
+    workspace_id: workspace.id,
+    channel_id: channel.id,
+    channel: channel.name,
+    provider,
+    path_glob: pathGlob,
+  });
+});
+
+relayfileInboundRoutes.post('/integrations/relayfile/inbound/:workspaceId/:channelId', async (c) => {
+  const logger = getRequestLogger(c, 'relayfile.inbound');
+  const workspaceId = c.req.param('workspaceId');
+  const channelId = c.req.param('channelId');
+  const provider = normalizeProvider(c.req.query('provider') ?? '');
+  const pathGlob = normalizePathGlob(c.req.query('pathGlob') ?? '');
+  if (!workspaceId || !channelId || !provider || !pathGlob) {
+    return jsonError(c, 'bad_request', 'missing relayfile inbound route parameters', 400);
+  }
+
+  const master = c.get('engine').config?.relayfileInboundSecret?.trim();
+  if (!master) {
+    return jsonError(c, 'relayfile_inbound_unavailable', 'Relayfile inbound bridge is not configured', 503);
+  }
+
+  const rawBody = await c.req.raw.clone().arrayBuffer();
+  const secret = await deriveRelayfileInboundSecret(master, { workspaceId, channelId, provider, pathGlob });
+  const verified = await verifyRelayfileSignature(c.req.raw.headers, rawBody, secret, Date.now());
+  if (!verified.ok) {
+    logger.warn('relayfile inbound signature rejected', { workspace_id: workspaceId, channel_id: channelId, reason: verified.reason });
+    return jsonError(c, 'unauthorized', 'invalid relayfile signature', 401);
+  }
+
+  let event: RelayfileEvent;
+  try {
+    event = JSON.parse(new TextDecoder().decode(rawBody)) as RelayfileEvent;
+  } catch {
+    return jsonError(c, 'bad_request', 'invalid relayfile event body', 400);
+  }
+  const deliveryEventId = c.req.header('X-Relay-Event-Id')?.trim() || event.eventId;
+
+  if (!event.path || !event.type) {
+    return jsonOk(c, { ok: true, skipped: 'missing_event_fields' });
+  }
+  if (event.provider && normalizeProvider(event.provider) !== provider) {
+    return jsonOk(c, { ok: true, skipped: 'provider_mismatch' });
+  }
+  if (!eventMatchesGlob(event.path, pathGlob)) {
+    return jsonOk(c, { ok: true, skipped: 'path_mismatch' });
+  }
+  if (event.origin === 'agent_write') {
+    return jsonOk(c, { ok: true, skipped: 'agent_write' });
+  }
+  if (event.type !== 'file.created' && event.type !== 'file.updated') {
+    return jsonOk(c, { ok: true, skipped: 'ignored_event_type' });
+  }
+
+  const channel = await getChannelById(c.get('db'), workspaceId, channelId);
+  if (!channel) {
+    return jsonOk(c, { ok: true, skipped: 'channel_not_found' });
+  }
+
+  const message = formatRelayfileEventMessage(event, provider);
+  if (!message) {
+    return jsonOk(c, { ok: true, skipped: 'unformatted_event' });
+  }
+
+  const mailbox = resolveMailboxConfig(c.get('engine').config, workspaceId);
+
+  try {
+    const result = await runIdempotent({
+      workspaceId,
+      actorId: 'relayfile-inbound',
+      scope: `relayfile-inbound:${channelId}`,
+      key: deliveryEventId,
+      fingerprint: JSON.stringify({ path: event.path, revision: event.revision, contentHash: event.contentHash }),
+      kv: c.get('engine').kv,
+      ttlSeconds: IDEMPOTENCY_TTL_SECONDS,
+      operation: () => inboundWebhookEngine.triggerIntegrationMessage(c.get('db'), workspaceId, channelId, {
+        text: message.text,
+        source: `relayfile:${provider}`,
+        author: message.author,
+        webhookId: `relayfile:${provider}`,
+        webhookName: `Relayfile ${provider}`,
+        payload: {
+          relayfile: {
+            workspaceId: eventWorkspaceId(event),
+            path: event.path,
+            revision: event.revision,
+            eventId: deliveryEventId,
+            provider,
+            contentHash: event.contentHash,
+          },
+          provider,
+          path: event.path,
+          event: event.type,
+          record: message.record,
+        },
+      }, { mailbox }),
+    });
+
+    if (!result.replayed) {
+      const eventData = {
+        id: result.data.message_id,
+        channel: result.data.channel,
+        channel_name: result.data.channel,
+        channel_id: result.data.channel_id,
+        text: result.data.text,
+        created_at: result.data.created_at,
+        from_name: result.data.author,
+        metadata: result.data.metadata,
+      };
+      try {
+        await sendWebhookEvent(c, { type: 'message.created', workspaceId, data: eventData });
+      } catch (err) {
+        logger.error('relayfile inbound outbox enqueue failed', {
+          workspace_id: workspaceId,
+          channel_id: channelId,
+          provider,
+          error: err instanceof Error ? err.message : String(err),
+        });
+      }
+      // Fan out to workspace-stream subscribers (dashboard/websocket) and
+      // dispatch the computed mailbox deliveries to node-connected (broker)
+      // agents. Without routeDeliveryOutcomes, fanoutToChannel alone reaches only
+      // workspace-stream subscribers and node agents get nothing. Both run in the
+      // background so a delivery-routing hiccup never fails the ingress — it must
+      // return 2xx fast, since the transport retries (and eventually DLQs) non-2xx.
+      runInBackground(
+        c,
+        fanoutToChannel(c, channelId, 'message.created', eventData, workspaceId),
+        'relayfile inbound fanout',
+      );
+      const deliveries = result.data._deliveries;
+      if (deliveries && deliveries.length > 0) {
+        runInBackground(
+          c,
+          routeDeliveryOutcomes(c, deliveries, 'message.created', eventData),
+          'relayfile inbound deliveries',
+        );
+      }
+      emitServerEvent(c, workspaceId, 'relaycast_server_relayfile_inbound_delivered', {
+        channel_id: channelId,
+        message_id: result.data.message_id,
+        provider,
+      });
+    }
+
+    return jsonCreated(c, { ok: true, replayed: result.replayed, message_id: result.data.message_id });
+  } catch (err) {
+    const code = (err as Error & { code?: string }).code;
+    if (code === 'idempotency_in_progress') {
+      return jsonOk(c, { ok: true, skipped: 'duplicate_in_progress' });
+    }
+    if (code === 'idempotency_key_reused') {
+      logger.warn('relayfile inbound event id reused with different payload', { workspace_id: workspaceId, event_id: deliveryEventId });
+      return jsonOk(c, { ok: true, skipped: 'event_id_reused' });
+    }
+    logger.error('relayfile inbound delivery failed', {
+      workspace_id: workspaceId,
+      channel_id: channelId,
+      provider,
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return jsonOk(c, { ok: true, skipped: 'delivery_failed' });
+  }
+});
+
+async function getChannelByName(db: AppEnv['Variables']['db'], workspaceId: string, name: string) {
+  const [row] = await db
+    .select({ id: channels.id, name: channels.name })
+    .from(channels)
+    .where(and(eq(channels.workspaceId, workspaceId), eq(channels.name, name)));
+  return row ?? null;
+}
+
+async function getChannelById(db: AppEnv['Variables']['db'], workspaceId: string, channelId: string) {
+  const [row] = await db
+    .select({ id: channels.id, name: channels.name })
+    .from(channels)
+    .where(and(eq(channels.workspaceId, workspaceId), eq(channels.id, channelId)));
+  return row ?? null;
+}
+
+export async function deriveRelayfileInboundSecret(
+  master: string,
+  input: { workspaceId: string; channelId: string; provider: string; pathGlob: string },
+): Promise<string> {
+  const label = `${SECRET_LABEL}:${input.workspaceId}:${input.channelId}:${normalizeProvider(input.provider)}:${normalizePathGlob(input.pathGlob)}`;
+  const key = await crypto.subtle.importKey('raw', new TextEncoder().encode(master), { name: 'HMAC', hash: 'SHA-256' }, false, ['sign']);
+  const signed = await crypto.subtle.sign('HMAC', key, new TextEncoder().encode(label));
+  return bytesToHex(new Uint8Array(signed));
+}
+
+export async function verifyRelayfileSignature(
+  headers: Headers,
+  body: ArrayBuffer,
+  secret: string,
+  nowMs = Date.now(),
+): Promise<{ ok: true } | { ok: false; reason: string }> {
+  const timestamp = headers.get('X-Relay-Timestamp')?.trim() ?? '';
+  const signature = headers.get('X-Relay-Signature')?.trim().toLowerCase() ?? '';
+  if (!timestamp || !signature) return { ok: false, reason: 'missing_headers' };
+  const timestampMs = parseRelayTimestamp(timestamp);
+  if (!Number.isFinite(timestampMs)) return { ok: false, reason: 'invalid_timestamp' };
+  if (Math.abs(nowMs - timestampMs) > MAX_SKEW_MS) return { ok: false, reason: 'timestamp_skew' };
+
+  const providedHex = signature.startsWith('sha256=') ? signature.slice('sha256='.length) : signature;
+  const provided = hexToBytes(providedHex);
+  if (!provided) return { ok: false, reason: 'invalid_signature_encoding' };
+  const raw = new TextDecoder().decode(body);
+  const key = await crypto.subtle.importKey('raw', new TextEncoder().encode(secret), { name: 'HMAC', hash: 'SHA-256' }, false, ['sign']);
+  const signed = await crypto.subtle.sign('HMAC', key, new TextEncoder().encode(`${timestamp}.${raw}`));
+  if (!constantTimeEqual(provided, new Uint8Array(signed))) return { ok: false, reason: 'signature_mismatch' };
+  return { ok: true };
+}
+
+export function formatRelayfileEventMessage(event: RelayfileEvent, provider: string): { text: string; author: string; record: unknown } | null {
+  const record = parseSnapshotRecord(event.snapshot);
+  const author = recordAuthor(record) ?? provider;
+  const title = recordTitle(record);
+  const body = recordBody(record);
+  const providerLabel = provider.charAt(0).toUpperCase() + provider.slice(1);
+  const lines = [`${providerLabel} update`];
+  if (title) lines.push(title);
+  if (body && body !== title) lines.push(body);
+  lines.push(`Relayfile path: ${event.path}`);
+  return { text: lines.filter(Boolean).join('\n'), author, record };
+}
+
+function parseSnapshotRecord(snapshot: RelayfileSnapshot | undefined): unknown {
+  if (!snapshot?.content) return null;
+  if (snapshot.encoding === 'base64') return null;
+  const content = snapshot.content.trim();
+  if (!content) return null;
+  try {
+    return JSON.parse(content) as unknown;
+  } catch {
+    return content.slice(0, 500);
+  }
+}
+
+function recordAuthor(record: unknown): string | null {
+  const r = asRecord(record);
+  if (!r) return null;
+  return firstString(
+    r.author,
+    r.author_name,
+    r.user_name,
+    r.username,
+    asRecord(r.user)?.name,
+    asRecord(r.user)?.login,
+    asRecord(r.assignee)?.name,
+  );
+}
+
+function recordTitle(record: unknown): string | null {
+  if (typeof record === 'string') return record;
+  const r = asRecord(record);
+  if (!r) return null;
+  return firstString(r.title, r.name, r.identifier, r.subject, r.text, r.body, r.message);
+}
+
+function recordBody(record: unknown): string | null {
+  const r = asRecord(record);
+  if (!r) return null;
+  const text = firstString(r.text, r.body, r.description, r.message, r.content);
+  if (text && text.length > 1200) return `${text.slice(0, 1200)}...`;
+  return text;
+}
+
+function firstString(...values: unknown[]): string | null {
+  for (const value of values) {
+    if (typeof value === 'string' && value.trim()) return value.trim();
+  }
+  return null;
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === 'object' && !Array.isArray(value) ? value as Record<string, unknown> : null;
+}
+
+function normalizeProvider(provider: string): string {
+  return provider.trim().toLowerCase();
+}
+
+function normalizePathGlob(pathGlob: string): string {
+  const trimmed = pathGlob.trim();
+  if (!trimmed || trimmed === '*') return '/**';
+  return trimmed.startsWith('/') ? trimmed : `/${trimmed}`;
+}
+
+function eventMatchesGlob(path: string, glob: string): boolean {
+  const normalizedPath = normalizePathGlob(path);
+  const normalizedGlob = normalizePathGlob(glob);
+  if (normalizedGlob === '/**' || normalizedGlob === normalizedPath) return true;
+  if (normalizedGlob.endsWith('/**')) {
+    const prefix = normalizedGlob.slice(0, -'/**'.length);
+    return normalizedPath === prefix || normalizedPath.startsWith(`${prefix}/`);
+  }
+  if (normalizedGlob.endsWith('/*')) {
+    const prefix = normalizedGlob.slice(0, -'/*'.length);
+    const rest = normalizedPath.slice(prefix.length + 1);
+    return normalizedPath.startsWith(`${prefix}/`) && !rest.includes('/');
+  }
+  if (normalizedGlob.endsWith('*')) return normalizedPath.startsWith(normalizedGlob.slice(0, -1));
+  return false;
+}
+
+function eventWorkspaceId(event: RelayfileEvent): string | undefined {
+  const correlation = event.correlationId ?? '';
+  return correlation.startsWith('workspace:') ? correlation.slice('workspace:'.length) : undefined;
+}
+
+function parseRelayTimestamp(timestamp: string): number {
+  if (/^\d+$/.test(timestamp)) {
+    const seconds = Number.parseInt(timestamp, 10);
+    return seconds * 1000;
+  }
+  return Date.parse(timestamp);
+}
+
+function constantTimeEqual(a: Uint8Array, b: Uint8Array): boolean {
+  let diff = a.length ^ b.length;
+  const len = Math.max(a.length, b.length);
+  for (let i = 0; i < len; i += 1) {
+    diff |= (a[i] ?? 0) ^ (b[i] ?? 0);
+  }
+  return diff === 0;
+}
+
+function bytesToHex(bytes: Uint8Array): string {
+  let out = '';
+  for (const b of bytes) out += b.toString(16).padStart(2, '0');
+  return out;
+}
+
+function hexToBytes(hex: string): Uint8Array | null {
+  if (!hex || hex.length % 2 !== 0 || /[^0-9a-f]/.test(hex)) return null;
+  const out = new Uint8Array(hex.length / 2);
+  for (let i = 0; i < out.length; i += 1) out[i] = Number.parseInt(hex.slice(i * 2, i * 2 + 2), 16);
+  return out;
+}

--- a/packages/engine/src/routes/relayfileInbound.ts
+++ b/packages/engine/src/routes/relayfileInbound.ts
@@ -119,6 +119,15 @@ relayfileInboundRoutes.post('/integrations/relayfile/inbound/:workspaceId/:chann
   }
   const deliveryEventId = c.req.header('X-Relay-Event-Id')?.trim() || event.eventId;
 
+  // Without a stable dedupe key we cannot make delivery idempotent, so a
+  // relayfile-cloud retry/redelivery would inject the message twice. Skip
+  // cleanly (2xx) rather than inject un-deduplicated. relayfile-cloud always
+  // sends X-Relay-Event-Id, so this only trips on malformed deliveries.
+  if (!deliveryEventId) {
+    logger.warn('relayfile inbound missing event id', { workspace_id: workspaceId, channel_id: channelId });
+    return jsonOk(c, { ok: true, skipped: 'missing_event_id' });
+  }
+
   if (!event.path || !event.type) {
     return jsonOk(c, { ok: true, skipped: 'missing_event_fields' });
   }
@@ -242,7 +251,11 @@ relayfileInboundRoutes.post('/integrations/relayfile/inbound/:workspaceId/:chann
       provider,
       error: err instanceof Error ? err.message : String(err),
     });
-    return jsonOk(c, { ok: true, skipped: 'delivery_failed' });
+    // Unknown failures here mean the message insert / delivery-row write itself
+    // failed — most likely transient (DB/infra), not a poison payload. Return 5xx
+    // so relayfile-cloud's queue consumer retries (and eventually DLQs) instead of
+    // recording the drop as a successful 2xx and silently losing the message.
+    return jsonError(c, 'delivery_failed', 'inbound delivery failed', 500);
   }
 });
 

--- a/packages/engine/src/routes/relayfileInbound.ts
+++ b/packages/engine/src/routes/relayfileInbound.ts
@@ -26,7 +26,7 @@ const IDEMPOTENCY_TTL_SECONDS = 60 * 60 * 24 * 30;
 const createTargetSchema = z.object({
   channel: z.string().min(1),
   provider: z.string().min(1),
-  path_glob: z.string().min(1),
+  path_glob: z.string().trim().min(1),
 });
 
 const relayfileSnapshotSchema = z.object({
@@ -117,10 +117,11 @@ relayfileInboundRoutes.post('/integrations/relayfile/inbound/:workspaceId/:chann
   const workspaceId = c.req.param('workspaceId');
   const channelId = c.req.param('channelId');
   const provider = normalizeProvider(c.req.query('provider') ?? '');
-  const pathGlob = normalizePathGlob(c.req.query('path_glob') ?? '');
-  if (!workspaceId || !channelId || !provider || !pathGlob) {
+  const rawPathGlob = c.req.query('path_glob')?.trim();
+  if (!workspaceId || !channelId || !provider || !rawPathGlob) {
     return jsonError(c, 'bad_request', 'missing relayfile inbound route parameters', 400);
   }
+  const pathGlob = normalizePathGlob(rawPathGlob);
 
   const master = c.get('engine').config?.relayfileInboundSecret?.trim();
   if (!master) {

--- a/packages/openclaw/package.json
+++ b/packages/openclaw/package.json
@@ -32,7 +32,7 @@
   },
   "scripts": {
     "build": "tsc",
-    "test": "../../node_modules/.bin/vitest run --root ../.. packages/openclaw/src/__tests__/bridge.test.ts packages/openclaw/src/__tests__/config.test.ts packages/openclaw/src/__tests__/setup.test.ts",
+    "test": "vitest run --root ../.. packages/openclaw/src/__tests__/bridge.test.ts packages/openclaw/src/__tests__/config.test.ts packages/openclaw/src/__tests__/setup.test.ts",
     "lint": "eslint src/"
   },
   "dependencies": {

--- a/packages/openclaw/package.json
+++ b/packages/openclaw/package.json
@@ -32,7 +32,7 @@
   },
   "scripts": {
     "build": "tsc",
-    "test": "vitest run",
+    "test": "../../node_modules/.bin/vitest run --root ../.. packages/openclaw/src/__tests__/bridge.test.ts packages/openclaw/src/__tests__/config.test.ts packages/openclaw/src/__tests__/setup.test.ts",
     "lint": "eslint src/"
   },
   "dependencies": {

--- a/packages/types/src/__tests__/sdk-openapi-sync.test.ts
+++ b/packages/types/src/__tests__/sdk-openapi-sync.test.ts
@@ -32,6 +32,8 @@ const NON_SDK_OPENAPI_PATHS = new Set([
   '/v1/.well-known/agent-card.json',
   '/v1/a2a/rpc',
   '/v1/a2a/webhook/{param}/{param}',
+  '/v1/integrations/relayfile/inbound-target',
+  '/v1/integrations/relayfile/inbound/{param}/{param}',
 ]);
 
 const CORE_SDK_PATHS = new Set([


### PR DESCRIPTION
Part of the **inbound integration bridge** (provider → relay agent, server-side, no client process). Companion PRs: relaycast (ingress), relaycast-cloud (secret+expose), relay (CLI subscribe), relayfile (control-plane proxy), relayfile-cloud (snapshot enrichment). **Cross-repo — review/merge together.**

New `POST /v1/integrations/relayfile/inbound/:workspaceId/:channelId` ingress: verifies the relayfile-cloud HMAC (`${timestamp}.${body}`, ±5min skew, constant-time), dedupes on `X-Relay-Event-Id`, renders a provider-agnostic message from the inlined `event.snapshot`, and injects it so **on-node/broker agents receive it** — via delivery rows + `routeDeliveryOutcomes` (the original WIP only inserted a row, so node agents got nothing). Derived per-target secret; stateless create-target endpoint.

Tests: `relayfileInbound.test.ts` (4 passing) — bad-signature→401, duplicate-event-id→single injection, delivery-row creation.

### Review status
3-way fresh-eyes review completed. Fixed: fail-closed HMAC secret normalization, 5xx-on-transient (no silent loss), require-dedupe-key (no double-inject). Verified correct: exactly-once node delivery, snapshot bounds, signing order.

### ⚠️ Draft — before merge
- [ ] Fix C: `unsubscribe` must delete the relayfile-cloud webhook_subscription (persist its id on the binding) — currently unsubscribe does not stop inbound delivery (cross-repo: relay CLI + relayfile daemon)
- [ ] Add tests: golden-fixture HMAC round-trip, enrichment bounds/lazy hydration, CLI rollback/unsubscribe assertions
- [ ] Add `cast.agentrelay.com` to `RELAYFILE_WEBHOOK_HOST_ALLOWLIST` for the preview/prod host
- [ ] E2E on a preview stage: real Slack/GitHub/Linear message → relay channel, no client process
🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/AgentWorkforce/relaycast/pull/229?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

