### PR TITLE
fix(observer-dashboard): accept ot_live_ observer tokens for login

### DIFF
--- a/packages/observer-dashboard/src/app/api/auth/login/route.ts
+++ b/packages/observer-dashboard/src/app/api/auth/login/route.ts
@@ -16,13 +16,21 @@ const COOKIE_MAX_AGE = 60 * 60 * 24 * 30; // 30 days
  * POST /api/auth/login
  * Validates the API key against the candidate engines (gateway first, api
  * fallback), remembers the resolved engine, and sets httpOnly cookies.
- * WebSocket stream authenticates directly with the workspace key.
+ *
+ * Accepts either a full workspace key (`rk_live_...`) or a scoped, read-only
+ * observer token (`ot_live_...`). Both are treated identically here — the
+ * engine enforces the actual read-only scope restrictions for observer
+ * tokens on every request, this route just validates the credential and
+ * remembers which engine it belongs to. The WebSocket stream authenticates
+ * directly with whichever credential was used to log in (workspace key or
+ * observer token) — the engine's realtime endpoint (`GET /v1/ws`) already
+ * requires an observer token with `stream:read` scope.
  */
 export async function POST(request: NextRequest) {
   try {
     const { apiKey } = await request.json();
 
-    if (!apiKey || !apiKey.startsWith('rk_live_')) {
+    if (!apiKey || (!apiKey.startsWith('rk_live_') && !apiKey.startsWith('ot_live_'))) {
       return NextResponse.json(
         { success: false, error: 'Invalid API key format' },
         { status: 400 }
@@ -64,7 +72,8 @@ export async function POST(request: NextRequest) {
     cookieStore.set(COOKIE_NAME, apiKey, cookieOptions);
 
     // Agent cookie remains for compatibility with existing client shape.
-    // Workspace keys are accepted by read-only endpoints used in dashboard.
+    // Both workspace keys and observer tokens are accepted by the read-only
+    // endpoints used in this dashboard.
     cookieStore.set(AGENT_COOKIE_NAME, apiKey, cookieOptions);
 
     // Remember the resolved engine so session/check/logout target it directly

--- a/packages/observer-dashboard/src/app/api/auth/login/route.ts
+++ b/packages/observer-dashboard/src/app/api/auth/login/route.ts
@@ -30,7 +30,7 @@ export async function POST(request: NextRequest) {
   try {
     const { apiKey } = await request.json();
 
-    if (!apiKey || (!apiKey.startsWith('rk_live_') && !apiKey.startsWith('ot_live_'))) {
+    if (typeof apiKey !== 'string' || (!apiKey.startsWith('rk_live_') && !apiKey.startsWith('ot_live_'))) {
       return NextResponse.json(
         { success: false, error: 'Invalid API key format' },
         { status: 400 }

--- a/packages/observer-dashboard/src/app/login/page.tsx
+++ b/packages/observer-dashboard/src/app/login/page.tsx
@@ -14,8 +14,8 @@ export default function LoginPage() {
     e.preventDefault();
     setError('');
 
-    if (!apiKey.startsWith('rk_live_')) {
-      setError('API key must start with rk_live_');
+    if (!apiKey.startsWith('rk_live_') && !apiKey.startsWith('ot_live_')) {
+      setError('API key must start with rk_live_ or ot_live_');
       return;
     }
 
@@ -62,7 +62,7 @@ export default function LoginPage() {
                   placeholder="rk_live_..."
                   autoFocus
                 />
-                <p className="text-xs text-[var(--text-faint)]">Starts with <code className="rounded-md bg-[color-mix(in_srgb,var(--brand-primary-faint)_78%,transparent)] px-1.5 py-0.5 text-[var(--brand-primary-strong)]">rk_live_…</code></p>
+                <p className="text-xs text-[var(--text-faint)]">Starts with <code className="rounded-md bg-[color-mix(in_srgb,var(--brand-primary-faint)_78%,transparent)] px-1.5 py-0.5 text-[var(--brand-primary-strong)]">rk_live_…</code> or <code className="rounded-md bg-[color-mix(in_srgb,var(--brand-primary-faint)_78%,transparent)] px-1.5 py-0.5 text-[var(--brand-primary-strong)]">ot_live_…</code></p>
               </div>
 
               {error && (

--- a/packages/observer-dashboard/src/components/RelaySessionProvider.tsx
+++ b/packages/observer-dashboard/src/components/RelaySessionProvider.tsx
@@ -25,7 +25,7 @@ export function RelaySessionProvider({ children }: { children: React.ReactNode }
 
     async function initSession() {
       try {
-        if (keyParam?.startsWith('rk_live_')) {
+        if (keyParam?.startsWith('rk_live_') || keyParam?.startsWith('ot_live_')) {
           const success = await setAuth(keyParam);
           if (seq !== requestSeq.current) return;
           if (!success) {


### PR DESCRIPTION
## Summary

Pear's "Join as observer" link currently embeds the full, un-scoped Relaycast workspace key (`rk_live_...`). A parallel fix mints a properly scoped, read-only observer token (`ot_live_...`) instead. This app (`packages/observer-dashboard`), the actual web app the observer link points at, hard-rejected `ot_live_` tokens in three places before they ever reached the engine:

- `src/app/login/page.tsx` — client-side validation only accepted `rk_live_`.
- `src/app/api/auth/login/route.ts` (`POST /api/auth/login`) — server-side validation only accepted `rk_live_`.
- `src/components/RelaySessionProvider.tsx` — the `?key=` query-param handler (the code path the observer link's URL actually drives) only forwarded `rk_live_` values into `setAuth()`. An `ot_live_` token in the URL was silently skipped, so no session cookie was ever set and the user landed on `/login` with no error — this was the most impactful bug of the three, since it's the exact path the observer link uses.

All three now accept either prefix, additively — `rk_live_` support is unchanged.

## What I changed

- `page.tsx`: validation accepts `rk_live_` or `ot_live_`; help text updated to mention both.
- `route.ts`: format check accepts both; updated stale comments (see engine finding below).
- `RelaySessionProvider.tsx`: `?key=` handler recognizes both prefixes.

`selectEngineForKey()` / `resolveRelayServerCandidatesFromRequest()` (`src/lib/relay-server.ts`) and `GET /api/auth/session` needed **no changes** — they're already prefix-agnostic; they just probe the resolved engine with whatever key they're given and trust the HTTP response.

## Engine-side finding (not fixed here — flagging for review)

I traced `selectEngineForKey()`'s probe target, `GET /v1/workspace`, into the engine (`packages/engine/src/routes/workspace.ts`). That route uses `requireWorkspaceKey`, which only accepts `rk_live_` tokens (see `packages/engine/src/auth/tokenKind.ts` — `require: 'workspace'` only allows token kind `'workspace'`; an observer token gets a **401 `observer_token_forbidden`**, a *definitive* rejection). Since `selectEngineForKey` treats any 401/403 as a conclusive "invalid key" rejection, **an `ot_live_` token will fail the login/session probe against production today**, even with these dashboard-side fixes in place, until the engine changes.

I initially patched this in the engine (swapping `GET /v1/workspace`'s middleware to `requireWorkspaceRead` with the full `OBSERVER_SCOPES` list, so any active observer token — regardless of specific scope — could pass, since `GET /workspace` only returns non-sensitive metadata: id/name/plan/system_prompt/metadata). I've since **reverted that engine change** and am reporting it here instead, per this task's instruction to stop and describe rather than unilaterally weaken engine auth requirements — this is a call for a human/separate PR to make deliberately, not something I should decide alone.

Options for whoever picks this up:
1. Change `GET /v1/workspace`'s middleware to allow observer tokens (any scope, since it's low-sensitivity metadata) — the approach I drafted and reverted.
2. Add a dedicated, minimal credential-probe endpoint that both token kinds can hit, leaving `GET /v1/workspace` untouched.
3. Have `selectEngineForKey`/the login route pick a different, already-observer-accessible probe endpoint conditioned on token prefix (e.g. `GET /v1/agents` with `agents:read`) — no engine changes, but a 403 from insufficient scope would still be mis-reported as "invalid key" rather than "insufficient permissions."

**Everything else about the engine's observer-token scope enforcement already works correctly and needed no changes:**
- The realtime WS stream (`GET /v1/ws`, `packages/engine/src/engine/wsAuth.ts` → `authenticateRealtimeWs`) **already requires an observer token with `stream:read`** and explicitly rejects workspace keys ("Observer token required for workspace stream"). This means the WS path is actually already observer-token-native — `docs/self-hosting.md` (uncommitted local changes I found already in the working tree, unrelated to this PR) independently confirms the same thing. `@relaycast/react`'s `RelayProvider`/`WsClient` just pass `wsToken` through verbatim with no prefix assumptions, so once login/session correctly stores an `ot_live_` token as `wsToken`, the WS "just works" against the engine as-is.
- Every other engine endpoint this dashboard calls (`GET /v1/agents`, `GET /v1/agents/presence`, `GET /v1/channels`, `GET /v1/channels/:name/messages`, `GET /v1/dm/conversations/all`, `GET /v1/messages/:id/replies`, `GET /v1/console/*`) already uses `requireWorkspaceRead` with scopes drawn from `agents:read`, `channels:read`, `messages:read`, `dms:read`, `threads:read`, `activity:read` — all of which are already in the default scope set (`stream:read, messages:read, threads:read, dms:read, channels:read, activity:read, agents:read`) requested by the parallel observer-token-minting PR in `relay`. **I found no scope this dashboard needs that's missing from that default list**, and no scope in that list that's unused by this app.

## Test plan

- [x] `npx tsc --noEmit -p .` in `packages/observer-dashboard` — clean.
- [x] `npx vitest run` in `packages/observer-dashboard` — 11/11 passing (existing `relay-server.test.ts` suite, unaffected).
- [x] `npx next build` in `packages/observer-dashboard` — compiles, lints, and generates all routes successfully.
- [ ] Manual end-to-end login with a real `ot_live_` token — blocked until the engine-side `GET /v1/workspace` gap above is resolved (see caveat).

## Production-deploy caveat

This app is deployed at `agentrelay.com/observer`. **This PR must be reviewed and deployed before Pear's minted `ot_live_` observer links will actually log in successfully against the live site** — and, per the finding above, deploying this PR alone is not sufficient; the `GET /v1/workspace` probe-endpoint gap in the engine also needs to be resolved first (or in the same rollout), otherwise `selectEngineForKey` will still 401-reject every observer token in production. Until both land, the parallel Pear/relay PRs' new observer links will only work against a locally-run instance of this app pointed at a local engine build that includes the engine-side fix (not against production).

## Update
The engine-side gap described above (`GET /v1/workspace` rejecting `ot_live_` tokens) is now resolved in #231, which broadens that route to accept observer tokens (option 1 from the list below). Both PRs are needed together for observer-token logins to actually work end-to-end.

Not merging or deploying this myself, per instructions.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/AgentWorkforce/relaycast/pull/230?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


