### PR TITLE
fix(engine): let observer tokens read GET /workspace

### DIFF
--- a/packages/engine/src/__tests__/conformance/observerToken.test.ts
+++ b/packages/engine/src/__tests__/conformance/observerToken.test.ts
@@ -981,4 +981,56 @@ describe('observer tokens', () => {
     expect(withoutDmScopeSock.ofType('thread.reply')).toHaveLength(0);
     expect(threadWithoutDmScopeSock.ofType('thread.reply')).toHaveLength(0);
   });
+
+  it('allows GET /workspace with any observer token, still allows a workspace key, and still blocks PATCH', async () => {
+    const ws = await createWorkspace(stack.app, 'observer-workspace-read-ws');
+
+    const asKey = await stack.app.request('/v1/workspace', {
+      headers: { authorization: `Bearer ${ws.workspaceKey}` },
+    });
+    expect(asKey.status).toBe(200);
+    const asKeyBody = await asKey.json() as { data: { id: string; name: string } };
+    expect(asKeyBody.data.id).toBe(ws.workspaceId);
+
+    // A narrowly-scoped observer token unrelated to workspace metadata (there
+    // is no dedicated "workspace:read" scope) should still be able to read
+    // this low-sensitivity endpoint — any valid observer token suffices.
+    const observer = await createObserverToken(stack, ws.workspaceKey, {
+      name: 'workspace-metadata-reader',
+      scopes: ['agents:read'],
+    });
+    const token = observer.data.token!;
+
+    const asObserver = await stack.app.request('/v1/workspace', {
+      headers: { authorization: `Bearer ${token}` },
+    });
+    expect(asObserver.status).toBe(200);
+    const asObserverBody = await asObserver.json() as {
+      data: { id: string; name: string; plan: unknown; system_prompt: unknown; metadata: unknown };
+    };
+    expect(asObserverBody.data.id).toBe(ws.workspaceId);
+    expect(asObserverBody.data).not.toHaveProperty('token');
+    expect(asObserverBody.data).not.toHaveProperty('apiKey');
+
+    // Writes remain workspace-key-only.
+    const patchAsObserver = await stack.app.request('/v1/workspace', {
+      method: 'PATCH',
+      headers: { 'content-type': 'application/json', authorization: `Bearer ${token}` },
+      body: JSON.stringify({ name: 'renamed-by-observer' }),
+    });
+    expect(patchAsObserver.status).toBe(401);
+
+    // Agent/node tokens are still rejected for this route, matching prior
+    // behavior (only the observer-token additive path was opened up):
+    // allowAgent/allowNode: false means requireWorkspaceRead requires
+    // `require: 'workspace'` for non-observer tokens, so an agent-kind
+    // token fails token-kind validation itself (401) rather than reaching
+    // the redundant in-handler 403 branch (that branch only fires when
+    // allowNode/allowAgent mix true+false, widening `require` to 'any').
+    const alice = await registerAgent(stack.app, ws.workspaceKey, 'alice-workspace-read');
+    const asAgent = await stack.app.request('/v1/workspace', {
+      headers: { authorization: `Bearer ${alice.token}` },
+    });
+    expect(asAgent.status).toBe(401);
+  });
 });

--- a/packages/engine/src/routes/workspace.ts
+++ b/packages/engine/src/routes/workspace.ts
@@ -14,6 +14,7 @@ import {
   getObserverTokenFromContext,
   observerAllowsConversation,
   observerAllowsMessage,
+  OBSERVER_SCOPES,
 } from '../engine/observerToken.js';
 import { emitServerEvent } from '../lib/serverTelemetry.js';
 import { errorResponse } from '../lib/httpError.js';
@@ -163,19 +164,30 @@ workspaceRoutes.get('/workspaces/by-name/:name', publicWorkspaceLookupRateLimit,
   }
 });
 
-// GET /workspace - get current workspace
-workspaceRoutes.get('/workspace', requireWorkspaceKey, rateLimit, async (c) => {
-  try {
-    const db = c.get('db');
-    const workspace = await workspaceEngine.getWorkspace(db, c.get('workspace').id);
-    if (!workspace) {
-      return workspaceNotFound(c);
+// GET /workspace - get current workspace metadata (id/name/plan/system_prompt/
+// created_at/metadata only, nothing sensitive) — accepts an observer token
+// (any scope; this endpoint predates per-scope enforcement and there's no
+// narrower scope that fits "read workspace metadata") in addition to a
+// workspace key, so `selectEngineForKey`-style credential probes succeed for
+// observer-token logins, not just full workspace keys. Agent/node tokens are
+// still rejected, matching prior behavior.
+workspaceRoutes.get(
+  '/workspace',
+  requireWorkspaceRead([...OBSERVER_SCOPES], { allowAgent: false, allowNode: false }),
+  rateLimit,
+  async (c) => {
+    try {
+      const db = c.get('db');
+      const workspace = await workspaceEngine.getWorkspace(db, c.get('workspace').id);
+      if (!workspace) {
+        return workspaceNotFound(c);
+      }
+      return jsonOk(c, workspace);
+    } catch (err: unknown) {
+      return errorResponse(c, err);
     }
-    return jsonOk(c, workspace);
-  } catch (err: unknown) {
-    return errorResponse(c, err);
-  }
-});
+  },
+);
 
 // PATCH /workspace - update workspace
 workspaceRoutes.patch('/workspace', requireWorkspaceKey, rateLimit, async (c) => {


### PR DESCRIPTION
## Summary
- PR #230 taught the observer-dashboard app to accept `ot_live_` observer tokens in its login flow, but flagged (and deliberately left open, with three options) that `selectEngineForKey` still probes `GET /v1/workspace` to validate a credential, and that route was `requireWorkspaceKey`-only — so it rejects observer tokens with `observer_token_forbidden`, meaning `/api/auth/login` would still 401 before ever setting cookies. This PR closes that gap (option 1 from #230's write-up).
- `GET /workspace` only returns non-sensitive metadata (`id`, `name`, `plan`, `system_prompt`, `created_at`, `metadata` — no keys/tokens). Broadened its middleware to `requireWorkspaceRead([...OBSERVER_SCOPES], { allowAgent: false, allowNode: false })` — any valid observer token is sufficient (there's no dedicated `workspace:read` scope, and no other observer-facing endpoint needs a narrower one for this).
- Additive only: `rk_live_` workspace-key behavior is unchanged, and agent/node tokens are still rejected exactly as before (they now fail token-kind validation with 401, same outcome as before via a different code path).
- `PATCH /workspace` (the write path) is untouched — still `requireWorkspaceKey`-only.

Related: #230 (observer-dashboard accepts `ot_live_` tokens).

## Test plan
- [x] New test in `packages/engine/src/__tests__/conformance/observerToken.test.ts`: `GET /workspace` succeeds with an observer token (any scope) and with a workspace key; `PATCH /workspace` with an observer token still 401s; an agent token still can't read `/workspace`.
- [x] `npm run typecheck` — clean
- [x] `npm run lint` — clean
- [x] `npm test` — 209/209 passing (24 test files)

Not merging or deploying — this is a security-relevant auth-boundary change and should get human review first.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/AgentWorkforce/relaycast/pull/231?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

