### PR TITLE
fix(engine): observer-token name conflict returns 500 on D1, not 409

### DIFF
--- a/packages/engine/src/engine/observerToken.conflictDetection.test.ts
+++ b/packages/engine/src/engine/observerToken.conflictDetection.test.ts
@@ -73,6 +73,41 @@ describe('isObserverTokenNameConflict', () => {
     expect(isObserverTokenNameConflict(circular)).toBe(false);
   });
 
+  it('does not stack-overflow on a multi-step .cause cycle (A -> B -> A)', () => {
+    const a: { message: string; cause?: unknown } = { message: 'A' };
+    const b: { message: string; cause?: unknown } = { message: 'B' };
+    a.cause = b;
+    b.cause = a;
+    expect(() => isObserverTokenNameConflict(a)).not.toThrow();
+    // Neither message mentions a unique-constraint violation anywhere in the cycle, so
+    // walking the whole chain (without looping forever) must still land on `false` —
+    // not merely terminate.
+    expect(isObserverTokenNameConflict(a)).toBe(false);
+    expect(isObserverTokenNameConflict(b)).toBe(false);
+  });
+
+  it('still finds a real conflict when it precedes a multi-step .cause cycle', () => {
+    const tail: { message: string; cause?: unknown } = { message: 'tail' };
+    const conflict: { code: string; message: string; cause?: unknown } = {
+      code: 'SQLITE_CONSTRAINT_UNIQUE',
+      message: 'UNIQUE constraint failed: observer_tokens.workspace_id, observer_tokens.name',
+      cause: tail,
+    };
+    tail.cause = conflict;
+    expect(isObserverTokenNameConflict(conflict)).toBe(true);
+  });
+
+  it('does not misreport a non-unique constraint violation carrying the bare SQLITE_CONSTRAINT code', () => {
+    expect(isObserverTokenNameConflict({
+      code: 'SQLITE_CONSTRAINT',
+      message: 'FOREIGN KEY constraint failed',
+    })).toBe(false);
+    expect(isObserverTokenNameConflict({
+      code: 'SQLITE_CONSTRAINT',
+      message: 'NOT NULL constraint failed: observer_tokens.workspace_id',
+    })).toBe(false);
+  });
+
   it('handles non-object and null inputs safely', () => {
     expect(isObserverTokenNameConflict(null)).toBe(false);
     expect(isObserverTokenNameConflict(undefined)).toBe(false);

--- a/packages/engine/src/engine/observerToken.conflictDetection.test.ts
+++ b/packages/engine/src/engine/observerToken.conflictDetection.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from 'vitest';
+import { isObserverTokenNameConflict } from './observerToken.js';
+
+/**
+ * Regression coverage for the D1-vs-better-sqlite3 driver mismatch: a name-collision
+ * insert into `observer_tokens` must be recognized as a conflict (and converted to a
+ * clean 409) no matter which driver threw it, or which shape that driver used.
+ *
+ * The better-sqlite3 shape is exercised end-to-end (through the real HTTP route, against
+ * a real better-sqlite3-backed db) by
+ * `src/__tests__/conformance/observerToken.test.ts` — "returns a conflict for duplicate
+ * observer token names in one workspace". This file instead unit-tests the pure detection
+ * function directly against driver error shapes that can't be produced by the
+ * better-sqlite3 test harness at all, most importantly Cloudflare D1's, since we can't
+ * spin up a real D1 binding in this package's test suite.
+ *
+ * The D1 shape below (`.code === 'SQLITE_CONSTRAINT_UNIQUE'`, `.message` prefixed
+ * `D1_ERROR: UNIQUE constraint failed: ...`, and drizzle-orm's `.cause` wrapping) is not
+ * speculative — it mirrors the shape this engine already confirmed and handles in
+ * `engine/agent.ts`'s `isUniqueConstraintError` (added in PR #193 for the identical class
+ * of bug: a 409 unique-name conflict silently regressing to an uncaught 500 against D1).
+ */
+describe('isObserverTokenNameConflict', () => {
+  it('recognizes the better-sqlite3 shape (code + raw message)', () => {
+    expect(isObserverTokenNameConflict({
+      code: 'SQLITE_CONSTRAINT_UNIQUE',
+      message: 'UNIQUE constraint failed: observer_tokens.workspace_id, observer_tokens.name',
+    })).toBe(true);
+  });
+
+  it('recognizes the legacy better-sqlite3 code without SQLITE_CONSTRAINT_UNIQUE', () => {
+    expect(isObserverTokenNameConflict({
+      code: 'SQLITE_CONSTRAINT',
+      message: 'SQLITE_CONSTRAINT: UNIQUE constraint failed: observer_tokens.workspace_id, observer_tokens.name',
+    })).toBe(true);
+  });
+
+  it('recognizes the Cloudflare D1 shape (D1_ERROR-prefixed message, top level)', () => {
+    expect(isObserverTokenNameConflict({
+      code: 'SQLITE_CONSTRAINT_UNIQUE',
+      message: 'D1_ERROR: UNIQUE constraint failed: observer_tokens.workspace_id, observer_tokens.name: SQLITE_CONSTRAINT',
+    })).toBe(true);
+  });
+
+  it('recognizes D1 errors that drizzle-orm re-wraps under .cause', () => {
+    const d1Error = {
+      code: 'SQLITE_CONSTRAINT_UNIQUE',
+      message: 'D1_ERROR: UNIQUE constraint failed: observer_tokens.workspace_id, observer_tokens.name: SQLITE_CONSTRAINT',
+    };
+    const wrapped = {
+      message: 'Failed query: insert into "observer_tokens" ...',
+      cause: d1Error,
+    };
+    expect(isObserverTokenNameConflict(wrapped)).toBe(true);
+  });
+
+  it('recognizes a generic case-insensitive "unique constraint" message with no recognizable code', () => {
+    expect(isObserverTokenNameConflict({
+      message: 'Unique Constraint Failed on observer_tokens',
+    })).toBe(true);
+  });
+
+  it('does not falsely match unrelated errors', () => {
+    expect(isObserverTokenNameConflict({ code: 'SQLITE_BUSY', message: 'database is locked' })).toBe(false);
+    expect(isObserverTokenNameConflict(new Error('workspace not found'))).toBe(false);
+    expect(isObserverTokenNameConflict({ message: 'Failed query', cause: { message: 'connection reset' } })).toBe(false);
+  });
+
+  it('does not recurse infinitely or throw on a self-referential .cause', () => {
+    const circular: { message: string; cause?: unknown } = { message: 'wrapped' };
+    circular.cause = circular;
+    expect(() => isObserverTokenNameConflict(circular)).not.toThrow();
+    expect(isObserverTokenNameConflict(circular)).toBe(false);
+  });
+
+  it('handles non-object and null inputs safely', () => {
+    expect(isObserverTokenNameConflict(null)).toBe(false);
+    expect(isObserverTokenNameConflict(undefined)).toBe(false);
+    expect(isObserverTokenNameConflict('some string error')).toBe(false);
+  });
+});

--- a/packages/engine/src/engine/observerToken.ts
+++ b/packages/engine/src/engine/observerToken.ts
@@ -124,29 +124,55 @@ function publicObserverToken(row: ObserverToken, token?: string): PublicObserver
  * regressing to an uncaught 500 against D1 because the detection only matched
  * better-sqlite3's shape.
  *
- * This intentionally recurses into `.cause` and falls back to a broad, case-insensitive
- * "unique constraint" message match — not just the exact index/column substrings — so a
- * future shift in a driver's error format doesn't silently reopen this bug again. The
- * `observer_tokens` table does have a second unique index (`token_hash`), but a token-hash
- * collision is a collision of a random 192-bit hex token's SHA-256 — astronomically
- * unlikely — so treating any unique-constraint violation from this insert as a name
- * conflict is an acceptable, deliberately-broad trade-off against risking a silent 500.
+ * This walks the `.cause` chain and falls back to a broad, case-insensitive "unique
+ * constraint" message match — not just the exact index/column substrings — so a future
+ * shift in a driver's error format doesn't silently reopen this bug again. The walk is
+ * iterative (not recursive) and tracks every error object visited so far in a `WeakSet`,
+ * breaking on *any* revisit rather than only a direct `cause === self` self-reference —
+ * a multi-step cycle (`A -> B -> A`) would bypass a direct-reference-only guard and blow
+ * the call stack, turning the very check meant to prevent a 500 into one itself.
+ *
+ * `candidate.code === 'SQLITE_CONSTRAINT'` alone (the bare, non-extended SQLite result
+ * code, as opposed to `'SQLITE_CONSTRAINT_UNIQUE'`) is only treated as a match when the
+ * message also mentions "unique" — otherwise an unrelated constraint violation on this
+ * insert (e.g. a `FOREIGN KEY`/`NOT NULL` failure on `workspace_id`) could be misreported
+ * as a name conflict. In practice better-sqlite3 always throws the extended
+ * `SQLITE_CONSTRAINT_UNIQUE`/`_FOREIGNKEY`/`_NOTNULL`/`_CHECK` codes (verified locally
+ * against the installed better-sqlite3 version — FK, NOT NULL, and CHECK violations each
+ * throw their own distinct extended code, never the bare `SQLITE_CONSTRAINT`), and the D1
+ * shape confirmed via `engine/agent.ts` also uses the extended `_UNIQUE` code, so the bare
+ * code is not known to occur for any of these in the drivers this engine actually runs on
+ * today — this check is a defense-in-depth guard, not a fix for an observed false positive.
+ *
+ * The `observer_tokens` table does have a second unique index (`token_hash`), but a
+ * token-hash collision is a collision of a random 192-bit hex token's SHA-256 —
+ * astronomically unlikely — so treating any *unique*-constraint violation from this insert
+ * as a name conflict (as opposed to disambiguating which of the two unique indexes fired)
+ * is an acceptable, deliberately-broad trade-off against risking a silent 500.
  */
 export function isObserverTokenNameConflict(err: unknown): boolean {
-  if (!err || typeof err !== 'object') return false;
-  const candidate = err as { code?: string; message?: string; cause?: unknown };
-  const message = candidate.message ?? '';
-  const isNameIndexMessage = (
-    message.includes('observer_tokens_workspace_name_unique')
-    || message.includes('observer_tokens.workspace_id, observer_tokens.name')
-  );
-  const isGenericUniqueViolation = (
-    candidate.code === 'SQLITE_CONSTRAINT'
-    || candidate.code === 'SQLITE_CONSTRAINT_UNIQUE'
-    || message.toLowerCase().includes('unique constraint failed')
-  );
-  if (isNameIndexMessage || isGenericUniqueViolation) return true;
-  if (candidate.cause && candidate.cause !== err) return isObserverTokenNameConflict(candidate.cause);
+  const visited = new WeakSet<object>();
+  let current: unknown = err;
+  while (current && typeof current === 'object') {
+    if (visited.has(current)) return false;
+    visited.add(current);
+
+    const candidate = current as { code?: string; message?: string; cause?: unknown };
+    const message = candidate.message ?? '';
+    const lowerMessage = message.toLowerCase();
+    const isNameIndexMessage = (
+      message.includes('observer_tokens_workspace_name_unique')
+      || message.includes('observer_tokens.workspace_id, observer_tokens.name')
+    );
+    const isGenericUniqueViolation = (
+      candidate.code === 'SQLITE_CONSTRAINT_UNIQUE'
+      || lowerMessage.includes('unique constraint failed')
+      || (candidate.code === 'SQLITE_CONSTRAINT' && lowerMessage.includes('unique'))
+    );
+    if (isNameIndexMessage || isGenericUniqueViolation) return true;
+
+    current = candidate.cause;
+  }
   return false;
 }
 

--- a/packages/engine/src/engine/observerToken.ts
+++ b/packages/engine/src/engine/observerToken.ts
@@ -106,15 +106,48 @@ function publicObserverToken(row: ObserverToken, token?: string): PublicObserver
   };
 }
 
-function isObserverTokenNameConflict(err: unknown): boolean {
-  const candidate = err as { code?: string; message?: string };
+/**
+ * Recognize a unique-constraint violation on the `observer_tokens` table (either the
+ * `observer_tokens_workspace_name_unique` index on (workspace_id, name), or the
+ * `observer_tokens_token_hash_unique` index) regardless of the underlying SQLite driver.
+ *
+ * Self-hosted engine deployments run on `better-sqlite3`, whose errors carry
+ * `.code === 'SQLITE_CONSTRAINT'` / `'SQLITE_CONSTRAINT_UNIQUE'` and a `.message` like
+ * `UNIQUE constraint failed: observer_tokens.workspace_id, observer_tokens.name`.
+ *
+ * The hosted engine (relaycast-cloud) runs on Cloudflare D1 via `drizzle-orm/d1`. D1
+ * throws the same `.code` values, but its `.message` is prefixed
+ * `D1_ERROR: UNIQUE constraint failed: ...`, and drizzle-orm may additionally re-wrap the
+ * original driver error underneath `.cause` instead of surfacing it at the top level. This
+ * is confirmed by this engine's own `engine/agent.ts` `isUniqueConstraintError`, added in
+ * PR #193 after the exact same class of bug: clean 409 "already exists" handling silently
+ * regressing to an uncaught 500 against D1 because the detection only matched
+ * better-sqlite3's shape.
+ *
+ * This intentionally recurses into `.cause` and falls back to a broad, case-insensitive
+ * "unique constraint" message match — not just the exact index/column substrings — so a
+ * future shift in a driver's error format doesn't silently reopen this bug again. The
+ * `observer_tokens` table does have a second unique index (`token_hash`), but a token-hash
+ * collision is a collision of a random 192-bit hex token's SHA-256 — astronomically
+ * unlikely — so treating any unique-constraint violation from this insert as a name
+ * conflict is an acceptable, deliberately-broad trade-off against risking a silent 500.
+ */
+export function isObserverTokenNameConflict(err: unknown): boolean {
+  if (!err || typeof err !== 'object') return false;
+  const candidate = err as { code?: string; message?: string; cause?: unknown };
   const message = candidate.message ?? '';
-  return (
-    candidate.code === 'SQLITE_CONSTRAINT'
-    || candidate.code === 'SQLITE_CONSTRAINT_UNIQUE'
-    || message.includes('observer_tokens_workspace_name_unique')
+  const isNameIndexMessage = (
+    message.includes('observer_tokens_workspace_name_unique')
     || message.includes('observer_tokens.workspace_id, observer_tokens.name')
   );
+  const isGenericUniqueViolation = (
+    candidate.code === 'SQLITE_CONSTRAINT'
+    || candidate.code === 'SQLITE_CONSTRAINT_UNIQUE'
+    || message.toLowerCase().includes('unique constraint failed')
+  );
+  if (isNameIndexMessage || isGenericUniqueViolation) return true;
+  if (candidate.cause && candidate.cause !== err) return isObserverTokenNameConflict(candidate.cause);
+  return false;
 }
 
 function observerTokenNameConflict(): never {


### PR DESCRIPTION
## Bug

`POST /v1/observer-tokens` re-minting an existing name (e.g. Pear's broker calling `RelaycastHttpClient::create_observer_token` with the fixed default name `pear-dashboard-observer` more than once for the same workspace) returns an uncaught `500` in production instead of a clean `409 observer_token_name_conflict`. Reproduced live: the first mint for a workspace succeeds; a later mint under the same name fails with a client-side "Max retries exceeded" (the Rust SDK retrying on 5xx and giving up).

Root cause: `isObserverTokenNameConflict()` in `packages/engine/src/engine/observerToken.ts` only recognized **better-sqlite3**'s error shape (`.code === 'SQLITE_CONSTRAINT*'`, raw `"UNIQUE constraint failed: ..."` message). Self-hosted engine deployments use better-sqlite3 (so the existing conformance test for this passes), but the hosted engine (`relaycast-cloud`) runs on **Cloudflare D1** via `drizzle-orm/d1`, which throws a differently-shaped error, so the conflict was never caught there and fell through as an uncaught exception → 500.

## D1 error shape — evidence

I didn't have to guess or spin up a D1 emulator: this exact class of bug was already hit and fixed once before in this codebase, in `engine/agent.ts`'s `isUniqueConstraintError` (added in #193, "bounded-durable mailbox, location routing, §5 cleanup"). That commit's message documents the confirmed shape:

- D1's `.code` is `SQLITE_CONSTRAINT_UNIQUE` (same as better-sqlite3's code convention)
- D1's `.message` is prefixed: `D1_ERROR: UNIQUE constraint failed: <table>.<col1>, <table>.<col2>` (not the raw better-sqlite3 message)
- drizzle-orm may re-wrap the original driver error underneath `.cause` instead of surfacing it at the top level

`observerToken.ts`'s check predated that fix and was never updated to match, so it silently rotted for this one table's insert path while `agent.ts`'s equivalent check (for `agent_already_exists`) was already correct.

## Fix

Widened `isObserverTokenNameConflict` (now exported for direct unit testing) to:
- keep the existing index/column-specific substring checks (unchanged)
- keep the existing `.code` checks (unchanged)
- **add** a case-insensitive, driver-agnostic `"unique constraint failed"` message fallback
- **add** recursion into `.cause` (guarded against self-referential cycles)

This covers the D1 shape (including drizzle's `.cause` wrapping) without narrowing or replacing the self-hosted (better-sqlite3) behavior.

## Tests

- New `packages/engine/src/engine/observerToken.conflictDetection.test.ts`: unit-tests the exported detection function directly against the better-sqlite3 shape, the D1 top-level shape, the drizzle-`.cause`-wrapped D1 shape, and negative cases (unrelated errors, circular `.cause`, non-object/null input) — shapes that can't be produced by this package's better-sqlite3-backed test harness, so a real D1 emulator isn't needed to verify them.
- Existing `src/__tests__/conformance/observerToken.test.ts` ("returns a conflict for duplicate observer token names in one workspace") continues to pass unchanged — end-to-end coverage of the better-sqlite3 path through the real HTTP route, confirming no self-hosted regression.
- Full suite: `npm run typecheck`, `npm run lint`, `npm test` all pass (218/218 tests, `packages/engine`).

## Design question: should re-minting under an existing name just work (upsert), instead of erroring?

Investigated the existing patterns in this codebase before deciding:
- `engine/agent.ts`'s `registerAgent` treats a duplicate `(workspace_id, name)` the same way: a strict `409 agent_already_exists`, not an upsert.
- `engine/reaction.ts`'s `addReaction` is the one place in this codebase that *does* treat a unique-constraint hit as idempotent-success (same agent/message/emoji reacting twice is genuinely the same action, so it re-reads and returns the existing row).

Observer tokens are not like reactions: minting one produces a genuinely new secret, and the plaintext token is only ever returned once (at create/rotate time) — the row's `tokenHash` is all that persists. If `createObserverToken` returned the *existing* row on a name conflict, the caller would get token metadata with **no usable secret** (defeats the purpose of calling create). If it silently *rotated* the existing row instead, that's a meaningful, surprising side effect on a `POST .../observer-tokens` "create" call — it invalidates whatever consumer is currently using the old secret under that name, with no explicit opt-in.

So I kept `POST /v1/observer-tokens` strict/create-only (`409` on conflict) — this matches the `agent.ts` precedent for named-unique resources, is what the existing conformance test already asserts, and avoids a surprising implicit-invalidation side effect on a plain POST. I did **not** add new upsert/`on_conflict` API surface in this PR.

The actual fix for "make this far less likely to occur" is caller-side: `list_observer_tokens` and `rotate_observer_token` already exist and fully support an idempotent-mint pattern — list first, and if a token with that name exists, call `rotate_observer_token(id)` to get a fresh usable secret instead of blindly `create_observer_token`-ing every time. **This requires a change in the `relay` repo** (wherever `RelaycastHttpClient::create_observer_token` is called for Pear's dashboard, e.g. its broker), not in this engine — flagging as a manual follow-up since it's out of scope for this repo/PR.

## Additional finding (not fixed here, flagged for follow-up)

While verifying this, I confirmed (via a scratch test against the real HTTP route) that `observer_tokens_workspace_name_unique` is an **unconditional** unique index on `(workspace_id, name)` — not scoped to `status = 'active'`. That means **revoking** a token does not free up its name for reuse; a later create under the same name still 409s forever, even on the already-passing better-sqlite3 path. Making that index partial (`WHERE status = 'active'`) would need a schema migration on a table that's live on Cloudflare D1 in production — bigger surface than this bug-fix PR, so I'm calling it out here for a human to decide on separately rather than bundling it in.

## Scope note

No changes needed in `relaycast-cloud` (the only place D1 is actually wired up) — it consumes `@relaycast/engine` as a plain npm dependency with no override of this function, so once this fix ships in a new `@relaycast/engine` release, `relaycast-cloud` needs its dependency bumped to pick it up. **I can't publish that npm release myself — a human needs to do the version bump/publish, then bump the dependency in `relaycast-cloud`,** as a manual follow-up after this PR merges.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/AgentWorkforce/relaycast/pull/232?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

