### PR TITLE
test(a2a): cover A2A protocol zod schemas

### DIFF
--- a/packages/a2a/src/__tests__/schemas.test.ts
+++ b/packages/a2a/src/__tests__/schemas.test.ts
@@ -16,13 +16,20 @@ import {
   A2aResponseSchema,
 } from '../index.js';
 
-// Helper: does any validation issue point at the given top-level field?
+// Helper: does any validation issue point at the given (possibly nested) path?
+// Pass a single key to match a top-level field, or multiple keys to pin an
+// exact nested path (e.g. 'file', 'bytes' or 'skills', 0, 'name'). Every path
+// segment must match in order, so a nested assertion no longer passes merely
+// because some unrelated issue exists under the same top-level key.
 function hasIssueAtPath(
   result: { success: boolean; error?: { issues: { path: PropertyKey[] }[] } },
-  key: PropertyKey,
+  ...path: PropertyKey[]
 ): boolean {
   if (result.success || !result.error) return false;
-  return result.error.issues.some((issue) => issue.path[0] === key);
+  return result.error.issues.some((issue) => {
+    if (issue.path.length < path.length) return false;
+    return path.every((key, i) => issue.path[i] === key);
+  });
 }
 
 describe('A2aSkillSchema', () => {
@@ -138,7 +145,7 @@ describe('A2aAgentCardSchema', () => {
     });
     expect(result.success).toBe(false);
     // Issue path should descend into the skills array element's name.
-    expect(hasIssueAtPath(result, 'skills')).toBe(true);
+    expect(hasIssueAtPath(result, 'skills', 0, 'name')).toBe(true);
   });
 });
 
@@ -171,16 +178,16 @@ describe('individual part schemas', () => {
   it('A2aFilePartSchema rejects a file with an empty name', () => {
     const result = A2aFilePartSchema.safeParse({ kind: 'file', file: { name: '' } });
     expect(result.success).toBe(false);
-    expect(hasIssueAtPath(result, 'file')).toBe(true);
+    expect(hasIssueAtPath(result, 'file', 'name')).toBe(true);
   });
 
   it('A2aFilePartSchema rejects negative or non-integer bytes', () => {
     const negative = A2aFilePartSchema.safeParse({ kind: 'file', file: { name: 'f', bytes: -1 } });
     expect(negative.success).toBe(false);
-    expect(hasIssueAtPath(negative, 'file')).toBe(true);
+    expect(hasIssueAtPath(negative, 'file', 'bytes')).toBe(true);
     const fractional = A2aFilePartSchema.safeParse({ kind: 'file', file: { name: 'f', bytes: 1.5 } });
     expect(fractional.success).toBe(false);
-    expect(hasIssueAtPath(fractional, 'file')).toBe(true);
+    expect(hasIssueAtPath(fractional, 'file', 'bytes')).toBe(true);
   });
 
   it('A2aDataPartSchema accepts a data part', () => {
@@ -276,7 +283,8 @@ describe('A2aMessageSchema', () => {
       parts: [{ kind: 'bogus' }],
     });
     expect(result.success).toBe(false);
-    expect(hasIssueAtPath(result, 'parts')).toBe(true);
+    // The invalid element is the first part, failing on its `kind` discriminator.
+    expect(hasIssueAtPath(result, 'parts', 0, 'kind')).toBe(true);
   });
 });
 
@@ -351,7 +359,7 @@ describe('A2aTaskSchema', () => {
       status: { state: 'not-a-state' },
     });
     expect(result.success).toBe(false);
-    expect(hasIssueAtPath(result, 'status')).toBe(true);
+    expect(hasIssueAtPath(result, 'status', 'state')).toBe(true);
   });
 
   it('rejects a task missing status', () => {
@@ -411,7 +419,7 @@ describe('JsonRpcRequestSchema', () => {
       params: { message: { message_id: 'm1', parts: [] } },
     });
     expect(result.success).toBe(false);
-    expect(hasIssueAtPath(result, 'params')).toBe(true);
+    expect(hasIssueAtPath(result, 'params', 'message', 'parts')).toBe(true);
   });
 });
 
@@ -485,7 +493,8 @@ describe('JsonRpcResponseSchema', () => {
       error: { code: -1 },
     });
     expect(result.success).toBe(false);
-    expect(hasIssueAtPath(result, 'error')).toBe(true);
+    // The nested error object is missing its required `message`.
+    expect(hasIssueAtPath(result, 'error', 'message')).toBe(true);
   });
 });
 
@@ -527,7 +536,7 @@ describe('A2aResponseSchema', () => {
       task: { id: 't1', status: { state: 'bogus' } },
     });
     expect(result.success).toBe(false);
-    expect(hasIssueAtPath(result, 'task')).toBe(true);
+    expect(hasIssueAtPath(result, 'task', 'status', 'state')).toBe(true);
   });
 
   it('rejects an invalid nested response envelope', () => {
@@ -535,6 +544,6 @@ describe('A2aResponseSchema', () => {
       response: { jsonrpc: 'nope' },
     });
     expect(result.success).toBe(false);
-    expect(hasIssueAtPath(result, 'response')).toBe(true);
+    expect(hasIssueAtPath(result, 'response', 'jsonrpc')).toBe(true);
   });
 });

--- a/packages/a2a/src/__tests__/schemas.test.ts
+++ b/packages/a2a/src/__tests__/schemas.test.ts
@@ -1,0 +1,540 @@
+import { describe, it, expect } from 'vitest';
+import {
+  A2aSkillSchema,
+  A2aAgentCardSchema,
+  A2aFilePartSchema,
+  A2aDataPartSchema,
+  A2aTextPartSchema,
+  A2aPartSchema,
+  A2aMessageSchema,
+  A2aArtifactSchema,
+  A2aTaskStateSchema,
+  A2aTaskSchema,
+  JsonRpcRequestSchema,
+  JsonRpcErrorSchema,
+  JsonRpcResponseSchema,
+  A2aResponseSchema,
+} from '../index.js';
+
+// Helper: does any validation issue point at the given top-level field?
+function hasIssueAtPath(
+  result: { success: boolean; error?: { issues: { path: PropertyKey[] }[] } },
+  key: PropertyKey,
+): boolean {
+  if (result.success || !result.error) return false;
+  return result.error.issues.some((issue) => issue.path[0] === key);
+}
+
+describe('A2aSkillSchema', () => {
+  it('accepts a minimal skill (name only)', () => {
+    expect(A2aSkillSchema.safeParse({ name: 'search' }).success).toBe(true);
+  });
+
+  it('accepts a full skill', () => {
+    expect(
+      A2aSkillSchema.safeParse({
+        id: 'skill-1',
+        name: 'search',
+        description: 'searches things',
+        tags: ['web', 'index'],
+      }).success,
+    ).toBe(true);
+  });
+
+  it('rejects a missing name', () => {
+    const result = A2aSkillSchema.safeParse({ description: 'no name' });
+    expect(result.success).toBe(false);
+    expect(hasIssueAtPath(result, 'name')).toBe(true);
+  });
+
+  it('rejects an empty name (min(1))', () => {
+    const result = A2aSkillSchema.safeParse({ name: '' });
+    expect(result.success).toBe(false);
+    expect(hasIssueAtPath(result, 'name')).toBe(true);
+  });
+
+  it('rejects an empty id (min(1)) when present', () => {
+    const result = A2aSkillSchema.safeParse({ name: 'ok', id: '' });
+    expect(result.success).toBe(false);
+    expect(hasIssueAtPath(result, 'id')).toBe(true);
+  });
+});
+
+describe('A2aAgentCardSchema', () => {
+  const minimalCard = {
+    name: 'My Agent',
+    url: 'https://agent.example.com',
+    version: '1.0.0',
+    skills: [{ name: 'search' }],
+  };
+
+  it('accepts a minimal valid agent card', () => {
+    expect(A2aAgentCardSchema.safeParse(minimalCard).success).toBe(true);
+  });
+
+  it('accepts a full valid agent card', () => {
+    const result = A2aAgentCardSchema.safeParse({
+      ...minimalCard,
+      description: 'does stuff',
+      provider: { organization: 'acme' },
+      capabilities: { streaming: true },
+      default_input_modes: ['text'],
+      default_output_modes: ['text', 'file'],
+      documentation_url: 'https://docs.example.com',
+      skills: [
+        { id: 's1', name: 'search', description: 'd', tags: ['a'] },
+        { name: 'summarize' },
+      ],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects when required name is missing', () => {
+    const { name, ...rest } = minimalCard;
+    void name;
+    const result = A2aAgentCardSchema.safeParse(rest);
+    expect(result.success).toBe(false);
+    expect(hasIssueAtPath(result, 'name')).toBe(true);
+  });
+
+  it('rejects an empty name (min(1))', () => {
+    const result = A2aAgentCardSchema.safeParse({ ...minimalCard, name: '' });
+    expect(result.success).toBe(false);
+    expect(hasIssueAtPath(result, 'name')).toBe(true);
+  });
+
+  it('rejects an empty version (min(1))', () => {
+    const result = A2aAgentCardSchema.safeParse({ ...minimalCard, version: '' });
+    expect(result.success).toBe(false);
+    expect(hasIssueAtPath(result, 'version')).toBe(true);
+  });
+
+  it('rejects a non-URL url field', () => {
+    const result = A2aAgentCardSchema.safeParse({ ...minimalCard, url: 'not-a-url' });
+    expect(result.success).toBe(false);
+    // The failure must be about `url`, not some unrelated field.
+    expect(hasIssueAtPath(result, 'url')).toBe(true);
+  });
+
+  it('rejects an invalid documentation_url when present', () => {
+    const result = A2aAgentCardSchema.safeParse({
+      ...minimalCard,
+      documentation_url: 'nope',
+    });
+    expect(result.success).toBe(false);
+    expect(hasIssueAtPath(result, 'documentation_url')).toBe(true);
+  });
+
+  it('rejects an empty skills array (min(1))', () => {
+    const result = A2aAgentCardSchema.safeParse({ ...minimalCard, skills: [] });
+    expect(result.success).toBe(false);
+    expect(hasIssueAtPath(result, 'skills')).toBe(true);
+  });
+
+  it('rejects a skill with an empty name inside skills[]', () => {
+    const result = A2aAgentCardSchema.safeParse({
+      ...minimalCard,
+      skills: [{ name: '' }],
+    });
+    expect(result.success).toBe(false);
+    // Issue path should descend into the skills array element's name.
+    expect(hasIssueAtPath(result, 'skills')).toBe(true);
+  });
+});
+
+describe('individual part schemas', () => {
+  it('A2aTextPartSchema accepts a text part', () => {
+    expect(A2aTextPartSchema.safeParse({ kind: 'text', text: 'hello' }).success).toBe(true);
+  });
+
+  it('A2aTextPartSchema rejects a missing text field', () => {
+    const result = A2aTextPartSchema.safeParse({ kind: 'text' });
+    expect(result.success).toBe(false);
+    expect(hasIssueAtPath(result, 'text')).toBe(true);
+  });
+
+  it('A2aFilePartSchema accepts a minimal file part', () => {
+    expect(A2aFilePartSchema.safeParse({ kind: 'file', file: { name: 'f.txt' } }).success).toBe(
+      true,
+    );
+  });
+
+  it('A2aFilePartSchema accepts a full file part', () => {
+    expect(
+      A2aFilePartSchema.safeParse({
+        kind: 'file',
+        file: { name: 'f.txt', mime_type: 'text/plain', uri: 's3://x', bytes: 12 },
+      }).success,
+    ).toBe(true);
+  });
+
+  it('A2aFilePartSchema rejects a file with an empty name', () => {
+    const result = A2aFilePartSchema.safeParse({ kind: 'file', file: { name: '' } });
+    expect(result.success).toBe(false);
+    expect(hasIssueAtPath(result, 'file')).toBe(true);
+  });
+
+  it('A2aFilePartSchema rejects negative or non-integer bytes', () => {
+    const negative = A2aFilePartSchema.safeParse({ kind: 'file', file: { name: 'f', bytes: -1 } });
+    expect(negative.success).toBe(false);
+    expect(hasIssueAtPath(negative, 'file')).toBe(true);
+    const fractional = A2aFilePartSchema.safeParse({ kind: 'file', file: { name: 'f', bytes: 1.5 } });
+    expect(fractional.success).toBe(false);
+    expect(hasIssueAtPath(fractional, 'file')).toBe(true);
+  });
+
+  it('A2aDataPartSchema accepts a data part', () => {
+    expect(A2aDataPartSchema.safeParse({ kind: 'data', data: { a: 1, b: 'x' } }).success).toBe(
+      true,
+    );
+  });
+
+  it('A2aDataPartSchema rejects a missing data field', () => {
+    const result = A2aDataPartSchema.safeParse({ kind: 'data' });
+    expect(result.success).toBe(false);
+    expect(hasIssueAtPath(result, 'data')).toBe(true);
+  });
+});
+
+describe('A2aPartSchema (discriminated union on kind)', () => {
+  it('accepts each valid kind', () => {
+    expect(A2aPartSchema.safeParse({ kind: 'text', text: 'hi' }).success).toBe(true);
+    expect(A2aPartSchema.safeParse({ kind: 'file', file: { name: 'f' } }).success).toBe(true);
+    expect(A2aPartSchema.safeParse({ kind: 'data', data: { k: 'v' } }).success).toBe(true);
+  });
+
+  it('rejects an unknown discriminator value', () => {
+    const result = A2aPartSchema.safeParse({ kind: 'image', url: 'https://x' });
+    expect(result.success).toBe(false);
+    // A widened union (e.g. accepting arbitrary kinds) would regress this.
+    expect(hasIssueAtPath(result, 'kind')).toBe(true);
+  });
+
+  it('rejects a missing discriminator', () => {
+    const result = A2aPartSchema.safeParse({ text: 'orphan' });
+    expect(result.success).toBe(false);
+    expect(hasIssueAtPath(result, 'kind')).toBe(true);
+  });
+
+  it('narrows to the text branch: a text part with a data-part shape fails', () => {
+    // kind:'text' selects the text schema, which requires `text`; the stray
+    // `data` field does not satisfy it. Proves the union narrows by discriminator.
+    const result = A2aPartSchema.safeParse({ kind: 'text', data: { k: 'v' } });
+    expect(result.success).toBe(false);
+    expect(hasIssueAtPath(result, 'text')).toBe(true);
+  });
+
+  it('narrows to the file branch: a file part missing `file` fails', () => {
+    const result = A2aPartSchema.safeParse({ kind: 'file', text: 'wrong' });
+    expect(result.success).toBe(false);
+    expect(hasIssueAtPath(result, 'file')).toBe(true);
+  });
+});
+
+describe('A2aMessageSchema', () => {
+  it('accepts a minimal message and defaults role to "user"', () => {
+    const result = A2aMessageSchema.safeParse({
+      message_id: 'm1',
+      parts: [{ kind: 'text', text: 'hi' }],
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.role).toBe('user');
+    }
+  });
+
+  it('accepts an explicit valid role', () => {
+    expect(
+      A2aMessageSchema.safeParse({
+        message_id: 'm1',
+        role: 'agent',
+        context_id: 'c1',
+        parts: [{ kind: 'text', text: 'hi' }],
+      }).success,
+    ).toBe(true);
+  });
+
+  it('rejects an unknown role', () => {
+    const result = A2aMessageSchema.safeParse({
+      message_id: 'm1',
+      role: 'robot',
+      parts: [{ kind: 'text', text: 'hi' }],
+    });
+    expect(result.success).toBe(false);
+    expect(hasIssueAtPath(result, 'role')).toBe(true);
+  });
+
+  it('rejects an empty parts array (min(1))', () => {
+    const result = A2aMessageSchema.safeParse({ message_id: 'm1', parts: [] });
+    expect(result.success).toBe(false);
+    expect(hasIssueAtPath(result, 'parts')).toBe(true);
+  });
+
+  it('rejects an invalid part inside parts[]', () => {
+    const result = A2aMessageSchema.safeParse({
+      message_id: 'm1',
+      parts: [{ kind: 'bogus' }],
+    });
+    expect(result.success).toBe(false);
+    expect(hasIssueAtPath(result, 'parts')).toBe(true);
+  });
+});
+
+describe('A2aArtifactSchema', () => {
+  it('accepts a valid artifact', () => {
+    expect(
+      A2aArtifactSchema.safeParse({
+        name: 'out',
+        description: 'd',
+        parts: [{ kind: 'data', data: { k: 'v' } }],
+      }).success,
+    ).toBe(true);
+  });
+
+  it('rejects an empty parts array (min(1))', () => {
+    const result = A2aArtifactSchema.safeParse({ name: 'out', parts: [] });
+    expect(result.success).toBe(false);
+    expect(hasIssueAtPath(result, 'parts')).toBe(true);
+  });
+});
+
+describe('A2aTaskStateSchema (enum)', () => {
+  it('accepts every valid state', () => {
+    for (const state of [
+      'submitted',
+      'working',
+      'input-required',
+      'completed',
+      'failed',
+      'canceled',
+      'unknown',
+    ]) {
+      expect(A2aTaskStateSchema.safeParse(state).success).toBe(true);
+    }
+  });
+
+  it('rejects an out-of-enum state (would regress if the enum widened)', () => {
+    const result = A2aTaskStateSchema.safeParse('in-progress');
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects a near-miss casing variant', () => {
+    expect(A2aTaskStateSchema.safeParse('Completed').success).toBe(false);
+  });
+});
+
+describe('A2aTaskSchema', () => {
+  it('accepts a minimal valid task', () => {
+    expect(
+      A2aTaskSchema.safeParse({
+        id: 't1',
+        status: { state: 'working' },
+      }).success,
+    ).toBe(true);
+  });
+
+  it('accepts a full valid task', () => {
+    const result = A2aTaskSchema.safeParse({
+      id: 't1',
+      context_id: 'c1',
+      status: { state: 'completed', message: 'done' },
+      artifacts: [{ name: 'out', parts: [{ kind: 'text', text: 'x' }] }],
+      history: [{ message_id: 'm1', parts: [{ kind: 'text', text: 'hi' }] }],
+      metadata: { foo: 'bar' },
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects a task with an invalid status.state', () => {
+    const result = A2aTaskSchema.safeParse({
+      id: 't1',
+      status: { state: 'not-a-state' },
+    });
+    expect(result.success).toBe(false);
+    expect(hasIssueAtPath(result, 'status')).toBe(true);
+  });
+
+  it('rejects a task missing status', () => {
+    const result = A2aTaskSchema.safeParse({ id: 't1' });
+    expect(result.success).toBe(false);
+    expect(hasIssueAtPath(result, 'status')).toBe(true);
+  });
+});
+
+describe('JsonRpcRequestSchema', () => {
+  it('accepts a minimal valid request', () => {
+    expect(JsonRpcRequestSchema.safeParse({ jsonrpc: '2.0', method: 'message/send' }).success).toBe(
+      true,
+    );
+  });
+
+  it('accepts a request with id and structured params', () => {
+    expect(
+      JsonRpcRequestSchema.safeParse({
+        jsonrpc: '2.0',
+        id: 7,
+        method: 'message/send',
+        params: { message: { message_id: 'm1', parts: [{ kind: 'text', text: 'hi' }] } },
+      }).success,
+    ).toBe(true);
+  });
+
+  it('retains unknown params keys via .passthrough()', () => {
+    const result = JsonRpcRequestSchema.safeParse({
+      jsonrpc: '2.0',
+      method: 'message/send',
+      params: { message: { message_id: 'm1', parts: [{ kind: 'text', text: 'hi' }] }, blocking: true, extra: 42 },
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      // Extra keys must survive parsing rather than being stripped.
+      expect(result.data.params).toMatchObject({ blocking: true, extra: 42 });
+    }
+  });
+
+  it('rejects a wrong jsonrpc version literal', () => {
+    const result = JsonRpcRequestSchema.safeParse({ jsonrpc: '1.0', method: 'x' });
+    expect(result.success).toBe(false);
+    expect(hasIssueAtPath(result, 'jsonrpc')).toBe(true);
+  });
+
+  it('rejects an empty method (min(1))', () => {
+    const result = JsonRpcRequestSchema.safeParse({ jsonrpc: '2.0', method: '' });
+    expect(result.success).toBe(false);
+    expect(hasIssueAtPath(result, 'method')).toBe(true);
+  });
+
+  it('rejects an invalid params.message payload', () => {
+    const result = JsonRpcRequestSchema.safeParse({
+      jsonrpc: '2.0',
+      method: 'x',
+      params: { message: { message_id: 'm1', parts: [] } },
+    });
+    expect(result.success).toBe(false);
+    expect(hasIssueAtPath(result, 'params')).toBe(true);
+  });
+});
+
+describe('JsonRpcErrorSchema', () => {
+  it('accepts a valid error', () => {
+    expect(JsonRpcErrorSchema.safeParse({ code: -32600, message: 'Invalid Request' }).success).toBe(
+      true,
+    );
+  });
+
+  it('accepts an error with data', () => {
+    expect(
+      JsonRpcErrorSchema.safeParse({ code: -32000, message: 'boom', data: { detail: 'x' } }).success,
+    ).toBe(true);
+  });
+
+  it('rejects a non-numeric code', () => {
+    const result = JsonRpcErrorSchema.safeParse({ code: 'oops', message: 'x' });
+    expect(result.success).toBe(false);
+    expect(hasIssueAtPath(result, 'code')).toBe(true);
+  });
+
+  it('rejects a missing message', () => {
+    const result = JsonRpcErrorSchema.safeParse({ code: -1 });
+    expect(result.success).toBe(false);
+    expect(hasIssueAtPath(result, 'message')).toBe(true);
+  });
+});
+
+describe('JsonRpcResponseSchema', () => {
+  it('accepts a result response', () => {
+    expect(
+      JsonRpcResponseSchema.safeParse({
+        jsonrpc: '2.0',
+        id: 1,
+        result: { task: { id: 't1', status: { state: 'completed' } } },
+      }).success,
+    ).toBe(true);
+  });
+
+  it('accepts an error response', () => {
+    expect(
+      JsonRpcResponseSchema.safeParse({
+        jsonrpc: '2.0',
+        id: 1,
+        error: { code: -32601, message: 'Method not found' },
+      }).success,
+    ).toBe(true);
+  });
+
+  it('retains unknown result keys via .passthrough()', () => {
+    const result = JsonRpcResponseSchema.safeParse({
+      jsonrpc: '2.0',
+      result: { task: { id: 't1', status: { state: 'working' } }, cursor: 'abc' },
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.result).toMatchObject({ cursor: 'abc' });
+    }
+  });
+
+  it('rejects a wrong jsonrpc version literal', () => {
+    const result = JsonRpcResponseSchema.safeParse({ jsonrpc: '2', id: 1 });
+    expect(result.success).toBe(false);
+    expect(hasIssueAtPath(result, 'jsonrpc')).toBe(true);
+  });
+
+  it('rejects a malformed nested error', () => {
+    const result = JsonRpcResponseSchema.safeParse({
+      jsonrpc: '2.0',
+      error: { code: -1 },
+    });
+    expect(result.success).toBe(false);
+    expect(hasIssueAtPath(result, 'error')).toBe(true);
+  });
+});
+
+describe('A2aResponseSchema', () => {
+  it('accepts an empty object (all fields optional)', () => {
+    expect(A2aResponseSchema.safeParse({}).success).toBe(true);
+  });
+
+  it('accepts a task-bearing response', () => {
+    expect(
+      A2aResponseSchema.safeParse({
+        task: { id: 't1', status: { state: 'submitted' } },
+      }).success,
+    ).toBe(true);
+  });
+
+  it('accepts a message-bearing response', () => {
+    expect(
+      A2aResponseSchema.safeParse({
+        message: { message_id: 'm1', parts: [{ kind: 'text', text: 'hi' }] },
+      }).success,
+    ).toBe(true);
+  });
+
+  it('accepts a wrapped JSON-RPC response', () => {
+    expect(
+      A2aResponseSchema.safeParse({
+        response: {
+          jsonrpc: '2.0',
+          id: 1,
+          result: { message: { message_id: 'm1', parts: [{ kind: 'text', text: 'hi' }] } },
+        },
+      }).success,
+    ).toBe(true);
+  });
+
+  it('rejects an invalid nested task', () => {
+    const result = A2aResponseSchema.safeParse({
+      task: { id: 't1', status: { state: 'bogus' } },
+    });
+    expect(result.success).toBe(false);
+    expect(hasIssueAtPath(result, 'task')).toBe(true);
+  });
+
+  it('rejects an invalid nested response envelope', () => {
+    const result = A2aResponseSchema.safeParse({
+      response: { jsonrpc: 'nope' },
+    });
+    expect(result.success).toBe(false);
+    expect(hasIssueAtPath(result, 'response')).toBe(true);
+  });
+});

--- a/packages/a2a/tsconfig.json
+++ b/packages/a2a/tsconfig.json
@@ -8,5 +8,6 @@
     "sourceMap": true,
     "tsBuildInfoFile": "tsconfig.tsbuildinfo"
   },
-  "include": ["src/**/*.ts"]
+  "include": ["src/**/*.ts"],
+  "exclude": ["src/__tests__"]
 }


### PR DESCRIPTION
## What & why

`packages/a2a` had **zero tests** (its test script was `vitest run --passWithNoTests`). This package holds the zod schemas that validate inbound **external** A2A agent cards and JSON-RPC envelopes — a security-relevant external-input boundary — so it warrants direct, assertion-backed coverage. This is a **test-only** PR: no product/schema logic was changed.

## Coverage added

New file `packages/a2a/src/__tests__/schemas.test.ts` (62 tests) exercising **every** exported schema via `.safeParse()` with real positive *and* negative assertions. A `hasIssueAtPath()` helper asserts each negative case fails on the **intended** field (`issue.path[0]`), so a rejection can't pass for an unrelated reason and a schema-widening regression is caught.

- **`A2aSkillSchema`** — minimal/full accept; reject missing/empty `name`, empty `id`.
- **`A2aAgentCardSchema`** — minimal + full accept; reject missing/empty `name`, empty `version`, non-URL `url`, invalid `documentation_url`, empty `skills` (`min(1)`), and an empty-named skill inside `skills[]`.
- **`A2aTextPartSchema` / `A2aFilePartSchema` / `A2aDataPartSchema`** — valid shapes; reject missing `text`/`data`, empty file name, negative/fractional `bytes`.
- **`A2aPartSchema`** (discriminated union on `kind`) — accepts each valid `kind`; rejects unknown `kind`, missing `kind`; and pins union **narrowing**: a `kind:'text'` part with a data-part shape fails on `text`, a `kind:'file'` part without `file` fails on `file`. These would regress if the union were widened.
- **`A2aMessageSchema`** — role defaults to `user`; rejects unknown role, empty `parts` (`min(1)`), and an invalid part element.
- **`A2aArtifactSchema`** — valid accept; reject empty `parts`.
- **`A2aTaskStateSchema`** (enum) — accepts all 7 states; rejects out-of-enum and casing variants (pins enum boundary).
- **`A2aTaskSchema`** — minimal + full accept; reject invalid `status.state`, missing `status`.
- **`JsonRpcRequestSchema`** — valid request; asserts `.passthrough()` retains extra `params` keys; rejects wrong `jsonrpc` literal, empty `method`, invalid nested `params.message`.
- **`JsonRpcErrorSchema`** — valid (with/without `data`); reject non-numeric `code`, missing `message`.
- **`JsonRpcResponseSchema`** — result/error responses; `.passthrough()` on `result`; reject wrong `jsonrpc`, malformed nested `error`.
- **`A2aResponseSchema`** — empty/task/message/wrapped-envelope accept; reject invalid nested `task` and `response`.

### One config change (test infrastructure, not product logic)

`packages/a2a/tsconfig.json` now excludes `src/__tests__` from the tsc build, mirroring the existing `@relaycast/types` package convention. Without it, adding a test file causes the tests to be compiled into `dist/` (which ships via `files: ["dist"]`) and to be **double-run** by vitest (once from `src`, once from `dist`). The exclude keeps compiled tests out of the published package and out of the test run.

## Verification

Full monorepo gate green from the worktree:

- `npx turbo lint` — **13/13 tasks successful**
- `npx turbo build` — **9/9 tasks successful**
- `npx turbo test` — **18/18 tasks successful**
- `packages/a2a`: `vitest run` → **1 file, 62 tests passed** (single run; no dist double-count).

A fresh-context reviewer subagent confirmed every negative test fails for the right field, the discriminated-union tests catch a widened union, and all 14 exported schemas have ≥1 positive and ≥1 negative test, with no vacuous assertions.

## Suspected bugs (not fixed)

None found in the schemas. Note the tsconfig behavior above is a pre-existing packaging gap (only latent because the package previously had no tests) — addressed here as test infrastructure rather than left to ship test files into `dist/`.

---
Test-only PR: adds tests + one test-scoping tsconfig exclude; no schema/product behavior changed.


---
_Generated by [Claude Code](https://claude.ai/code/session_019XanmenzNQ2XLMmhHuZrWj)_

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/AgentWorkforce/relaycast/pull/236?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

