### PR TITLE
Engine: multi-provider nodes and node-scoped actions

### DIFF
--- a/.agentworkforce/trajectories/completed/2026-07/traj_jr7ymbkdqrkm/summary.md
+++ b/.agentworkforce/trajectories/completed/2026-07/traj_jr7ymbkdqrkm/summary.md
@@ -1,0 +1,32 @@
+# Trajectory: Engine: multi-provider nodes and node-scoped actions (node-providers spec step 1)
+
+> **Status:** ✅ Completed
+> **Task:** node-providers
+> **Confidence:** 80%
+> **Started:** July 8, 2026 at 06:43 AM
+> **Completed:** July 8, 2026 at 07:26 AM
+
+---
+
+## Summary
+
+Engine multi-provider nodes: fleet-wire provider fields, node_providers table, node-scoped actions + node-addressed invoke, spawn shadowing, per-provider liveness/deliver routing, synthetic default provider
+
+**Approach:** Standard approach
+
+---
+
+## Key Decisions
+
+### Kept nodes aggregate columns + per-provider node_providers table; default-provider actions stay workspace-global aliases (first-writer-wins) for additive migration
+- **Chose:** Kept nodes aggregate columns + per-provider node_providers table; default-provider actions stay workspace-global aliases (first-writer-wins) for additive migration
+- **Reasoning:** Preserves current broker behavior while adding provider persistence, routing, and node-scoped actions
+
+---
+
+## Chapters
+
+### 1. Work
+*Agent: default*
+
+- Kept nodes aggregate columns + per-provider node_providers table; default-provider actions stay workspace-global aliases (first-writer-wins) for additive migration: Kept nodes aggregate columns + per-provider node_providers table; default-provider actions stay workspace-global aliases (first-writer-wins) for additive migration

--- a/.agentworkforce/trajectories/completed/2026-07/traj_jr7ymbkdqrkm/trajectory.json
+++ b/.agentworkforce/trajectories/completed/2026-07/traj_jr7ymbkdqrkm/trajectory.json
@@ -1,0 +1,57 @@
+{
+  "id": "traj_jr7ymbkdqrkm",
+  "version": 1,
+  "task": {
+    "title": "Engine: multi-provider nodes and node-scoped actions (node-providers spec step 1)",
+    "source": {
+      "system": "plain",
+      "id": "node-providers"
+    }
+  },
+  "status": "completed",
+  "startedAt": "2026-07-08T10:43:33.469Z",
+  "completedAt": "2026-07-08T11:26:51.690Z",
+  "agents": [
+    {
+      "name": "default",
+      "role": "lead",
+      "joinedAt": "2026-07-08T11:17:58.215Z"
+    }
+  ],
+  "chapters": [
+    {
+      "id": "chap_kz834ibim082",
+      "title": "Work",
+      "agentName": "default",
+      "startedAt": "2026-07-08T11:17:58.215Z",
+      "endedAt": "2026-07-08T11:26:51.690Z",
+      "events": [
+        {
+          "ts": 1783509478216,
+          "type": "decision",
+          "content": "Kept nodes aggregate columns + per-provider node_providers table; default-provider actions stay workspace-global aliases (first-writer-wins) for additive migration: Kept nodes aggregate columns + per-provider node_providers table; default-provider actions stay workspace-global aliases (first-writer-wins) for additive migration",
+          "raw": {
+            "question": "Kept nodes aggregate columns + per-provider node_providers table; default-provider actions stay workspace-global aliases (first-writer-wins) for additive migration",
+            "chosen": "Kept nodes aggregate columns + per-provider node_providers table; default-provider actions stay workspace-global aliases (first-writer-wins) for additive migration",
+            "alternatives": [],
+            "reasoning": "Preserves current broker behavior while adding provider persistence, routing, and node-scoped actions"
+          },
+          "significance": "high"
+        }
+      ]
+    }
+  ],
+  "retrospective": {
+    "summary": "Engine multi-provider nodes: fleet-wire provider fields, node_providers table, node-scoped actions + node-addressed invoke, spawn shadowing, per-provider liveness/deliver routing, synthetic default provider",
+    "approach": "Standard approach",
+    "confidence": 0.8
+  },
+  "commits": [],
+  "filesChanged": [],
+  "projectId": "AgentWorkforce/relaycast",
+  "tags": [],
+  "_trace": {
+    "startRef": "27d04a7dc2ca813d513729d978570db937a18c99",
+    "endRef": "27d04a7dc2ca813d513729d978570db937a18c99"
+  }
+}

--- a/README.md
+++ b/README.md
@@ -467,7 +467,10 @@ Adapters that terminate `/v1/node/ws` outside the engine request handler should 
 node control frames to `handleNodeControlMessage` from `@relaycast/engine/node-control`:
 the handler only needs `{ db, registry, workspaceId, nodeId, socket, raw }`, where
 `socket` is any object with `send(data: string): void`. It is self-contained and does
-not read Hono context. Pass `completionDeps` (`db`, `realtime`, `webhookQueue`, and
+not read Hono context. Pass `connectionId` (the registry's id for this socket) so a
+provider binds its name to the connection at `node.register` and later frames resolve
+their provider from it; omit it and every frame keys to the synthetic `default`
+provider. Pass `completionDeps` (`db`, `realtime`, `webhookQueue`, and
 `nodeConnections`) if `action.result` should emit completion fan-out and webhook effects;
 without it, the invocation state is still completed in the database. The handler already
 drains queued node invocations and replays pending node deliveries after
@@ -533,7 +536,9 @@ Programmability, directory & observability:
 
 ```text
 POST   /v1/actions                   Register an action (agent-to-agent RPC)
-POST   /v1/actions/:name/invoke      Invoke an action
+POST   /v1/actions/:name/invoke      Invoke an action (workspace-scoped / global alias)
+POST   /v1/nodes/:node/actions/:name/invoke  Invoke a node-addressed action
+DELETE /v1/nodes/:node/providers/:name       Remove a node provider
 POST   /v1/agents/:name/events       Emit an agent session event
 POST   /v1/directory/agents          Publish an agent to the directory
 GET    /v1/directory/search          Search the agent directory

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -3918,6 +3918,97 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
 
+  /nodes/{node}/actions/{name}/invoke:
+    post:
+      summary: Invoke a node-addressed action
+      description: >
+        Invoke an action on a specific node. The engine resolves the action to
+        the provider that registered it and dispatches over that provider's
+        socket. A `spawn:<harness>` name with no shadow action falls through to
+        the node's native capacity. Fails fast with `handler_unavailable` when
+        the owning provider is offline unless the capability opted into queueing.
+      tags:
+        - Nodes
+      security:
+        - agentToken: []
+      parameters:
+        - name: node
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: name
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                input:
+                  type: object
+      responses:
+        '201':
+          description: Invocation created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SuccessResponse'
+        '403':
+          description: Agent token required or caller not authorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '404':
+          description: Node or action not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '503':
+          description: Owning provider offline (fail fast)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+  /nodes/{node}/providers/{name}:
+    delete:
+      summary: Remove a node provider
+      description: >
+        Remove a provider's attachment, its persisted capability set, and the
+        actions it materialized on the node. When it was the node's last provider
+        the node goes offline.
+      tags:
+        - Nodes
+      security:
+        - workspaceKey: []
+      parameters:
+        - name: node
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: name
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '204':
+          description: Provider removed
+        '404':
+          description: Node not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
   /node/ws:
     get:
       summary: Node control WebSocket

--- a/packages/engine/src/__tests__/conformance/node.test.ts
+++ b/packages/engine/src/__tests__/conformance/node.test.ts
@@ -1318,7 +1318,10 @@ describe('node adapter conformance', () => {
       const rejectingRegistry: NodeConnectionRegistry = {
         upgradeNode: async () => new Response(null, { status: 501 }),
         sendToNode: async () => false,
+        sendToProvider: async () => false,
         isNodeConnected: () => true,
+        isProviderConnected: () => true,
+        detachProvider: () => {},
         disconnectNode: async () => {},
         drainNode: async () => {},
       };

--- a/packages/engine/src/__tests__/conformance/nodeProviders.test.ts
+++ b/packages/engine/src/__tests__/conformance/nodeProviders.test.ts
@@ -271,6 +271,30 @@ describe('node providers', () => {
     expect(deliverFramesOfType(rb.sock, 'message.created')).toHaveLength(0);
   });
 
+  it('releases reserved capacity when a fail-fast node-scoped spawn hits an offline provider', async () => {
+    const ws = await createWorkspace(stack.app, 'np-failfast-capacity');
+    const caller = await registerAgent(stack.app, ws.workspaceKey, 'caller');
+    await enrollNode(ws, 'node_a', 'alpha');
+    // Broker provides native capacity so the node is online with capacity.
+    await attachProvider(ws.workspaceId, 'node_a', 'alpha', 'default', [{ name: 'spawn:claude', kind: 'capacity' }], { maxAgents: 4 });
+    // A shadow spawn:claude action whose provider then goes offline.
+    const py = await attachProvider(ws.workspaceId, 'node_a', 'alpha', 'py', [{ name: 'spawn:claude', kind: 'action' }]);
+    await py.handle.handleClose();
+
+    const res = await stack.app.request('/v1/nodes/alpha/actions/spawn:claude/invoke', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', authorization: `Bearer ${caller.token}` },
+      body: JSON.stringify({ input: { name: 'w1' } }),
+    });
+    expect(res.status).toBe(503);
+
+    const [node] = await stack.runtime.handle.db
+      .select({ reserved: nodes.reservedAgents })
+      .from(nodes)
+      .where(and(eq(nodes.workspaceId, ws.workspaceId), eq(nodes.id, 'node_a')));
+    expect(node.reserved).toBe(0);
+  });
+
   it('routes context.update to the provider hosting the agent, not a phantom node default', async () => {
     const ws = await createWorkspace(stack.app, 'np-context');
     const alice = await registerAgent(stack.app, ws.workspaceKey, 'alice');

--- a/packages/engine/src/__tests__/conformance/nodeProviders.test.ts
+++ b/packages/engine/src/__tests__/conformance/nodeProviders.test.ts
@@ -265,7 +265,10 @@ describe('node providers', () => {
       body: JSON.stringify({ text: 'hello worker' }),
     });
     expect(post.status).toBe(201);
-    await new Promise((r) => setTimeout(r, 60));
+    // Poll for the async fanout instead of a fixed sleep, to avoid CI flakiness.
+    for (let i = 0; i < 50 && deliverFramesOfType(py.sock, 'message.created').length === 0; i++) {
+      await new Promise((r) => setTimeout(r, 10));
+    }
 
     expect(deliverFramesOfType(py.sock, 'message.created').length).toBeGreaterThanOrEqual(1);
     expect(deliverFramesOfType(rb.sock, 'message.created')).toHaveLength(0);
@@ -293,6 +296,67 @@ describe('node providers', () => {
       .from(nodes)
       .where(and(eq(nodes.workspaceId, ws.workspaceId), eq(nodes.id, 'node_a')));
     expect(node.reserved).toBe(0);
+  });
+
+  it('does not release another spawn’s reservation when a shadowed spawn completes', async () => {
+    const ws = await createWorkspace(stack.app, 'np-shadow-capacity');
+    const caller = await registerAgent(stack.app, ws.workspaceKey, 'caller');
+    await enrollNode(ws, 'node_a', 'alpha');
+    // Broker offers native capacity for two harnesses; policy shadows only claude.
+    await attachProvider(ws.workspaceId, 'node_a', 'alpha', 'default', [
+      { name: 'spawn:claude', kind: 'capacity' },
+      { name: 'spawn:codex', kind: 'capacity' },
+    ], { maxAgents: 4 });
+    const policy = await attachProvider(ws.workspaceId, 'node_a', 'alpha', 'policy', [{ name: 'spawn:claude', kind: 'action' }]);
+
+    // A native codex spawn reserves capacity and stays in flight.
+    const codex = await stack.app.request('/v1/actions/spawn/invoke', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', authorization: `Bearer ${caller.token}` },
+      body: JSON.stringify({ input: { cli: 'codex', name: 'codex-1' } }),
+    });
+    expect(codex.status).toBe(201);
+    const reservedAfterCodex = await stack.runtime.handle.db
+      .select({ reserved: nodes.reservedAgents })
+      .from(nodes)
+      .where(and(eq(nodes.workspaceId, ws.workspaceId), eq(nodes.id, 'node_a')))
+      .then((r) => r[0].reserved);
+    expect(reservedAfterCodex).toBe(1);
+
+    // A shadowed claude spawn dispatches to policy (holds no native reservation).
+    const claude = await stack.app.request('/v1/actions/spawn/invoke', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', authorization: `Bearer ${caller.token}` },
+      body: JSON.stringify({ input: { cli: 'claude', name: 'claude-1' } }),
+    });
+    expect(claude.status).toBe(201);
+    const claudeInv = (await claude.json() as { data: { invocation_id: string } }).data.invocation_id;
+
+    // Completing the shadow spawn must not release the codex spawn's reservation.
+    await policy.handle.handleMessage(JSON.stringify({ v: 1, type: 'action.result', invocation_id: claudeInv, output: { ok: true } }));
+    const reservedAfterClaude = await stack.runtime.handle.db
+      .select({ reserved: nodes.reservedAgents })
+      .from(nodes)
+      .where(and(eq(nodes.workspaceId, ws.workspaceId), eq(nodes.id, 'node_a')))
+      .then((r) => r[0].reserved);
+    expect(reservedAfterClaude).toBe(1);
+  });
+
+  it('rejects an explicit global alias that would shadow an agent-hosted action', async () => {
+    const ws = await createWorkspace(stack.app, 'np-global-conflict');
+    const helper = await registerAgent(stack.app, ws.workspaceKey, 'helper');
+    const reg = await stack.app.request('/v1/actions', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', authorization: `Bearer ${helper.token}` },
+      body: JSON.stringify({ name: 'run-etl', description: 'agent hosted', handler_agent: 'helper' }),
+    });
+    expect(reg.status).toBe(201);
+
+    await enrollNode(ws, 'node_a', 'alpha');
+    const sock = new FakeSocket();
+    const handle = stack.runtime.realtime.attachNodeSocket(ws.workspaceId, 'node_a', sock);
+    await handle.handleMessage(registerFrame('node_a', 'alpha', { name: 'py', instance_id: 'py-i1' }, [{ name: 'run-etl', kind: 'action', global: true }]));
+    expect(sock.ofType('error').at(-1)).toMatchObject({ code: 'action_name_conflict' });
   });
 
   it('routes context.update to the provider hosting the agent, not a phantom node default', async () => {

--- a/packages/engine/src/__tests__/conformance/nodeProviders.test.ts
+++ b/packages/engine/src/__tests__/conformance/nodeProviders.test.ts
@@ -6,6 +6,7 @@ import {
   registerAgent,
   FakeSocket,
   deliverFramesOfType,
+  contextUpdatesOfType,
   type TestStack,
 } from './harness.js';
 import { actions, agents, nodeProviders, nodes } from '../../db/schema.js';
@@ -268,6 +269,23 @@ describe('node providers', () => {
 
     expect(deliverFramesOfType(py.sock, 'message.created').length).toBeGreaterThanOrEqual(1);
     expect(deliverFramesOfType(rb.sock, 'message.created')).toHaveLength(0);
+  });
+
+  it('routes context.update to the provider hosting the agent, not a phantom node default', async () => {
+    const ws = await createWorkspace(stack.app, 'np-context');
+    const alice = await registerAgent(stack.app, ws.workspaceKey, 'alice');
+    await enrollNode(ws, 'node_a', 'alpha');
+    const py = await attachProvider(ws.workspaceId, 'node_a', 'alpha', 'py', [{ name: 'run-etl', kind: 'action' }]);
+    const rb = await attachProvider(ws.workspaceId, 'node_a', 'alpha', 'rb', [{ name: 'build', kind: 'action' }]);
+    await py.handle.handleMessage(JSON.stringify({ v: 1, id: 'agent-1', type: 'agent.register', name: 'worker', session_ref: 'pty://py/worker' }));
+
+    py.sock.received.length = 0;
+    rb.sock.received.length = 0;
+    await stack.runtime.presence.heartbeat(ws.workspaceId, alice.agentId, 'alice');
+    await new Promise((r) => setTimeout(r, 40));
+
+    expect(contextUpdatesOfType(py.sock, 'agent.status.active').length).toBeGreaterThanOrEqual(1);
+    expect(contextUpdatesOfType(rb.sock, 'agent.status.active')).toHaveLength(0);
   });
 
   it('provider-scoped deregister removes its attachment, capabilities, and actions', async () => {

--- a/packages/engine/src/__tests__/conformance/nodeProviders.test.ts
+++ b/packages/engine/src/__tests__/conformance/nodeProviders.test.ts
@@ -365,14 +365,23 @@ describe('node providers', () => {
     await enrollNode(ws, 'node_a', 'alpha');
     const py = await attachProvider(ws.workspaceId, 'node_a', 'alpha', 'py', [{ name: 'run-etl', kind: 'action' }]);
     const rb = await attachProvider(ws.workspaceId, 'node_a', 'alpha', 'rb', [{ name: 'build', kind: 'action' }]);
+    // The recipient `worker` is hosted by py; rb hosts no agents.
     await py.handle.handleMessage(JSON.stringify({ v: 1, id: 'agent-1', type: 'agent.register', name: 'worker', session_ref: 'pty://py/worker' }));
+    const workerId = (py.sock.ofType('reply').at(-1) as { data?: { agent_id?: string } }).data?.agent_id;
+    expect(workerId).toBeTruthy();
 
     py.sock.received.length = 0;
     rb.sock.received.length = 0;
+    // A presence change on alice (the subject) fans context out to the agents
+    // that host it — worker on py — and never to rb, which hosts none.
     await stack.runtime.presence.heartbeat(ws.workspaceId, alice.agentId, 'alice');
-    await new Promise((r) => setTimeout(r, 40));
+    for (let i = 0; i < 50 && contextUpdatesOfType(py.sock, 'agent.status.active').length === 0; i++) {
+      await new Promise((r) => setTimeout(r, 10));
+    }
 
-    expect(contextUpdatesOfType(py.sock, 'agent.status.active').length).toBeGreaterThanOrEqual(1);
+    const pyUpdates = contextUpdatesOfType(py.sock, 'agent.status.active');
+    expect(pyUpdates.length).toBeGreaterThanOrEqual(1);
+    expect(pyUpdates[0].agent_ids).toContain(workerId);
     expect(contextUpdatesOfType(rb.sock, 'agent.status.active')).toHaveLength(0);
   });
 

--- a/packages/engine/src/__tests__/conformance/nodeProviders.test.ts
+++ b/packages/engine/src/__tests__/conformance/nodeProviders.test.ts
@@ -1,0 +1,327 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { and, eq } from 'drizzle-orm';
+import {
+  makeNodeStack,
+  createWorkspace,
+  registerAgent,
+  FakeSocket,
+  deliverFramesOfType,
+  type TestStack,
+} from './harness.js';
+import { actions, agents, nodeProviders, nodes } from '../../db/schema.js';
+
+type Cap = { name: string; kind?: string; global?: boolean; queue?: boolean };
+
+/**
+ * Multi-provider node model: N provider sockets per node, node-scoped actions,
+ * node-addressed invoke, spawn shadowing, per-provider liveness, and provider
+ * deregister/pruning. The synthetic `default` provider keeps the pre-provider
+ * broker working.
+ */
+describe('node providers', () => {
+  let stack: TestStack;
+  beforeEach(() => { stack = makeNodeStack({ ttlMs: 60_000 }); });
+  afterEach(() => stack.close());
+
+  async function enrollNode(ws: { workspaceKey: string }, nodeId: string, name: string) {
+    const res = await stack.app.request('/v1/nodes', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', authorization: `Bearer ${ws.workspaceKey}` },
+      body: JSON.stringify({ node_id: nodeId, name, role: 'broker', capabilities: [], max_agents: 4, tags: ['test'], version: 'v0' }),
+    });
+    expect(res.status).toBe(201);
+  }
+
+  function attachSocket(workspaceId: string, nodeId: string) {
+    const sock = new FakeSocket();
+    const handle = stack.runtime.realtime.attachNodeSocket(workspaceId, nodeId, sock);
+    return { sock, handle };
+  }
+
+  function registerFrame(nodeId: string, name: string, provider: { name: string; instance_id: string } | undefined, capabilities: Cap[], maxAgents = 4) {
+    return JSON.stringify({
+      v: 1,
+      id: `reg-${provider?.name ?? 'default'}-${provider?.instance_id ?? '0'}`,
+      type: 'node.register',
+      name,
+      node_id: nodeId,
+      ...(provider ? { provider } : {}),
+      capabilities,
+      max_agents: maxAgents,
+      tags: ['test'],
+      version: 'v1',
+      resume_cursor: null,
+    });
+  }
+
+  async function attachProvider(
+    workspaceId: string,
+    nodeId: string,
+    nodeName: string,
+    providerName: string | undefined,
+    capabilities: Cap[],
+    opts: { instanceId?: string; maxAgents?: number } = {},
+  ) {
+    const provider = providerName ? { name: providerName, instance_id: opts.instanceId ?? `${providerName}-i1` } : undefined;
+    const { sock, handle } = attachSocket(workspaceId, nodeId);
+    await handle.handleMessage(registerFrame(nodeId, nodeName, provider, capabilities, opts.maxAgents));
+    await handle.handleMessage(JSON.stringify({
+      v: 1, type: 'node.heartbeat', ...(provider ? { provider } : {}), load: 0, active_agents: 0, handlers_live: true,
+    }));
+    return { sock, handle };
+  }
+
+  it('keys a registration with no provider field to the synthetic default provider', async () => {
+    const ws = await createWorkspace(stack.app, 'np-default');
+    await enrollNode(ws, 'node_a', 'alpha');
+    const { sock, handle } = attachSocket(ws.workspaceId, 'node_a');
+    await handle.handleMessage(registerFrame('node_a', 'alpha', undefined, [{ name: 'run-etl', kind: 'action' }]));
+
+    const reply = sock.ofType('reply').at(-1) as { data?: { provider?: { name?: string }; accepted_capabilities?: unknown[] } };
+    expect(reply.data?.provider?.name).toBe('default');
+    expect(reply.data?.accepted_capabilities).toEqual([
+      expect.objectContaining({ name: 'run-etl', kind: 'action', accepted: true }),
+    ]);
+
+    const providers = await stack.runtime.handle.db
+      .select({ name: nodeProviders.name })
+      .from(nodeProviders)
+      .where(and(eq(nodeProviders.workspaceId, ws.workspaceId), eq(nodeProviders.nodeId, 'node_a')));
+    expect(providers).toEqual([{ name: 'default' }]);
+  });
+
+  it('attaches, replaces on reconnect, and rejects a duplicate live instance', async () => {
+    const ws = await createWorkspace(stack.app, 'np-attach');
+    await enrollNode(ws, 'node_a', 'alpha');
+
+    const first = attachSocket(ws.workspaceId, 'node_a');
+    await first.handle.handleMessage(registerFrame('node_a', 'alpha', { name: 'py', instance_id: 'i1' }, [{ name: 'run-etl', kind: 'action' }]));
+    expect(first.sock.ofType('reply').at(-1)).toMatchObject({ ok: true });
+
+    // Duplicate: a second connection claims `py` while i1 is still live.
+    const dup = attachSocket(ws.workspaceId, 'node_a');
+    await dup.handle.handleMessage(registerFrame('node_a', 'alpha', { name: 'py', instance_id: 'i2' }, [{ name: 'run-etl', kind: 'action' }]));
+    expect(dup.sock.ofType('error').at(-1)).toMatchObject({ code: 'provider_instance_conflict' });
+
+    // Reconnect: i1 drops, a new instance replaces the attachment.
+    await first.handle.handleClose();
+    const reconnect = attachSocket(ws.workspaceId, 'node_a');
+    await reconnect.handle.handleMessage(registerFrame('node_a', 'alpha', { name: 'py', instance_id: 'i3' }, [{ name: 'run-etl', kind: 'action' }]));
+    expect(reconnect.sock.ofType('reply').at(-1)).toMatchObject({ ok: true });
+    const [provider] = await stack.runtime.handle.db
+      .select({ instanceId: nodeProviders.instanceId })
+      .from(nodeProviders)
+      .where(and(eq(nodeProviders.workspaceId, ws.workspaceId), eq(nodeProviders.nodeId, 'node_a'), eq(nodeProviders.name, 'py')));
+    expect(provider.instanceId).toBe('i3');
+  });
+
+  it('rejects a second provider registering an action another provider already owns on the node', async () => {
+    const ws = await createWorkspace(stack.app, 'np-conflict');
+    await enrollNode(ws, 'node_a', 'alpha');
+    await attachProvider(ws.workspaceId, 'node_a', 'alpha', 'py', [{ name: 'run-etl', kind: 'action' }]);
+
+    const rb = attachSocket(ws.workspaceId, 'node_a');
+    await rb.handle.handleMessage(registerFrame('node_a', 'alpha', { name: 'rb', instance_id: 'rb-i1' }, [{ name: 'run-etl', kind: 'action' }]));
+    expect(rb.sock.ofType('error').at(-1)).toMatchObject({ code: 'action_name_conflict' });
+  });
+
+  it('materializes only action-kind capabilities; capacity entries feed placement', async () => {
+    const ws = await createWorkspace(stack.app, 'np-kind');
+    await enrollNode(ws, 'node_a', 'alpha');
+    await attachProvider(ws.workspaceId, 'node_a', 'alpha', 'default', [
+      { name: 'run-etl', kind: 'action' },
+      { name: 'deploy' }, // inferred action
+      { name: 'spawn:claude', kind: 'capacity' },
+      { name: 'spawn:codex' }, // inferred capacity
+      { name: 'release' }, // inferred capacity
+    ]);
+
+    const rows = await stack.runtime.handle.db
+      .select({ name: actions.name })
+      .from(actions)
+      .where(eq(actions.workspaceId, ws.workspaceId));
+    expect(rows.map((r) => r.name).sort()).toEqual(['deploy', 'run-etl']);
+  });
+
+  it('routes a node-addressed invoke to the provider that registered the action', async () => {
+    const ws = await createWorkspace(stack.app, 'np-invoke');
+    const caller = await registerAgent(stack.app, ws.workspaceKey, 'caller');
+    await enrollNode(ws, 'node_a', 'alpha');
+    const py = await attachProvider(ws.workspaceId, 'node_a', 'alpha', 'py', [{ name: 'run-etl', kind: 'action' }]);
+    const rb = await attachProvider(ws.workspaceId, 'node_a', 'alpha', 'rb', [{ name: 'build', kind: 'action' }]);
+
+    const res = await stack.app.request('/v1/nodes/alpha/actions/run-etl/invoke', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', authorization: `Bearer ${caller.token}` },
+      body: JSON.stringify({ input: { rows: 3 } }),
+    });
+    expect(res.status).toBe(201);
+    const body = await res.json() as { data: { invocation_id: string } };
+    expect(py.sock.ofType('action.invoke').at(-1)).toMatchObject({ invocation_id: body.data.invocation_id, action: 'run-etl' });
+    expect(rb.sock.ofType('action.invoke')).toHaveLength(0);
+  });
+
+  it('shadows native spawn capacity with a provider action and never silently bypasses it', async () => {
+    const ws = await createWorkspace(stack.app, 'np-shadow');
+    const caller = await registerAgent(stack.app, ws.workspaceKey, 'caller');
+    await enrollNode(ws, 'node_a', 'alpha');
+    // Broker provider offers native spawn:claude capacity.
+    const broker = await attachProvider(ws.workspaceId, 'node_a', 'alpha', 'default', [{ name: 'spawn:claude', kind: 'capacity' }]);
+    // Policy provider shadows it with a spawn:claude action.
+    const policy = await attachProvider(ws.workspaceId, 'node_a', 'alpha', 'policy', [{ name: 'spawn:claude', kind: 'action' }]);
+
+    const spawn = await stack.app.request('/v1/actions/spawn/invoke', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', authorization: `Bearer ${caller.token}` },
+      body: JSON.stringify({ input: { cli: 'claude', name: 'worker-1' } }),
+    });
+    expect(spawn.status).toBe(201);
+    const body = await spawn.json() as { data: { invocation_id: string } };
+    expect(policy.sock.ofType('action.invoke').at(-1)).toMatchObject({ invocation_id: body.data.invocation_id, action: 'spawn:claude' });
+    expect(broker.sock.ofType('action.invoke')).toHaveLength(0);
+
+    // Shadow provider offline -> fail fast; never falls back to native capacity.
+    await policy.handle.handleClose();
+    broker.sock.received.length = 0;
+    const blocked = await stack.app.request('/v1/actions/spawn/invoke', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', authorization: `Bearer ${caller.token}` },
+      body: JSON.stringify({ input: { cli: 'claude', name: 'worker-2' } }),
+    });
+    expect(blocked.status).toBe(503);
+    expect(broker.sock.ofType('action.invoke')).toHaveLength(0);
+  });
+
+  it('gates capability liveness per provider', async () => {
+    const ws = await createWorkspace(stack.app, 'np-liveness');
+    const caller = await registerAgent(stack.app, ws.workspaceKey, 'caller');
+    await enrollNode(ws, 'node_a', 'alpha');
+    const py = await attachProvider(ws.workspaceId, 'node_a', 'alpha', 'py', [{ name: 'run-etl', kind: 'action' }]);
+    const rb = await attachProvider(ws.workspaceId, 'node_a', 'alpha', 'rb', [{ name: 'build', kind: 'action' }]);
+
+    // py drops; rb stays live. The node still shows both capabilities.
+    await py.handle.handleClose();
+    const manifest = await stack.runtime.handle.db
+      .select({ capabilities: nodes.capabilities })
+      .from(nodes)
+      .where(and(eq(nodes.workspaceId, ws.workspaceId), eq(nodes.id, 'node_a')))
+      .then((r) => r[0]);
+    expect(manifest.capabilities.map((c) => c.name).sort()).toEqual(['build', 'run-etl']);
+
+    const etl = await stack.app.request('/v1/nodes/alpha/actions/run-etl/invoke', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', authorization: `Bearer ${caller.token}` },
+      body: JSON.stringify({ input: {} }),
+    });
+    expect(etl.status).toBe(503); // py offline -> fail fast
+
+    const build = await stack.app.request('/v1/nodes/alpha/actions/build/invoke', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', authorization: `Bearer ${caller.token}` },
+      body: JSON.stringify({ input: {} }),
+    });
+    expect(build.status).toBe(201);
+    expect(rb.sock.ofType('action.invoke').at(-1)).toMatchObject({ action: 'build' });
+  });
+
+  it('queues an invoke for an offline provider when the capability opts into queue', async () => {
+    const ws = await createWorkspace(stack.app, 'np-queue');
+    const caller = await registerAgent(stack.app, ws.workspaceKey, 'caller');
+    await enrollNode(ws, 'node_a', 'alpha');
+    const py = await attachProvider(ws.workspaceId, 'node_a', 'alpha', 'py', [{ name: 'run-etl', kind: 'action', queue: true }]);
+
+    await py.handle.handleClose();
+    const res = await stack.app.request('/v1/nodes/alpha/actions/run-etl/invoke', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', authorization: `Bearer ${caller.token}` },
+      body: JSON.stringify({ input: {} }),
+    });
+    expect(res.status).toBe(201);
+    expect((await res.json() as { data: { status: string } }).data.status).toBe('pending');
+  });
+
+  it('routes deliver frames to the provider whose connection registered the agent', async () => {
+    const ws = await createWorkspace(stack.app, 'np-deliver');
+    const poster = await registerAgent(stack.app, ws.workspaceKey, 'poster');
+    await enrollNode(ws, 'node_a', 'alpha');
+    const py = await attachProvider(ws.workspaceId, 'node_a', 'alpha', 'py', [{ name: 'run-etl', kind: 'action' }]);
+    const rb = await attachProvider(ws.workspaceId, 'node_a', 'alpha', 'rb', [{ name: 'build', kind: 'action' }]);
+
+    // Register a worker agent over the py connection: it binds agent -> py.
+    await py.handle.handleMessage(JSON.stringify({ v: 1, id: 'agent-1', type: 'agent.register', name: 'worker', session_ref: 'pty://py/worker' }));
+    expect(py.sock.ofType('reply').at(-1)).toMatchObject({ ok: true, data: expect.objectContaining({ name: 'worker' }) });
+    const [worker] = await stack.runtime.handle.db
+      .select({ providerName: agents.providerName })
+      .from(agents)
+      .where(and(eq(agents.workspaceId, ws.workspaceId), eq(agents.name, 'worker')));
+    expect(worker.providerName).toBe('py');
+
+    py.sock.received.length = 0;
+    rb.sock.received.length = 0;
+    const post = await stack.app.request('/v1/channels/general/messages', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', authorization: `Bearer ${poster.token}` },
+      body: JSON.stringify({ text: 'hello worker' }),
+    });
+    expect(post.status).toBe(201);
+    await new Promise((r) => setTimeout(r, 60));
+
+    expect(deliverFramesOfType(py.sock, 'message.created').length).toBeGreaterThanOrEqual(1);
+    expect(deliverFramesOfType(rb.sock, 'message.created')).toHaveLength(0);
+  });
+
+  it('provider-scoped deregister removes its attachment, capabilities, and actions', async () => {
+    const ws = await createWorkspace(stack.app, 'np-deregister');
+    await enrollNode(ws, 'node_a', 'alpha');
+    const py = await attachProvider(ws.workspaceId, 'node_a', 'alpha', 'py', [{ name: 'run-etl', kind: 'action' }]);
+    await attachProvider(ws.workspaceId, 'node_a', 'alpha', 'rb', [{ name: 'build', kind: 'action' }]);
+
+    await py.handle.handleMessage(JSON.stringify({ v: 1, type: 'node.deregister', provider: { name: 'py', instance_id: 'py-i1' } }));
+
+    const providers = await stack.runtime.handle.db
+      .select({ name: nodeProviders.name })
+      .from(nodeProviders)
+      .where(and(eq(nodeProviders.workspaceId, ws.workspaceId), eq(nodeProviders.nodeId, 'node_a')));
+    expect(providers.map((p) => p.name)).toEqual(['rb']);
+
+    const actionRows = await stack.runtime.handle.db
+      .select({ name: actions.name })
+      .from(actions)
+      .where(eq(actions.workspaceId, ws.workspaceId));
+    expect(actionRows.map((a) => a.name).sort()).toEqual(['build']);
+  });
+
+  it('fully replaces a provider capability set on re-register, pruning dropped actions', async () => {
+    const ws = await createWorkspace(stack.app, 'np-prune');
+    await enrollNode(ws, 'node_a', 'alpha');
+    const py = await attachProvider(ws.workspaceId, 'node_a', 'alpha', 'py', [
+      { name: 'run-etl', kind: 'action' },
+      { name: 'sync', kind: 'action' },
+    ]);
+
+    await py.handle.handleMessage(registerFrame('node_a', 'alpha', { name: 'py', instance_id: 'py-i1' }, [{ name: 'run-etl', kind: 'action' }]));
+
+    const actionRows = await stack.runtime.handle.db
+      .select({ name: actions.name })
+      .from(actions)
+      .where(eq(actions.workspaceId, ws.workspaceId));
+    expect(actionRows.map((a) => a.name).sort()).toEqual(['run-etl']);
+  });
+
+  it('removes a provider through DELETE /v1/nodes/:node/providers/:name', async () => {
+    const ws = await createWorkspace(stack.app, 'np-delete');
+    await enrollNode(ws, 'node_a', 'alpha');
+    await attachProvider(ws.workspaceId, 'node_a', 'alpha', 'py', [{ name: 'run-etl', kind: 'action' }]);
+
+    const del = await stack.app.request('/v1/nodes/alpha/providers/py', {
+      method: 'DELETE',
+      headers: { authorization: `Bearer ${ws.workspaceKey}` },
+    });
+    expect(del.status).toBe(204);
+    const providers = await stack.runtime.handle.db
+      .select({ name: nodeProviders.name })
+      .from(nodeProviders)
+      .where(and(eq(nodeProviders.workspaceId, ws.workspaceId), eq(nodeProviders.nodeId, 'node_a')));
+    expect(providers).toHaveLength(0);
+  });
+});

--- a/packages/engine/src/adapters/node/realtime.ts
+++ b/packages/engine/src/adapters/node/realtime.ts
@@ -110,8 +110,13 @@ export class InProcessRealtime implements RealtimeBus, ConnectionRegistry, NodeC
   private providerSocket(nodeKey: string, providerName: string): EngineSocket | undefined {
     const connId = this.providerConnId(nodeKey, providerName);
     if (connId) return this.nodeConnections.get(connId)?.socket;
-    // Reconnect-before-reregister: a node's sole live connection is addressable
-    // even before it has bound a provider, so queued frames drain to it.
+    // Reconnect-before-reregister applies only to the synthetic `default`
+    // provider (the legacy single-socket broker): its sole live connection is
+    // addressable even before it re-registers, so queued frames drain to it. A
+    // named provider's queue never drains to an unbound connection whose
+    // identity isn't yet established — that could misroute to a different
+    // provider that happens to be reconnecting.
+    if (providerName !== DEFAULT_PROVIDER_NAME) return undefined;
     const conns = this.nodeConnIndex.get(nodeKey);
     if (conns && conns.size === 1) {
       const [only] = [...conns];

--- a/packages/engine/src/adapters/node/realtime.ts
+++ b/packages/engine/src/adapters/node/realtime.ts
@@ -121,12 +121,17 @@ export class InProcessRealtime implements RealtimeBus, ConnectionRegistry, NodeC
     return undefined;
   }
 
-  /** The provider a node-addressed message should target when none is specified. */
+  /**
+   * The provider a node-addressed message targets when none is specified: the
+   * `default` provider if attached, otherwise any currently-attached provider.
+   * Never returns a name that is not in the index, so node-level sends do not
+   * silently target a phantom provider. `undefined` means nothing is attached.
+   */
   private defaultProviderName(nodeKey: string): string | undefined {
     const providers = this.providerIndex.get(nodeKey);
     if (!providers || providers.size === 0) return undefined;
     if (providers.has(DEFAULT_PROVIDER_NAME)) return DEFAULT_PROVIDER_NAME;
-    return providers.size === 1 ? [...providers.keys()][0] : DEFAULT_PROVIDER_NAME;
+    return [...providers.keys()][0];
   }
 
   async publishToWorkspaceStream(args: { workspaceId: string; event: EngineEvent }): Promise<void> {
@@ -302,6 +307,11 @@ export class InProcessRealtime implements RealtimeBus, ConnectionRegistry, NodeC
     if (existingConnId && existingConnId !== connectionId) {
       const superseded = this.nodeConnections.get(existingConnId);
       this.nodeConnections.delete(existingConnId);
+      const conns = this.nodeConnIndex.get(nodeKey);
+      if (conns) {
+        conns.delete(existingConnId);
+        if (conns.size === 0) this.nodeConnIndex.delete(nodeKey);
+      }
       if (superseded) {
         superseded.providerName = undefined;
         try {

--- a/packages/engine/src/adapters/node/realtime.ts
+++ b/packages/engine/src/adapters/node/realtime.ts
@@ -10,7 +10,9 @@ import type { ObserverToken } from '../../ports/auth.js';
 import { and, eq, gt, isNull, or } from 'drizzle-orm';
 import type { EngineDb } from '../../ports/database.js';
 import { observerTokens } from '../../db/schema.js';
-import { handleNodeControlMessage, markNodeOffline } from '../../engine/node.js';
+import { handleNodeControlMessage, handleProviderDisconnect, markNodeOffline } from '../../engine/node.js';
+import { DEFAULT_PROVIDER_NAME } from '../../engine/nodeProvider.js';
+import { NODE_LIVENESS_TTL_MS } from '../../engine/placement.js';
 import { drainNodeInvocations } from '../../engine/action.js';
 import { observerAllowsEvent } from '../../engine/observerToken.js';
 import type { InvocationCompletionDeps } from '../../engine/invocationCompletion.js';
@@ -33,8 +35,18 @@ export interface SocketHandle {
   handleClose(): Promise<void>;
 }
 
+/**
+ * One node control connection. A provider binds its name at `node.register`;
+ * `lastSeen` bounds how long a still-open-but-silent instance is treated as live
+ * for duplicate-vs-reconnect arbitration.
+ */
 interface NodeConn {
   socket: EngineSocket;
+  workspaceId: string;
+  nodeId: string;
+  providerName?: string;
+  instanceId?: string;
+  lastSeen: number;
 }
 
 interface WorkspaceConn {
@@ -64,11 +76,18 @@ interface QueuedNodeMessage {
  */
 export class InProcessRealtime implements RealtimeBus, ConnectionRegistry, NodeConnectionRegistry {
   private readonly workspaceSockets = new Map<string, Set<WorkspaceConn>>();
-  private readonly nodeSockets = new Map<string, NodeConn>();
+  /** Every attached node control connection, keyed by its registry connection id. */
+  private readonly nodeConnections = new Map<string, NodeConn>();
+  /** All connection ids attached to a node (bound to a provider or not yet). */
+  private readonly nodeConnIndex = new Map<string, Set<string>>();
+  /** Per node, the connection id currently bound to each provider name. */
+  private readonly providerIndex = new Map<string, Map<string, string>>();
+  /** Per-provider queued `action.invoke` frames (`workspace:node::provider`). */
   private readonly nodeQueues = new Map<string, QueuedNodeMessage[]>();
   /** Serializes drains per node so concurrent triggers never overlap. */
   private readonly nodeDrainChains = new Map<string, Promise<void>>();
   private nodeCompletionDeps: InvocationCompletionDeps | undefined;
+  private connectionSeq = 0;
 
   constructor(private readonly db: EngineDb) {}
 
@@ -78,6 +97,36 @@ export class InProcessRealtime implements RealtimeBus, ConnectionRegistry, NodeC
 
   private nodeKey(workspaceId: string, nodeId: string): string {
     return `${workspaceId}:${nodeId}`;
+  }
+
+  private providerQueueKey(nodeKey: string, providerName: string): string {
+    return `${nodeKey}::${providerName}`;
+  }
+
+  private providerConnId(nodeKey: string, providerName: string): string | undefined {
+    return this.providerIndex.get(nodeKey)?.get(providerName);
+  }
+
+  private providerSocket(nodeKey: string, providerName: string): EngineSocket | undefined {
+    const connId = this.providerConnId(nodeKey, providerName);
+    if (connId) return this.nodeConnections.get(connId)?.socket;
+    // Reconnect-before-reregister: a node's sole live connection is addressable
+    // even before it has bound a provider, so queued frames drain to it.
+    const conns = this.nodeConnIndex.get(nodeKey);
+    if (conns && conns.size === 1) {
+      const [only] = [...conns];
+      const conn = this.nodeConnections.get(only);
+      if (conn && !conn.providerName) return conn.socket;
+    }
+    return undefined;
+  }
+
+  /** The provider a node-addressed message should target when none is specified. */
+  private defaultProviderName(nodeKey: string): string | undefined {
+    const providers = this.providerIndex.get(nodeKey);
+    if (!providers || providers.size === 0) return undefined;
+    if (providers.has(DEFAULT_PROVIDER_NAME)) return DEFAULT_PROVIDER_NAME;
+    return providers.size === 1 ? [...providers.keys()][0] : DEFAULT_PROVIDER_NAME;
   }
 
   async publishToWorkspaceStream(args: { workspaceId: string; event: EngineEvent }): Promise<void> {
@@ -161,14 +210,25 @@ export class InProcessRealtime implements RealtimeBus, ConnectionRegistry, NodeC
     nodeId: string,
     message: FleetRelaycastToBrokerMessage,
   ): Promise<boolean> {
-    const key = this.nodeKey(workspaceId, nodeId);
-    const current = this.nodeSockets.get(key)?.socket;
-    if (current) {
+    const nodeKey = this.nodeKey(workspaceId, nodeId);
+    const providerName = this.defaultProviderName(nodeKey) ?? DEFAULT_PROVIDER_NAME;
+    return this.sendToProvider(workspaceId, nodeId, providerName, message);
+  }
+
+  async sendToProvider(
+    workspaceId: string,
+    nodeId: string,
+    providerName: string,
+    message: FleetRelaycastToBrokerMessage,
+  ): Promise<boolean> {
+    const nodeKey = this.nodeKey(workspaceId, nodeId);
+    const socket = this.providerSocket(nodeKey, providerName);
+    if (socket) {
       try {
-        current.send(JSON.stringify(message));
+        socket.send(JSON.stringify(message));
         return true;
       } catch {
-        this.nodeSockets.delete(key);
+        this.detachProvider(workspaceId, nodeId, providerName);
       }
     }
 
@@ -176,30 +236,123 @@ export class InProcessRealtime implements RealtimeBus, ConnectionRegistry, NodeC
       return false;
     }
 
-    const queue = this.nodeQueues.get(key) ?? [];
-    const queueKey = `${message.type}:${message.invocation_id}`;
-    if (!queue.some((item) => item.key === queueKey)) {
-      queue.push({ key: queueKey, message });
+    const queueKey = this.providerQueueKey(nodeKey, providerName);
+    const queue = this.nodeQueues.get(queueKey) ?? [];
+    const dedupKey = `${message.type}:${message.invocation_id}`;
+    if (!queue.some((item) => item.key === dedupKey)) {
+      queue.push({ key: dedupKey, message });
     }
     while (queue.length > 100) queue.shift();
-    this.nodeQueues.set(key, queue);
+    this.nodeQueues.set(queueKey, queue);
     return true;
   }
 
   isNodeConnected(workspaceId: string, nodeId: string): boolean {
-    return !!this.nodeSockets.get(this.nodeKey(workspaceId, nodeId));
+    const conns = this.nodeConnIndex.get(this.nodeKey(workspaceId, nodeId));
+    return !!conns && conns.size > 0;
+  }
+
+  isProviderConnected(workspaceId: string, nodeId: string, providerName: string): boolean {
+    return !!this.providerSocket(this.nodeKey(workspaceId, nodeId), providerName);
+  }
+
+  providerNameForConnection(connectionId: string): string | undefined {
+    return this.nodeConnections.get(connectionId)?.providerName;
+  }
+
+  providerAttachConflict(
+    workspaceId: string,
+    nodeId: string,
+    providerName: string,
+    _instanceId: string,
+    connectionId: string,
+  ): { code: string; message: string } | null {
+    const nodeKey = this.nodeKey(workspaceId, nodeId);
+    const existingConnId = this.providerConnId(nodeKey, providerName);
+    if (!existingConnId || existingConnId === connectionId) return null;
+    const existing = this.nodeConnections.get(existingConnId);
+    if (!existing) return null;
+    // A still-live instance owns the name (duplicate process). A dropped or
+    // silent (stale) instance is a reconnect and gets replaced on attach.
+    if (Date.now() - existing.lastSeen <= NODE_LIVENESS_TTL_MS) {
+      return {
+        code: 'provider_instance_conflict',
+        message: `Provider "${providerName}" is already connected on this node`,
+      };
+    }
+    return null;
+  }
+
+  attachProvider(
+    workspaceId: string,
+    nodeId: string,
+    providerName: string,
+    instanceId: string,
+    connectionId: string,
+  ): void {
+    const conn = this.nodeConnections.get(connectionId);
+    if (!conn) return;
+    const nodeKey = this.nodeKey(workspaceId, nodeId);
+    let providers = this.providerIndex.get(nodeKey);
+    if (!providers) {
+      providers = new Map();
+      this.providerIndex.set(nodeKey, providers);
+    }
+    const existingConnId = providers.get(providerName);
+    if (existingConnId && existingConnId !== connectionId) {
+      const superseded = this.nodeConnections.get(existingConnId);
+      this.nodeConnections.delete(existingConnId);
+      if (superseded) {
+        superseded.providerName = undefined;
+        try {
+          superseded.socket.close(1000, 'superseded');
+        } catch {
+          // already closed
+        }
+      }
+    }
+    conn.providerName = providerName;
+    conn.instanceId = instanceId;
+    conn.lastSeen = Date.now();
+    providers.set(providerName, connectionId);
+  }
+
+  detachProvider(workspaceId: string, nodeId: string, providerName: string): void {
+    const nodeKey = this.nodeKey(workspaceId, nodeId);
+    const providers = this.providerIndex.get(nodeKey);
+    const connId = providers?.get(providerName);
+    if (providers) {
+      providers.delete(providerName);
+      if (providers.size === 0) this.providerIndex.delete(nodeKey);
+    }
+    if (connId) {
+      const conn = this.nodeConnections.get(connId);
+      if (conn) conn.providerName = undefined;
+    }
+    this.nodeQueues.delete(this.providerQueueKey(nodeKey, providerName));
   }
 
   async disconnectNode(workspaceId: string, nodeId: string): Promise<void> {
-    const key = this.nodeKey(workspaceId, nodeId);
-    const conn = this.nodeSockets.get(key);
-    if (!conn) return;
-    this.nodeSockets.delete(key);
-    try {
-      conn.socket.close(1000, 'force-disconnect');
-    } catch {
-      // already closed
+    const nodeKey = this.nodeKey(workspaceId, nodeId);
+    const providers = this.providerIndex.get(nodeKey);
+    const connIds = new Set<string>(providers ? providers.values() : []);
+    // Also close any connections bound to this node that never registered.
+    for (const [connId, conn] of this.nodeConnections) {
+      if (conn.nodeId === nodeId && conn.workspaceId === workspaceId) connIds.add(connId);
     }
+    for (const connId of connIds) {
+      const conn = this.nodeConnections.get(connId);
+      this.nodeConnections.delete(connId);
+      if (conn) {
+        try {
+          conn.socket.close(1000, 'force-disconnect');
+        } catch {
+          // already closed
+        }
+      }
+    }
+    this.providerIndex.delete(nodeKey);
+    this.nodeConnIndex.delete(nodeKey);
   }
 
   /* --------------------- Node transport attach helpers ----------------- */
@@ -228,39 +381,68 @@ export class InProcessRealtime implements RealtimeBus, ConnectionRegistry, NodeC
 
   /** Register a live fleet node control socket; returns handlers the transport drives. */
   attachNodeSocket(workspaceId: string, nodeId: string, socket: EngineSocket): SocketHandle {
-    const key = this.nodeKey(workspaceId, nodeId);
-    const previous = this.nodeSockets.get(key)?.socket;
-    this.nodeSockets.set(key, { socket });
-    if (previous && previous !== socket) {
-      try {
-        previous.close(1000, 'superseded');
-      } catch {
-        // already closed
-      }
+    const connectionId = `nconn_${++this.connectionSeq}`;
+    const nodeKey = this.nodeKey(workspaceId, nodeId);
+    this.nodeConnections.set(connectionId, {
+      socket,
+      workspaceId,
+      nodeId,
+      lastSeen: Date.now(),
+    });
+    let conns = this.nodeConnIndex.get(nodeKey);
+    if (!conns) {
+      conns = new Set();
+      this.nodeConnIndex.set(nodeKey, conns);
     }
+    conns.add(connectionId);
     const handle: SocketHandle = {
-      handleMessage: async (raw) => handleNodeControlMessage({
-        db: this.db,
-        registry: this,
-        completionDeps: this.nodeCompletionDeps,
-        workspaceId,
-        nodeId,
-        socket,
-        raw,
-      }),
-      handleClose: async () => {
-        const conn = this.nodeSockets.get(key);
-        if (conn?.socket === socket) {
-          this.nodeSockets.delete(key);
-          await markNodeOffline(this.db, this, workspaceId, nodeId).catch(() => {});
-        }
+      handleMessage: async (raw) => {
+        const conn = this.nodeConnections.get(connectionId);
+        if (conn) conn.lastSeen = Date.now();
+        return handleNodeControlMessage({
+          db: this.db,
+          registry: this,
+          completionDeps: this.nodeCompletionDeps,
+          workspaceId,
+          nodeId,
+          socket,
+          connectionId,
+          raw,
+        });
       },
+      handleClose: async () => this.onNodeConnectionClose(connectionId),
     };
     // Best-effort early flush (covers non-spawn frames that need no capacity);
     // the authoritative drain fires post node.register/heartbeat once the node
     // is marked online, so queued spawns can reserve capacity. See drainNode.
     void this.drainNode(workspaceId, nodeId);
     return handle;
+  }
+
+  private async onNodeConnectionClose(connectionId: string): Promise<void> {
+    const conn = this.nodeConnections.get(connectionId);
+    if (!conn) return;
+    this.nodeConnections.delete(connectionId);
+    const { workspaceId, nodeId, providerName } = conn;
+    const nodeKey = this.nodeKey(workspaceId, nodeId);
+    const conns = this.nodeConnIndex.get(nodeKey);
+    if (conns) {
+      conns.delete(connectionId);
+      if (conns.size === 0) this.nodeConnIndex.delete(nodeKey);
+    }
+    const providers = this.providerIndex.get(nodeKey);
+    if (providerName && providers?.get(providerName) === connectionId) {
+      providers.delete(providerName);
+      if (providers.size === 0) this.providerIndex.delete(nodeKey);
+      this.nodeQueues.delete(this.providerQueueKey(nodeKey, providerName));
+    }
+    const hasRemaining = this.isNodeConnected(workspaceId, nodeId);
+    if (providerName) {
+      await handleProviderDisconnect(this.db, this, workspaceId, nodeId, providerName, hasRemaining).catch(() => {});
+    } else if (!hasRemaining) {
+      // Connection dropped before it bound a provider and it was the node's last.
+      await markNodeOffline(this.db, this, workspaceId, nodeId).catch(() => {});
+    }
   }
 
   /**
@@ -280,11 +462,14 @@ export class InProcessRealtime implements RealtimeBus, ConnectionRegistry, NodeC
   }
 
   private async drainNodeQueue(workspaceId: string, nodeId: string): Promise<void> {
-    const key = this.nodeKey(workspaceId, nodeId);
-    const conn = this.nodeSockets.get(key)?.socket;
-    if (!conn) return;
+    if (!this.isNodeConnected(workspaceId, nodeId)) return;
     await drainNodeInvocations(this.db, this, workspaceId, nodeId);
-    this.nodeQueues.delete(key);
+    // The authoritative re-dispatch is DB-driven; clear the per-provider
+    // in-memory buffers now that their frames have been re-sent.
+    const nodeKey = this.nodeKey(workspaceId, nodeId);
+    for (const queueKey of [...this.nodeQueues.keys()]) {
+      if (queueKey.startsWith(`${nodeKey}::`)) this.nodeQueues.delete(queueKey);
+    }
   }
 
   private async onWorkspaceMessage(socket: EngineSocket, raw: string): Promise<void> {

--- a/packages/engine/src/db/migrations/0028_node_providers.sql
+++ b/packages/engine/src/db/migrations/0028_node_providers.sql
@@ -1,0 +1,55 @@
+-- Multi-provider nodes and node-scoped actions.
+--
+-- A node hosts N providers (the broker plus capability providers). Provider
+-- capability sets persist in node_providers so an offline node still shows its
+-- full manifest, and per-provider liveness/capacity aggregates onto the nodes
+-- row. Actions become node-scoped with a recorded handler provider; a node
+-- action may claim a workspace-global alias.
+
+ALTER TABLE nodes ADD COLUMN machine_id TEXT DEFAULT NULL;
+ALTER TABLE agents ADD COLUMN provider_name TEXT NOT NULL DEFAULT 'default';
+ALTER TABLE actions ADD COLUMN handler_provider TEXT DEFAULT NULL;
+ALTER TABLE actions ADD COLUMN is_global INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE actions ADD COLUMN queue INTEGER NOT NULL DEFAULT 0;
+
+CREATE TABLE node_providers (
+  id TEXT PRIMARY KEY,
+  workspace_id TEXT NOT NULL REFERENCES workspaces(id) ON DELETE CASCADE,
+  node_id TEXT NOT NULL REFERENCES nodes(id) ON DELETE CASCADE,
+  name TEXT NOT NULL,
+  instance_id TEXT NOT NULL,
+  capabilities TEXT NOT NULL DEFAULT '[]',
+  max_agents INTEGER NOT NULL DEFAULT 0,
+  active_agents INTEGER NOT NULL DEFAULT 0,
+  load REAL NOT NULL DEFAULT 0,
+  handlers_live INTEGER NOT NULL DEFAULT 0,
+  status TEXT NOT NULL DEFAULT 'offline',
+  version TEXT NOT NULL DEFAULT 'unknown',
+  last_heartbeat_at INTEGER DEFAULT NULL,
+  created_at INTEGER NOT NULL DEFAULT (unixepoch())
+);
+
+CREATE UNIQUE INDEX node_providers_node_name_unique ON node_providers (workspace_id, node_id, name);
+CREATE INDEX idx_node_providers_node ON node_providers (workspace_id, node_id);
+
+-- Existing node-hosted actions were owned by the broker; record it and let them
+-- keep resolving through the workspace-scoped invoke as global aliases.
+UPDATE actions SET handler_provider = 'default', is_global = 1 WHERE handler_node_id IS NOT NULL;
+
+-- Every broker node becomes its own `default` provider carrying its manifest.
+INSERT INTO node_providers (
+  id, workspace_id, node_id, name, instance_id, capabilities,
+  max_agents, active_agents, load, handlers_live, status, version, last_heartbeat_at, created_at
+)
+SELECT
+  'nprov_' || id, workspace_id, id, 'default', 'migrated', capabilities,
+  max_agents, active_agents, load, handlers_live, status, version, last_heartbeat_at, created_at
+FROM nodes
+WHERE role = 'broker';
+
+-- Node-scoped uniqueness replaces the workspace-global unique; agent-hosted and
+-- global-alias uniqueness are enforced by partial indexes.
+DROP INDEX IF EXISTS actions_workspace_name_unique;
+CREATE UNIQUE INDEX actions_workspace_node_name_unique ON actions (workspace_id, handler_node_id, name);
+CREATE UNIQUE INDEX actions_workspace_agent_name_unique ON actions (workspace_id, name) WHERE handler_node_id IS NULL;
+CREATE UNIQUE INDEX actions_workspace_global_name_unique ON actions (workspace_id, name) WHERE is_global = 1;

--- a/packages/engine/src/db/schema.ts
+++ b/packages/engine/src/db/schema.ts
@@ -796,6 +796,10 @@ export const actions = sqliteTable(
     // NULL handlerNodeId (agent-hosted) rows as distinct here, so agent-hosted
     // uniqueness is enforced by the partial index below.
     uniqueIndex('actions_workspace_node_name_unique').on(table.workspaceId, table.handlerNodeId, table.name),
+    // Agent-hosted actions (no node) keep one action per workspace name.
+    uniqueIndex('actions_workspace_agent_name_unique').on(table.workspaceId, table.name).where(sql`${table.handlerNodeId} IS NULL`),
+    // At most one node action may claim a given workspace-global alias.
+    uniqueIndex('actions_workspace_global_name_unique').on(table.workspaceId, table.name).where(sql`${table.isGlobal} = 1`),
     index('idx_actions_workspace').on(table.workspaceId),
     index('idx_actions_handler').on(table.handlerAgentId),
     index('idx_actions_node_handler').on(table.handlerNodeId),

--- a/packages/engine/src/db/schema.ts
+++ b/packages/engine/src/db/schema.ts
@@ -68,6 +68,10 @@ export const agents = sqliteTable(
     capabilities: text('capabilities', { mode: 'json' }).$type<Record<string, unknown>>(),
     locationType: text('location_type').notNull().default('self_connected'),
     locationNodeId: text('location_node_id').references((): AnySQLiteColumn => nodes.id, { onDelete: 'set null' }),
+    // The node provider whose connection registered this agent. `deliver` frames
+    // route to that provider's socket. Defaults to the synthetic `default`
+    // provider (the broker) for agents registered before the provider model.
+    providerName: text('provider_name').notNull().default('default'),
     resumable: integer('resumable', { mode: 'boolean' }).notNull().default(false),
     sessionRef: text('session_ref'),
     originNodeId: text('origin_node_id').references((): AnySQLiteColumn => nodes.id, { onDelete: 'set null' }),
@@ -95,6 +99,9 @@ export const nodes = sqliteTable(
       .references(() => workspaces.id, { onDelete: 'cascade' }),
     name: text('name').notNull(),
     tokenHash: text('token_hash').notNull().unique(),
+    // Physical machine grouping in fleet views and a placement input; never a
+    // capability scope. Null until a provider reports it on register.
+    machineId: text('machine_id'),
     kind: text('kind').notNull().default('ws'),
     role: text('role').notNull().default('broker'),
     deliveryAdapter: text('delivery_adapter').notNull().default('ws.node.v1'),
@@ -117,6 +124,45 @@ export const nodes = sqliteTable(
     index('idx_nodes_workspace').on(table.workspaceId),
     index('idx_nodes_token').on(table.tokenHash),
     index('idx_nodes_status').on(table.workspaceId, table.status),
+  ],
+);
+
+// ============================================
+// Node Providers
+// ============================================
+/**
+ * A process attached to a broker-role node, keyed by provider `name`. Each
+ * provider registers a subset of the node's capabilities and executes their
+ * invokes over its own socket. `instanceId` is the connection epoch. Capability
+ * sets persist here so an offline node still displays its full manifest, and the
+ * per-provider liveness/capacity/load columns are aggregated onto the `nodes`
+ * row. Implicit direct nodes (per self-connected agent) do not use this table.
+ */
+export const nodeProviders = sqliteTable(
+  'node_providers',
+  {
+    id: text('id').primaryKey(),
+    workspaceId: text('workspace_id')
+      .notNull()
+      .references(() => workspaces.id, { onDelete: 'cascade' }),
+    nodeId: text('node_id')
+      .notNull()
+      .references(() => nodes.id, { onDelete: 'cascade' }),
+    name: text('name').notNull(),
+    instanceId: text('instance_id').notNull(),
+    capabilities: text('capabilities', { mode: 'json' }).$type<FleetCapability[]>().notNull().default([]),
+    maxAgents: integer('max_agents').notNull().default(0),
+    activeAgents: integer('active_agents').notNull().default(0),
+    load: real('load').notNull().default(0),
+    handlersLive: integer('handlers_live', { mode: 'boolean' }).notNull().default(false),
+    status: text('status').notNull().default('offline'),
+    version: text('version').notNull().default('unknown'),
+    lastHeartbeatAt: integer('last_heartbeat_at', { mode: 'timestamp' }),
+    createdAt: integer('created_at', { mode: 'timestamp' }).notNull().default(sql`(unixepoch())`),
+  },
+  (table) => [
+    uniqueIndex('node_providers_node_name_unique').on(table.workspaceId, table.nodeId, table.name),
+    index('idx_node_providers_node').on(table.workspaceId, table.nodeId),
   ],
 );
 
@@ -729,6 +775,16 @@ export const actions = sqliteTable(
     handlerAgentId: text('handler_agent_id')
       .references(() => agents.id, { onDelete: 'cascade' }),
     handlerNodeId: text('handler_node_id').references(() => nodes.id, { onDelete: 'cascade' }),
+    // The provider (within handlerNodeId) that registered this action; dispatch
+    // resolves capability -> provider -> socket through it. Null for agent-hosted
+    // actions.
+    handlerProvider: text('handler_provider'),
+    // A node-scoped action may claim the workspace-global name so it resolves
+    // through `POST /v1/actions/:name/invoke`. At most one global alias per name.
+    isGlobal: integer('is_global', { mode: 'boolean' }).notNull().default(false),
+    // When true, an invoke whose provider is offline queues instead of failing
+    // fast (the per-provider offline queue).
+    queue: integer('queue', { mode: 'boolean' }).notNull().default(false),
     inputSchema: text('input_schema', { mode: 'json' }).$type<Record<string, unknown>>().default({}),
     outputSchema: text('output_schema', { mode: 'json' }).$type<Record<string, unknown>>().default({}),
     availableTo: text('available_to', { mode: 'json' }).$type<string[]>(),
@@ -736,7 +792,10 @@ export const actions = sqliteTable(
     createdAt: integer('created_at', { mode: 'timestamp' }).notNull().default(sql`(unixepoch())`),
   },
   (table) => [
-    uniqueIndex('actions_workspace_name_unique').on(table.workspaceId, table.name),
+    // Node-scoped uniqueness: two nodes may both define `run-etl`. SQLite treats
+    // NULL handlerNodeId (agent-hosted) rows as distinct here, so agent-hosted
+    // uniqueness is enforced by the partial index below.
+    uniqueIndex('actions_workspace_node_name_unique').on(table.workspaceId, table.handlerNodeId, table.name),
     index('idx_actions_workspace').on(table.workspaceId),
     index('idx_actions_handler').on(table.handlerAgentId),
     index('idx_actions_node_handler').on(table.handlerNodeId),

--- a/packages/engine/src/engine/action.ts
+++ b/packages/engine/src/engine/action.ts
@@ -6,6 +6,7 @@ import { codedError } from '../lib/httpError.js';
 import { toFleetWireJson } from './deliveryWire.js';
 import type { NodeConnectionRegistry } from '../ports/realtime.js';
 import { claimSpawnNode, chooseNodeForAction, isNodeLive, releaseNodeCapacity, reserveNodeCapacity } from './placement.js';
+import { DEFAULT_PROVIDER_NAME, capacityProviderName, getProvider, isProviderLive } from './nodeProvider.js';
 
 type Db = ReturnType<typeof getDb>;
 type ActionRow = typeof actions.$inferSelect;
@@ -123,8 +124,14 @@ function publicAction(row: {
   };
 }
 
+/**
+ * Resolve a workspace-scoped invoke (`POST /v1/actions/:name/invoke`). Only
+ * agent-hosted actions and node actions that claimed a workspace-global alias
+ * are reachable here; plain node-scoped actions are node-addressed. Agent-hosted
+ * actions win when both somehow exist for a name.
+ */
 async function fetchAction(db: Db, workspaceId: string, actionName: string): Promise<ActionRow | null> {
-  const [action] = await db
+  const rows = await db
     .select()
     .from(actions)
     .where(
@@ -132,8 +139,23 @@ async function fetchAction(db: Db, workspaceId: string, actionName: string): Pro
         eq(actions.workspaceId, workspaceId),
         eq(actions.name, actionName),
         eq(actions.isActive, true),
+        or(isNull(actions.handlerNodeId), eq(actions.isGlobal, true)),
       ),
     );
+  return rows.sort((a, b) => Number(a.handlerNodeId !== null) - Number(b.handlerNodeId !== null))[0] ?? null;
+}
+
+/** Resolve a node-addressed action by its unique `(node, name)` key. */
+async function fetchNodeAction(db: Db, workspaceId: string, nodeId: string, actionName: string): Promise<ActionRow | null> {
+  const [action] = await db
+    .select()
+    .from(actions)
+    .where(and(
+      eq(actions.workspaceId, workspaceId),
+      eq(actions.handlerNodeId, nodeId),
+      eq(actions.name, actionName),
+      eq(actions.isActive, true),
+    ));
   return action ?? null;
 }
 
@@ -307,6 +329,55 @@ async function createInvocation(
   return invocation;
 }
 
+/** Is a node provider currently invokable — connection up AND heartbeat handlers_live. */
+async function isNodeProviderLive(
+  db: Db,
+  registry: NodeConnectionRegistry,
+  workspaceId: string,
+  nodeId: string,
+  providerName: string,
+): Promise<boolean> {
+  if (!registry.isProviderConnected(workspaceId, nodeId, providerName)) return false;
+  const provider = await getProvider(db, workspaceId, nodeId, providerName);
+  return !!provider && isProviderLive(provider);
+}
+
+/**
+ * Dispatch an invoke to a specific provider on a node. When the provider is
+ * offline the invoke fails fast (the invocation is failed) unless it opted into
+ * the per-provider offline queue.
+ */
+async function dispatchNodeProviderInvocation(args: {
+  db: Db;
+  registry: NodeConnectionRegistry;
+  workspaceId: string;
+  invocationId: string;
+  nodeId: string;
+  providerName: string;
+  action: string;
+  input: Record<string, unknown>;
+  agent?: { id: string; name: string } | null;
+  queue: boolean;
+  reservationHeld?: boolean;
+}): Promise<{ accepted: boolean; pending: boolean }> {
+  const live = await isNodeProviderLive(args.db, args.registry, args.workspaceId, args.nodeId, args.providerName);
+  if (!live) {
+    if (!args.queue) {
+      await args.db
+        .update(actionInvocations)
+        .set({ status: 'failed', error: 'handler_unavailable', completedAt: new Date(), spawnReservedAt: null })
+        .where(and(
+          eq(actionInvocations.workspaceId, args.workspaceId),
+          eq(actionInvocations.id, args.invocationId),
+          inArray(actionInvocations.status, OPEN_INVOCATION_STATUSES),
+        ));
+      throw codedError(`Provider "${args.providerName}" is offline for action "${args.action}"`, 'handler_unavailable', 503);
+    }
+    return dispatchNodeInvocation({ ...args, pending: true });
+  }
+  return dispatchNodeInvocation({ ...args });
+}
+
 async function dispatchRelease(args: {
   db: Db;
   registry?: NodeConnectionRegistry;
@@ -344,12 +415,14 @@ async function dispatchRelease(args: {
     action_name: 'release',
   });
 
+  // Release is a capacity operation handled by the provider hosting the agent.
   const dispatched = await dispatchNodeInvocation({
     db: args.db,
     registry: args.registry,
     workspaceId: args.workspaceId,
     invocationId: invocation.id,
     nodeId: agent.locationNodeId,
+    providerName: agent.providerName,
     action: 'release',
     input,
   });
@@ -366,6 +439,23 @@ async function dispatchRelease(args: {
   };
 }
 
+function spawnResult(
+  invocation: InvocationRow,
+  nodeId: string,
+  dispatched: { accepted: boolean; pending: boolean },
+) {
+  return {
+    invocation_id: invocation.id,
+    action_name: 'spawn',
+    handler_agent_id: null,
+    handler_node_id: nodeId,
+    dispatched_node_id: dispatched.accepted ? nodeId : null,
+    input: recordInput(invocation.input),
+    status: dispatched.accepted ? (dispatched.pending ? 'pending' : 'dispatched') : 'pending',
+    created_at: invocation.createdAt.toISOString(),
+  };
+}
+
 async function dispatchSpawn(args: {
   db: Db;
   registry?: NodeConnectionRegistry;
@@ -375,10 +465,17 @@ async function dispatchSpawn(args: {
     caller_id?: string;
     caller_name?: string;
   };
+  /** Node-address the spawn instead of placing by capacity. */
+  targetNodeId?: string;
+  /** Capacity-direct delegation (`ctx.spawnAgent`) — never re-enters a shadow. */
+  bypassShadow?: boolean;
 }) {
   if (!args.registry) {
     throw codedError('Node dispatch is not available', 'node_dispatch_unavailable', 503);
   }
+
+  const input = recordInput(args.data.input);
+  const capability = dispatchActionNameForInvocation('spawn', input);
 
   const invocation = await createInvocation(args.db, args.workspaceId, null, {
     input: args.data.input,
@@ -388,28 +485,136 @@ async function dispatchSpawn(args: {
 
   const placement = await claimSpawnNode(args.db, args.workspaceId, {
     actionName: 'spawn',
-    input: args.data.input,
+    input,
     callerId: args.data.caller_id,
+    preferredNodeId: args.targetNodeId,
   });
+  const nodeId = placement.node.id;
 
+  // A registered `spawn:<harness>` action shadows native capacity on this node.
+  // Capacity-direct delegation (ctx.spawnAgent) bypasses the shadow so a handler
+  // that delegates cannot re-enter itself.
+  if (!args.bypassShadow) {
+    const shadow = await fetchNodeAction(args.db, args.workspaceId, nodeId, capability);
+    if (shadow && shadow.handlerProvider) {
+      if (!placement.queued) await releaseNodeCapacity(args.db, args.workspaceId, nodeId);
+      const dispatched = await dispatchNodeProviderInvocation({
+        db: args.db,
+        registry: args.registry,
+        workspaceId: args.workspaceId,
+        invocationId: invocation.id,
+        nodeId,
+        providerName: shadow.handlerProvider,
+        action: capability,
+        input,
+        queue: shadow.queue,
+      });
+      return spawnResult(invocation, nodeId, dispatched);
+    }
+  }
+
+  const capProvider = (await capacityProviderName(args.db, args.workspaceId, nodeId, capability)) ?? DEFAULT_PROVIDER_NAME;
   const dispatched = await dispatchNodeInvocation({
     db: args.db,
     registry: args.registry,
     workspaceId: args.workspaceId,
     invocationId: invocation.id,
-    nodeId: placement.node.id,
-    action: placement.capability,
-    input: recordInput(invocation.input),
+    nodeId,
+    providerName: capProvider,
+    action: capability,
+    input,
     pending: placement.queued,
     reservationHeld: !placement.queued,
   });
+  return spawnResult(invocation, nodeId, dispatched);
+}
 
+/**
+ * Capacity-direct spawn used by handler-context `ctx.spawnAgent`: it targets a
+ * node's capacity executor and never re-enters action dispatch, so a
+ * `spawn:<harness>` shadow handler that delegates cannot recurse into itself.
+ */
+export async function dispatchCapacitySpawn(
+  db: Db,
+  workspaceId: string,
+  data: { input?: Record<string, unknown>; caller_id?: string; caller_name?: string; target_node_id?: string },
+  options: { nodeConnections?: NodeConnectionRegistry } = {},
+) {
+  return dispatchSpawn({
+    db,
+    registry: options.nodeConnections,
+    workspaceId,
+    data,
+    targetNodeId: data.target_node_id,
+    bypassShadow: true,
+  });
+}
+
+/**
+ * Invoke a node-addressed action: `POST /v1/nodes/:node/actions/:name/invoke`.
+ * Resolves capability -> provider -> socket on the given node. A `spawn:*` name
+ * with no shadow action falls through to native capacity on that node.
+ */
+export async function invokeNodeAction(
+  db: Db,
+  workspaceId: string,
+  nodeId: string,
+  actionName: string,
+  data: {
+    input?: Record<string, unknown>;
+    caller_id?: string;
+    caller_name?: string;
+  },
+  options: { nodeConnections?: NodeConnectionRegistry } = {},
+) {
+  if (!options.nodeConnections) {
+    throw codedError('Node dispatch is not available', 'node_dispatch_unavailable', 503);
+  }
+  const action = await fetchNodeAction(db, workspaceId, nodeId, actionName);
+  if (!action) {
+    if (isSpawnInvocation(actionName)) {
+      return dispatchSpawn({ db, registry: options.nodeConnections, workspaceId, data, targetNodeId: nodeId });
+    }
+    if (isReleaseInvocation(actionName)) {
+      return dispatchRelease({ db, registry: options.nodeConnections, workspaceId, data });
+    }
+    throw codedError(`Action "${actionName}" not found on node`, 'action_not_found', 404);
+  }
+
+  if (action.availableTo && action.availableTo.length > 0) {
+    if (!data.caller_name || !action.availableTo.includes(data.caller_name)) {
+      const who = data.caller_name ? `Agent "${data.caller_name}"` : 'Caller';
+      throw codedError(`${who} is not authorized to invoke action "${actionName}"`, 'action_denied', 403);
+    }
+  }
+
+  const invocation = await createInvocation(db, workspaceId, action, {
+    input: data.input,
+    caller_id: data.caller_id,
+    caller_name: data.caller_name,
+  });
+  const providerName = action.handlerProvider ?? DEFAULT_PROVIDER_NAME;
+  const reservedNode = isSpawnInvocation(action.name)
+    ? await reserveNodeCapacity(db, workspaceId, nodeId)
+    : null;
+  const dispatched = await dispatchNodeProviderInvocation({
+    db,
+    registry: options.nodeConnections,
+    workspaceId,
+    invocationId: invocation.id,
+    nodeId,
+    providerName,
+    action: action.name,
+    input: recordInput(invocation.input),
+    queue: action.queue,
+    reservationHeld: !!reservedNode,
+  });
   return {
     invocation_id: invocation.id,
-    action_name: 'spawn',
+    action_name: actionName,
     handler_agent_id: null,
-    handler_node_id: placement.node.id,
-    dispatched_node_id: dispatched.accepted ? placement.node.id : null,
+    handler_node_id: nodeId,
+    dispatched_node_id: dispatched.accepted ? nodeId : null,
     input: recordInput(invocation.input),
     status: dispatched.accepted ? (dispatched.pending ? 'pending' : 'dispatched') : 'pending',
     created_at: invocation.createdAt.toISOString(),
@@ -483,6 +688,7 @@ export async function invokeAction(
       workspaceId,
       invocationId: invocation.id,
       nodeId: action.handlerNodeId,
+      providerName: action.handlerProvider ?? DEFAULT_PROVIDER_NAME,
       action: action.name,
       input: recordInput(invocation.input),
       reservationHeld: !!reservedNode,
@@ -512,6 +718,7 @@ export async function invokeAction(
       name: agents.name,
       locationType: agents.locationType,
       locationNodeId: agents.locationNodeId,
+      providerName: agents.providerName,
     })
     .from(agents)
     .where(and(eq(agents.workspaceId, workspaceId), eq(agents.id, action.handlerAgentId)));
@@ -530,6 +737,7 @@ export async function invokeAction(
     workspaceId,
     invocationId: invocation.id,
     nodeId: handlerAgent.locationNodeId,
+    providerName: handlerAgent.providerName,
     action: action.name,
     input: recordInput(invocation.input),
     agent: { id: handlerAgent.id, name: handlerAgent.name },
@@ -711,6 +919,8 @@ async function dispatchNodeInvocation(args: {
   workspaceId: string;
   invocationId: string;
   nodeId: string;
+  /** When set, route to this provider's socket; otherwise the node default. */
+  providerName?: string;
   action: string;
   input: Record<string, unknown>;
   agent?: { id: string; name: string } | null;
@@ -719,15 +929,20 @@ async function dispatchNodeInvocation(args: {
   reservationHeld?: boolean;
   skipIncrementAttempts?: boolean;
 }): Promise<{ accepted: boolean; pending: boolean }> {
-  const connectedBefore = args.registry.isNodeConnected(args.workspaceId, args.nodeId);
-  const sent = await args.registry.sendToNode(args.workspaceId, args.nodeId, {
-    v: 1,
-    type: 'action.invoke',
+  const frame = {
+    v: 1 as const,
+    type: 'action.invoke' as const,
     invocation_id: args.invocationId,
     action: args.action,
     ...(args.agent ? { agent_id: args.agent.id, agent_name: args.agent.name } : {}),
     input: toFleetWireJson(args.input),
-  });
+  };
+  const connectedBefore = args.providerName
+    ? args.registry.isProviderConnected(args.workspaceId, args.nodeId, args.providerName)
+    : args.registry.isNodeConnected(args.workspaceId, args.nodeId);
+  const sent = args.providerName
+    ? await args.registry.sendToProvider(args.workspaceId, args.nodeId, args.providerName, frame)
+    : await args.registry.sendToNode(args.workspaceId, args.nodeId, frame);
 
   if (!sent) return { accepted: false, pending: false };
 
@@ -814,10 +1029,12 @@ export async function drainNodeInvocations(
       spawnReservedAt: actionInvocations.spawnReservedAt,
       dispatchedNodeId: actionInvocations.dispatchedNodeId,
       handlerNodeId: actions.handlerNodeId,
+      handlerProvider: actions.handlerProvider,
       handlerAgentId: agents.id,
       handlerAgentName: agents.name,
       handlerAgentLocationType: agents.locationType,
       handlerAgentNodeId: agents.locationNodeId,
+      handlerAgentProvider: agents.providerName,
     })
     .from(actionInvocations)
     .leftJoin(actions, eq(actionInvocations.actionId, actions.id))
@@ -845,11 +1062,29 @@ export async function drainNodeInvocations(
     const targetNodeId = targetAgent?.nodeId ?? row.handlerNodeId ?? row.dispatchedNodeId;
     if (targetNodeId !== nodeId) continue;
 
+    const input = recordInput(row.input);
+    // Resolve the target provider so the offline queue drains per provider. A
+    // spawn with a registered shadow re-dispatches to the shadow (no capacity
+    // reservation); otherwise native capacity handles it.
+    let shadowProvider: string | null = null;
+    if (isSpawnInvocation(row.actionName)) {
+      const shadow = await fetchNodeAction(db, workspaceId, nodeId, dispatchActionNameForInvocation(row.actionName, input));
+      shadowProvider = shadow?.handlerProvider ?? null;
+    }
+    const providerName = targetAgent
+      ? row.handlerAgentProvider ?? DEFAULT_PROVIDER_NAME
+      : row.handlerNodeId
+        ? row.handlerProvider ?? DEFAULT_PROVIDER_NAME
+        : shadowProvider
+          ?? (isSpawnInvocation(row.actionName)
+            ? (await capacityProviderName(db, workspaceId, nodeId, dispatchActionNameForInvocation(row.actionName, input))) ?? DEFAULT_PROVIDER_NAME
+            : DEFAULT_PROVIDER_NAME);
+    const nativeSpawn = isSpawnInvocation(row.actionName) && !shadowProvider;
+
     let reservedForDrain = false;
     try {
-      const input = recordInput(row.input);
-      let reservationHeld = isSpawnInvocation(row.actionName) && !!row.spawnReservedAt;
-      if (isSpawnInvocation(row.actionName) && !reservationHeld) {
+      let reservationHeld = nativeSpawn && !!row.spawnReservedAt;
+      if (nativeSpawn && !reservationHeld) {
         const reserved = await reserveNodeCapacity(db, workspaceId, nodeId);
         if (!reserved) {
           const [node] = await db
@@ -882,6 +1117,7 @@ export async function drainNodeInvocations(
         workspaceId,
         invocationId: row.id,
         nodeId,
+        providerName,
         action: dispatchActionNameForInvocation(row.actionName, input),
         input,
         agent: targetAgent ? { id: targetAgent.id, name: targetAgent.name } : null,
@@ -912,6 +1148,25 @@ export async function rescheduleNodeInvocation(
 ) {
   if (invocation.dispatchedNodeId && isSpawnInvocation(invocation.actionName)) {
     await releaseNodeCapacity(db, invocation.workspaceId, invocation.dispatchedNodeId);
+  }
+  // A shadowed spawn stays pinned to its node: while a `spawn:<harness>` shadow
+  // is registered there, native capacity for that harness is unreachable — even
+  // across a node loss — so it never falls through to generic placement (which
+  // would silently bypass the shadow). It re-drains when the provider returns.
+  if (invocation.dispatchedNodeId && isSpawnInvocation(invocation.actionName)) {
+    const capability = dispatchActionNameForInvocation(invocation.actionName, recordInput(invocation.input));
+    const shadow = await fetchNodeAction(db, invocation.workspaceId, invocation.dispatchedNodeId, capability);
+    if (shadow) {
+      await db
+        .update(actionInvocations)
+        .set({ status: 'pending', dispatchedAt: null, spawnReservedAt: null, retryAfterAt: null })
+        .where(and(
+          eq(actionInvocations.workspaceId, invocation.workspaceId),
+          eq(actionInvocations.id, invocation.id),
+          inArray(actionInvocations.status, OPEN_INVOCATION_STATUSES),
+        ));
+      return false;
+    }
   }
   const targetAgent = await targetAgentForInvocation(db, invocation);
   if (targetAgent) {

--- a/packages/engine/src/engine/action.ts
+++ b/packages/engine/src/engine/action.ts
@@ -363,6 +363,11 @@ async function dispatchNodeProviderInvocation(args: {
   const live = await isNodeProviderLive(args.db, args.registry, args.workspaceId, args.nodeId, args.providerName);
   if (!live) {
     if (!args.queue) {
+      // Release any capacity reserved for this fail-fast spawn so the node's
+      // reserved-agent count doesn't stay inflated.
+      if (args.reservationHeld) {
+        await releaseNodeCapacity(args.db, args.workspaceId, args.nodeId);
+      }
       await args.db
         .update(actionInvocations)
         .set({ status: 'failed', error: 'handler_unavailable', completedAt: new Date(), spawnReservedAt: null })

--- a/packages/engine/src/engine/action.ts
+++ b/packages/engine/src/engine/action.ts
@@ -13,7 +13,7 @@ type ActionRow = typeof actions.$inferSelect;
 type InvocationRow = typeof actionInvocations.$inferSelect;
 type RetryableInvocationRow = Pick<
   InvocationRow,
-  'id' | 'workspaceId' | 'actionName' | 'callerId' | 'input' | 'status' | 'dispatchedNodeId' | 'attemptedNodeIds' | 'dispatchAttempts'
+  'id' | 'workspaceId' | 'actionName' | 'callerId' | 'input' | 'status' | 'dispatchedNodeId' | 'spawnReservedAt' | 'attemptedNodeIds' | 'dispatchAttempts'
 >;
 
 const OPEN_INVOCATION_STATUSES = ['pending', 'dispatched', 'invoked'];
@@ -578,7 +578,11 @@ export async function invokeNodeAction(
   const action = await fetchNodeAction(db, workspaceId, nodeId, actionName);
   if (!action) {
     if (isSpawnInvocation(actionName)) {
-      return dispatchSpawn({ db, registry: options.nodeConnections, workspaceId, data, targetNodeId: nodeId });
+      // Carry the harness from the URL (`spawn:<harness>`) into placement so the
+      // native fallback targets the right capacity even when the body omits it.
+      const harness = actionName.startsWith('spawn:') ? actionName.slice('spawn:'.length) : undefined;
+      const spawnInput = harness ? { ...(data.input ?? {}), capability: harness } : data.input;
+      return dispatchSpawn({ db, registry: options.nodeConnections, workspaceId, data: { ...data, input: spawnInput }, targetNodeId: nodeId });
     }
     if (isReleaseInvocation(actionName)) {
       return dispatchRelease({ db, registry: options.nodeConnections, workspaceId, data });
@@ -687,15 +691,21 @@ export async function invokeAction(
     const reservedNode = isSpawnInvocation(action.name)
       ? await reserveNodeCapacity(db, workspaceId, action.handlerNodeId)
       : null;
-    const dispatched = await dispatchNodeInvocation({
+    const providerName = action.handlerProvider ?? DEFAULT_PROVIDER_NAME;
+    // Route through the per-provider liveness gate so an offline provider fails
+    // fast unless the capability opted into queue. The synthetic `default`
+    // provider keeps the legacy queue-on-offline behavior (broker reconnect
+    // resilience), so its aliases queue and drain on reconnect as before.
+    const dispatched = await dispatchNodeProviderInvocation({
       db,
       registry: options.nodeConnections,
       workspaceId,
       invocationId: invocation.id,
       nodeId: action.handlerNodeId,
-      providerName: action.handlerProvider ?? DEFAULT_PROVIDER_NAME,
+      providerName,
       action: action.name,
       input: recordInput(invocation.input),
+      queue: action.queue || providerName === DEFAULT_PROVIDER_NAME,
       reservationHeld: !!reservedNode,
     });
     return {
@@ -999,13 +1009,14 @@ async function selectRetryPlacement(
 async function targetAgentForInvocation(
   db: Db,
   invocation: Pick<InvocationRow, 'id' | 'workspaceId'>,
-): Promise<{ agentId: string; agentName: string; nodeId: string } | null> {
+): Promise<{ agentId: string; agentName: string; nodeId: string; providerName: string } | null> {
   const [row] = await db
     .select({
       agentId: agents.id,
       agentName: agents.name,
       locationType: agents.locationType,
       nodeId: agents.locationNodeId,
+      providerName: agents.providerName,
     })
     .from(actionInvocations)
     .innerJoin(actions, eq(actionInvocations.actionId, actions.id))
@@ -1015,7 +1026,7 @@ async function targetAgentForInvocation(
       eq(actionInvocations.id, invocation.id),
     ));
   if (!row || row.locationType !== 'via_node' || !row.nodeId) return null;
-  return { agentId: row.agentId, agentName: row.agentName, nodeId: row.nodeId };
+  return { agentId: row.agentId, agentName: row.agentName, nodeId: row.nodeId, providerName: row.providerName };
 }
 
 export async function drainNodeInvocations(
@@ -1151,7 +1162,10 @@ export async function rescheduleNodeInvocation(
   invocation: RetryableInvocationRow,
   opts: { allowAttemptedFallback?: boolean; retryAfterAt?: Date | null } = {},
 ) {
-  if (invocation.dispatchedNodeId && isSpawnInvocation(invocation.actionName)) {
+  // Only release capacity the invocation actually holds. A shadowed spawn
+  // dropped its native reservation at dispatch (spawnReservedAt is null), so it
+  // must not release capacity that now belongs to another spawn.
+  if (invocation.dispatchedNodeId && isSpawnInvocation(invocation.actionName) && invocation.spawnReservedAt) {
     await releaseNodeCapacity(db, invocation.workspaceId, invocation.dispatchedNodeId);
   }
   // A shadowed spawn stays pinned to its node: while a `spawn:<harness>` shadow
@@ -1181,6 +1195,7 @@ export async function rescheduleNodeInvocation(
       workspaceId: invocation.workspaceId,
       invocationId: invocation.id,
       nodeId: targetAgent.nodeId,
+      providerName: targetAgent.providerName,
       action: invocation.actionName,
       input: recordInput(invocation.input),
       agent: { id: targetAgent.agentId, name: targetAgent.agentName },
@@ -1378,6 +1393,7 @@ export async function completeNodeInvocation(
       durationMs: actionInvocations.durationMs,
       dispatchedNodeId: actionInvocations.dispatchedNodeId,
       dispatchedAt: actionInvocations.dispatchedAt,
+      spawnReservedAt: actionInvocations.spawnReservedAt,
       attemptedNodeIds: actionInvocations.attemptedNodeIds,
       dispatchAttempts: actionInvocations.dispatchAttempts,
       createdAt: actionInvocations.createdAt,
@@ -1427,7 +1443,10 @@ export async function completeNodeInvocation(
     ))
     .returning();
 
-  if (updated && isSpawnInvocation(updated.actionName) && updated.dispatchedNodeId) {
+  // Release only capacity this invocation actually reserved. A shadowed spawn
+  // holds no native reservation (spawnReservedAt is null), so releasing here
+  // would decrement capacity owned by another spawn.
+  if (updated && isSpawnInvocation(updated.actionName) && updated.dispatchedNodeId && existing.spawnReservedAt) {
     await releaseNodeCapacity(db, workspaceId, updated.dispatchedNodeId);
   }
 

--- a/packages/engine/src/engine/action.ts
+++ b/packages/engine/src/engine/action.ts
@@ -1097,6 +1097,12 @@ export async function drainNodeInvocations(
             : DEFAULT_PROVIDER_NAME);
     const nativeSpawn = isSpawnInvocation(row.actionName) && !shadowProvider;
 
+    // Skip draining to a provider that isn't connected yet (e.g. a named
+    // provider reconnecting before it re-registers). Dispatching here would mark
+    // the frame delivered and push retryAfterAt out by the dispatch timeout,
+    // leaving it idle; leave it pending so the post-register drain re-sends it.
+    if (!registry.isProviderConnected(workspaceId, nodeId, providerName)) continue;
+
     let reservedForDrain = false;
     try {
       let reservationHeld = nativeSpawn && !!row.spawnReservedAt;

--- a/packages/engine/src/engine/delivery.ts
+++ b/packages/engine/src/engine/delivery.ts
@@ -725,6 +725,7 @@ export async function deliverPendingToNode(
     .select({
       delivery: deliveries,
       recipientAgentName: agents.name,
+      recipientProviderName: agents.providerName,
       ackSeq: agents.deliveryAckSeq,
       body: messages.body,
       blocks: messages.blocks,
@@ -763,7 +764,7 @@ export async function deliverPendingToNode(
     const attachments = attachmentsByMessageId.get(row.delivery.messageId) ?? [];
     const { eventType, eventData } = buildRoutableDeliveryEvent(row, attachments);
 
-    const sent = await registry.sendToNode(workspaceId, nodeId, buildDeliverFrame({
+    const sent = await registry.sendToProvider(workspaceId, nodeId, row.recipientProviderName, buildDeliverFrame({
       delivery_id: row.delivery.id,
       agent_id: row.delivery.agentId,
       agent: row.recipientAgentName,

--- a/packages/engine/src/engine/node.ts
+++ b/packages/engine/src/engine/node.ts
@@ -549,8 +549,11 @@ export async function deregisterProvider(
   if (!remaining || remaining.count === 0) {
     await markNodeOffline(db, registry, workspaceId, nodeId);
   } else {
+    // Other providers remain: recompute the node aggregate but don't reschedule
+    // node-wide — that would disturb the surviving providers' in-flight invokes.
+    // Work dispatched to the removed provider is caught by the dispatch-timeout
+    // sweep, matching the provider-disconnect path.
     await recomputeNodeAggregate(db, workspaceId, nodeId);
-    await rescheduleInvocationsForLostNode(db, registry, workspaceId, nodeId);
   }
 }
 
@@ -1273,6 +1276,7 @@ export async function reconcileInventory(
       input: actionInvocations.input,
       status: actionInvocations.status,
       dispatchedNodeId: actionInvocations.dispatchedNodeId,
+      spawnReservedAt: actionInvocations.spawnReservedAt,
       attemptedNodeIds: actionInvocations.attemptedNodeIds,
       dispatchAttempts: actionInvocations.dispatchAttempts,
     })
@@ -1359,9 +1363,12 @@ export async function handleNodeControlMessage(args: HandleNodeControlMessageArg
   const boundProviderName = args.connectionId
     ? args.registry.providerNameForConnection?.(args.connectionId)
     : undefined;
-  const frameProviderName = (
-    'provider' in message && message.provider ? message.provider.name : undefined
-  ) ?? boundProviderName ?? DEFAULT_PROVIDER_NAME;
+  // The connection's registered identity is authoritative — a provider can't act
+  // on another provider by putting a different name in the frame. The frame's
+  // provider is only a hint for unbound/back-compat traffic.
+  const frameProviderName = boundProviderName
+    ?? ('provider' in message && message.provider ? message.provider.name : undefined)
+    ?? DEFAULT_PROVIDER_NAME;
 
   try {
     switch (message.type) {

--- a/packages/engine/src/engine/node.ts
+++ b/packages/engine/src/engine/node.ts
@@ -2,15 +2,17 @@ import { and, eq, inArray, ne, or, sql } from 'drizzle-orm';
 import type {
   FleetAgentRegisterMessage,
   FleetBrokerToRelaycastMessage,
+  FleetCapabilityAcceptance,
   FleetInventoryAgent,
   FleetNodeHeartbeatMessage,
   FleetNodeRegisterMessage,
+  FleetProviderIdentity,
   FleetCapability,
   AgentRegisterReplyData,
 } from '@relaycast/types';
 import { parseFleetBrokerToRelaycastMessage } from '@relaycast/types';
 import type { getDb } from '../db/index.js';
-import { actionInvocations, actions, agents, agentNodeBindings, channelMembers, channels, nodes } from '../db/schema.js';
+import { actionInvocations, agents, agentNodeBindings, channelMembers, channels, nodeProviders, nodes } from '../db/schema.js';
 import { randomHex, sha256Hex } from '../lib/crypto.js';
 import { codedError } from '../lib/httpError.js';
 import { runAtomic } from '../ports/database.js';
@@ -18,6 +20,16 @@ import type { EngineDb } from '../ports/database.js';
 import type { NodeConnectionRegistry } from '../ports/realtime.js';
 import { generateId } from './snowflake.js';
 import { isNodeLive, nodeHasCapability } from './placement.js';
+import {
+  DEFAULT_PROVIDER_NAME,
+  capabilityKind,
+  heartbeatProvider,
+  markProviderOffline,
+  materializeProviderActions,
+  recomputeNodeAggregate,
+  removeProvider,
+  upsertProvider,
+} from './nodeProvider.js';
 import { completeNodeInvocation, rescheduleInvocationsForLostNode, rescheduleNodeInvocation } from './action.js';
 import { emitInvocationCompletionEffects } from './invocationCompletion.js';
 import type { InvocationCompletionDeps } from './invocationCompletion.js';
@@ -41,7 +53,21 @@ export interface HandleNodeControlMessageArgs {
   workspaceId: string;
   nodeId: string;
   socket?: NodeSocketLike;
+  /**
+   * The registry connection this frame arrived on. Providers are bound to it at
+   * `node.register`; later frames resolve their provider from it. Absent when a
+   * caller drives node control without a registry-managed socket.
+   */
+  connectionId?: string;
   raw: string;
+}
+
+function resolveProviderIdentity(
+  message: { provider?: FleetProviderIdentity },
+  connectionId: string | undefined,
+): FleetProviderIdentity {
+  if (message.provider) return message.provider;
+  return { name: DEFAULT_PROVIDER_NAME, instance_id: connectionId ?? generateId() };
 }
 
 type CapabilityLike = string | FleetCapability;
@@ -56,11 +82,6 @@ function directNodeNameForAgent(agentId: string): string {
 
 function isImplicitDirectLocation(agent: Pick<AgentRow, 'id' | 'locationNodeId'>): boolean {
   return agent.locationNodeId === directNodeIdForAgent(agent.id);
-}
-
-function capabilityName(capability: CapabilityLike | null | undefined): string | null {
-  if (typeof capability === 'string') return capability;
-  return capability?.name ?? null;
 }
 
 function normalizeCapabilities(capabilities: CapabilityLike[]): FleetCapability[] {
@@ -149,35 +170,6 @@ function normalizeLegacyAdapter(adapter: string | null | undefined): string | un
   if (!adapter) return undefined;
   if (adapter === 'fleet.ws.v1' || adapter === 'direct.ws.v1') return 'ws.node.v1';
   return adapter;
-}
-
-async function ensureCapabilityActions(db: Db, workspaceId: string, nodeId: string, capabilities: CapabilityLike[]) {
-  for (const capability of capabilities) {
-    const name = capabilityName(capability);
-    if (!name || name.startsWith('spawn:')) continue;
-    const [existing] = await db
-      .select()
-      .from(actions)
-      .where(and(eq(actions.workspaceId, workspaceId), eq(actions.name, name)));
-    if (!existing) {
-      await db.insert(actions).values({
-        id: `act_${generateId()}`,
-        workspaceId,
-        name,
-        description: `Node handler ${name}`,
-        handlerAgentId: null,
-        handlerNodeId: nodeId,
-        inputSchema: {},
-        outputSchema: {},
-        availableTo: null,
-      });
-    } else if (!existing.handlerAgentId && (!existing.handlerNodeId || existing.handlerNodeId === nodeId)) {
-      await db
-        .update(actions)
-        .set({ handlerNodeId: nodeId, isActive: true })
-        .where(eq(actions.id, existing.id));
-    }
-  }
 }
 
 export async function createNodeToken(
@@ -283,12 +275,19 @@ export async function getNodeByName(db: Db, workspaceId: string, name: string) {
   return node ?? null;
 }
 
+export interface RegisterNodeResult {
+  node: ReturnType<typeof publicNode>;
+  acceptance: FleetCapabilityAcceptance[];
+  provider: FleetProviderIdentity;
+}
+
 export async function registerNode(
   db: Db,
   workspaceId: string,
   authenticatedNodeId: string,
   message: FleetNodeRegisterMessage,
-) {
+  provider: FleetProviderIdentity,
+): Promise<RegisterNodeResult> {
   if (message.node_id !== authenticatedNodeId) {
     throw codedError('node_id does not match the authenticated node token', 'node_id_mismatch', 403);
   }
@@ -311,48 +310,75 @@ export async function registerNode(
     throw codedError(`Node name "${message.name}" is already enrolled`, 'node_name_conflict', 409);
   }
 
-  const role: NodeRole = existing.role === 'direct' ? 'direct' : 'broker';
-  const capabilities = role === 'direct' ? [] : normalizeCapabilities(message.capabilities);
-  const maxAgents = role === 'direct' ? 1 : message.max_agents;
-  const [updated] = await db
-    .update(nodes)
-    .set({
-      name: message.name,
-      capabilities,
-      kind: 'ws',
-      role,
-      deliveryAdapter: 'ws.node.v1',
-      deliveryConfig: role === 'direct' ? existing.deliveryConfig : null,
-      maxAgents,
-      activeAgents: role === 'direct' ? 1 : existing.activeAgents,
-      tags: role === 'direct' ? existing.tags : message.tags,
-      version: message.version,
-      status: 'online',
-      handlersLive: role === 'broker' && capabilities.length > 0,
-      lastHeartbeatAt: now,
-    })
-    .where(and(eq(nodes.workspaceId, workspaceId), eq(nodes.id, authenticatedNodeId)))
-    .returning();
-
-  if (role === 'broker') {
-    await ensureCapabilityActions(db, workspaceId, updated.id, capabilities);
+  // Direct nodes are the per-agent delivery hosts: they never carry providers.
+  if (existing.role === 'direct') {
+    const [updated] = await db
+      .update(nodes)
+      .set({
+        name: message.name,
+        capabilities: [],
+        kind: 'ws',
+        role: 'direct',
+        deliveryAdapter: 'ws.node.v1',
+        deliveryConfig: existing.deliveryConfig,
+        maxAgents: 1,
+        activeAgents: 1,
+        tags: existing.tags,
+        version: message.version,
+        status: 'online',
+        handlersLive: false,
+        lastHeartbeatAt: now,
+      })
+      .where(and(eq(nodes.workspaceId, workspaceId), eq(nodes.id, authenticatedNodeId)))
+      .returning();
+    return { node: publicNode(updated), acceptance: [], provider };
   }
-  return publicNode(updated);
+
+  const capabilities = normalizeCapabilities(message.capabilities);
+  await runAtomic(db, async (tx) => {
+    await upsertProvider(tx, workspaceId, authenticatedNodeId, {
+      name: provider.name,
+      instanceId: provider.instance_id,
+      capabilities,
+      maxAgents: message.max_agents,
+      version: message.version,
+      handlersLive: capabilities.length > 0,
+    });
+    await materializeProviderActions(tx, workspaceId, authenticatedNodeId, provider.name, capabilities);
+    await tx
+      .update(nodes)
+      .set({ name: message.name, kind: 'ws', role: 'broker', deliveryAdapter: 'ws.node.v1', deliveryConfig: null, tags: message.tags })
+      .where(and(eq(nodes.workspaceId, workspaceId), eq(nodes.id, authenticatedNodeId)));
+    await recomputeNodeAggregate(tx, workspaceId, authenticatedNodeId, {
+      version: message.version,
+      machineId: message.machine_id ?? null,
+    });
+  });
+
+  const [updated] = await db
+    .select()
+    .from(nodes)
+    .where(and(eq(nodes.workspaceId, workspaceId), eq(nodes.id, authenticatedNodeId)));
+  const acceptance: FleetCapabilityAcceptance[] = capabilities.map((cap) => ({
+    name: cap.name,
+    kind: capabilityKind(cap),
+    accepted: true,
+  }));
+  return { node: publicNode(updated), acceptance, provider };
 }
 
 export async function heartbeatNode(
   db: Db,
   workspaceId: string,
   nodeId: string,
+  providerName: string,
   message: FleetNodeHeartbeatMessage,
 ) {
-  // A heartbeat may carry the node's roster snapshot so the engine can keep its
-  // node descriptor fresh between (or in the absence of a fresh) node.register —
-  // e.g. after an engine restart where the broker keeps heartbeating an
-  // already-registered node. The roster fields are optional; a minimal heartbeat
-  // updates only liveness/capacity. lastHeartbeatAt is always stamped
-  // server-side here as the authoritative receipt time — the broker never sends
-  // it, and any client-supplied value would be ignored.
+  // A heartbeat is provider-scoped by connection. It may carry the provider's
+  // roster snapshot so the engine can refresh the descriptor between (or in the
+  // absence of a fresh) node.register — e.g. after an engine restart where the
+  // provider keeps heartbeating. lastHeartbeatAt is always stamped server-side
+  // as the authoritative receipt time; the client never sends it.
   if (message.node_id !== undefined && message.node_id !== nodeId) {
     throw codedError('node_id does not match the authenticated node token', 'node_id_mismatch', 403);
   }
@@ -361,36 +387,69 @@ export async function heartbeatNode(
     .select({ role: nodes.role })
     .from(nodes)
     .where(and(eq(nodes.workspaceId, workspaceId), eq(nodes.id, nodeId)));
-  const role: NodeRole = nodeState?.role === 'direct' ? 'direct' : 'broker';
-  const rosterUpdate: Partial<typeof nodes.$inferInsert> = {};
-  if (message.name !== undefined) rosterUpdate.name = message.name;
-  if (message.capabilities !== undefined) {
-    if (role !== 'direct') {
-      rosterUpdate.capabilities = normalizeCapabilities(message.capabilities);
+  if (!nodeState) return null;
+
+  if (nodeState.role === 'direct') {
+    const rosterUpdate: Partial<typeof nodes.$inferInsert> = {};
+    if (message.name !== undefined) rosterUpdate.name = message.name;
+    if (message.version !== undefined) rosterUpdate.version = message.version;
+    const [updated] = await db
+      .update(nodes)
+      .set({
+        ...rosterUpdate,
+        status: 'online',
+        load: message.load,
+        activeAgents: 1,
+        handlersLive: false,
+        lastHeartbeatAt: new Date(),
+      })
+      .where(and(eq(nodes.workspaceId, workspaceId), eq(nodes.id, nodeId)))
+      .returning();
+    return updated ? publicNode(updated) : null;
+  }
+
+  await runAtomic(db, async (tx) => {
+    if (message.capabilities !== undefined) {
+      const caps = normalizeCapabilities(message.capabilities);
+      const [existingProvider] = await tx
+        .select({ instanceId: nodeProviders.instanceId, maxAgents: nodeProviders.maxAgents, version: nodeProviders.version })
+        .from(nodeProviders)
+        .where(and(
+          eq(nodeProviders.workspaceId, workspaceId),
+          eq(nodeProviders.nodeId, nodeId),
+          eq(nodeProviders.name, providerName),
+        ));
+      await upsertProvider(tx, workspaceId, nodeId, {
+        name: providerName,
+        instanceId: existingProvider?.instanceId ?? `${providerName}:heartbeat`,
+        capabilities: caps,
+        maxAgents: message.max_agents ?? existingProvider?.maxAgents ?? 0,
+        version: message.version ?? existingProvider?.version ?? 'unknown',
+        handlersLive: message.handlers_live,
+      });
+      await heartbeatProvider(tx, workspaceId, nodeId, providerName, {
+        load: message.load,
+        activeAgents: message.active_agents,
+        handlersLive: message.handlers_live,
+      });
+      await materializeProviderActions(tx, workspaceId, nodeId, providerName, caps);
+    } else {
+      await heartbeatProvider(tx, workspaceId, nodeId, providerName, {
+        load: message.load,
+        activeAgents: message.active_agents,
+        handlersLive: message.handlers_live,
+      });
     }
-  }
-  if (message.max_agents !== undefined) {
-    rosterUpdate.maxAgents = role === 'direct' ? 1 : message.max_agents;
-  }
-  if (message.version !== undefined) rosterUpdate.version = message.version;
+    if (message.name !== undefined) {
+      await tx.update(nodes).set({ name: message.name }).where(and(eq(nodes.workspaceId, workspaceId), eq(nodes.id, nodeId)));
+    }
+    await recomputeNodeAggregate(tx, workspaceId, nodeId, message.version !== undefined ? { version: message.version } : {});
+  });
 
   const [updated] = await db
-    .update(nodes)
-    .set({
-      ...rosterUpdate,
-      status: 'online',
-      load: message.load,
-      activeAgents: role === 'direct' ? 1 : message.active_agents,
-      handlersLive: role !== 'direct' && message.handlers_live,
-      lastHeartbeatAt: new Date(),
-    })
-    .where(and(eq(nodes.workspaceId, workspaceId), eq(nodes.id, nodeId)))
-    .returning();
-
-  if (updated && updated.role !== 'direct' && message.capabilities !== undefined) {
-    await ensureCapabilityActions(db, workspaceId, updated.id, message.capabilities);
-  }
-
+    .select()
+    .from(nodes)
+    .where(and(eq(nodes.workspaceId, workspaceId), eq(nodes.id, nodeId)));
   return updated ? publicNode(updated) : null;
 }
 
@@ -411,6 +470,13 @@ export async function markNodeOffline(
     })
     .where(and(eq(nodes.workspaceId, workspaceId), eq(nodes.id, nodeId)));
 
+  // Provider capability sets persist (offline nodes still show their manifest);
+  // only their liveness flips.
+  await db
+    .update(nodeProviders)
+    .set({ status: 'offline', handlersLive: false, load: 0, lastHeartbeatAt: new Date() })
+    .where(and(eq(nodeProviders.workspaceId, workspaceId), eq(nodeProviders.nodeId, nodeId)));
+
   await db
     .update(agents)
     .set({ status: 'offline', lastSeen: new Date() })
@@ -423,13 +489,69 @@ export async function markNodeOffline(
   await rescheduleInvocationsForLostNode(db, registry, workspaceId, nodeId);
 }
 
-export async function deregisterNode(
+/**
+ * A provider's control connection dropped. Its capability set persists (marked
+ * offline) so the node still shows the manifest; agents it hosted go offline.
+ * When it was the node's last connection the whole node goes offline.
+ */
+export async function handleProviderDisconnect(
   db: Db,
   registry: NodeConnectionRegistry,
   workspaceId: string,
   nodeId: string,
+  providerName: string,
+  hasRemainingConnections: boolean,
 ) {
-  await markNodeOffline(db, registry, workspaceId, nodeId);
+  if (!hasRemainingConnections) {
+    await markNodeOffline(db, registry, workspaceId, nodeId);
+    return;
+  }
+  await markProviderOffline(db, workspaceId, nodeId, providerName);
+  await db
+    .update(agents)
+    .set({ status: 'offline', lastSeen: new Date() })
+    .where(and(
+      eq(agents.workspaceId, workspaceId),
+      eq(agents.locationType, 'via_node'),
+      eq(agents.locationNodeId, nodeId),
+      eq(agents.providerName, providerName),
+    ));
+  await recomputeNodeAggregate(db, workspaceId, nodeId);
+}
+
+/**
+ * Provider-scoped deregister: removes the provider's attachment, persisted
+ * capability set, and materialized actions. When it was the node's last
+ * provider the node goes fully offline.
+ */
+export async function deregisterProvider(
+  db: Db,
+  registry: NodeConnectionRegistry,
+  workspaceId: string,
+  nodeId: string,
+  providerName: string,
+) {
+  await removeProvider(db, workspaceId, nodeId, providerName);
+  registry.detachProvider(workspaceId, nodeId, providerName);
+  await db
+    .update(agents)
+    .set({ status: 'offline', lastSeen: new Date() })
+    .where(and(
+      eq(agents.workspaceId, workspaceId),
+      eq(agents.locationType, 'via_node'),
+      eq(agents.locationNodeId, nodeId),
+      eq(agents.providerName, providerName),
+    ));
+  const [remaining] = await db
+    .select({ count: sql<number>`count(*)` })
+    .from(nodeProviders)
+    .where(and(eq(nodeProviders.workspaceId, workspaceId), eq(nodeProviders.nodeId, nodeId)));
+  if (!remaining || remaining.count === 0) {
+    await markNodeOffline(db, registry, workspaceId, nodeId);
+  } else {
+    await recomputeNodeAggregate(db, workspaceId, nodeId);
+    await rescheduleInvocationsForLostNode(db, registry, workspaceId, nodeId);
+  }
 }
 
 export async function sweepOfflineNodes(db: Db, registry: NodeConnectionRegistry): Promise<number> {
@@ -874,6 +996,7 @@ export async function registerAgentViaNode(
   db: Db,
   workspaceId: string,
   nodeId: string,
+  providerName: string,
   message: FleetAgentRegisterMessage,
 ): Promise<AgentRegisterReplyData> {
   return runAtomic(db, async (tx) => {
@@ -905,6 +1028,7 @@ export async function registerAgentViaNode(
         metadata: { fleet: { node_id: nodeId, invocation_id: message.invocation_id ?? null, registered_at: now } },
         locationType: 'via_node',
         locationNodeId: nodeId,
+        providerName,
         originNodeId: nodeId,
         resumable: message.resumable ?? false,
         sessionRef: message.session_ref ?? null,
@@ -918,6 +1042,7 @@ export async function registerAgentViaNode(
           metadata: sql`json_patch(COALESCE(${agents.metadata}, '{}'), ${fleetMetadata})`,
           locationType: 'via_node',
           locationNodeId: nodeId,
+          providerName,
           originNodeId: sql`COALESCE(${agents.originNodeId}, ${nodeId})`,
           resumable: message.resumable ?? false,
           sessionRef: message.session_ref ?? null,
@@ -1227,16 +1352,53 @@ export async function handleNodeControlMessage(args: HandleNodeControlMessageArg
     return;
   }
 
+  // A provider binds its name to the connection at node.register; later frames
+  // (heartbeat, deregister, agent.register, results) resolve it from the
+  // connection. Absent a bound provider (or when driven without a registry
+  // connection), fall back to the synthetic `default` provider.
+  const boundProviderName = args.connectionId
+    ? args.registry.providerNameForConnection?.(args.connectionId)
+    : undefined;
+  const frameProviderName = (
+    'provider' in message && message.provider ? message.provider.name : undefined
+  ) ?? boundProviderName ?? DEFAULT_PROVIDER_NAME;
+
   try {
     switch (message.type) {
       case 'node.register': {
-        const registered = await registerNode(args.db, args.workspaceId, args.nodeId, message);
+        const provider = resolveProviderIdentity(message, args.connectionId);
+        if (args.connectionId && args.registry.providerAttachConflict) {
+          const conflict = args.registry.providerAttachConflict(
+            args.workspaceId,
+            args.nodeId,
+            provider.name,
+            provider.instance_id,
+            args.connectionId,
+          );
+          if (conflict) {
+            throw codedError(conflict.message, conflict.code, 409);
+          }
+        }
+        const registered = await registerNode(args.db, args.workspaceId, args.nodeId, message, provider);
+        if (args.connectionId && args.registry.attachProvider) {
+          args.registry.attachProvider(
+            args.workspaceId,
+            args.nodeId,
+            provider.name,
+            provider.instance_id,
+            args.connectionId,
+          );
+        }
         sendControl(args.socket, {
           v: 1,
           id: requestId(message),
           type: 'reply',
           ok: true,
-          data: registered,
+          data: {
+            ...registered.node,
+            provider: registered.provider,
+            accepted_capabilities: registered.acceptance,
+          },
         });
         // Node is now marked online: flush any queued action.invoke frames so
         // spawns queued while it was offline can reserve capacity and dispatch.
@@ -1248,16 +1410,16 @@ export async function handleNodeControlMessage(args: HandleNodeControlMessageArg
         return;
       }
       case 'node.heartbeat':
-        await heartbeatNode(args.db, args.workspaceId, args.nodeId, message);
+        await heartbeatNode(args.db, args.workspaceId, args.nodeId, frameProviderName, message);
         // Heartbeat refreshes online/capacity state; re-drain as a backstop in
         // case a queued spawn could not reserve capacity at register time.
         await args.registry.drainNode(args.workspaceId, args.nodeId);
         return;
       case 'node.deregister':
-        await deregisterNode(args.db, args.registry, args.workspaceId, args.nodeId);
+        await deregisterProvider(args.db, args.registry, args.workspaceId, args.nodeId, frameProviderName);
         return;
       case 'agent.register': {
-        const registered = await registerAgentViaNode(args.db, args.workspaceId, args.nodeId, message);
+        const registered = await registerAgentViaNode(args.db, args.workspaceId, args.nodeId, frameProviderName, message);
         // The relay broker's node_control client awaits a `reply` frame keyed by
         // the request id (it matches `pending_agent_registrations` by `reply.id`
         // and parses `data` as {agent_id, token, name} with deny_unknown_fields).

--- a/packages/engine/src/engine/nodeContext.ts
+++ b/packages/engine/src/engine/nodeContext.ts
@@ -23,6 +23,7 @@ type ScopedNodeRow = {
   agentId: string;
   nodeKind: string;
   nodeRole: string;
+  providerName: string;
   deliveryAdapter: string | null;
   deliveryConfig: Record<string, unknown> | null;
 };
@@ -39,6 +40,8 @@ function normalizeDeliveryAdapter(adapter: string | null | undefined, nodeKind: 
 }
 
 type GroupedNode = {
+  nodeId: string;
+  providerName: string;
   nodeKind: string;
   nodeRole: string;
   deliveryAdapter: string | null;
@@ -46,10 +49,15 @@ type GroupedNode = {
   agentIds: string[];
 };
 
-function groupByNode(rows: ScopedNodeRow[]): Map<string, GroupedNode> {
+// Group by (node, provider) so a WebSocket context.update lands on the provider
+// whose connection hosts those agents, not a phantom node-default provider.
+function groupByNodeProvider(rows: ScopedNodeRow[]): Map<string, GroupedNode> {
   const grouped = new Map<string, GroupedNode>();
   for (const row of rows) {
-    const existing = grouped.get(row.nodeId) ?? {
+    const key = `${row.nodeId}::${row.providerName}`;
+    const existing = grouped.get(key) ?? {
+      nodeId: row.nodeId,
+      providerName: row.providerName,
       nodeKind: row.nodeKind,
       nodeRole: row.nodeRole,
       deliveryAdapter: row.deliveryAdapter,
@@ -57,7 +65,7 @@ function groupByNode(rows: ScopedNodeRow[]): Map<string, GroupedNode> {
       agentIds: [],
     };
     existing.agentIds.push(row.agentId);
-    grouped.set(row.nodeId, existing);
+    grouped.set(key, existing);
   }
   return grouped;
 }
@@ -72,13 +80,14 @@ async function sendContextToRows(
     data: Record<string, unknown>;
   },
 ): Promise<void> {
-  const grouped = groupByNode(rows);
+  const grouped = groupByNodeProvider(rows);
   const tasks: Promise<unknown>[] = [];
-  for (const [nodeId, group] of grouped.entries()) {
+  for (const group of grouped.values()) {
+    const nodeId = group.nodeId;
     const agentIds = [...new Set(group.agentIds)];
     if (normalizeDeliveryAdapter(group.deliveryAdapter, group.nodeKind) === 'ws.node.v1') {
       tasks.push(
-        deps.nodeConnections.sendToNode(deps.workspaceId, nodeId, {
+        deps.nodeConnections.sendToProvider(deps.workspaceId, nodeId, group.providerName, {
           v: 1,
           type: 'context.update',
           topic: message.topic,
@@ -139,6 +148,7 @@ export async function sendNodeContextForChannel(
       agentId: agentNodeBindings.agentId,
       nodeKind: nodes.kind,
       nodeRole: nodes.role,
+      providerName: agents.providerName,
       deliveryAdapter: nodes.deliveryAdapter,
       deliveryConfig: nodes.deliveryConfig,
     })
@@ -185,6 +195,7 @@ export async function sendNodePresenceContext(
       agentId: agentNodeBindings.agentId,
       nodeKind: nodes.kind,
       nodeRole: nodes.role,
+      providerName: agents.providerName,
       deliveryAdapter: nodes.deliveryAdapter,
       deliveryConfig: nodes.deliveryConfig,
     })
@@ -229,6 +240,7 @@ export async function sendNodeContextToAgents(
       agentId: agentNodeBindings.agentId,
       nodeKind: nodes.kind,
       nodeRole: nodes.role,
+      providerName: agents.providerName,
       deliveryAdapter: nodes.deliveryAdapter,
       deliveryConfig: nodes.deliveryConfig,
     })

--- a/packages/engine/src/engine/nodeContext.ts
+++ b/packages/engine/src/engine/nodeContext.ts
@@ -54,7 +54,9 @@ type GroupedNode = {
 function groupByNodeProvider(rows: ScopedNodeRow[]): Map<string, GroupedNode> {
   const grouped = new Map<string, GroupedNode>();
   for (const row of rows) {
-    const key = `${row.nodeId}::${row.providerName}`;
+    // Collision-safe key: node ids and provider names are free-form and may
+    // contain any separator, so encode the tuple rather than joining on a string.
+    const key = JSON.stringify([row.nodeId, row.providerName]);
     const existing = grouped.get(key) ?? {
       nodeId: row.nodeId,
       providerName: row.providerName,

--- a/packages/engine/src/engine/nodeDeliver.ts
+++ b/packages/engine/src/engine/nodeDeliver.ts
@@ -20,6 +20,7 @@ type NodeDeliverRecipient = {
   agentName: string;
   nodeId: string;
   nodeKind: string;
+  providerName: string;
   deliveryConfig: Record<string, unknown> | null;
 };
 
@@ -47,6 +48,7 @@ async function channelRecipients(deps: NodeDeliverDeps, channelId: string): Prom
         agentName: agents.name,
         nodeId: agentNodeBindings.nodeId,
         nodeKind: nodes.kind,
+        providerName: agents.providerName,
         deliveryConfig: nodes.deliveryConfig,
       })
       .from(dmParticipants)
@@ -78,6 +80,7 @@ async function channelRecipients(deps: NodeDeliverDeps, channelId: string): Prom
       agentName: agents.name,
       nodeId: agentNodeBindings.nodeId,
       nodeKind: nodes.kind,
+      providerName: agents.providerName,
       deliveryConfig: nodes.deliveryConfig,
     })
     .from(channelMembers)
@@ -126,7 +129,7 @@ function deliverEventToRecipient(
       },
     });
   }
-  return deps.nodeConnections.sendToNode(deps.workspaceId, recipient.nodeId, buildDeliverFrame({
+  return deps.nodeConnections.sendToProvider(deps.workspaceId, recipient.nodeId, recipient.providerName, buildDeliverFrame({
     delivery_id: eventDeliveryId(args.event, args.eventKey, recipient.agentId),
     agent_id: recipient.agentId,
     agent: recipient.agentName,
@@ -178,6 +181,7 @@ export async function sendNodeDeliveriesToAgents(
       agentName: agents.name,
       nodeId: agentNodeBindings.nodeId,
       nodeKind: nodes.kind,
+      providerName: agents.providerName,
       deliveryConfig: nodes.deliveryConfig,
     })
     .from(agents)

--- a/packages/engine/src/engine/nodeProvider.ts
+++ b/packages/engine/src/engine/nodeProvider.ts
@@ -1,0 +1,316 @@
+import { and, eq, notInArray, sql } from 'drizzle-orm';
+import type { FleetCapability, FleetCapabilityKind } from '@relaycast/types';
+import type { getDb } from '../db/index.js';
+import { actions, nodeProviders, nodes } from '../db/schema.js';
+import { generateId } from './snowflake.js';
+import { codedError } from '../lib/httpError.js';
+import { NODE_LIVENESS_TTL_MS } from './placement.js';
+
+type Db = ReturnType<typeof getDb>;
+type ProviderRow = typeof nodeProviders.$inferSelect;
+
+/**
+ * The reserved provider synthesized for registrations that carry no `provider`
+ * field. It keeps pre-provider clients (the current broker) working: their
+ * capabilities, heartbeats, and hosted agents are all keyed to `default`.
+ */
+export const DEFAULT_PROVIDER_NAME = 'default';
+
+/**
+ * Classify a capability. A declared `action`/`capacity` kind is authoritative;
+ * otherwise the name decides — `spawn`, `spawn:<harness>`, and `release` are
+ * capacity (placement/delegation, never materialized), everything else is an
+ * action (materialized and invoked).
+ */
+export function capabilityKind(capability: FleetCapability | string): FleetCapabilityKind {
+  const name = typeof capability === 'string' ? capability : capability.name;
+  const declared = typeof capability === 'string' ? undefined : capability.kind;
+  if (declared === 'action' || declared === 'capacity') return declared;
+  if (name === 'spawn' || name === 'release' || name.startsWith('spawn:')) return 'capacity';
+  return 'action';
+}
+
+export function isProviderLive(
+  provider: Pick<ProviderRow, 'status' | 'handlersLive' | 'lastHeartbeatAt'>,
+  now = Date.now(),
+): boolean {
+  return (
+    provider.status === 'online' &&
+    provider.handlersLive &&
+    !!provider.lastHeartbeatAt &&
+    now - provider.lastHeartbeatAt.getTime() <= NODE_LIVENESS_TTL_MS
+  );
+}
+
+export async function getProvider(db: Db, workspaceId: string, nodeId: string, name: string): Promise<ProviderRow | null> {
+  const [row] = await db
+    .select()
+    .from(nodeProviders)
+    .where(and(
+      eq(nodeProviders.workspaceId, workspaceId),
+      eq(nodeProviders.nodeId, nodeId),
+      eq(nodeProviders.name, name),
+    ));
+  return row ?? null;
+}
+
+export async function listProviders(db: Db, workspaceId: string, nodeId: string): Promise<ProviderRow[]> {
+  return db
+    .select()
+    .from(nodeProviders)
+    .where(and(eq(nodeProviders.workspaceId, workspaceId), eq(nodeProviders.nodeId, nodeId)));
+}
+
+/**
+ * Resolve the provider that hosts a capacity capability (e.g. `spawn:claude`) on
+ * a node — the executor `ctx.spawnAgent` and native spawn dispatch target.
+ */
+export async function capacityProviderName(
+  db: Db,
+  workspaceId: string,
+  nodeId: string,
+  capability: string,
+): Promise<string | null> {
+  const providers = await listProviders(db, workspaceId, nodeId);
+  for (const provider of providers) {
+    const caps = Array.isArray(provider.capabilities) ? provider.capabilities : [];
+    if (caps.some((cap) => cap.name === capability && capabilityKind(cap) === 'capacity')) {
+      return provider.name;
+    }
+  }
+  return null;
+}
+
+/** Persist a provider's registration, fully replacing its previous capability set. */
+export async function upsertProvider(
+  db: Db,
+  workspaceId: string,
+  nodeId: string,
+  data: {
+    name: string;
+    instanceId: string;
+    capabilities: FleetCapability[];
+    maxAgents: number;
+    version: string;
+    handlersLive: boolean;
+  },
+): Promise<void> {
+  const now = new Date();
+  const existing = await getProvider(db, workspaceId, nodeId, data.name);
+  if (existing) {
+    await db
+      .update(nodeProviders)
+      .set({
+        instanceId: data.instanceId,
+        capabilities: data.capabilities,
+        maxAgents: data.maxAgents,
+        version: data.version,
+        handlersLive: data.handlersLive,
+        status: 'online',
+        lastHeartbeatAt: now,
+      })
+      .where(eq(nodeProviders.id, existing.id));
+    return;
+  }
+  await db.insert(nodeProviders).values({
+    id: `nprov_${generateId()}`,
+    workspaceId,
+    nodeId,
+    name: data.name,
+    instanceId: data.instanceId,
+    capabilities: data.capabilities,
+    maxAgents: data.maxAgents,
+    activeAgents: 0,
+    load: 0,
+    handlersLive: data.handlersLive,
+    status: 'online',
+    version: data.version,
+    lastHeartbeatAt: now,
+    createdAt: now,
+  });
+}
+
+export async function heartbeatProvider(
+  db: Db,
+  workspaceId: string,
+  nodeId: string,
+  name: string,
+  data: { load: number; activeAgents: number; handlersLive: boolean },
+): Promise<void> {
+  await db
+    .update(nodeProviders)
+    .set({
+      load: data.load,
+      activeAgents: data.activeAgents,
+      handlersLive: data.handlersLive,
+      status: 'online',
+      lastHeartbeatAt: new Date(),
+    })
+    .where(and(
+      eq(nodeProviders.workspaceId, workspaceId),
+      eq(nodeProviders.nodeId, nodeId),
+      eq(nodeProviders.name, name),
+    ));
+}
+
+export async function markProviderOffline(db: Db, workspaceId: string, nodeId: string, name: string): Promise<void> {
+  await db
+    .update(nodeProviders)
+    .set({ status: 'offline', handlersLive: false, load: 0, lastHeartbeatAt: new Date() })
+    .where(and(
+      eq(nodeProviders.workspaceId, workspaceId),
+      eq(nodeProviders.nodeId, nodeId),
+      eq(nodeProviders.name, name),
+    ));
+}
+
+/** Remove a provider and the actions it materialized (provider-scoped deregister / prune). */
+export async function removeProvider(db: Db, workspaceId: string, nodeId: string, name: string): Promise<void> {
+  await db
+    .delete(actions)
+    .where(and(
+      eq(actions.workspaceId, workspaceId),
+      eq(actions.handlerNodeId, nodeId),
+      eq(actions.handlerProvider, name),
+    ));
+  await db
+    .delete(nodeProviders)
+    .where(and(
+      eq(nodeProviders.workspaceId, workspaceId),
+      eq(nodeProviders.nodeId, nodeId),
+      eq(nodeProviders.name, name),
+    ));
+}
+
+/**
+ * Materialize a provider's `action`-kind capabilities into node-scoped action
+ * rows, fully replacing this provider's previous set. `capacity` entries are
+ * ignored (they feed placement, not dispatch). The synthetic `default` provider
+ * keeps the pre-provider behavior: its actions claim the workspace-global name
+ * so triggers and `POST /v1/actions/:name/invoke` keep resolving them.
+ */
+export async function materializeProviderActions(
+  db: Db,
+  workspaceId: string,
+  nodeId: string,
+  providerName: string,
+  capabilities: FleetCapability[],
+): Promise<void> {
+  const actionCaps = capabilities.filter((cap) => capabilityKind(cap) === 'action');
+  const keepNames = actionCaps.map((cap) => cap.name);
+
+  // Prune actions this provider previously materialized that it no longer offers.
+  const pruneConditions = [
+    eq(actions.workspaceId, workspaceId),
+    eq(actions.handlerNodeId, nodeId),
+    eq(actions.handlerProvider, providerName),
+  ];
+  await db.delete(actions).where(and(
+    ...pruneConditions,
+    keepNames.length > 0 ? notInArray(actions.name, keepNames) : sql`1 = 1`,
+  ));
+
+  const isDefault = providerName === DEFAULT_PROVIDER_NAME;
+  for (const cap of actionCaps) {
+    const name = cap.name;
+    if (isDefault) {
+      // Never clobber an agent-hosted action of the same name (legacy behavior).
+      const [agentHosted] = await db
+        .select({ id: actions.id })
+        .from(actions)
+        .where(and(eq(actions.workspaceId, workspaceId), eq(actions.name, name), sql`${actions.handlerNodeId} IS NULL`));
+      if (agentHosted) continue;
+    }
+
+    const wantGlobal = isDefault || cap.global === true;
+    if (wantGlobal) {
+      const [existingGlobal] = await db
+        .select({ id: actions.id, handlerNodeId: actions.handlerNodeId })
+        .from(actions)
+        .where(and(eq(actions.workspaceId, workspaceId), eq(actions.name, name), eq(actions.isGlobal, true)));
+      if (existingGlobal && existingGlobal.handlerNodeId !== nodeId) {
+        // The default provider does not steal a workspace name another node
+        // already owns (first-writer-wins, matching legacy broker behavior);
+        // an explicit `global: true` collides loudly.
+        if (isDefault) continue;
+        throw codedError(`Action "${name}" already claims the workspace-global alias`, 'action_name_conflict', 409);
+      }
+    }
+
+    const [existing] = await db
+      .select()
+      .from(actions)
+      .where(and(eq(actions.workspaceId, workspaceId), eq(actions.handlerNodeId, nodeId), eq(actions.name, name)));
+    if (existing && existing.handlerProvider && existing.handlerProvider !== providerName) {
+      throw codedError(`Action "${name}" is already registered by provider "${existing.handlerProvider}" on this node`, 'action_name_conflict', 409);
+    }
+
+    const wantQueue = cap.queue === true;
+    if (existing) {
+      await db
+        .update(actions)
+        .set({ handlerProvider: providerName, handlerAgentId: null, isGlobal: wantGlobal, queue: wantQueue, isActive: true })
+        .where(eq(actions.id, existing.id));
+    } else {
+      await db.insert(actions).values({
+        id: `act_${generateId()}`,
+        workspaceId,
+        name,
+        description: `Node handler ${name}`,
+        handlerAgentId: null,
+        handlerNodeId: nodeId,
+        handlerProvider: providerName,
+        isGlobal: wantGlobal,
+        queue: wantQueue,
+        inputSchema: {},
+        outputSchema: {},
+        availableTo: null,
+      });
+    }
+  }
+}
+
+/**
+ * Recompute a broker node's aggregate columns from its providers: the union
+ * manifest, summed capacity, max load, and OR'd liveness. Direct nodes never
+ * call this — they carry no providers.
+ */
+export async function recomputeNodeAggregate(
+  db: Db,
+  workspaceId: string,
+  nodeId: string,
+  extra: { version?: string; machineId?: string | null } = {},
+): Promise<void> {
+  const providers = await listProviders(db, workspaceId, nodeId);
+  const online = providers.filter((p) => p.status === 'online');
+
+  const capabilityByName = new Map<string, FleetCapability>();
+  for (const provider of providers) {
+    for (const cap of provider.capabilities ?? []) {
+      if (!capabilityByName.has(cap.name)) capabilityByName.set(cap.name, cap);
+    }
+  }
+
+  const maxAgents = providers.reduce((sum, p) => sum + p.maxAgents, 0);
+  const activeAgents = providers.reduce((sum, p) => sum + p.activeAgents, 0);
+  const load = providers.reduce((max, p) => Math.max(max, p.load), 0);
+  const handlersLive = online.some((p) => p.handlersLive);
+  const lastHeartbeatAt = providers.reduce<Date | null>((latest, p) => {
+    if (!p.lastHeartbeatAt) return latest;
+    return !latest || p.lastHeartbeatAt > latest ? p.lastHeartbeatAt : latest;
+  }, null);
+
+  const update: Partial<typeof nodes.$inferInsert> = {
+    capabilities: [...capabilityByName.values()],
+    maxAgents,
+    activeAgents,
+    load,
+    handlersLive,
+    status: online.length > 0 ? 'online' : 'offline',
+    lastHeartbeatAt: lastHeartbeatAt ?? new Date(),
+  };
+  if (extra.version !== undefined) update.version = extra.version;
+  if (extra.machineId !== undefined && extra.machineId !== null) update.machineId = extra.machineId;
+
+  await db.update(nodes).set(update).where(and(eq(nodes.workspaceId, workspaceId), eq(nodes.id, nodeId)));
+}

--- a/packages/engine/src/engine/nodeProvider.ts
+++ b/packages/engine/src/engine/nodeProvider.ts
@@ -235,6 +235,18 @@ export async function materializeProviderActions(
         if (isDefault) continue;
         throw codedError(`Action "${name}" already claims the workspace-global alias`, 'action_name_conflict', 409);
       }
+      // An explicit global alias must not shadow an agent-hosted action of the
+      // same name — the agent-hosted row wins workspace-invoke resolution, so the
+      // alias would be unreachable. Collide loudly instead.
+      if (!isDefault) {
+        const [agentHosted] = await db
+          .select({ id: actions.id })
+          .from(actions)
+          .where(and(eq(actions.workspaceId, workspaceId), eq(actions.name, name), sql`${actions.handlerNodeId} IS NULL`));
+        if (agentHosted) {
+          throw codedError(`Action "${name}" is already registered as an agent-hosted action`, 'action_name_conflict', 409);
+        }
+      }
     }
 
     const [existing] = await db
@@ -295,7 +307,10 @@ export async function recomputeNodeAggregate(
   const activeAgents = providers.reduce((sum, p) => sum + p.activeAgents, 0);
   const load = providers.reduce((max, p) => Math.max(max, p.load), 0);
   const handlersLive = online.some((p) => p.handlersLive);
-  const lastHeartbeatAt = providers.reduce<Date | null>((latest, p) => {
+  // Node liveness must reflect an online provider's heartbeat. An offline
+  // provider's disconnect timestamp is fresh, so including it here could keep a
+  // node "live" while every online provider has gone stale.
+  const lastHeartbeatAt = online.reduce<Date | null>((latest, p) => {
     if (!p.lastHeartbeatAt) return latest;
     return !latest || p.lastHeartbeatAt > latest ? p.lastHeartbeatAt : latest;
   }, null);

--- a/packages/engine/src/ports/realtime.ts
+++ b/packages/engine/src/ports/realtime.ts
@@ -70,15 +70,57 @@ export interface NodeConnectionRegistry {
    */
   upgradeNode(args: NodeUpgradeArgs): Promise<Response>;
 
-  /** Push a typed node protocol message to a live broker node or implicit direct node. */
+  /**
+   * Push a typed node protocol message to a node's default provider (or its sole
+   * connected provider). Provider-addressed callers use {@link sendToProvider}.
+   */
   sendToNode(
     workspaceId: string,
     nodeId: string,
     message: FleetRelaycastToBrokerMessage,
   ): Promise<boolean>;
 
-  /** True when the node currently has a live control connection. */
+  /** Push a typed node protocol message to a specific provider's socket. */
+  sendToProvider(
+    workspaceId: string,
+    nodeId: string,
+    providerName: string,
+    message: FleetRelaycastToBrokerMessage,
+  ): Promise<boolean>;
+
+  /** True when the node currently has at least one connected provider. */
   isNodeConnected(workspaceId: string, nodeId: string): boolean;
+
+  /** True when a specific provider currently has a connected socket. */
+  isProviderConnected(workspaceId: string, nodeId: string, providerName: string): boolean;
+
+  /** The provider name bound to a registry connection, once it has registered. */
+  providerNameForConnection?(connectionId: string): string | undefined;
+
+  /**
+   * Read-only pre-check for a provider registration: returns a conflict when the
+   * name's current instance is a different, still-live connection (duplicate
+   * process). A dropped/stale instance is replaced on {@link attachProvider}.
+   */
+  providerAttachConflict?(
+    workspaceId: string,
+    nodeId: string,
+    providerName: string,
+    instanceId: string,
+    connectionId: string,
+  ): { code: string; message: string } | null;
+
+  /** Bind a provider name to a connection, superseding a stale prior attachment. */
+  attachProvider?(
+    workspaceId: string,
+    nodeId: string,
+    providerName: string,
+    instanceId: string,
+    connectionId: string,
+  ): void;
+
+  /** Drop a provider's attachment (provider-scoped deregister / prune). */
+  detachProvider(workspaceId: string, nodeId: string, providerName: string): void;
 
   /** Force-close all sockets for a node. */
   disconnectNode(workspaceId: string, nodeId: string): Promise<void>;

--- a/packages/engine/src/routes/deliveryRouting.ts
+++ b/packages/engine/src/routes/deliveryRouting.ts
@@ -30,6 +30,7 @@ type DeliveryTarget = {
   nodeRole: string | null;
   deliveryAdapter: string | null;
   deliveryConfig: Record<string, unknown> | null;
+  providerName?: string;
 };
 
 const HTTP_PUSH_RETRY_DELAY_MS = 30_000;
@@ -115,6 +116,7 @@ async function resolveLiveLocations(
       nodeRole: nodes.role,
       deliveryAdapter: nodes.deliveryAdapter,
       deliveryConfig: nodes.deliveryConfig,
+      providerName: agents.providerName,
     })
     .from(agentNodeBindings)
     .innerJoin(agents, and(
@@ -140,6 +142,7 @@ async function resolveLiveLocations(
       nodeRole: binding.nodeRole,
       deliveryAdapter: binding.deliveryAdapter,
       deliveryConfig: binding.deliveryConfig as Record<string, unknown> | null,
+      providerName: binding.providerName,
     });
   }
 
@@ -152,6 +155,7 @@ async function resolveLiveLocations(
       nodeRole: nodes.role,
       deliveryAdapter: nodes.deliveryAdapter,
       deliveryConfig: nodes.deliveryConfig,
+      providerName: agents.providerName,
     })
     .from(agents)
     .leftJoin(nodes, eq(agents.locationNodeId, nodes.id))
@@ -166,6 +170,7 @@ async function resolveLiveLocations(
       nodeRole: row.nodeRole ?? (row.locationNodeId ? 'broker' : null),
       deliveryAdapter: row.deliveryAdapter ?? (row.locationNodeId ? 'ws.node.v1' : null),
       deliveryConfig: row.deliveryConfig as Record<string, unknown> | null,
+      providerName: row.providerName,
     });
   }
 
@@ -410,7 +415,8 @@ async function routeOneDeliveryOutcome(
   const deliveryAdapter = normalizeDeliveryAdapter(target?.deliveryAdapter ?? delivery.deliveryAdapter, nodeKind);
 
   if (locationType === 'via_node' && locationNodeId && deliveryAdapter === 'ws.node.v1') {
-    const sent = await ctx.engine.nodeConnections.sendToNode(ctx.workspaceId, locationNodeId, buildDeliverFrame({
+    const providerName = liveLocation?.providerName ?? recordedTarget?.providerName ?? 'default';
+    const sent = await ctx.engine.nodeConnections.sendToProvider(ctx.workspaceId, locationNodeId, providerName, buildDeliverFrame({
       delivery_id: delivery.id,
       agent_id: delivery.agentId,
       agent: delivery.agentName,

--- a/packages/engine/src/routes/node.ts
+++ b/packages/engine/src/routes/node.ts
@@ -1,9 +1,9 @@
 import { Hono } from 'hono';
 import { z } from 'zod';
 import type { AppEnv } from '../env.js';
-import { requireWorkspaceRead, requireWorkspaceKey } from '../middleware/auth.js';
+import { requireAuth, requireWorkspaceRead, requireWorkspaceKey } from '../middleware/auth.js';
 import { rateLimit } from '../middleware/rateLimit.js';
-import { errorResponse } from '../lib/httpError.js';
+import { asCodedError, errorResponse } from '../lib/httpError.js';
 import { isSafeExternalUrl } from '../lib/ssrf.js';
 import {
   jsonCreated,
@@ -12,8 +12,15 @@ import {
   jsonNoContent,
   jsonOk,
   parseJsonBody,
+  parseOptionalJsonBody,
 } from '../lib/httpResponse.js';
 import * as nodeEngine from '../engine/node.js';
+import * as actionEngine from '../engine/action.js';
+import { sendNodeDeliveriesToAgents } from '../engine/nodeDeliver.js';
+import { fanoutToWorkspace } from './fanout.js';
+import { runInBackground } from './background.js';
+import { sendWebhookEvent } from './webhookOutbox.js';
+import { emitServerEvent } from '../lib/serverTelemetry.js';
 import {
   getObserverTokenFromContext,
   normalizeObserverFilters,
@@ -69,6 +76,10 @@ const bindAgentSchema = z.object({
   agent_name: z.string().min(1),
   session_ref: z.string().nullable().optional(),
   priority: z.number().int().optional(),
+});
+
+const invokeNodeActionSchema = z.object({
+  input: z.record(z.string(), z.unknown()).optional(),
 });
 
 function normalizeDelivery(kind: z.infer<typeof nodeKindSchema>, delivery: Record<string, unknown> | null | undefined) {
@@ -237,6 +248,97 @@ nodeRoutes.delete('/nodes/:name/agents/:agentName', requireWorkspaceKey, rateLim
     if (!deleted) {
       return jsonNotFound(c, 'node_agent_binding_not_found', 'Node agent binding not found');
     }
+    return jsonNoContent(c);
+  } catch (err: unknown) {
+    return errorResponse(c, err);
+  }
+});
+
+// POST /v1/nodes/:node/actions/:name/invoke - node-addressed action invoke
+nodeRoutes.post('/nodes/:node/actions/:name/invoke', requireAuth, rateLimit, async (c) => {
+  try {
+    const db = c.get('db');
+    const workspace = c.get('workspace');
+    const agent = c.get('agent');
+    if (!agent) {
+      return jsonError(c, 'agent_token_required', 'Agent token required to invoke actions', 403);
+    }
+    const node = await nodeEngine.getNodeByName(db, workspace.id, c.req.param('node'));
+    if (!node) {
+      return jsonNotFound(c, 'node_not_found', 'Node not found');
+    }
+    const parsed = await parseOptionalJsonBody(c, invokeNodeActionSchema, 'invalid invocation body');
+    if (!parsed.ok) {
+      return parsed.response;
+    }
+
+    const { nodeConnections } = c.get('engine');
+    const actionName = c.req.param('name');
+    const result = await actionEngine.invokeNodeAction(
+      db,
+      workspace.id,
+      node.id,
+      actionName,
+      { input: parsed.data.input, caller_id: agent.id, caller_name: agent.name },
+      { nodeConnections },
+    );
+
+    const eventData = {
+      invocation_id: result.invocation_id,
+      action_name: result.action_name,
+      caller_name: agent.name,
+      handler_agent_id: result.handler_agent_id,
+      handler_node_id: result.handler_node_id,
+    };
+    await sendWebhookEvent(c, { type: 'action.invoked', workspaceId: workspace.id, data: eventData });
+    emitServerEvent(c, workspace.id, 'relaycast_server_action_invoked', {
+      action_name: result.action_name,
+      invocation_id: result.invocation_id,
+      caller_agent_id: agent.id,
+    });
+    runInBackground(c, fanoutToWorkspace(c, 'action.invoked', eventData), 'fanout action.invoked');
+    return jsonCreated(c, result);
+  } catch (err: unknown) {
+    const error = asCodedError(err);
+    if (error.code === 'action_denied') {
+      const workspace = c.get('workspace');
+      const agent = c.get('agent')!;
+      const eventData = { action_name: c.req.param('name'), caller_name: agent.name, error: error.message };
+      runInBackground(
+        c,
+        sendNodeDeliveriesToAgents(
+          {
+            db: c.get('db'),
+            nodeConnections: c.get('engine').nodeConnections,
+            environment: c.get('engine').config?.environment,
+            httpPushProxy: c.get('engine').config?.httpPushProxy,
+            workspaceId: workspace.id,
+          },
+          {
+            agentIds: [agent.id],
+            event: 'action.denied',
+            eventKey: `${c.req.param('name')}:${agent.id}`,
+            data: eventData,
+            messageId: c.req.param('name'),
+          },
+        ),
+        'node deliver action.denied',
+      );
+    }
+    return errorResponse(c, error);
+  }
+});
+
+// DELETE /v1/nodes/:node/providers/:name - remove a provider's attachment + manifest
+nodeRoutes.delete('/nodes/:node/providers/:name', requireWorkspaceKey, rateLimit, async (c) => {
+  try {
+    const db = c.get('db');
+    const workspace = c.get('workspace');
+    const node = await nodeEngine.getNodeByName(db, workspace.id, c.req.param('node'));
+    if (!node) {
+      return jsonNotFound(c, 'node_not_found', 'Node not found');
+    }
+    await nodeEngine.deregisterProvider(db, c.get('engine').nodeConnections, workspace.id, node.id, c.req.param('name'));
     return jsonNoContent(c);
   } catch (err: unknown) {
     return errorResponse(c, err);

--- a/packages/engine/src/routes/node.ts
+++ b/packages/engine/src/routes/node.ts
@@ -324,6 +324,8 @@ nodeRoutes.post('/nodes/:node/actions/:name/invoke', requireAuth, rateLimit, asy
         ),
         'node deliver action.denied',
       );
+      await sendWebhookEvent(c, { type: 'action.denied', workspaceId: workspace.id, data: eventData });
+      runInBackground(c, fanoutToWorkspace(c, 'action.denied', eventData), 'fanout action.denied');
     }
     return errorResponse(c, error);
   }

--- a/packages/types/src/__tests__/sdk-openapi-sync.test.ts
+++ b/packages/types/src/__tests__/sdk-openapi-sync.test.ts
@@ -39,6 +39,11 @@ const NON_SDK_OPENAPI_PATHS = new Set([
   // Observer-plane backfill: consumed by observer clients (agent-relay SDK
   // observer mode, pear) with observer tokens, not by the agent SDKs.
   '/v1/workspace/events',
+  // Node provider control: node-addressed invoke and provider removal. The
+  // node-provider client that consumes these lands with the SDK step of the
+  // node-providers work; the engine surface ships first.
+  '/v1/nodes/{param}/actions/{param}/invoke',
+  '/v1/nodes/{param}/providers/{param}',
 ]);
 
 const CORE_SDK_PATHS = new Set([

--- a/packages/types/src/fleet-wire.ts
+++ b/packages/types/src/fleet-wire.ts
@@ -39,14 +39,55 @@ const FleetResponseEnvelopeFields = {
   id: z.string(),
 } as const;
 
+/**
+ * Canonical capability kinds. `action` capabilities are invokable handlers the
+ * engine materializes and dispatches to the registering provider; `capacity`
+ * capabilities (`spawn:<harness>`, `release`) describe what a node can run and
+ * feed placement and `ctx.spawnAgent` delegation without being materialized.
+ * Registrations that omit `kind` (or carry a legacy value) are classified by
+ * name: `spawn:*` and `release` are capacity, everything else is an action.
+ */
+export const FleetCapabilityKindSchema = z.enum(['action', 'capacity']);
+export type FleetCapabilityKind = z.infer<typeof FleetCapabilityKindSchema>;
+
 export const FleetCapabilitySchema = z
   .object({
     name: z.string(),
     kind: z.string().optional(),
+    /** `action` capability opts into a workspace-global alias claiming this name. */
+    global: z.boolean().optional(),
+    /** `action` capability opts into the offline queue when its provider is down. */
+    queue: z.boolean().optional(),
     metadata: z.record(z.string(), FleetWireJsonValueSchema).optional(),
   })
   .strict();
 export type FleetCapability = z.infer<typeof FleetCapabilitySchema>;
+
+/**
+ * Provider identity carried on connection-scoped node frames. `name` is the
+ * provider's stable identity — persistence, capability-conflict checks, and
+ * routing key on it. `instance_id` is the connection epoch: re-registering the
+ * same name with a new instance replaces the previous attachment (reconnect),
+ * while a name whose current instance is still connected is rejected.
+ */
+export const FleetProviderIdentitySchema = z
+  .object({
+    name: z.string(),
+    instance_id: z.string(),
+  })
+  .strict();
+export type FleetProviderIdentity = z.infer<typeof FleetProviderIdentitySchema>;
+
+/** Per-capability outcome reported in a `node.register` reply. */
+export const FleetCapabilityAcceptanceSchema = z
+  .object({
+    name: z.string(),
+    kind: FleetCapabilityKindSchema,
+    accepted: z.boolean(),
+    reason: z.string().optional(),
+  })
+  .strict();
+export type FleetCapabilityAcceptance = z.infer<typeof FleetCapabilityAcceptanceSchema>;
 
 function forbidOwnProperty(property: string) {
   return (message: object, ctx: z.RefinementCtx): void => {
@@ -66,10 +107,16 @@ export const FleetNodeRegisterMessageSchema = z
     type: z.literal('node.register'),
     name: z.string(),
     node_id: z.string(),
+    // Absent means the synthetic `default` provider (the current broker), keyed
+    // to the connection epoch — additive migration for pre-provider clients.
+    provider: FleetProviderIdentitySchema.optional(),
+    // The registering provider's own capabilities (fully replaces its prior set).
     capabilities: z.array(FleetCapabilitySchema),
+    // Provider-level capacity; the node figure is the aggregate across providers.
     max_agents: z.number().int().nonnegative(),
     tags: z.array(z.string()),
     version: z.string(),
+    machine_id: z.string().optional(),
     // Absent and null both mean a fresh node with no resume cursor.
     resume_cursor: z.string().nullable().optional(),
   })
@@ -80,6 +127,10 @@ export const FleetNodeHeartbeatMessageSchema = z
   .object({
     ...FleetRequestEnvelopeFields,
     type: z.literal('node.heartbeat'),
+    // Heartbeats are provider-scoped by connection; absent provider means the
+    // synthetic `default` provider. Load/active_agents/handlers_live describe
+    // the sending provider, and the node figures aggregate across providers.
+    provider: FleetProviderIdentitySchema.optional(),
     load: z.number().finite().nonnegative(),
     active_agents: z.number().int().nonnegative(),
     handlers_live: z.boolean(),
@@ -105,6 +156,9 @@ export const FleetNodeDeregisterMessageSchema = z
   .object({
     ...FleetRequestEnvelopeFields,
     type: z.literal('node.deregister'),
+    // Removes this provider's attachment and persisted capability set; absent
+    // provider means the synthetic `default` provider.
+    provider: FleetProviderIdentitySchema.optional(),
   })
   .strict();
 export type FleetNodeDeregisterMessage = z.infer<typeof FleetNodeDeregisterMessageSchema>;
@@ -198,6 +252,19 @@ export const AgentRegisterReplyDataSchema = z
   })
   .strict();
 export type AgentRegisterReplyData = z.infer<typeof AgentRegisterReplyDataSchema>;
+
+/**
+ * `node.register` reply data. Carries the resolved provider identity and
+ * per-capability acceptance alongside the node's public descriptor (which is
+ * passed through as additional fields).
+ */
+export const NodeRegisterReplyDataSchema = z
+  .object({
+    provider: FleetProviderIdentitySchema,
+    accepted_capabilities: z.array(FleetCapabilityAcceptanceSchema),
+  })
+  .passthrough();
+export type NodeRegisterReplyData = z.infer<typeof NodeRegisterReplyDataSchema>;
 
 export const FleetReplyMessageSchema = z
   .object({


### PR DESCRIPTION
## What this is

The engine's node plane is now multi-provider. A node hosts N providers — the broker plus capability providers — each a socket that registers a subset of the node's capabilities and executes their invokes. The broker is one provider among several.

### Wire protocol (`@relaycast/types` fleet-wire)
- `node.register`, `node.heartbeat`, and `node.deregister` carry `provider: { name, instance_id }`. `name` is the stable identity (persistence, conflict, routing); `instance_id` is the connection epoch.
- `FleetCapability` formalizes `kind: 'action' | 'capacity'` (legacy/absent kinds are inferred by name — `spawn:*`/`release` are capacity), plus per-capability `global` and `queue` flags.
- The `node.register` reply carries the resolved provider identity and per-capability acceptance.

### Engine
- **Provider attachment.** N sockets per node, keyed by provider name. Re-registering a name with a new `instance_id` replaces a dropped attachment (reconnect); a duplicate while the current instance is still live is rejected (`provider_instance_conflict`).
- **Synthetic default provider.** A registration with no `provider` field keys to the reserved `{ name: "default", instance_id: <connection id> }`, used uniformly for heartbeats, routing, and persistence — the current broker keeps working unchanged (additive migration).
- **Per-provider persistence.** A new `node_providers` table stores each provider's capability set, instance, liveness, capacity, and load. Capabilities persist keyed by provider name so an offline node still shows its full manifest; a provider's registration fully replaces its previous set; provider-scoped `node.deregister` and `DELETE /v1/nodes/:node/providers/:name` remove it.
- **Node-scoped actions.** Actions are unique per `(node, name)` with a recorded handler provider. Only `action`-kind capabilities materialize; `capacity` feeds placement. Node-addressed invoke lives at `POST /v1/nodes/:node/actions/:name/invoke`. A node action may claim a workspace-global alias (`global: true`, loud conflict); the default provider's actions claim the workspace name first-writer-wins so triggers and `POST /v1/actions/:name/invoke` keep resolving them.
- **Spawn shadowing.** A registered `action` named `spawn:<harness>` shadows native capacity on its node and dispatches to the shadow provider; it never silently falls back to native capacity, even when the shadow's provider is offline (fail fast / queue). Capacity-direct delegation (`ctx.spawnAgent`) bypasses the shadow so a handler that delegates cannot recurse.
- **Per-provider liveness.** A capability is live iff its provider's connection is up and its heartbeat reports `handlers_live`. An invoke to an offline provider fails fast (`handler_unavailable`) unless the capability opted into `queue`.
- **Deliver routing.** `deliver` frames route to the provider whose connection registered the target agent (`agent.register` binds agent → provider).
- **Node record.** Adds a `machine_id` column for grouping; the `nodes` row's capability manifest, capacity, load, and liveness are aggregates over its providers.

## Breaking schema changes

Migration `0028_node_providers.sql` (data-breaking, acceptable pre-launch):
- New `node_providers` table; existing broker nodes are backfilled as a `default` provider carrying their manifest.
- `nodes.machine_id`; `agents.provider_name` (default `default`); `actions.handler_provider`, `actions.is_global`, `actions.queue`.
- Drops `actions_workspace_name_unique`; adds node-scoped `(workspace, handler_node_id, name)` uniqueness plus partial unique indexes for agent-hosted names and global aliases. Existing node-hosted actions are backfilled as `default`-provider global aliases so their invocation keeps resolving.

## Migration behavior

The synthetic `default` provider is the only compatibility affordance (spec-mandated). Node identity, enrollment/tokens, heartbeat cadence, and delivery semantics are unchanged. The current Rust broker connects with no `provider` field, is keyed as `default`, and works without changes.

## Tests

`npx turbo build test lint --filter=@relaycast/engine --filter=@relaycast/types` — all green.
- Engine: 245 tests (28 files), including a new `nodeProviders.test.ts` (12 cases) covering provider attach/replace/duplicate-reject, synthetic default provider, action-name conflict rejection, kind-based materialization, node-addressed invoke routing to the right provider socket, spawn shadowing + no-silent-bypass, per-provider liveness, offline-queue opt-in, deliver routing by agent binding, provider deregister, capability-set pruning, and provider DELETE.
- Types: 161 tests. Full repo `turbo test`: 18/18 tasks pass.

## Resolved spec ambiguities

- **`handlers_live` stays a provider-level boolean** rather than a per-capability name list. Keeping the existing heartbeat framing (§7 "heartbeat framing does not change") lets the current broker keep heartbeating during the additive transition; a live provider's registered capabilities are all considered live.
- **Capacity reservation for spawn stays on the `nodes` aggregate** (there is exactly one capacity provider, the broker/`default`, during the transition). Per-provider `max_agents` is stored on `node_providers` and aggregated; per-provider reservation across multiple capacity providers is follow-up.
- **`ctx.spawnAgent` (capacity-direct) is implemented as an engine surface** (`dispatchCapacitySpawn`, bypasses shadowing) but not wired to a public route here — its consumer is the node-provider SDK client (step 2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/AgentWorkforce/relaycast/pull/242?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

