### PR TITLE
SDKs: node provider clients (TS, Python, Swift)

### DIFF
--- a/packages/engine/src/__tests__/conformance/nodeProviders.test.ts
+++ b/packages/engine/src/__tests__/conformance/nodeProviders.test.ts
@@ -498,6 +498,29 @@ describe('node providers', () => {
     expect(py.sock.ofType('error').at(-1)).toMatchObject({ id: 'bad-channel', code: 'channel_not_found' });
   });
 
+  it('scopes node.message attribution to the node workspace, rejecting a cross-workspace from', async () => {
+    // The `from` agent resolves only within the authenticated node's workspace,
+    // so a node token cannot post as an agent that exists in another workspace.
+    const other = await createWorkspace(stack.app, 'np-msg-other-ws');
+    await registerAgent(stack.app, other.workspaceKey, 'outsider');
+
+    const ws = await createWorkspace(stack.app, 'np-msg-scope');
+    await enrollNode(ws, 'node_a', 'alpha');
+    const py = await attachProvider(ws.workspaceId, 'node_a', 'alpha', 'py', [{ name: 'run-etl', kind: 'action' }]);
+
+    await py.handle.handleMessage(JSON.stringify({
+      v: 1, id: 'cross-ws', type: 'node.message', to: 'general', from: 'outsider', text: 'hi',
+    }));
+    expect(py.sock.ofType('error').at(-1)).toMatchObject({ id: 'cross-ws', code: 'agent_not_found' });
+
+    // No message leaked into the other workspace under the outsider's name.
+    const leaked = await stack.runtime.handle.db
+      .select({ id: messages.id })
+      .from(messages)
+      .where(eq(messages.workspaceId, other.workspaceId));
+    expect(leaked).toHaveLength(0);
+  });
+
   it('removes a provider through DELETE /v1/nodes/:node/providers/:name', async () => {
     const ws = await createWorkspace(stack.app, 'np-delete');
     await enrollNode(ws, 'node_a', 'alpha');

--- a/packages/engine/src/__tests__/conformance/nodeProviders.test.ts
+++ b/packages/engine/src/__tests__/conformance/nodeProviders.test.ts
@@ -9,7 +9,7 @@ import {
   contextUpdatesOfType,
   type TestStack,
 } from './harness.js';
-import { actions, agents, nodeProviders, nodes } from '../../db/schema.js';
+import { actions, agents, messages, nodeProviders, nodes, workspaceEvents } from '../../db/schema.js';
 
 type Cap = { name: string; kind?: string; global?: boolean; queue?: boolean };
 
@@ -421,6 +421,81 @@ describe('node providers', () => {
       .from(actions)
       .where(eq(actions.workspaceId, ws.workspaceId));
     expect(actionRows.map((a) => a.name).sort()).toEqual(['run-etl']);
+  });
+
+  it('routes a node.spawn frame capacity-direct, bypassing any spawn shadow', async () => {
+    const ws = await createWorkspace(stack.app, 'np-node-spawn');
+    await enrollNode(ws, 'node_a', 'alpha');
+    // Broker provider offers native spawn:claude capacity.
+    const broker = await attachProvider(ws.workspaceId, 'node_a', 'alpha', 'default', [{ name: 'spawn:claude', kind: 'capacity' }]);
+    // A policy provider shadows it with a spawn:claude action, and is where the
+    // handler runs: its ctx.spawnAgent must delegate to broker capacity, never
+    // re-enter its own shadow.
+    const policy = await attachProvider(ws.workspaceId, 'node_a', 'alpha', 'policy', [{ name: 'spawn:claude', kind: 'action' }]);
+
+    await policy.handle.handleMessage(JSON.stringify({
+      v: 1,
+      id: 'spawn-1',
+      type: 'node.spawn',
+      input: { cli: 'claude', name: 'worker-1' },
+    }));
+
+    // Delegated to the broker's native capacity...
+    expect(broker.sock.ofType('action.invoke').at(-1)).toMatchObject({ action: 'spawn:claude' });
+    // ...not back into the policy provider's shadow action.
+    expect(policy.sock.ofType('action.invoke')).toHaveLength(0);
+    const reply = policy.sock.ofType('reply').at(-1) as { ok?: boolean; id?: string; data?: { invocation_id?: string } };
+    expect(reply).toMatchObject({ ok: true, id: 'spawn-1' });
+    expect(typeof reply.data?.invocation_id).toBe('string');
+  });
+
+  it('posts a channel message from a node.message frame and fans out to observers', async () => {
+    const ws = await createWorkspace(stack.app, 'np-node-message');
+    await registerAgent(stack.app, ws.workspaceKey, 'reporter');
+    await enrollNode(ws, 'node_a', 'alpha');
+    const py = await attachProvider(ws.workspaceId, 'node_a', 'alpha', 'py', [{ name: 'run-etl', kind: 'action' }]);
+
+    await py.handle.handleMessage(JSON.stringify({
+      v: 1,
+      id: 'msg-1',
+      type: 'node.message',
+      to: 'general',
+      from: 'reporter',
+      text: 'etl finished',
+    }));
+
+    const reply = py.sock.ofType('reply').at(-1) as { ok?: boolean; id?: string; data?: { id?: string; text?: string } };
+    expect(reply).toMatchObject({ ok: true, id: 'msg-1' });
+    expect(reply.data?.text).toBe('etl finished');
+
+    const rows = await stack.runtime.handle.db
+      .select({ body: messages.body, agentId: messages.agentId })
+      .from(messages)
+      .where(eq(messages.workspaceId, ws.workspaceId));
+    expect(rows.map((r) => r.body)).toContain('etl finished');
+
+    const events = await stack.runtime.handle.db
+      .select({ type: workspaceEvents.type })
+      .from(workspaceEvents)
+      .where(and(eq(workspaceEvents.workspaceId, ws.workspaceId), eq(workspaceEvents.type, 'message.created')));
+    expect(events.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('rejects a node.message from an unknown agent or to an unknown channel', async () => {
+    const ws = await createWorkspace(stack.app, 'np-node-message-errors');
+    await registerAgent(stack.app, ws.workspaceKey, 'reporter');
+    await enrollNode(ws, 'node_a', 'alpha');
+    const py = await attachProvider(ws.workspaceId, 'node_a', 'alpha', 'py', [{ name: 'run-etl', kind: 'action' }]);
+
+    await py.handle.handleMessage(JSON.stringify({
+      v: 1, id: 'bad-agent', type: 'node.message', to: 'general', from: 'ghost', text: 'hi',
+    }));
+    expect(py.sock.ofType('error').at(-1)).toMatchObject({ id: 'bad-agent', code: 'agent_not_found' });
+
+    await py.handle.handleMessage(JSON.stringify({
+      v: 1, id: 'bad-channel', type: 'node.message', to: 'nowhere', from: 'reporter', text: 'hi',
+    }));
+    expect(py.sock.ofType('error').at(-1)).toMatchObject({ id: 'bad-channel', code: 'channel_not_found' });
   });
 
   it('removes a provider through DELETE /v1/nodes/:node/providers/:name', async () => {

--- a/packages/engine/src/__tests__/conformance/nodeProviders.test.ts
+++ b/packages/engine/src/__tests__/conformance/nodeProviders.test.ts
@@ -9,7 +9,7 @@ import {
   contextUpdatesOfType,
   type TestStack,
 } from './harness.js';
-import { actions, agents, messages, nodeProviders, nodes, workspaceEvents } from '../../db/schema.js';
+import { actions, agents, nodeProviders, nodes } from '../../db/schema.js';
 
 type Cap = { name: string; kind?: string; global?: boolean; queue?: boolean };
 
@@ -456,76 +456,80 @@ describe('node providers', () => {
     expect(reply.data?.handler_node_id).toBe('node_a');
   });
 
-  it('posts a channel message from a node.message frame and fans out to observers', async () => {
-    const ws = await createWorkspace(stack.app, 'np-node-message');
-    await registerAgent(stack.app, ws.workspaceKey, 'reporter');
-    await enrollNode(ws, 'node_a', 'alpha');
+  // ctx.sendMessage posts through the canonical message route with a node token
+  // and a required `from`, so node-attributed posts get delivery routing,
+  // observer events, and triggers by construction (no parallel posting path).
+  async function enrollNodeWithToken(ws: { workspaceKey: string }, nodeId: string, name: string): Promise<string> {
+    const res = await stack.app.request('/v1/nodes', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', authorization: `Bearer ${ws.workspaceKey}` },
+      body: JSON.stringify({ node_id: nodeId, name, role: 'broker', capabilities: [], max_agents: 4, tags: ['test'], version: 'v0' }),
+    });
+    expect(res.status).toBe(201);
+    return (await res.json() as { data: { token: string } }).data.token;
+  }
+
+  function postMessage(token: string, channel: string, body: Record<string, unknown>) {
+    return stack.app.request(`/v1/channels/${channel}/messages`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', authorization: `Bearer ${token}` },
+      body: JSON.stringify(body),
+    });
+  }
+
+  it('posts a node-token message attributed to `from`, delivered to node-hosted recipients', async () => {
+    const ws = await createWorkspace(stack.app, 'nt-msg');
+    await registerAgent(stack.app, ws.workspaceKey, 'poster');
+    const nodeToken = await enrollNodeWithToken(ws, 'node_a', 'alpha');
     const py = await attachProvider(ws.workspaceId, 'node_a', 'alpha', 'py', [{ name: 'run-etl', kind: 'action' }]);
+    // A worker agent hosted by py joins #general, so it is a delivery recipient.
+    await py.handle.handleMessage(JSON.stringify({ v: 1, id: 'agent-1', type: 'agent.register', name: 'worker', session_ref: 'pty://py/worker' }));
+    py.sock.received.length = 0;
 
-    await py.handle.handleMessage(JSON.stringify({
-      v: 1,
-      id: 'msg-1',
-      type: 'node.message',
-      to: 'general',
-      from: 'reporter',
-      text: 'etl finished',
-    }));
+    const res = await postMessage(nodeToken, 'general', { text: 'etl finished', from: 'poster' });
+    expect(res.status).toBe(201);
+    const body = await res.json() as { data: { agent_name: string; text: string } };
+    expect(body.data).toMatchObject({ agent_name: 'poster', text: 'etl finished' });
 
-    const reply = py.sock.ofType('reply').at(-1) as { ok?: boolean; id?: string; data?: { id?: string; text?: string } };
-    expect(reply).toMatchObject({ ok: true, id: 'msg-1' });
-    expect(reply.data?.text).toBe('etl finished');
-
-    const rows = await stack.runtime.handle.db
-      .select({ body: messages.body, agentId: messages.agentId })
-      .from(messages)
-      .where(eq(messages.workspaceId, ws.workspaceId));
-    expect(rows.map((r) => r.body)).toContain('etl finished');
-
-    const events = await stack.runtime.handle.db
-      .select({ type: workspaceEvents.type })
-      .from(workspaceEvents)
-      .where(and(eq(workspaceEvents.workspaceId, ws.workspaceId), eq(workspaceEvents.type, 'message.created')));
-    expect(events.length).toBeGreaterThanOrEqual(1);
+    await new Promise((r) => setTimeout(r, 60));
+    // Delivery routing came for free from the canonical route.
+    expect(deliverFramesOfType(py.sock, 'message.created').length).toBeGreaterThanOrEqual(1);
   });
 
-  it('rejects a node.message from an unknown agent or to an unknown channel', async () => {
-    const ws = await createWorkspace(stack.app, 'np-node-message-errors');
-    await registerAgent(stack.app, ws.workspaceKey, 'reporter');
-    await enrollNode(ws, 'node_a', 'alpha');
-    const py = await attachProvider(ws.workspaceId, 'node_a', 'alpha', 'py', [{ name: 'run-etl', kind: 'action' }]);
-
-    await py.handle.handleMessage(JSON.stringify({
-      v: 1, id: 'bad-agent', type: 'node.message', to: 'general', from: 'ghost', text: 'hi',
-    }));
-    expect(py.sock.ofType('error').at(-1)).toMatchObject({ id: 'bad-agent', code: 'agent_not_found' });
-
-    await py.handle.handleMessage(JSON.stringify({
-      v: 1, id: 'bad-channel', type: 'node.message', to: 'nowhere', from: 'reporter', text: 'hi',
-    }));
-    expect(py.sock.ofType('error').at(-1)).toMatchObject({ id: 'bad-channel', code: 'channel_not_found' });
+  it('requires `from` on a node-token message', async () => {
+    const ws = await createWorkspace(stack.app, 'nt-msg-from-required');
+    const nodeToken = await enrollNodeWithToken(ws, 'node_a', 'alpha');
+    const res = await postMessage(nodeToken, 'general', { text: 'hi' });
+    expect(res.status).toBe(400);
+    expect((await res.json() as { error: { code: string } }).error.code).toBe('from_required');
   });
 
-  it('scopes node.message attribution to the node workspace, rejecting a cross-workspace from', async () => {
-    // The `from` agent resolves only within the authenticated node's workspace,
-    // so a node token cannot post as an agent that exists in another workspace.
-    const other = await createWorkspace(stack.app, 'np-msg-other-ws');
+  it('rejects a node-token message whose `from` agent does not exist', async () => {
+    const ws = await createWorkspace(stack.app, 'nt-msg-unknown');
+    const nodeToken = await enrollNodeWithToken(ws, 'node_a', 'alpha');
+    const res = await postMessage(nodeToken, 'general', { text: 'hi', from: 'ghost' });
+    expect(res.status).toBe(404);
+    expect((await res.json() as { error: { code: string } }).error.code).toBe('agent_not_found');
+  });
+
+  it('scopes node-token `from` to the node workspace, rejecting a cross-workspace agent', async () => {
+    const other = await createWorkspace(stack.app, 'nt-msg-other-ws');
     await registerAgent(stack.app, other.workspaceKey, 'outsider');
 
-    const ws = await createWorkspace(stack.app, 'np-msg-scope');
-    await enrollNode(ws, 'node_a', 'alpha');
-    const py = await attachProvider(ws.workspaceId, 'node_a', 'alpha', 'py', [{ name: 'run-etl', kind: 'action' }]);
+    const ws = await createWorkspace(stack.app, 'nt-msg-scope');
+    const nodeToken = await enrollNodeWithToken(ws, 'node_a', 'alpha');
+    const res = await postMessage(nodeToken, 'general', { text: 'hi', from: 'outsider' });
+    expect(res.status).toBe(404);
+    expect((await res.json() as { error: { code: string } }).error.code).toBe('agent_not_found');
+  });
 
-    await py.handle.handleMessage(JSON.stringify({
-      v: 1, id: 'cross-ws', type: 'node.message', to: 'general', from: 'outsider', text: 'hi',
-    }));
-    expect(py.sock.ofType('error').at(-1)).toMatchObject({ id: 'cross-ws', code: 'agent_not_found' });
-
-    // No message leaked into the other workspace under the outsider's name.
-    const leaked = await stack.runtime.handle.db
-      .select({ id: messages.id })
-      .from(messages)
-      .where(eq(messages.workspaceId, other.workspaceId));
-    expect(leaked).toHaveLength(0);
+  it('rejects `from` on an agent-token message', async () => {
+    const ws = await createWorkspace(stack.app, 'nt-msg-agent-from');
+    const agent = await registerAgent(stack.app, ws.workspaceKey, 'poster');
+    const other = await registerAgent(stack.app, ws.workspaceKey, 'other');
+    const res = await postMessage(agent.token, 'general', { text: 'hi', from: other.name });
+    expect(res.status).toBe(400);
+    expect((await res.json() as { error: { code: string } }).error.code).toBe('from_not_allowed');
   });
 
   it('removes a provider through DELETE /v1/nodes/:node/providers/:name', async () => {

--- a/packages/engine/src/__tests__/conformance/nodeProviders.test.ts
+++ b/packages/engine/src/__tests__/conformance/nodeProviders.test.ts
@@ -423,15 +423,19 @@ describe('node providers', () => {
     expect(actionRows.map((a) => a.name).sort()).toEqual(['run-etl']);
   });
 
-  it('routes a node.spawn frame capacity-direct, bypassing any spawn shadow', async () => {
+  it('routes a node.spawn frame to the connection\'s own node capacity, bypassing any spawn shadow', async () => {
     const ws = await createWorkspace(stack.app, 'np-node-spawn');
     await enrollNode(ws, 'node_a', 'alpha');
-    // Broker provider offers native spawn:claude capacity.
+    // node_a: broker provider offers native spawn:claude capacity.
     const broker = await attachProvider(ws.workspaceId, 'node_a', 'alpha', 'default', [{ name: 'spawn:claude', kind: 'capacity' }]);
     // A policy provider shadows it with a spawn:claude action, and is where the
     // handler runs: its ctx.spawnAgent must delegate to broker capacity, never
     // re-enter its own shadow.
     const policy = await attachProvider(ws.workspaceId, 'node_a', 'alpha', 'policy', [{ name: 'spawn:claude', kind: 'action' }]);
+    // A second node with its own spawn capacity: a node.spawn from node_a must
+    // never reach it — a node credential cannot direct a spawn at another node.
+    await enrollNode(ws, 'node_b', 'beta');
+    const otherBroker = await attachProvider(ws.workspaceId, 'node_b', 'beta', 'default', [{ name: 'spawn:claude', kind: 'capacity' }]);
 
     await policy.handle.handleMessage(JSON.stringify({
       v: 1,
@@ -440,13 +444,16 @@ describe('node providers', () => {
       input: { cli: 'claude', name: 'worker-1' },
     }));
 
-    // Delegated to the broker's native capacity...
+    // Delegated to node_a's broker capacity...
     expect(broker.sock.ofType('action.invoke').at(-1)).toMatchObject({ action: 'spawn:claude' });
-    // ...not back into the policy provider's shadow action.
+    // ...not back into the policy provider's shadow action...
     expect(policy.sock.ofType('action.invoke')).toHaveLength(0);
-    const reply = policy.sock.ofType('reply').at(-1) as { ok?: boolean; id?: string; data?: { invocation_id?: string } };
+    // ...and never crossing to the other node.
+    expect(otherBroker.sock.ofType('action.invoke')).toHaveLength(0);
+    const reply = policy.sock.ofType('reply').at(-1) as { ok?: boolean; id?: string; data?: { invocation_id?: string; handler_node_id?: string } };
     expect(reply).toMatchObject({ ok: true, id: 'spawn-1' });
     expect(typeof reply.data?.invocation_id).toBe('string');
+    expect(reply.data?.handler_node_id).toBe('node_a');
   });
 
   it('posts a channel message from a node.message frame and fans out to observers', async () => {

--- a/packages/engine/src/__tests__/conformance/nodeProviders.test.ts
+++ b/packages/engine/src/__tests__/conformance/nodeProviders.test.ts
@@ -491,7 +491,10 @@ describe('node providers', () => {
     const body = await res.json() as { data: { agent_name: string; text: string } };
     expect(body.data).toMatchObject({ agent_name: 'poster', text: 'etl finished' });
 
-    await new Promise((r) => setTimeout(r, 60));
+    // Poll for the async fanout instead of a fixed sleep, to avoid CI flakiness.
+    for (let i = 0; i < 50 && deliverFramesOfType(py.sock, 'message.created').length === 0; i++) {
+      await new Promise((r) => setTimeout(r, 10));
+    }
     // Delivery routing came for free from the canonical route.
     expect(deliverFramesOfType(py.sock, 'message.created').length).toBeGreaterThanOrEqual(1);
   });

--- a/packages/engine/src/auth/tokenKind.ts
+++ b/packages/engine/src/auth/tokenKind.ts
@@ -65,7 +65,7 @@ export function getAuthTokenKind(token: string): AuthTokenKind | undefined {
   return parseAuthToken(token)?.kind;
 }
 
-export function requiredTokenMessage(kind: Exclude<AuthRequire, 'any'>): string {
+export function requiredTokenMessage(kind: Exclude<AuthRequire, 'any' | 'sender'>): string {
   return tokenKindConfig[kind].requiredMessage;
 }
 
@@ -77,6 +77,9 @@ const allowedKindsByRequire = {
   // `any` intentionally means user/workspace API credentials, not transport-only
   // node credentials or scoped observer credentials.
   any: ['workspace', 'agent'],
+  // `sender` is a principal that can post a message: a workspace key, an agent
+  // (posts as itself), or a node token (posts as an explicit `from` agent).
+  sender: ['workspace', 'agent', 'node'],
 } as const satisfies Record<AuthRequire, readonly AuthTokenKind[]>;
 
 export type AuthRequirementValidation =
@@ -108,7 +111,7 @@ export function validateTokenRequirement(
     };
   }
 
-  if (require === 'any') {
+  if (require === 'any' || require === 'sender') {
     return { ok: false, code: 'unauthorized', message: 'Invalid token format' };
   }
 

--- a/packages/engine/src/engine/node.ts
+++ b/packages/engine/src/engine/node.ts
@@ -1436,15 +1436,17 @@ export async function handleNodeControlMessage(args: HandleNodeControlMessageArg
         await deregisterProvider(args.db, args.registry, args.workspaceId, args.nodeId, frameProviderName);
         return;
       case 'node.spawn': {
-        // Handler-context `ctx.spawnAgent`: capacity-direct delegation to the
-        // node's capacity executor (the broker provider). Bypasses action
-        // dispatch so a `spawn:<harness>` shadow handler cannot re-enter itself.
+        // Handler-context `ctx.spawnAgent`: capacity-direct delegation to this
+        // connection's own node capacity executor (the broker provider).
+        // Bypasses action dispatch so a `spawn:<harness>` shadow handler cannot
+        // re-enter itself. The target is always the connection's node — a node
+        // credential cannot direct a spawn at another node.
         const result = await dispatchCapacitySpawn(
           args.db,
           args.workspaceId,
           {
             input: message.input,
-            target_node_id: message.target_node_id ?? args.nodeId,
+            target_node_id: args.nodeId,
           },
           { nodeConnections: args.registry },
         );

--- a/packages/engine/src/engine/node.ts
+++ b/packages/engine/src/engine/node.ts
@@ -39,11 +39,6 @@ import {
 import { emitInvocationCompletionEffects } from './invocationCompletion.js';
 import type { InvocationCompletionDeps } from './invocationCompletion.js';
 import { ackDeliveriesUpToSeq, deliverPendingToNode } from './delivery.js';
-import { getChannel } from './channel.js';
-import { postMessage } from './message.js';
-import { buildMessageCreatedEventData } from './deliveryWire.js';
-import { transformForClient } from './wsTransform.js';
-import { appendAndPublishWorkspaceEvent } from './workspaceEvents.js';
 
 type Db = ReturnType<typeof getDb>;
 type NodeRow = typeof nodes.$inferSelect;
@@ -1456,58 +1451,6 @@ export async function handleNodeControlMessage(args: HandleNodeControlMessageArg
           type: 'reply',
           ok: true,
           data: result as Record<string, unknown>,
-        });
-        return;
-      }
-      case 'node.message': {
-        // Handler-context `ctx.sendMessage`: post a channel message attributed
-        // to `from` (an agent resolved by name in the workspace).
-        const channel = await getChannel(args.db, args.workspaceId, message.to);
-        if (!channel) {
-          throw codedError(`Channel "${message.to}" not found`, 'channel_not_found', 404);
-        }
-        const [fromAgent] = await args.db
-          .select({ id: agents.id, name: agents.name })
-          .from(agents)
-          .where(and(eq(agents.workspaceId, args.workspaceId), eq(agents.name, message.from)));
-        if (!fromAgent) {
-          throw codedError(`Agent "${message.from}" not found`, 'agent_not_found', 404);
-        }
-        const posted = await postMessage(args.db, args.workspaceId, channel.id, fromAgent.id, {
-          text: message.text,
-          ...(message.data ? { data: message.data } : {}),
-          ...(message.mode ? { mode: message.mode } : {}),
-        });
-        // Fan out to workspace observers, mirroring the message route's publish.
-        if (args.completionDeps) {
-          const eventData = buildMessageCreatedEventData(posted as unknown as Record<string, unknown>, {
-            channelName: message.to,
-            fromName: fromAgent.name,
-            ...(message.mode ? { mode: message.mode } : {}),
-          });
-          const payload = transformForClient({
-            type: 'message.created',
-            workspace_id: args.workspaceId,
-            channel_id: channel.id,
-            data: eventData,
-            timestamp: new Date().toISOString(),
-          });
-          await appendAndPublishWorkspaceEvent(
-            { db: args.completionDeps.db, realtime: args.completionDeps.realtime },
-            args.workspaceId,
-            { type: 'message.created', channelId: channel.id, payload },
-          );
-        }
-        const { _deliveries, _delivery_rejections, ...publicMessage } = posted as typeof posted & {
-          _deliveries?: unknown;
-          _delivery_rejections?: unknown;
-        };
-        sendControl(args.socket, {
-          v: 1,
-          id: requestId(message),
-          type: 'reply',
-          ok: true,
-          data: publicMessage as Record<string, unknown>,
         });
         return;
       }

--- a/packages/engine/src/engine/node.ts
+++ b/packages/engine/src/engine/node.ts
@@ -30,10 +30,20 @@ import {
   removeProvider,
   upsertProvider,
 } from './nodeProvider.js';
-import { completeNodeInvocation, rescheduleInvocationsForLostNode, rescheduleNodeInvocation } from './action.js';
+import {
+  completeNodeInvocation,
+  dispatchCapacitySpawn,
+  rescheduleInvocationsForLostNode,
+  rescheduleNodeInvocation,
+} from './action.js';
 import { emitInvocationCompletionEffects } from './invocationCompletion.js';
 import type { InvocationCompletionDeps } from './invocationCompletion.js';
 import { ackDeliveriesUpToSeq, deliverPendingToNode } from './delivery.js';
+import { getChannel } from './channel.js';
+import { postMessage } from './message.js';
+import { buildMessageCreatedEventData } from './deliveryWire.js';
+import { transformForClient } from './wsTransform.js';
+import { appendAndPublishWorkspaceEvent } from './workspaceEvents.js';
 
 type Db = ReturnType<typeof getDb>;
 type NodeRow = typeof nodes.$inferSelect;
@@ -1425,6 +1435,80 @@ export async function handleNodeControlMessage(args: HandleNodeControlMessageArg
       case 'node.deregister':
         await deregisterProvider(args.db, args.registry, args.workspaceId, args.nodeId, frameProviderName);
         return;
+      case 'node.spawn': {
+        // Handler-context `ctx.spawnAgent`: capacity-direct delegation to the
+        // node's capacity executor (the broker provider). Bypasses action
+        // dispatch so a `spawn:<harness>` shadow handler cannot re-enter itself.
+        const result = await dispatchCapacitySpawn(
+          args.db,
+          args.workspaceId,
+          {
+            input: message.input,
+            target_node_id: message.target_node_id ?? args.nodeId,
+          },
+          { nodeConnections: args.registry },
+        );
+        sendControl(args.socket, {
+          v: 1,
+          id: requestId(message),
+          type: 'reply',
+          ok: true,
+          data: result as Record<string, unknown>,
+        });
+        return;
+      }
+      case 'node.message': {
+        // Handler-context `ctx.sendMessage`: post a channel message attributed
+        // to `from` (an agent resolved by name in the workspace).
+        const channel = await getChannel(args.db, args.workspaceId, message.to);
+        if (!channel) {
+          throw codedError(`Channel "${message.to}" not found`, 'channel_not_found', 404);
+        }
+        const [fromAgent] = await args.db
+          .select({ id: agents.id, name: agents.name })
+          .from(agents)
+          .where(and(eq(agents.workspaceId, args.workspaceId), eq(agents.name, message.from)));
+        if (!fromAgent) {
+          throw codedError(`Agent "${message.from}" not found`, 'agent_not_found', 404);
+        }
+        const posted = await postMessage(args.db, args.workspaceId, channel.id, fromAgent.id, {
+          text: message.text,
+          ...(message.data ? { data: message.data } : {}),
+          ...(message.mode ? { mode: message.mode } : {}),
+        });
+        // Fan out to workspace observers, mirroring the message route's publish.
+        if (args.completionDeps) {
+          const eventData = buildMessageCreatedEventData(posted as unknown as Record<string, unknown>, {
+            channelName: message.to,
+            fromName: fromAgent.name,
+            ...(message.mode ? { mode: message.mode } : {}),
+          });
+          const payload = transformForClient({
+            type: 'message.created',
+            workspace_id: args.workspaceId,
+            channel_id: channel.id,
+            data: eventData,
+            timestamp: new Date().toISOString(),
+          });
+          await appendAndPublishWorkspaceEvent(
+            { db: args.completionDeps.db, realtime: args.completionDeps.realtime },
+            args.workspaceId,
+            { type: 'message.created', channelId: channel.id, payload },
+          );
+        }
+        const { _deliveries, _delivery_rejections, ...publicMessage } = posted as typeof posted & {
+          _deliveries?: unknown;
+          _delivery_rejections?: unknown;
+        };
+        sendControl(args.socket, {
+          v: 1,
+          id: requestId(message),
+          type: 'reply',
+          ok: true,
+          data: publicMessage as Record<string, unknown>,
+        });
+        return;
+      }
       case 'agent.register': {
         const registered = await registerAgentViaNode(args.db, args.workspaceId, args.nodeId, frameProviderName, message);
         // The relay broker's node_control client awaits a `reply` frame keyed by

--- a/packages/engine/src/middleware/auth.ts
+++ b/packages/engine/src/middleware/auth.ts
@@ -127,6 +127,13 @@ export const requireWorkspaceKey = makeAuthMiddleware('workspace');
 /** Accepts either a workspace key or an agent token. */
 export const requireAuth = makeAuthMiddleware('any');
 
+/**
+ * Accepts a workspace key, an agent token, or a node token — the principals that
+ * can post a message. An agent posts as itself; a node posts as an explicit
+ * `from` agent resolved within the node's workspace.
+ */
+export const requireSender = makeAuthMiddleware('sender');
+
 /** Requires an agent token (`at_live_...`). */
 export const requireAgentToken = makeAuthMiddleware('agent');
 

--- a/packages/engine/src/ports/auth.ts
+++ b/packages/engine/src/ports/auth.ts
@@ -6,7 +6,7 @@ export type Agent = typeof agents.$inferSelect;
 export type Node = typeof nodes.$inferSelect;
 export type ObserverToken = typeof observerTokens.$inferSelect;
 
-export type AuthRequire = 'workspace' | 'agent' | 'node' | 'observer' | 'any';
+export type AuthRequire = 'workspace' | 'agent' | 'node' | 'observer' | 'any' | 'sender';
 
 export type AuthResult =
   | { ok: true; workspace: Workspace; agent?: Agent; node?: Node; observerToken?: ObserverToken }

--- a/packages/engine/src/routes/message.ts
+++ b/packages/engine/src/routes/message.ts
@@ -1,7 +1,9 @@
 import { Hono } from 'hono';
 import { z } from 'zod';
+import { and, eq } from 'drizzle-orm';
+import { agents } from '../db/schema.js';
 import type { AppEnv } from '../env.js';
-import { requireAuth, requireWorkspaceRead } from '../middleware/auth.js';
+import { requireSender, requireWorkspaceRead } from '../middleware/auth.js';
 import { rateLimit } from '../middleware/rateLimit.js';
 import { jsonIdempotentOk, parseIdempotencyKey, runIdempotent } from '../middleware/idempotency.js';
 import * as messageEngine from '../engine/message.js';
@@ -40,6 +42,9 @@ const postMessageSchema = z.object({
   data: z.record(z.string(), z.unknown()).nullable().optional(),
   content_type: z.string().optional(),
   mode: z.enum(['wait', 'steer']).default('wait'),
+  // Node-token posts attribute the message to `from` — an agent name resolved
+  // strictly within the node token's workspace. Agent-token posts must omit it.
+  from: z.string().min(1).optional(),
 });
 
 type ValidationFailure = { error: { issues: Array<{ path: PropertyKey[] }> } };
@@ -58,18 +63,19 @@ function postMessageInvalidMessage(failure: ValidationFailure) {
 // POST /v1/channels/:name/messages - post a message
 messageRoutes.post(
   '/channels/:name/messages',
-  requireAuth,
+  requireSender,
   rateLimit,
   async (c) => {
     try {
       const db = c.get('db');
       const workspace = c.get('workspace');
       const agent = c.get('agent');
+      const node = c.get('node');
       const parsed = await parseJsonBody(c, postMessageSchema, postMessageInvalidMessage);
       if (!parsed.ok) {
         return parsed.response;
       }
-      const { text, blocks, attachments, data, content_type, mode } = parsed.data;
+      const { text, blocks, attachments, data, content_type, mode, from } = parsed.data;
 
       const { key: idempotencyKey, error: idempotencyError } = parseIdempotencyKey(c.req.header('Idempotency-Key'));
       if (idempotencyError) {
@@ -84,33 +90,55 @@ messageRoutes.post(
         return jsonNotFound(c, 'channel_not_found', `Channel "${channelName}" not found`);
       }
 
-      // Determine agent ID (from agent token or body)
-      const agentId = agent?.id;
-      if (!agentId) {
-        return jsonError(c, 'agent_token_required', 'Agent token required to post messages', 403);
+      // Resolve the sender. An agent token posts as itself; a node token posts
+      // as `from`, an agent resolved strictly within the node's workspace (so a
+      // node credential can never attribute a message to another workspace).
+      let senderAgentId: string;
+      let senderAgentName: string;
+      if (agent) {
+        if (from !== undefined) {
+          return jsonError(c, 'from_not_allowed', '"from" is only valid with a node token', 400);
+        }
+        senderAgentId = agent.id;
+        senderAgentName = agent.name;
+      } else if (node) {
+        if (!from) {
+          return jsonError(c, 'from_required', 'A node token must set "from" (an agent name in the node workspace)', 400);
+        }
+        const [fromAgent] = await db
+          .select({ id: agents.id, name: agents.name })
+          .from(agents)
+          .where(and(eq(agents.workspaceId, workspace.id), eq(agents.name, from)));
+        if (!fromAgent) {
+          return jsonNotFound(c, 'agent_not_found', `Agent "${from}" not found in this workspace`);
+        }
+        senderAgentId = fromAgent.id;
+        senderAgentName = fromAgent.name;
+      } else {
+        return jsonError(c, 'agent_token_required', 'Agent or node token required to post messages', 403);
       }
 
       const mailbox = resolveMailboxConfig(c.get('engine').config, workspace.id);
       const toMessageCreatedEventData = (data: Awaited<ReturnType<typeof messageEngine.postMessage>>) => buildMessageCreatedEventData(data, {
         channelName,
-        fromName: agent?.name ?? 'unknown',
+        fromName: senderAgentName,
         mode,
       });
 
       const idempotent = await runIdempotent({
         workspaceId: workspace.id,
-        actorId: agentId,
+        actorId: senderAgentId,
         scope: `channel-message:${channel.id}`,
         key: idempotencyKey,
         status: 201,
-        fingerprint: JSON.stringify({ channelId: channel.id, text, blocks, attachments, data, content_type, mode }),
+        fingerprint: JSON.stringify({ channelId: channel.id, text, blocks, attachments, data, content_type, mode, from }),
         kv: c.get('engine').kv,
         operation: () =>
           messageEngine.postMessage(
             db,
             workspace.id,
             channel.id,
-            agentId,
+            senderAgentId,
             { text, blocks, attachments, data, content_type, mode },
             { mailbox },
           ),
@@ -146,7 +174,7 @@ messageRoutes.post(
         if (_delivery_rejections && _delivery_rejections.length > 0) {
           runInBackground(
             c,
-            notifyDeliveryRejections(c, agentId, _delivery_rejections),
+            notifyDeliveryRejections(c, senderAgentId, _delivery_rejections),
             'fanout delivery rejected',
           );
         }
@@ -170,8 +198,8 @@ messageRoutes.post(
                 id: String(publicData.id),
                 channel_id: channel.id,
                 channel_name: channelName,
-                agent_id: agentId,
-                agent_name: agent?.name,
+                agent_id: senderAgentId,
+                agent_name: senderAgentName,
                 text: String(publicData.text ?? text),
                 mentions: Array.isArray(publicData.mentions) ? publicData.mentions as string[] : [],
                 metadata: (publicData.metadata ?? null) as Record<string, unknown> | null,

--- a/packages/sdk-python/src/relay_sdk/__init__.py
+++ b/packages/sdk-python/src/relay_sdk/__init__.py
@@ -10,6 +10,7 @@ from .client import (
     sanitize_agent_relay_distinct_id,
 )
 from .errors import RelayError
+from .node import NodeProvider, NodeRegistrationError
 from .relay import AsyncRelay, Relay
 from .ws import WsClient
 
@@ -23,6 +24,8 @@ __all__ = [
     "AsyncHttpClient",
     "AsyncRelay",
     "HttpClient",
+    "NodeProvider",
+    "NodeRegistrationError",
     "Relay",
     "RelayError",
     "SDK_VERSION",

--- a/packages/sdk-python/src/relay_sdk/node.py
+++ b/packages/sdk-python/src/relay_sdk/node.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+import inspect
 import json
 import logging
 import random
@@ -130,7 +131,8 @@ class _RegisteredCapability:
     handler: "NodeCapabilityHandler"
 
 
-NodeCapabilityHandler = Callable[[Any, "NodeHandlerContext"], Awaitable[Any]]
+# A handler may be async (returning an awaitable) or a plain sync callable.
+NodeCapabilityHandler = Callable[[Any, "NodeHandlerContext"], Awaitable[Any] | Any]
 NodeCapabilitySpec = NodeCapabilityHandler | Mapping[str, Any]
 
 
@@ -469,11 +471,21 @@ class NodeProvider:
             frame["machine_id"] = self._machine_id
 
         data = await self._request(req_id, frame)
-        accepted = (data or {}).get("accepted_capabilities") or []
-        rejected = [c for c in accepted if not c.get("accepted")]
+        # The reply must carry a well-formed acceptance list (the engine always
+        # does). A missing/corrupt list means acceptance can't be confirmed, so
+        # fail registration rather than assume success; an entry missing
+        # `accepted` counts as rejected (fail-safe).
+        accepted = (data or {}).get("accepted_capabilities")
+        if not isinstance(accepted, list):
+            raise NodeRegistrationError(
+                "Registration reply is missing accepted_capabilities", "invalid_register_reply"
+            )
+        rejected = [c for c in accepted if not (isinstance(c, dict) and c.get("accepted") is True)]
         if rejected:
             detail = ", ".join(
-                f"{c.get('name')}" + (f" ({c['reason']})" if c.get("reason") else "") for c in rejected
+                f"{c.get('name') if isinstance(c, dict) else '<unknown>'}"
+                + (f" ({c['reason']})" if isinstance(c, dict) and c.get("reason") else "")
+                for c in rejected
             )
             raise NodeRegistrationError(f"Capabilities rejected: {detail}", "capabilities_rejected")
 
@@ -540,7 +552,9 @@ class NodeProvider:
             return
         ctx = NodeHandlerContext(self, invocation_id)
         try:
-            output = await cap.handler(input_, ctx)
+            # Support both async and plain (sync) handlers.
+            result = cap.handler(input_, ctx)
+            output = await result if inspect.isawaitable(result) else result
         except Exception as exc:  # a handler throw becomes an error result; never dropped
             await self._send_frame(
                 {"type": "action.result", "invocation_id": invocation_id, "error": str(exc)}

--- a/packages/sdk-python/src/relay_sdk/node.py
+++ b/packages/sdk-python/src/relay_sdk/node.py
@@ -206,10 +206,12 @@ class NodeProvider:
         connect: NodeConnectFactory | None = None,
     ) -> None:
         base = (base_url or _DEFAULT_BASE_URL).rstrip("/")
-        self._http_base_url = base
+        # The base may be given as ws(s):// (also accepted by the socket);
+        # normalize it back to http(s):// for the REST client.
+        self._http_base_url = base.replace("wss://", "https://").replace("ws://", "http://")
         self._ws_base_url = base.replace("https://", "wss://").replace("http://", "ws://")
         self._node_token = node_token
-        self._http = AsyncHttpClient(api_key=node_token, base_url=base, origin_client=_ORIGIN_CLIENT)
+        self._http = AsyncHttpClient(api_key=node_token, base_url=self._http_base_url, origin_client=_ORIGIN_CLIENT)
         self._node_id = node_id
         self._node_name = node_name
         self._provider_name = provider["name"]
@@ -509,6 +511,10 @@ class NodeProvider:
             self._register_future.set_result(data)
 
     def _reject_registered(self, err: Exception) -> None:
+        # Never overwrite a completed registration: once registered, a later
+        # disconnect/exhaustion must not make wait_registered() start raising.
+        if self._register_result is not None:
+            return
         self._register_error = err
         if self._register_future is not None and not self._register_future.done():
             self._register_future.set_exception(err)

--- a/packages/sdk-python/src/relay_sdk/node.py
+++ b/packages/sdk-python/src/relay_sdk/node.py
@@ -1,0 +1,610 @@
+"""Node provider client — attaches a process to a node's capabilities.
+
+A node provider connects to the engine's ``/v1/node/ws``, registers a subset
+of a node's capabilities, and executes their invokes. It is the language-
+neutral equivalent of the broker's Rust provider — connection, registration,
+heartbeats, invoke dispatch, and the handler-context helpers — with no local-
+broker dependency.
+
+Enrollment (reading the node token/URL from disk) layers on top of this in a
+thin wrapper; the client itself takes an explicit token and base URL.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import json
+import logging
+import random
+import uuid
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Any, Awaitable, Callable, Literal, Protocol
+from urllib.parse import quote
+
+import websockets
+from websockets.asyncio.client import ClientConnection
+
+from .client import SDK_VERSION
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_BASE_URL = "https://cast.agentrelay.com"
+_ORIGIN_CLIENT = "@relaycast/python-sdk"
+
+
+def _random_id() -> str:
+    return str(uuid.uuid4())
+
+
+class NodeProviderError(Exception):
+    """Raised for provider-client-level failures (transport, lifecycle)."""
+
+
+class NodeRegistrationError(Exception):
+    """Raised when the engine rejects the provider's registration, or when
+    an ``error`` frame answers any id-keyed request (register, spawn, message).
+    """
+
+    def __init__(self, message: str, code: str) -> None:
+        super().__init__(message)
+        self.code = code
+
+
+class NodeConnectionClosed(Exception):
+    """Raised by a `NodeConnection.recv()` implementation when the
+    underlying transport has closed."""
+
+
+class NodeConnection(Protocol):
+    """The minimal transport surface the provider client needs. Tests supply
+    a fake implementation; the default wraps `websockets.connect`."""
+
+    async def send(self, data: str) -> None: ...
+
+    async def recv(self) -> str: ...
+
+    async def close(self) -> None: ...
+
+
+NodeConnectFactory = Callable[[str], Awaitable[NodeConnection]]
+
+
+class _WebsocketConnection:
+    """Adapts a real `websockets` client connection to `NodeConnection`."""
+
+    def __init__(self, ws: ClientConnection) -> None:
+        self._ws = ws
+
+    async def send(self, data: str) -> None:
+        await self._ws.send(data)
+
+    async def recv(self) -> str:
+        try:
+            message = await self._ws.recv()
+        except websockets.exceptions.ConnectionClosed as exc:
+            raise NodeConnectionClosed(str(exc)) from exc
+        if isinstance(message, bytes):
+            return message.decode("utf-8")
+        return message
+
+    async def close(self) -> None:
+        with contextlib.suppress(Exception):
+            await self._ws.close()
+
+
+async def _default_connect(url: str) -> NodeConnection:
+    ws = await websockets.connect(url)
+    return _WebsocketConnection(ws)
+
+
+@dataclass(frozen=True)
+class NodeCapabilityOptions:
+    """A capability's declaration alongside its handler.
+
+    `kind` is 'action' (materializes an invokable handler) or 'capacity'
+    (describes what the node can run and is never materialized); omit to let
+    the engine classify by name. `global_` claims a workspace-global alias
+    for this action name (wire field `global`). `queue` queues invokes while
+    this provider is offline instead of failing fast.
+    """
+
+    kind: Literal["action", "capacity"] | None = None
+    global_: bool = False
+    queue: bool = False
+    metadata: dict[str, Any] | None = None
+
+
+@dataclass(frozen=True)
+class NodeInfo:
+    """Informational view of the node a provider is attached to."""
+
+    name: str
+    capabilities: list[str]
+
+
+@dataclass
+class _RegisteredCapability:
+    options: NodeCapabilityOptions
+    handler: "NodeCapabilityHandler"
+
+
+NodeCapabilityHandler = Callable[[Any, "NodeHandlerContext"], Awaitable[Any]]
+NodeCapabilitySpec = NodeCapabilityHandler | Mapping[str, Any]
+
+
+class NodeHandlerContext:
+    """Context passed to every capability handler."""
+
+    def __init__(self, provider: "NodeProvider", invocation_id: str) -> None:
+        self._provider = provider
+        self.invocation_id = invocation_id
+        self.node = NodeInfo(name=provider._node_name, capabilities=list(provider._handlers.keys()))
+
+    async def send_message(
+        self,
+        *,
+        to: str,
+        from_: str,
+        text: str,
+        thread_id: str | None = None,
+        mode: Literal["wait", "steer"] | None = None,
+        data: dict[str, Any] | None = None,
+    ) -> Any:
+        """Post a channel message, attributed to `from_` (an agent name
+        resolved in the workspace). Resolves with the posted message."""
+        frame: dict[str, Any] = {"type": "node.message", "to": to, "from": from_, "text": text}
+        if thread_id is not None:
+            frame["thread_id"] = thread_id
+        if mode is not None:
+            frame["mode"] = mode
+        if data is not None:
+            frame["data"] = data
+        return await self._provider._request(_random_id(), frame)
+
+    async def spawn_agent(self, input: Any) -> Any:
+        """Spawn an agent through the node's capacity executor.
+
+        Capacity-direct: it never re-enters action dispatch, so a
+        `spawn:<harness>` shadow handler that delegates cannot recurse into
+        itself. Resolves with the spawn placement."""
+        frame = {"type": "node.spawn", "input": input, "target_node_id": self._provider._node_id}
+        return await self._provider._request(_random_id(), frame)
+
+
+class NodeProvider:
+    """A node provider client: connects to a node's `/v1/node/ws`, registers
+    a subset of its capabilities, and dispatches their invokes.
+
+    Constructor takes explicit values — no enrollment-file logic; that is a
+    later, relay-side step layered on top of this client.
+    """
+
+    def __init__(
+        self,
+        *,
+        base_url: str | None = None,
+        node_token: str,
+        node_id: str,
+        node_name: str,
+        provider: Mapping[str, Any],
+        capabilities: Mapping[str, NodeCapabilitySpec] | None = None,
+        max_agents: int = 0,
+        tags: list[str] | None = None,
+        version: str | None = None,
+        machine_id: str | None = None,
+        heartbeat_interval: float = 15.0,
+        reconnect_base_delay: float = 0.5,
+        reconnect_max_delay: float = 30.0,
+        reconnect_jitter: bool = True,
+        max_reconnect_attempts: int | None = None,
+        on_error: Callable[[Exception], None] | None = None,
+        connect: NodeConnectFactory | None = None,
+    ) -> None:
+        base = (base_url or _DEFAULT_BASE_URL).rstrip("/")
+        self._ws_base_url = base.replace("https://", "wss://").replace("http://", "ws://")
+        self._node_token = node_token
+        self._node_id = node_id
+        self._node_name = node_name
+        self._provider_name = provider["name"]
+        self._initial_instance_id: str | None = provider.get("instance_id")
+        self._max_agents = max_agents
+        self._tags = list(tags) if tags else []
+        self._version = version or SDK_VERSION
+        self._machine_id = machine_id
+        self._heartbeat_interval = heartbeat_interval
+        self._reconnect_base_delay = reconnect_base_delay
+        self._reconnect_max_delay = reconnect_max_delay
+        self._reconnect_jitter = reconnect_jitter
+        self._max_reconnect_attempts = max_reconnect_attempts
+        self._on_error = on_error
+        self._connect_factory: NodeConnectFactory = connect or _default_connect
+
+        self._handlers: dict[str, _RegisteredCapability] = {}
+        self._pending: dict[str, asyncio.Future[Any]] = {}
+        self._invoke_tasks: set[asyncio.Task[None]] = set()
+
+        self._conn: NodeConnection | None = None
+        self._instance_id: str | None = None
+        self._registered = False
+        self._stopped = True
+        self._serving = False
+        self._reconnect_attempt = 0
+        self._reconnect_sleep_task: asyncio.Task[None] | None = None
+
+        self._register_future: asyncio.Future[dict[str, Any]] | None = None
+        self._register_result: dict[str, Any] | None = None
+        self._register_error: Exception | None = None
+
+        for name, spec in (capabilities or {}).items():
+            self._register_capability_spec(name, spec)
+
+    # ── Capability registration ──────────────────────────────────
+
+    def capability(
+        self,
+        name: str,
+        handler: NodeCapabilityHandler | None = None,
+        *,
+        kind: Literal["action", "capacity"] | None = None,
+        global_: bool = False,
+        queue: bool = False,
+        metadata: dict[str, Any] | None = None,
+    ) -> Any:
+        """Register a capability and its handler.
+
+        Usable as a decorator (`@node.capability("run-etl")`) when `handler`
+        is omitted, or as a direct call (`node.capability("run-etl", fn)`).
+        """
+        options = NodeCapabilityOptions(kind=kind, global_=global_, queue=queue, metadata=metadata)
+
+        def register(fn: NodeCapabilityHandler) -> NodeCapabilityHandler:
+            self._handlers[name] = _RegisteredCapability(options=options, handler=fn)
+            return fn
+
+        if handler is not None:
+            register(handler)
+            return self
+        return register
+
+    def _register_capability_spec(self, name: str, spec: NodeCapabilitySpec) -> None:
+        if callable(spec):
+            self.capability(name, spec)
+            return
+        if isinstance(spec, Mapping):
+            opts = dict(spec)
+            handler = opts.pop("handler", None)
+            if handler is None or not callable(handler):
+                raise ValueError(f'capability "{name}" requires a handler')
+            self.capability(
+                name,
+                handler,
+                kind=opts.pop("kind", None),
+                global_=bool(opts.pop("global", False)),
+                queue=bool(opts.pop("queue", False)),
+                metadata=opts.pop("metadata", None),
+            )
+            return
+        raise TypeError(f'capability "{name}" must be a handler function or a mapping with "handler"')
+
+    # ── Public lifecycle ─────────────────────────────────────────
+
+    @property
+    def connected(self) -> bool:
+        return self._registered and self._conn is not None
+
+    async def wait_registered(self) -> dict[str, Any]:
+        """Resolve once the provider is registered and its capabilities are
+        accepted. Raises if registration is hard-rejected."""
+        if self._register_error is not None:
+            raise self._register_error
+        if self._register_result is not None:
+            return self._register_result
+        if self._register_future is None:
+            self._register_future = asyncio.get_running_loop().create_future()
+        return await self._register_future
+
+    async def serve(self) -> None:
+        """Connect, register, and dispatch invokes until `stop()` is called.
+
+        Reconnects with backoff on unexpected drops, re-registering with a
+        fresh instance id each time. Raises if the initial registration is
+        rejected by the engine.
+        """
+        if self._serving:
+            raise NodeProviderError("serve() is already running")
+        self._serving = True
+        self._stopped = False
+        self._reconnect_attempt = 0
+        try:
+            while not self._stopped:
+                try:
+                    await self._run_connection()
+                except NodeRegistrationError as exc:
+                    self._reject_registered(exc)
+                    self._report_error(exc)
+                    self._stopped = True
+                    raise
+                if self._stopped:
+                    break
+                await self._backoff_sleep()
+        finally:
+            self._serving = False
+
+    async def stop(self) -> None:
+        """Gracefully deregister the provider and close the connection."""
+        self._stopped = True
+        if self._reconnect_sleep_task is not None:
+            self._reconnect_sleep_task.cancel()
+        conn = self._conn
+        if conn is not None and self._registered and self._instance_id:
+            await self._send_frame({"type": "node.deregister", "provider": self._provider_identity()})
+        self._reject_pending(NodeProviderError("node provider stopped"))
+        if conn is not None:
+            await self._safe_close(conn)
+        self._registered = False
+
+    # ── Connection lifecycle ─────────────────────────────────────
+
+    async def _run_connection(self) -> None:
+        self._instance_id = (
+            self._initial_instance_id
+            if self._reconnect_attempt == 0 and self._initial_instance_id
+            else _random_id()
+        )
+        self._registered = False
+        url = self._build_url()
+        try:
+            conn = await self._connect_factory(url)
+        except Exception as exc:  # connect failure: report and retry
+            self._report_error(exc)
+            return
+        self._conn = conn
+
+        reader_task = asyncio.create_task(self._reader_loop(conn))
+        try:
+            await self._send_register()
+        except NodeRegistrationError:
+            await self._cancel_task(reader_task)
+            await self._safe_close(conn)
+            if self._conn is conn:
+                self._conn = None
+            raise
+        except Exception as exc:  # transport failure while registering: retry
+            self._report_error(exc)
+            await self._cancel_task(reader_task)
+            await self._safe_close(conn)
+            if self._conn is conn:
+                self._conn = None
+            return
+
+        heartbeat_task = asyncio.create_task(self._heartbeat_loop())
+        try:
+            await reader_task
+        finally:
+            await self._cancel_task(heartbeat_task)
+            self._registered = False
+            self._reject_pending(NodeProviderError("node provider connection closed"))
+            await self._safe_close(conn)
+            if self._conn is conn:
+                self._conn = None
+
+    async def _reader_loop(self, conn: NodeConnection) -> None:
+        while True:
+            try:
+                raw = await conn.recv()
+            except NodeConnectionClosed:
+                return
+            except asyncio.CancelledError:
+                raise
+            except Exception as exc:
+                self._report_error(exc)
+                return
+            await self._handle_frame(raw)
+            if self._stopped:
+                return
+
+    async def _backoff_sleep(self) -> None:
+        if self._max_reconnect_attempts is not None and self._reconnect_attempt >= self._max_reconnect_attempts:
+            self._report_error(NodeProviderError("node provider exhausted reconnect attempts"))
+            self._stopped = True
+            return
+        self._reconnect_attempt += 1
+        exp = min(self._reconnect_base_delay * (2 ** (self._reconnect_attempt - 1)), self._reconnect_max_delay)
+        delay = exp * (0.5 + random.random()) if self._reconnect_jitter else exp
+        self._reconnect_sleep_task = asyncio.ensure_future(asyncio.sleep(delay))
+        try:
+            await self._reconnect_sleep_task
+        except asyncio.CancelledError:
+            pass
+        finally:
+            self._reconnect_sleep_task = None
+
+    @staticmethod
+    async def _cancel_task(task: asyncio.Task[Any]) -> None:
+        task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await task
+
+    async def _safe_close(self, conn: NodeConnection) -> None:
+        with contextlib.suppress(Exception):
+            await conn.close()
+
+    # ── Registration ─────────────────────────────────────────────
+
+    async def _send_register(self) -> None:
+        req_id = _random_id()
+        capabilities: list[dict[str, Any]] = []
+        for name, cap in self._handlers.items():
+            entry: dict[str, Any] = {"name": name}
+            if cap.options.kind:
+                entry["kind"] = cap.options.kind
+            if cap.options.global_:
+                entry["global"] = True
+            if cap.options.queue:
+                entry["queue"] = True
+            if cap.options.metadata:
+                entry["metadata"] = cap.options.metadata
+            capabilities.append(entry)
+
+        frame: dict[str, Any] = {
+            "type": "node.register",
+            "name": self._node_name,
+            "node_id": self._node_id,
+            "provider": self._provider_identity(),
+            "capabilities": capabilities,
+            "max_agents": self._max_agents,
+            "tags": self._tags,
+            "version": self._version,
+            "resume_cursor": None,
+        }
+        if self._machine_id:
+            frame["machine_id"] = self._machine_id
+
+        data = await self._request(req_id, frame)
+        accepted = (data or {}).get("accepted_capabilities") or []
+        rejected = [c for c in accepted if not c.get("accepted")]
+        if rejected:
+            detail = ", ".join(
+                f"{c.get('name')}" + (f" ({c['reason']})" if c.get("reason") else "") for c in rejected
+            )
+            raise NodeRegistrationError(f"Capabilities rejected: {detail}", "capabilities_rejected")
+
+        self._registered = True
+        self._reconnect_attempt = 0
+        self._resolve_registered(data or {})
+
+    def _resolve_registered(self, data: dict[str, Any]) -> None:
+        self._register_result = data
+        if self._register_future is not None and not self._register_future.done():
+            self._register_future.set_result(data)
+
+    def _reject_registered(self, err: Exception) -> None:
+        self._register_error = err
+        if self._register_future is not None and not self._register_future.done():
+            self._register_future.set_exception(err)
+
+    def _provider_identity(self) -> dict[str, str]:
+        return {"name": self._provider_name, "instance_id": self._instance_id or ""}
+
+    # ── Frame handling ────────────────────────────────────────────
+
+    async def _handle_frame(self, raw: str) -> None:
+        try:
+            message = json.loads(raw)
+        except (json.JSONDecodeError, TypeError):
+            return
+        if not isinstance(message, dict):
+            return
+        msg_type = message.get("type")
+        if msg_type == "reply":
+            fut = self._pending.pop(message.get("id"), None)
+            if fut is not None and not fut.done():
+                fut.set_result(message.get("data"))
+            return
+        if msg_type == "error":
+            fut = self._pending.pop(message.get("id"), None)
+            if fut is not None and not fut.done():
+                fut.set_exception(
+                    NodeRegistrationError(message.get("message", "error"), message.get("code", "error"))
+                )
+            return
+        if msg_type == "action.invoke":
+            invocation_id = message.get("invocation_id", "")
+            action = message.get("action", "")
+            input_ = message.get("input")
+            task = asyncio.create_task(self._dispatch_invoke(invocation_id, action, input_))
+            self._invoke_tasks.add(task)
+            task.add_done_callback(self._invoke_tasks.discard)
+            return
+        # deliver / context.update / ping carry no work for a provider client.
+        return
+
+    async def _dispatch_invoke(self, invocation_id: str, action: str, input_: Any) -> None:
+        cap = self._handlers.get(action)
+        if cap is None:
+            await self._send_frame(
+                {
+                    "type": "action.result",
+                    "invocation_id": invocation_id,
+                    "error": f'No handler registered for action "{action}"',
+                }
+            )
+            return
+        ctx = NodeHandlerContext(self, invocation_id)
+        try:
+            output = await cap.handler(input_, ctx)
+        except Exception as exc:  # a handler throw becomes an error result; never dropped
+            await self._send_frame(
+                {"type": "action.result", "invocation_id": invocation_id, "error": str(exc)}
+            )
+            return
+        await self._send_frame({"type": "action.result", "invocation_id": invocation_id, "output": output})
+
+    async def _heartbeat_loop(self) -> None:
+        try:
+            while True:
+                await asyncio.sleep(self._heartbeat_interval)
+                await self._send_frame(
+                    {
+                        "type": "node.heartbeat",
+                        "provider": self._provider_identity(),
+                        "load": 0,
+                        "active_agents": 0,
+                        "handlers_live": True,
+                    }
+                )
+        except asyncio.CancelledError:
+            raise
+
+    # ── Transport ─────────────────────────────────────────────────
+
+    def _build_url(self) -> str:
+        query = {
+            "token": self._node_token,
+            "origin_client": _ORIGIN_CLIENT,
+            "origin_version": SDK_VERSION,
+        }
+        qs = "&".join(f"{k}={quote(v, safe='')}" for k, v in query.items())
+        return f"{self._ws_base_url}/v1/node/ws?{qs}"
+
+    async def _request(self, req_id: str, frame: dict[str, Any]) -> Any:
+        conn = self._conn
+        if conn is None:
+            raise NodeProviderError("node provider websocket is not open")
+        fut: asyncio.Future[Any] = asyncio.get_running_loop().create_future()
+        self._pending[req_id] = fut
+        payload = {"v": 1, "id": req_id, **frame}
+        try:
+            await conn.send(json.dumps(payload))
+        except Exception:
+            self._pending.pop(req_id, None)
+            raise
+        return await fut
+
+    async def _send_frame(self, frame: dict[str, Any]) -> None:
+        conn = self._conn
+        if conn is None:
+            return
+        try:
+            await conn.send(json.dumps({"v": 1, **frame}))
+        except Exception as exc:
+            self._report_error(exc)
+
+    def _reject_pending(self, err: Exception) -> None:
+        pending = self._pending
+        self._pending = {}
+        for fut in pending.values():
+            if not fut.done():
+                fut.set_exception(err)
+
+    def _report_error(self, err: BaseException) -> None:
+        error = err if isinstance(err, Exception) else Exception(str(err))
+        if self._on_error is not None:
+            try:
+                self._on_error(error)
+            except Exception:
+                logger.exception("node provider on_error handler raised")
+        else:
+            logger.warning("node provider error: %s", error)

--- a/packages/sdk-python/src/relay_sdk/node.py
+++ b/packages/sdk-python/src/relay_sdk/node.py
@@ -346,11 +346,14 @@ class NodeProvider:
             self._reconnect_sleep_task.cancel()
         # Let in-flight invoke handlers finish (and send their action.result)
         # before the socket closes; bound the wait so a slow handler can't hang
-        # shutdown.
-        if self._invoke_tasks:
+        # shutdown. Exclude the caller's own task so a handler that calls stop()
+        # doesn't deadlock (and get cancelled) waiting on itself.
+        current = asyncio.current_task()
+        drain = [t for t in self._invoke_tasks if t is not current]
+        if drain:
             with contextlib.suppress(asyncio.TimeoutError):
                 await asyncio.wait_for(
-                    asyncio.gather(*list(self._invoke_tasks), return_exceptions=True), timeout=5.0
+                    asyncio.gather(*drain, return_exceptions=True), timeout=5.0
                 )
         conn = self._conn
         if conn is not None and self._registered and self._instance_id:
@@ -506,9 +509,12 @@ class NodeProvider:
         accepted_by_name = {
             c.get("name"): c for c in accepted if isinstance(c, dict) and isinstance(c.get("name"), str)
         }
-        # Every requested capability must be acknowledged; an empty/partial list
-        # cannot silently pass as success.
-        missing = sorted(set(self._handlers.keys()) - set(accepted_by_name.keys()))
+        # Every capability the register frame ADVERTISED must be acknowledged.
+        # Validate against the snapshot that was sent (`capabilities`), not the
+        # live handler map — a capability added after the frame was sent isn't
+        # in this reply.
+        requested = {entry["name"] for entry in capabilities}
+        missing = sorted(requested - set(accepted_by_name.keys()))
         if missing:
             raise NodeRegistrationError(
                 f"Registration reply omitted acceptance for: {', '.join(missing)}",
@@ -566,6 +572,10 @@ class NodeProvider:
                 )
             return
         if msg_type == "action.invoke":
+            # Stop accepting new invokes once shutting down/draining; the engine
+            # reschedules an undispatched invocation when the node goes offline.
+            if self._stopped:
+                return
             invocation_id = message.get("invocation_id", "")
             action = message.get("action", "")
             input_ = message.get("input")

--- a/packages/sdk-python/src/relay_sdk/node.py
+++ b/packages/sdk-python/src/relay_sdk/node.py
@@ -27,7 +27,7 @@ from urllib.parse import quote
 import websockets
 from websockets.asyncio.client import ClientConnection
 
-from .client import SDK_VERSION
+from .client import SDK_VERSION, AsyncHttpClient
 
 logger = logging.getLogger(__name__)
 
@@ -153,15 +153,17 @@ class NodeHandlerContext:
         mode: Literal["wait", "steer"] | None = None,
         data: dict[str, Any] | None = None,
     ) -> Any:
-        """Post a top-level channel message, attributed to `from_` (an agent
-        name resolved in the workspace). Resolves with the posted message.
-        Thread replies are not part of this surface."""
-        frame: dict[str, Any] = {"type": "node.message", "to": to, "from": from_, "text": text}
+        """Post a top-level channel message through the canonical message route
+        with the node token, attributed to `from_` (an agent name resolved in
+        the node's workspace). Node-attributed posts share the route's delivery
+        routing, observer events, and triggers by construction. Thread replies
+        are not part of this surface."""
+        payload: dict[str, Any] = {"text": text, "from": from_}
         if mode is not None:
-            frame["mode"] = mode
+            payload["mode"] = mode
         if data is not None:
-            frame["data"] = data
-        return await self._provider._request(_random_id(), frame)
+            payload["data"] = data
+        return await self._provider._post_channel_message(to, payload)
 
     async def spawn_agent(self, input: Any) -> Any:
         """Spawn an agent through the node's capacity executor.
@@ -204,8 +206,10 @@ class NodeProvider:
         connect: NodeConnectFactory | None = None,
     ) -> None:
         base = (base_url or _DEFAULT_BASE_URL).rstrip("/")
+        self._http_base_url = base
         self._ws_base_url = base.replace("https://", "wss://").replace("http://", "ws://")
         self._node_token = node_token
+        self._http = AsyncHttpClient(api_key=node_token, base_url=base, origin_client=_ORIGIN_CLIENT)
         self._node_id = node_id
         self._node_name = node_name
         self._provider_name = provider["name"]
@@ -344,6 +348,8 @@ class NodeProvider:
         self._reject_pending(NodeProviderError("node provider stopped"))
         if conn is not None:
             await self._safe_close(conn)
+        with contextlib.suppress(Exception):
+            await self._http.close()
         self._registered = False
 
     # ── Connection lifecycle ─────────────────────────────────────
@@ -588,6 +594,9 @@ class NodeProvider:
         }
         qs = "&".join(f"{k}={quote(v, safe='')}" for k, v in query.items())
         return f"{self._ws_base_url}/v1/node/ws?{qs}"
+
+    async def _post_channel_message(self, to: str, payload: dict[str, Any]) -> Any:
+        return await self._http.post(f"/v1/channels/{quote(to, safe='')}/messages", payload)
 
     async def _request(self, req_id: str, frame: dict[str, Any]) -> Any:
         conn = self._conn

--- a/packages/sdk-python/src/relay_sdk/node.py
+++ b/packages/sdk-python/src/relay_sdk/node.py
@@ -421,9 +421,13 @@ class NodeProvider:
 
     async def _backoff_sleep(self) -> None:
         if self._max_reconnect_attempts is not None and self._reconnect_attempt >= self._max_reconnect_attempts:
-            self._report_error(NodeProviderError("node provider exhausted reconnect attempts"))
+            err = NodeProviderError("node provider exhausted reconnect attempts")
+            self._report_error(err)
+            # If registration never completed, reject its waiter too — otherwise
+            # wait_registered() would hang forever after reconnects are exhausted.
+            self._reject_registered(err)
             self._stopped = True
-            return
+            raise err
         self._reconnect_attempt += 1
         exp = min(self._reconnect_base_delay * (2 ** (self._reconnect_attempt - 1)), self._reconnect_max_delay)
         delay = exp * (0.5 + random.random()) if self._reconnect_jitter else exp

--- a/packages/sdk-python/src/relay_sdk/node.py
+++ b/packages/sdk-python/src/relay_sdk/node.py
@@ -148,15 +148,13 @@ class NodeHandlerContext:
         to: str,
         from_: str,
         text: str,
-        thread_id: str | None = None,
         mode: Literal["wait", "steer"] | None = None,
         data: dict[str, Any] | None = None,
     ) -> Any:
-        """Post a channel message, attributed to `from_` (an agent name
-        resolved in the workspace). Resolves with the posted message."""
+        """Post a top-level channel message, attributed to `from_` (an agent
+        name resolved in the workspace). Resolves with the posted message.
+        Thread replies are not part of this surface."""
         frame: dict[str, Any] = {"type": "node.message", "to": to, "from": from_, "text": text}
-        if thread_id is not None:
-            frame["thread_id"] = thread_id
         if mode is not None:
             frame["mode"] = mode
         if data is not None:
@@ -392,19 +390,26 @@ class NodeProvider:
                 self._conn = None
 
     async def _reader_loop(self, conn: NodeConnection) -> None:
-        while True:
-            try:
-                raw = await conn.recv()
-            except NodeConnectionClosed:
-                return
-            except asyncio.CancelledError:
-                raise
-            except Exception as exc:
-                self._report_error(exc)
-                return
-            await self._handle_frame(raw)
-            if self._stopped:
-                return
+        try:
+            while True:
+                try:
+                    raw = await conn.recv()
+                except NodeConnectionClosed:
+                    return
+                except asyncio.CancelledError:
+                    raise
+                except Exception as exc:
+                    self._report_error(exc)
+                    return
+                await self._handle_frame(raw)
+                if self._stopped:
+                    return
+        finally:
+            # The socket ended; unblock any in-flight request — including a
+            # register still awaiting its reply — so the attempt can't hang
+            # waiting on a socket that is gone. A transport drop during the
+            # handshake then flows through _run_connection's retry path.
+            self._reject_pending(NodeProviderError("node provider connection closed"))
 
     async def _backoff_sleep(self) -> None:
         if self._max_reconnect_attempts is not None and self._reconnect_attempt >= self._max_reconnect_attempts:

--- a/packages/sdk-python/src/relay_sdk/node.py
+++ b/packages/sdk-python/src/relay_sdk/node.py
@@ -344,9 +344,20 @@ class NodeProvider:
         self._stopped = True
         if self._reconnect_sleep_task is not None:
             self._reconnect_sleep_task.cancel()
+        # Let in-flight invoke handlers finish (and send their action.result)
+        # before the socket closes; bound the wait so a slow handler can't hang
+        # shutdown.
+        if self._invoke_tasks:
+            with contextlib.suppress(asyncio.TimeoutError):
+                await asyncio.wait_for(
+                    asyncio.gather(*list(self._invoke_tasks), return_exceptions=True), timeout=5.0
+                )
         conn = self._conn
         if conn is not None and self._registered and self._instance_id:
             await self._send_frame({"type": "node.deregister", "provider": self._provider_identity()})
+        # A stop() before registration completed must not leave wait_registered()
+        # hanging (guarded to a no-op once registration already succeeded).
+        self._reject_registered(NodeProviderError("node provider stopped"))
         self._reject_pending(NodeProviderError("node provider stopped"))
         if conn is not None:
             await self._safe_close(conn)
@@ -492,11 +503,21 @@ class NodeProvider:
             raise NodeRegistrationError(
                 "Registration reply is missing accepted_capabilities", "invalid_register_reply"
             )
-        rejected = [c for c in accepted if not (isinstance(c, dict) and c.get("accepted") is True)]
+        accepted_by_name = {
+            c.get("name"): c for c in accepted if isinstance(c, dict) and isinstance(c.get("name"), str)
+        }
+        # Every requested capability must be acknowledged; an empty/partial list
+        # cannot silently pass as success.
+        missing = sorted(set(self._handlers.keys()) - set(accepted_by_name.keys()))
+        if missing:
+            raise NodeRegistrationError(
+                f"Registration reply omitted acceptance for: {', '.join(missing)}",
+                "invalid_register_reply",
+            )
+        rejected = [c for c in accepted_by_name.values() if c.get("accepted") is not True]
         if rejected:
             detail = ", ".join(
-                f"{c.get('name') if isinstance(c, dict) else '<unknown>'}"
-                + (f" ({c['reason']})" if isinstance(c, dict) and c.get("reason") else "")
+                f"{c.get('name')}" + (f" ({c['reason']})" if c.get("reason") else "")
                 for c in rejected
             )
             raise NodeRegistrationError(f"Capabilities rejected: {detail}", "capabilities_rejected")

--- a/packages/sdk-python/src/relay_sdk/node.py
+++ b/packages/sdk-python/src/relay_sdk/node.py
@@ -168,8 +168,9 @@ class NodeHandlerContext:
 
         Capacity-direct: it never re-enters action dispatch, so a
         `spawn:<harness>` shadow handler that delegates cannot recurse into
-        itself. Resolves with the spawn placement."""
-        frame = {"type": "node.spawn", "input": input, "target_node_id": self._provider._node_id}
+        itself. The engine always targets this connection's own node, so the
+        frame carries no node target. Resolves with the spawn placement."""
+        frame = {"type": "node.spawn", "input": input}
         return await self._provider._request(_random_id(), frame)
 
 

--- a/packages/sdk-python/tests/test_node.py
+++ b/packages/sdk-python/tests/test_node.py
@@ -366,7 +366,9 @@ async def test_spawn_agent_sends_capacity_direct_node_spawn_frame():
     await wait_until(lambda: len(conn.sent_of_type("node.spawn")) == 1)
     spawn_frame = conn.sent_of_type("node.spawn")[-1]
     assert spawn_frame["input"] == {"cli": "claude", "name": "worker-1"}
-    assert spawn_frame["target_node_id"] == "node_a"
+    # Capacity-direct: the frame carries no node target; the engine uses the
+    # connection's own node.
+    assert "target_node_id" not in spawn_frame
 
     conn.push(
         {

--- a/packages/sdk-python/tests/test_node.py
+++ b/packages/sdk-python/tests/test_node.py
@@ -330,6 +330,28 @@ async def test_reconnects_with_new_instance_id_after_unexpected_drop():
 
 
 @pytest.mark.asyncio
+async def test_reconnects_when_dropped_during_register_handshake():
+    # A transport drop before the register reply must retry, not hang or
+    # hard-fail: only a protocol rejection is a terminal failure.
+    server = FakeNodeServer()
+    node = NodeProvider(**base_kwargs(server))
+
+    task = asyncio.create_task(node.serve())
+    first = await server.next_connection()
+    await wait_until(lambda: len(first.sent_of_type("node.register")) == 1)
+    first.drop()  # drop before replying to node.register
+
+    second = await server.next_connection()
+    assert second is not first
+    second.push(accept_all(second.last_register()))
+    await asyncio.wait_for(node.wait_registered(), timeout=1.0)
+    assert node.connected is True
+
+    await node.stop()
+    await asyncio.wait_for(task, timeout=1.0)
+
+
+@pytest.mark.asyncio
 async def test_deregisters_on_graceful_stop():
     server = FakeNodeServer()
     node = NodeProvider(**base_kwargs(server))

--- a/packages/sdk-python/tests/test_node.py
+++ b/packages/sdk-python/tests/test_node.py
@@ -14,7 +14,7 @@ import httpx
 import pytest
 import respx
 
-from relay_sdk.node import NodeConnectionClosed, NodeProvider, NodeRegistrationError
+from relay_sdk.node import NodeConnectionClosed, NodeProvider, NodeProviderError, NodeRegistrationError
 
 BASE_URL = "https://engine.test"
 
@@ -389,6 +389,26 @@ async def test_reconnects_when_dropped_during_register_handshake():
     second.push(accept_all(second.last_register()))
     await asyncio.wait_for(node.wait_registered(), timeout=1.0)
     assert node.connected is True
+
+    await node.stop()
+    await asyncio.wait_for(task, timeout=1.0)
+
+
+@pytest.mark.asyncio
+async def test_reconnect_exhaustion_does_not_overwrite_successful_registration():
+    server = FakeNodeServer()
+    node = NodeProvider(**base_kwargs(server))
+    task = asyncio.create_task(node.serve())
+    conn = await server.next_connection()
+    conn.push(accept_all(conn.last_register()))
+    reg = await node.wait_registered()
+    assert reg is not None
+
+    # A later reconnect-exhaustion rejection must not overwrite the completed
+    # registration: wait_registered() keeps returning the success.
+    node._reject_registered(NodeProviderError("exhausted"))
+    again = await node.wait_registered()
+    assert again is not None
 
     await node.stop()
     await asyncio.wait_for(task, timeout=1.0)

--- a/packages/sdk-python/tests/test_node.py
+++ b/packages/sdk-python/tests/test_node.py
@@ -10,7 +10,9 @@ from __future__ import annotations
 import asyncio
 import json
 
+import httpx
 import pytest
+import respx
 
 from relay_sdk.node import NodeConnectionClosed, NodeProvider, NodeRegistrationError
 
@@ -448,7 +450,11 @@ async def test_spawn_agent_sends_capacity_direct_node_spawn_frame():
 
 
 @pytest.mark.asyncio
-async def test_send_message_sends_node_message_frame():
+@respx.mock
+async def test_send_message_posts_to_canonical_channel_route():
+    route = respx.post("https://engine.test/v1/channels/ops/messages").mock(
+        return_value=httpx.Response(201, json={"ok": True, "data": {"id": "m-1", "text": "done"}})
+    )
     server = FakeNodeServer()
     node = NodeProvider(**base_kwargs(server))
     posted: dict = {}
@@ -464,15 +470,15 @@ async def test_send_message_sends_node_message_frame():
     await node.wait_registered()
 
     conn.push({"v": 1, "type": "action.invoke", "invocation_id": "inv-msg", "action": "run-etl", "input": {}})
-    await wait_until(lambda: len(conn.sent_of_type("node.message")) == 1)
-    msg_frame = conn.sent_of_type("node.message")[-1]
-    assert msg_frame["to"] == "ops"
-    assert msg_frame["from"] == "reporter"
-    assert msg_frame["text"] == "done"
-
-    conn.push({"v": 1, "id": msg_frame["id"], "type": "reply", "ok": True, "data": {"id": "m-1", "text": "done"}})
     await wait_until(lambda: "value" in posted)
     assert posted["value"]["id"] == "m-1"
+
+    assert route.called
+    request = route.calls.last.request
+    assert request.headers["authorization"] == "Bearer nt_live_test"
+    assert json.loads(request.content) == {"text": "done", "from": "reporter"}
+    # No node.message frame is sent over the socket — posting is HTTP now.
+    assert conn.sent_of_type("node.message") == []
 
     await node.stop()
     await asyncio.wait_for(task, timeout=1.0)

--- a/packages/sdk-python/tests/test_node.py
+++ b/packages/sdk-python/tests/test_node.py
@@ -231,6 +231,45 @@ async def test_invoke_runs_handler_and_replies_with_output():
 
 
 @pytest.mark.asyncio
+async def test_invoke_supports_a_sync_handler():
+    server = FakeNodeServer()
+    node = NodeProvider(**base_kwargs(server))
+
+    @node.capability("run-etl")
+    def handler(input, ctx):  # a plain (non-async) handler
+        return {"echoed": input}
+
+    task = asyncio.create_task(node.serve())
+    conn = await server.next_connection()
+    conn.push(accept_all(conn.last_register()))
+    await node.wait_registered()
+
+    conn.push({"v": 1, "type": "action.invoke", "invocation_id": "inv-sync", "action": "run-etl", "input": {"rows": 2}})
+    await wait_until(lambda: len(conn.sent_of_type("action.result")) == 1)
+    result = conn.sent_of_type("action.result")[-1]
+    assert result["output"] == {"echoed": {"rows": 2}}
+
+    await node.stop()
+    await asyncio.wait_for(task, timeout=1.0)
+
+
+@pytest.mark.asyncio
+async def test_registration_missing_accepted_capabilities_raises():
+    server = FakeNodeServer()
+    node = NodeProvider(**base_kwargs(server))
+
+    task = asyncio.create_task(node.serve())
+    conn = await server.next_connection()
+    register = conn.last_register()
+    # A reply that confirms nothing about capability acceptance is not success.
+    conn.push({"v": 1, "id": register["id"], "type": "reply", "ok": True, "data": {"provider": register["provider"]}})
+    with pytest.raises(NodeRegistrationError):
+        await asyncio.wait_for(node.wait_registered(), timeout=1.0)
+    with pytest.raises(NodeRegistrationError):
+        await asyncio.wait_for(task, timeout=1.0)
+
+
+@pytest.mark.asyncio
 async def test_handler_throw_becomes_error_result_never_dropped():
     server = FakeNodeServer()
     node = NodeProvider(**base_kwargs(server))

--- a/packages/sdk-python/tests/test_node.py
+++ b/packages/sdk-python/tests/test_node.py
@@ -357,6 +357,7 @@ async def test_reconnects_with_new_instance_id_after_unexpected_drop():
     first.drop()
     second = await server.next_connection()
     assert second is not first
+    await wait_until(lambda: len(second.sent_of_type("node.register")) >= 1)
     second_register = second.last_register()
     assert second_register["name"] == "alpha"
     assert second_register["provider"]["name"] == "py"
@@ -384,6 +385,7 @@ async def test_reconnects_when_dropped_during_register_handshake():
 
     second = await server.next_connection()
     assert second is not first
+    await wait_until(lambda: len(second.sent_of_type("node.register")) >= 1)
     second.push(accept_all(second.last_register()))
     await asyncio.wait_for(node.wait_registered(), timeout=1.0)
     assert node.connected is True

--- a/packages/sdk-python/tests/test_node.py
+++ b/packages/sdk-python/tests/test_node.py
@@ -1,0 +1,442 @@
+"""Tests for NodeProvider — against an in-process fake node-ws server.
+
+Never opens a real socket: the fake `connect` factory hands the client an
+in-memory `FakeConnection` that the test drives directly (push frames in,
+inspect frames sent out).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+
+import pytest
+
+from relay_sdk.node import NodeConnectionClosed, NodeProvider, NodeRegistrationError
+
+BASE_URL = "https://engine.test"
+
+
+class FakeConnection:
+    """One fake node-ws connection: captures sent frames, lets the test
+    push incoming frames, and raises on `recv()` once dropped/closed."""
+
+    def __init__(self, url: str) -> None:
+        self.url = url
+        self.sent: list[dict] = []
+        self._incoming: asyncio.Queue[str | None] = asyncio.Queue()
+        self.closed = False
+
+    async def send(self, data: str) -> None:
+        self.sent.append(json.loads(data))
+
+    async def recv(self) -> str:
+        item = await self._incoming.get()
+        if item is None:
+            raise NodeConnectionClosed("closed")
+        return item
+
+    async def close(self) -> None:
+        self.closed = True
+        self._incoming.put_nowait(None)
+
+    def push(self, frame: dict) -> None:
+        self._incoming.put_nowait(json.dumps(frame))
+
+    def drop(self) -> None:
+        """Simulate an unexpected disconnect (not a graceful close)."""
+        self._incoming.put_nowait(None)
+
+    def sent_of_type(self, type_: str) -> list[dict]:
+        return [f for f in self.sent if f.get("type") == type_]
+
+    def last_register(self) -> dict:
+        return self.sent_of_type("node.register")[-1]
+
+
+class FakeNodeServer:
+    """Hands out `FakeConnection`s in connection order via an injectable
+    `connect` factory, and lets the test await the next one deterministically."""
+
+    def __init__(self) -> None:
+        self._queue: asyncio.Queue[FakeConnection] = asyncio.Queue()
+
+    async def connect(self, url: str) -> FakeConnection:
+        conn = FakeConnection(url)
+        await self._queue.put(conn)
+        return conn
+
+    async def next_connection(self) -> FakeConnection:
+        return await asyncio.wait_for(self._queue.get(), timeout=1.0)
+
+
+def accept_all(register: dict) -> dict:
+    caps = register.get("capabilities") or []
+    provider = register["provider"]
+    return {
+        "v": 1,
+        "id": register["id"],
+        "type": "reply",
+        "ok": True,
+        "data": {
+            "provider": provider,
+            "accepted_capabilities": [
+                {"name": c["name"], "kind": c.get("kind", "action"), "accepted": True} for c in caps
+            ],
+            "name": register["name"],
+        },
+    }
+
+
+def base_kwargs(server: FakeNodeServer, **overrides) -> dict:
+    kwargs = dict(
+        base_url=BASE_URL,
+        node_token="nt_live_test",
+        node_id="node_a",
+        node_name="alpha",
+        provider={"name": "py"},
+        connect=server.connect,
+        reconnect_jitter=False,
+        reconnect_base_delay=0.01,
+        reconnect_max_delay=0.05,
+        heartbeat_interval=15.0,
+    )
+    kwargs.update(overrides)
+    return kwargs
+
+
+async def wait_until(predicate, timeout: float = 1.0, interval: float = 0.005) -> None:
+    async def _poll():
+        while not predicate():
+            await asyncio.sleep(interval)
+
+    await asyncio.wait_for(_poll(), timeout)
+
+
+@pytest.mark.asyncio
+async def test_connects_and_registers_with_accepted_capabilities():
+    server = FakeNodeServer()
+    node = NodeProvider(**base_kwargs(server))
+
+    @node.capability("run-etl")
+    async def handler(input, ctx):
+        return "ok"
+
+    task = asyncio.create_task(node.serve())
+    conn = await server.next_connection()
+    assert conn.url.startswith("wss://engine.test/v1/node/ws?")
+    assert "token=nt_live_test" in conn.url
+
+    register = conn.last_register()
+    assert register["type"] == "node.register"
+    assert register["name"] == "alpha"
+    assert register["node_id"] == "node_a"
+    assert register["provider"]["name"] == "py"
+    assert register["provider"]["instance_id"]
+    assert register["capabilities"] == [{"name": "run-etl"}]
+
+    conn.push(accept_all(register))
+    data = await node.wait_registered()
+    assert data["name"] == "alpha"
+    assert node.connected is True
+
+    await node.stop()
+    await asyncio.wait_for(task, timeout=1.0)
+
+
+@pytest.mark.asyncio
+async def test_registration_rejected_capability_raises():
+    server = FakeNodeServer()
+    node = NodeProvider(**base_kwargs(server))
+    node.capability("run-etl", lambda input, ctx: "ok")
+
+    task = asyncio.create_task(node.serve())
+    conn = await server.next_connection()
+    register = conn.last_register()
+    conn.push(
+        {
+            "v": 1,
+            "id": register["id"],
+            "type": "reply",
+            "ok": True,
+            "data": {
+                "provider": register["provider"],
+                "accepted_capabilities": [
+                    {"name": "run-etl", "kind": "action", "accepted": False, "reason": "duplicate action name"}
+                ],
+            },
+        }
+    )
+
+    with pytest.raises(NodeRegistrationError, match="run-etl"):
+        await node.wait_registered()
+
+    with pytest.raises(NodeRegistrationError):
+        await asyncio.wait_for(task, timeout=1.0)
+
+
+@pytest.mark.asyncio
+async def test_registration_rejected_by_error_frame_raises():
+    server = FakeNodeServer()
+    node = NodeProvider(**base_kwargs(server))
+
+    task = asyncio.create_task(node.serve())
+    conn = await server.next_connection()
+    register = conn.last_register()
+    conn.push(
+        {
+            "v": 1,
+            "id": register["id"],
+            "type": "error",
+            "ok": False,
+            "code": "provider_instance_conflict",
+            "message": "already connected",
+        }
+    )
+
+    with pytest.raises(NodeRegistrationError) as exc_info:
+        await node.wait_registered()
+    assert exc_info.value.code == "provider_instance_conflict"
+
+    with pytest.raises(NodeRegistrationError):
+        await asyncio.wait_for(task, timeout=1.0)
+
+
+@pytest.mark.asyncio
+async def test_invoke_runs_handler_and_replies_with_output():
+    server = FakeNodeServer()
+    node = NodeProvider(**base_kwargs(server))
+
+    @node.capability("run-etl")
+    async def handler(input, ctx):
+        return {"echoed": input}
+
+    task = asyncio.create_task(node.serve())
+    conn = await server.next_connection()
+    conn.push(accept_all(conn.last_register()))
+    await node.wait_registered()
+
+    conn.push({"v": 1, "type": "action.invoke", "invocation_id": "inv-1", "action": "run-etl", "input": {"rows": 3}})
+    await wait_until(lambda: len(conn.sent_of_type("action.result")) == 1)
+    result = conn.sent_of_type("action.result")[-1]
+    assert result == {
+        "v": 1,
+        "type": "action.result",
+        "invocation_id": "inv-1",
+        "output": {"echoed": {"rows": 3}},
+    }
+
+    await node.stop()
+    await asyncio.wait_for(task, timeout=1.0)
+
+
+@pytest.mark.asyncio
+async def test_handler_throw_becomes_error_result_never_dropped():
+    server = FakeNodeServer()
+    node = NodeProvider(**base_kwargs(server))
+
+    @node.capability("run-etl")
+    async def handler(input, ctx):
+        raise ValueError("boom")
+
+    task = asyncio.create_task(node.serve())
+    conn = await server.next_connection()
+    conn.push(accept_all(conn.last_register()))
+    await node.wait_registered()
+
+    conn.push({"v": 1, "type": "action.invoke", "invocation_id": "inv-err", "action": "run-etl", "input": {}})
+    await wait_until(lambda: len(conn.sent_of_type("action.result")) == 1)
+    result = conn.sent_of_type("action.result")[-1]
+    assert result == {
+        "v": 1,
+        "type": "action.result",
+        "invocation_id": "inv-err",
+        "error": "boom",
+    }
+
+    await node.stop()
+    await asyncio.wait_for(task, timeout=1.0)
+
+
+@pytest.mark.asyncio
+async def test_unknown_action_errors_rather_than_dropping():
+    server = FakeNodeServer()
+    node = NodeProvider(**base_kwargs(server))
+    node.capability("run-etl", lambda input, ctx: "ok")
+
+    task = asyncio.create_task(node.serve())
+    conn = await server.next_connection()
+    conn.push(accept_all(conn.last_register()))
+    await node.wait_registered()
+
+    conn.push({"v": 1, "type": "action.invoke", "invocation_id": "inv-x", "action": "nope", "input": {}})
+    await wait_until(lambda: len(conn.sent_of_type("action.result")) == 1)
+    result = conn.sent_of_type("action.result")[-1]
+    assert result["invocation_id"] == "inv-x"
+    assert "nope" in result["error"]
+
+    await node.stop()
+    await asyncio.wait_for(task, timeout=1.0)
+
+
+@pytest.mark.asyncio
+async def test_heartbeat_is_provider_scoped_with_no_last_heartbeat_at():
+    server = FakeNodeServer()
+    node = NodeProvider(**base_kwargs(server, heartbeat_interval=0.02))
+
+    task = asyncio.create_task(node.serve())
+    conn = await server.next_connection()
+    conn.push(accept_all(conn.last_register()))
+    await node.wait_registered()
+
+    await wait_until(lambda: len(conn.sent_of_type("node.heartbeat")) >= 1)
+    hb = conn.sent_of_type("node.heartbeat")[-1]
+    assert hb["provider"] == {"name": "py", "instance_id": node._instance_id}
+    assert hb["load"] == 0
+    assert hb["active_agents"] == 0
+    assert hb["handlers_live"] is True
+    assert "last_heartbeat_at" not in hb
+
+    await node.stop()
+    await asyncio.wait_for(task, timeout=1.0)
+
+
+@pytest.mark.asyncio
+async def test_reconnects_with_new_instance_id_after_unexpected_drop():
+    server = FakeNodeServer()
+    node = NodeProvider(**base_kwargs(server))
+
+    task = asyncio.create_task(node.serve())
+    first = await server.next_connection()
+    first_register = first.last_register()
+    first.push(accept_all(first_register))
+    await node.wait_registered()
+    first_instance = first_register["provider"]["instance_id"]
+
+    first.drop()
+    second = await server.next_connection()
+    assert second is not first
+    second_register = second.last_register()
+    assert second_register["name"] == "alpha"
+    assert second_register["provider"]["name"] == "py"
+    second_instance = second_register["provider"]["instance_id"]
+    assert second_instance != first_instance
+
+    second.push(accept_all(second_register))
+    await wait_until(lambda: node.connected is True)
+
+    await node.stop()
+    await asyncio.wait_for(task, timeout=1.0)
+
+
+@pytest.mark.asyncio
+async def test_deregisters_on_graceful_stop():
+    server = FakeNodeServer()
+    node = NodeProvider(**base_kwargs(server))
+
+    task = asyncio.create_task(node.serve())
+    conn = await server.next_connection()
+    conn.push(accept_all(conn.last_register()))
+    await node.wait_registered()
+
+    await node.stop()
+    await asyncio.wait_for(task, timeout=1.0)
+
+    deregister = conn.sent_of_type("node.deregister")[-1]
+    assert deregister["provider"]["name"] == "py"
+
+
+@pytest.mark.asyncio
+async def test_spawn_agent_sends_capacity_direct_node_spawn_frame():
+    server = FakeNodeServer()
+    node = NodeProvider(**base_kwargs(server))
+    spawn_result: dict = {}
+
+    @node.capability("spawn:claude", kind="action")
+    async def handler(input, ctx):
+        spawn_result["value"] = await ctx.spawn_agent({"cli": "claude", "name": "worker-1"})
+        return spawn_result["value"]
+
+    task = asyncio.create_task(node.serve())
+    conn = await server.next_connection()
+    conn.push(accept_all(conn.last_register()))
+    await node.wait_registered()
+
+    conn.push({"v": 1, "type": "action.invoke", "invocation_id": "inv-spawn", "action": "spawn:claude", "input": {}})
+    await wait_until(lambda: len(conn.sent_of_type("node.spawn")) == 1)
+    spawn_frame = conn.sent_of_type("node.spawn")[-1]
+    assert spawn_frame["input"] == {"cli": "claude", "name": "worker-1"}
+    assert spawn_frame["target_node_id"] == "node_a"
+
+    conn.push(
+        {
+            "v": 1,
+            "id": spawn_frame["id"],
+            "type": "reply",
+            "ok": True,
+            "data": {"invocation_id": "spawned-1", "status": "dispatched"},
+        }
+    )
+    await wait_until(lambda: len(conn.sent_of_type("action.result")) == 1)
+    assert spawn_result["value"]["invocation_id"] == "spawned-1"
+
+    await node.stop()
+    await asyncio.wait_for(task, timeout=1.0)
+
+
+@pytest.mark.asyncio
+async def test_send_message_sends_node_message_frame():
+    server = FakeNodeServer()
+    node = NodeProvider(**base_kwargs(server))
+    posted: dict = {}
+
+    @node.capability("run-etl")
+    async def handler(input, ctx):
+        posted["value"] = await ctx.send_message(to="ops", from_="reporter", text="done")
+        return posted["value"]
+
+    task = asyncio.create_task(node.serve())
+    conn = await server.next_connection()
+    conn.push(accept_all(conn.last_register()))
+    await node.wait_registered()
+
+    conn.push({"v": 1, "type": "action.invoke", "invocation_id": "inv-msg", "action": "run-etl", "input": {}})
+    await wait_until(lambda: len(conn.sent_of_type("node.message")) == 1)
+    msg_frame = conn.sent_of_type("node.message")[-1]
+    assert msg_frame["to"] == "ops"
+    assert msg_frame["from"] == "reporter"
+    assert msg_frame["text"] == "done"
+
+    conn.push({"v": 1, "id": msg_frame["id"], "type": "reply", "ok": True, "data": {"id": "m-1", "text": "done"}})
+    await wait_until(lambda: "value" in posted)
+    assert posted["value"]["id"] == "m-1"
+
+    await node.stop()
+    await asyncio.wait_for(task, timeout=1.0)
+
+
+@pytest.mark.asyncio
+async def test_ctx_node_exposes_name_and_capability_names():
+    server = FakeNodeServer()
+    node = NodeProvider(**base_kwargs(server))
+    seen: dict = {}
+
+    @node.capability("run-etl")
+    async def handler(input, ctx):
+        seen["node"] = ctx.node
+        seen["invocation_id"] = ctx.invocation_id
+        return "ok"
+
+    task = asyncio.create_task(node.serve())
+    conn = await server.next_connection()
+    conn.push(accept_all(conn.last_register()))
+    await node.wait_registered()
+
+    conn.push({"v": 1, "type": "action.invoke", "invocation_id": "inv-ctx", "action": "run-etl", "input": {}})
+    await wait_until(lambda: "node" in seen)
+    assert seen["node"].name == "alpha"
+    assert seen["node"].capabilities == ["run-etl"]
+    assert seen["invocation_id"] == "inv-ctx"
+
+    await node.stop()
+    await asyncio.wait_for(task, timeout=1.0)

--- a/packages/sdk-python/tests/test_node.py
+++ b/packages/sdk-python/tests/test_node.py
@@ -415,6 +415,31 @@ async def test_reconnect_exhaustion_does_not_overwrite_successful_registration()
 
 
 @pytest.mark.asyncio
+async def test_handler_can_call_stop_without_deadlocking():
+    server = FakeNodeServer()
+    node = NodeProvider(**base_kwargs(server))
+    done: dict = {}
+
+    @node.capability("shutdown")
+    async def handler(input, ctx):
+        # A handler that triggers shutdown must not deadlock draining its own task.
+        await node.stop()
+        done["ok"] = True
+        return "ok"
+
+    task = asyncio.create_task(node.serve())
+    conn = await server.next_connection()
+    conn.push(accept_all(conn.last_register()))
+    await node.wait_registered()
+
+    conn.push({"v": 1, "type": "action.invoke", "invocation_id": "inv-stop", "action": "shutdown", "input": {}})
+    # serve() completes promptly (no 5s self-deadlock) and deregister was sent.
+    await asyncio.wait_for(task, timeout=2.0)
+    await wait_until(lambda: done.get("ok") is True)
+    assert len(conn.sent_of_type("node.deregister")) == 1
+
+
+@pytest.mark.asyncio
 async def test_deregisters_on_graceful_stop():
     server = FakeNodeServer()
     node = NodeProvider(**base_kwargs(server))

--- a/packages/sdk-swift/Sources/Relaycast/NodeProvider.swift
+++ b/packages/sdk-swift/Sources/Relaycast/NodeProvider.swift
@@ -685,10 +685,11 @@ public actor NodeProvider {
     }
 
     private func spawnAgentFrame(_ input: JSONValue) async throws -> JSONValue {
+        // Capacity-direct: the engine always targets this connection's own node,
+        // so the frame carries no node target.
         try await request([
             "type": .string("node.spawn"),
-            "input": input,
-            "target_node_id": .string(nodeID)
+            "input": input
         ])
     }
 

--- a/packages/sdk-swift/Sources/Relaycast/NodeProvider.swift
+++ b/packages/sdk-swift/Sources/Relaycast/NodeProvider.swift
@@ -1,0 +1,811 @@
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+// A node provider client: it attaches a process to a node, registers a subset
+// of that node's capabilities against the engine's `/v1/node/ws`, and executes
+// their invokes. Connection, registration, heartbeats, invoke dispatch, and
+// the handler-context helpers (`sendMessage`/`spawnAgent`) live here, with no
+// local-broker dependency.
+//
+// Enrollment (reading the node token/URL from disk) layers on top of this in
+// a thin wrapper; the client itself takes an explicit token and base URL.
+
+// MARK: - Capability registration
+
+public enum CapabilityKind: String, Sendable, Equatable, CaseIterable {
+    case action
+    case capacity
+}
+
+public typealias NodeActionHandler = @Sendable (JSONValue, NodeHandlerContext) async throws -> JSONValue
+
+private struct RegisteredCapability {
+    let kind: CapabilityKind?
+    let global: Bool
+    let queue: Bool
+    let metadata: [String: JSONValue]?
+    let handler: NodeActionHandler
+}
+
+// MARK: - Handler context
+
+public enum NodeMessageMode: String, Sendable, Equatable {
+    case wait
+    case steer
+}
+
+/// Context passed to every capability handler.
+public struct NodeHandlerContext: Sendable {
+    public struct NodeInfo: Sendable {
+        public let name: String
+        public let capabilities: [String]
+
+        public init(name: String, capabilities: [String]) {
+            self.name = name
+            self.capabilities = capabilities
+        }
+    }
+
+    /// Informational view of the node this provider is attached to.
+    public let node: NodeInfo
+    /// The invocation being handled.
+    public let invocationID: String
+
+    private let sendMessageImpl: @Sendable (String, String, String, String?, NodeMessageMode?, [String: JSONValue]?) async throws -> JSONValue
+    private let spawnAgentImpl: @Sendable (JSONValue) async throws -> JSONValue
+
+    init(
+        node: NodeInfo,
+        invocationID: String,
+        sendMessageImpl: @escaping @Sendable (String, String, String, String?, NodeMessageMode?, [String: JSONValue]?) async throws -> JSONValue,
+        spawnAgentImpl: @escaping @Sendable (JSONValue) async throws -> JSONValue
+    ) {
+        self.node = node
+        self.invocationID = invocationID
+        self.sendMessageImpl = sendMessageImpl
+        self.spawnAgentImpl = spawnAgentImpl
+    }
+
+    /// Post a channel message, attributed to `from` (an agent name resolved in
+    /// the workspace). Resolves with the posted message.
+    public func sendMessage(
+        to: String,
+        from: String,
+        text: String,
+        threadID: String? = nil,
+        mode: NodeMessageMode? = nil,
+        data: [String: JSONValue]? = nil
+    ) async throws -> JSONValue {
+        try await sendMessageImpl(to, from, text, threadID, mode, data)
+    }
+
+    /// Spawn an agent through the node's capacity executor. Capacity-direct: it
+    /// never re-enters action dispatch, so a `spawn:<harness>` shadow handler
+    /// that delegates cannot recurse into itself. Resolves with the spawn
+    /// placement.
+    public func spawnAgent(_ input: JSONValue) async throws -> JSONValue {
+        try await spawnAgentImpl(input)
+    }
+}
+
+// MARK: - Registration result / errors
+
+public struct NodeCapabilityAcceptance: Equatable, Sendable {
+    public let name: String
+    public let kind: String
+    public let accepted: Bool
+    public let reason: String?
+}
+
+/// `node.register` reply data. Carries the resolved provider identity and
+/// per-capability acceptance alongside the node's public descriptor (passed
+/// through in `raw`).
+public struct NodeRegisterReplyData: Equatable, Sendable {
+    public let providerName: String
+    public let instanceID: String
+    public let acceptedCapabilities: [NodeCapabilityAcceptance]
+    public let raw: JSONValue
+
+    static func parse(_ json: JSONValue) throws -> NodeRegisterReplyData {
+        guard case .object(let obj) = json,
+              case .object(let providerObj)? = obj["provider"],
+              case .string(let name)? = providerObj["name"],
+              case .string(let instanceID)? = providerObj["instance_id"]
+        else {
+            throw NodeProviderError.invalidRegisterReply
+        }
+
+        var acceptedCapabilities: [NodeCapabilityAcceptance] = []
+        if case .array(let items)? = obj["accepted_capabilities"] {
+            acceptedCapabilities = items.compactMap { item -> NodeCapabilityAcceptance? in
+                guard case .object(let capObj) = item,
+                      case .string(let capName)? = capObj["name"],
+                      case .bool(let accepted)? = capObj["accepted"]
+                else { return nil }
+                let kind: String = { if case .string(let k)? = capObj["kind"] { return k } else { return "action" } }()
+                let reason: String? = { if case .string(let r)? = capObj["reason"] { return r } else { return nil } }()
+                return NodeCapabilityAcceptance(name: capName, kind: kind, accepted: accepted, reason: reason)
+            }
+        }
+
+        return NodeRegisterReplyData(providerName: name, instanceID: instanceID, acceptedCapabilities: acceptedCapabilities, raw: json)
+    }
+}
+
+/// Thrown when the engine rejects the provider's registration (a capability
+/// was rejected, or the engine sent an `error` frame such as
+/// `provider_instance_conflict`).
+public struct NodeRegistrationError: Error, LocalizedError, Sendable, Equatable {
+    public let code: String
+    public let message: String
+
+    public init(code: String, message: String) {
+        self.code = code
+        self.message = message
+    }
+
+    public var errorDescription: String? { message }
+}
+
+public enum NodeProviderError: Error, LocalizedError, Sendable, Equatable {
+    case notConnected
+    case stopped
+    case connectionClosed
+    case reconnectAttemptsExhausted
+    case encodingFailed
+    case invalidRegisterReply
+
+    public var errorDescription: String? {
+        switch self {
+        case .notConnected: return "node provider websocket is not open"
+        case .stopped: return "node provider stopped"
+        case .connectionClosed: return "node provider connection closed"
+        case .reconnectAttemptsExhausted: return "node provider exhausted reconnect attempts"
+        case .encodingFailed: return "failed to encode node provider frame"
+        case .invalidRegisterReply: return "node provider received an invalid node.register reply"
+        }
+    }
+}
+
+// MARK: - Transport abstraction
+
+/// Abstracts the node socket so `NodeProvider` is unit-testable without a real
+/// network connection. `incoming` yields inbound text frames and finishes when
+/// the connection closes, expectedly or not.
+public protocol NodeTransport: Sendable {
+    func send(_ text: String) async throws
+    var incoming: AsyncStream<String> { get }
+    func close() async
+}
+
+/// The production transport: a `URLSessionWebSocketTask` bridged into
+/// `NodeTransport`'s async-stream shape.
+public final class URLSessionNodeTransport: NodeTransport, @unchecked Sendable {
+    private let task: URLSessionWebSocketTask
+    private let receiveTask: Task<Void, Never>
+    public let incoming: AsyncStream<String>
+
+    public init(url: URL, session: URLSession = .shared) {
+        let task = session.webSocketTask(with: url)
+        self.task = task
+        let (stream, continuation) = AsyncStream<String>.makeStream(of: String.self)
+        self.incoming = stream
+        task.resume()
+        self.receiveTask = Task {
+            while !Task.isCancelled {
+                do {
+                    let message = try await task.receive()
+                    switch message {
+                    case .string(let text):
+                        continuation.yield(text)
+                    case .data(let data):
+                        if let text = String(data: data, encoding: .utf8) {
+                            continuation.yield(text)
+                        }
+                    @unknown default:
+                        break
+                    }
+                } catch {
+                    continuation.finish()
+                    return
+                }
+            }
+            continuation.finish()
+        }
+    }
+
+    public func send(_ text: String) async throws {
+        try await task.send(.string(text))
+    }
+
+    public func close() async {
+        receiveTask.cancel()
+        task.cancel(with: .normalClosure, reason: nil)
+    }
+}
+
+// MARK: - NodeProvider
+
+/// A node provider client. Connects to `<baseURL>/v1/node/ws`, registers its
+/// capabilities, and dispatches `action.invoke` frames to their handlers until
+/// stopped. Reconnects with backoff on unexpected drops, minting a fresh
+/// `instanceID` per connection (the engine's replace semantic).
+public actor NodeProvider {
+    private enum RegistrationState {
+        case pending
+        case resolved(NodeRegisterReplyData)
+        case rejected(Error)
+    }
+
+    private enum ConnectionOutcome {
+        case stoppedGracefully
+        case registrationRejected(Error)
+        case droppedUnexpectedly
+    }
+
+    private let baseURL: String
+    private let nodeToken: String
+    private let nodeID: String
+    private let nodeName: String
+    private let providerName: String
+    private let initialInstanceID: String?
+    private let maxAgents: Int
+    private let tags: [String]
+    private let version: String
+    private let machineID: String?
+    private let heartbeatIntervalMilliseconds: Int
+    private let reconnectBaseDelayMilliseconds: Int
+    private let reconnectMaxDelayMilliseconds: Int
+    private let reconnectJitter: Bool
+    private let maxReconnectAttempts: Int
+    private let onError: (@Sendable (Error) -> Void)?
+    private let makeTransport: @Sendable () -> NodeTransport
+
+    private var capabilityOrder: [String] = []
+    private var capabilityHandlers: [String: RegisteredCapability] = [:]
+    private var pending: [String: CheckedContinuation<JSONValue, Error>] = [:]
+
+    private var transport: NodeTransport?
+    private var instanceID: String?
+    private var registered = false
+    private var stopped = true
+    private var reconnectAttempt = 0
+    private var heartbeatTask: Task<Void, Never>?
+    private var serveTask: Task<Void, Error>?
+
+    private var registrationState: RegistrationState = .pending
+    private var registrationWaiters: [CheckedContinuation<NodeRegisterReplyData, Error>] = []
+
+    public init(
+        baseURL: String? = nil,
+        nodeToken: String,
+        nodeID: String,
+        nodeName: String,
+        provider: (name: String, instanceID: String?),
+        capabilities: [String: NodeActionHandler] = [:],
+        maxAgents: Int = 0,
+        tags: [String] = [],
+        version: String? = nil,
+        machineID: String? = nil,
+        heartbeatIntervalMilliseconds: Int = 15_000,
+        reconnectBaseDelayMilliseconds: Int = 500,
+        reconnectMaxDelayMilliseconds: Int = 30_000,
+        reconnectJitter: Bool = true,
+        maxReconnectAttempts: Int = Int.max,
+        onError: (@Sendable (Error) -> Void)? = nil,
+        session: URLSession = .shared,
+        transport transportFactory: (@Sendable () -> NodeTransport)? = nil
+    ) {
+        let resolvedBaseURL = (baseURL ?? "https://cast.agentrelay.com")
+        self.baseURL = resolvedBaseURL
+        self.nodeToken = nodeToken
+        self.nodeID = nodeID
+        self.nodeName = nodeName
+        self.providerName = provider.name
+        self.initialInstanceID = provider.instanceID
+        self.maxAgents = maxAgents
+        self.tags = tags
+        self.version = version ?? relaycastSDKVersion
+        self.machineID = machineID
+        self.heartbeatIntervalMilliseconds = max(1, heartbeatIntervalMilliseconds)
+        self.reconnectBaseDelayMilliseconds = max(1, reconnectBaseDelayMilliseconds)
+        self.reconnectMaxDelayMilliseconds = max(reconnectBaseDelayMilliseconds, reconnectMaxDelayMilliseconds)
+        self.reconnectJitter = reconnectJitter
+        self.maxReconnectAttempts = maxReconnectAttempts
+        self.onError = onError
+
+        if let transportFactory {
+            self.makeTransport = transportFactory
+        } else {
+            let url = NodeProvider.webSocketURL(baseURL: resolvedBaseURL, token: nodeToken)
+            self.makeTransport = { URLSessionNodeTransport(url: url, session: session) }
+        }
+
+        for (name, handler) in capabilities {
+            capabilityOrder.append(name)
+            capabilityHandlers[name] = RegisteredCapability(kind: nil, global: false, queue: false, metadata: nil, handler: handler)
+        }
+    }
+
+    // MARK: Public API
+
+    public var connected: Bool {
+        registered && transport != nil
+    }
+
+    /// Register a capability and its handler.
+    public func capability(
+        _ name: String,
+        kind: CapabilityKind? = nil,
+        global: Bool = false,
+        queue: Bool = false,
+        metadata: [String: JSONValue]? = nil,
+        handler: @escaping NodeActionHandler
+    ) {
+        if capabilityHandlers[name] == nil {
+            capabilityOrder.append(name)
+        }
+        capabilityHandlers[name] = RegisteredCapability(kind: kind, global: global, queue: queue, metadata: metadata, handler: handler)
+    }
+
+    /// Resolves once the provider's first registration is accepted; throws if
+    /// it is hard-rejected. Later reconnect registrations do not resettle this
+    /// once the first attempt has settled.
+    public func waitRegistered() async throws -> NodeRegisterReplyData {
+        switch registrationState {
+        case .resolved(let data):
+            return data
+        case .rejected(let error):
+            throw error
+        case .pending:
+            return try await withCheckedThrowingContinuation { continuation in
+                registrationWaiters.append(continuation)
+            }
+        }
+    }
+
+    /// Connect, register, and dispatch invokes until `stop()` is called.
+    /// Reconnects with backoff on unexpected drops, re-registering with a
+    /// fresh instance id. Resolves on graceful `stop()`; throws if the initial
+    /// registration is rejected by the engine.
+    public func serve() async throws {
+        if let existing = serveTask {
+            try await existing.value
+            return
+        }
+        stopped = false
+        reconnectAttempt = 0
+        let task = Task<Void, Error> { [weak self] in
+            try await self?.runServeLoop()
+        }
+        serveTask = task
+        do {
+            try await task.value
+        } catch {
+            serveTask = nil
+            throw error
+        }
+        serveTask = nil
+    }
+
+    /// Gracefully deregister the provider and close the connection.
+    public func stop() async {
+        stopped = true
+        if let transport {
+            await sendDeregister(using: transport)
+            await transport.close()
+        }
+        stopHeartbeat()
+        rejectAllPending(NodeProviderError.stopped)
+        serveTask?.cancel()
+    }
+
+    // MARK: Serve loop
+
+    private func runServeLoop() async throws {
+        var isFirstAttempt = true
+        while !stopped {
+            let outcome = await runConnectionAttempt(isFirstAttempt: isFirstAttempt)
+            isFirstAttempt = false
+            switch outcome {
+            case .stoppedGracefully:
+                return
+            case .registrationRejected(let error):
+                stopped = true
+                reportError(error)
+                throw error
+            case .droppedUnexpectedly:
+                if reconnectAttempt >= maxReconnectAttempts {
+                    let error = NodeProviderError.reconnectAttemptsExhausted
+                    stopped = true
+                    reportError(error)
+                    throw error
+                }
+                reconnectAttempt += 1
+                let delayMs = computeBackoffDelayMilliseconds(attempt: reconnectAttempt)
+                try? await Task.sleep(nanoseconds: UInt64(delayMs) * 1_000_000)
+            }
+        }
+    }
+
+    private func runConnectionAttempt(isFirstAttempt: Bool) async -> ConnectionOutcome {
+        instanceID = isFirstAttempt ? (initialInstanceID ?? randomNodeProviderID()) : randomNodeProviderID()
+        registered = false
+        let newTransport = makeTransport()
+        transport = newTransport
+
+        let readLoop = Task { [weak self] in
+            for await text in newTransport.incoming {
+                await self?.handleFrame(text)
+            }
+            // The inbound stream finished (drop or close). Unblock any in-flight
+            // request — including a register still awaiting its reply — so the
+            // attempt can't hang waiting on a socket that is gone.
+            await self?.rejectAllPending(NodeProviderError.connectionClosed)
+        }
+
+        do {
+            let reply = try await sendRegister()
+            registered = true
+            reconnectAttempt = 0
+            settleRegistration(.success(reply))
+            startHeartbeat()
+
+            await readLoop.value
+
+            stopHeartbeat()
+            registered = false
+            transport = nil
+            let wasStopped = stopped
+            rejectAllPending(wasStopped ? NodeProviderError.stopped : NodeProviderError.connectionClosed)
+            return wasStopped ? .stoppedGracefully : .droppedUnexpectedly
+        } catch {
+            readLoop.cancel()
+            await newTransport.close()
+            transport = nil
+            registered = false
+            if stopped {
+                rejectAllPending(NodeProviderError.stopped)
+                return .stoppedGracefully
+            }
+            rejectAllPending(error)
+            // Only a protocol rejection (a rejected capability or an engine
+            // `error` frame) is a hard failure. A transport failure during the
+            // register handshake is a drop — reconnect rather than give up.
+            if error is NodeRegistrationError {
+                settleRegistration(.failure(error))
+                return .registrationRejected(error)
+            }
+            return .droppedUnexpectedly
+        }
+    }
+
+    private func computeBackoffDelayMilliseconds(attempt: Int) -> Int {
+        let exponential = min(
+            Double(reconnectBaseDelayMilliseconds) * pow(2, Double(attempt - 1)),
+            Double(reconnectMaxDelayMilliseconds)
+        )
+        guard reconnectJitter else { return Int(exponential.rounded()) }
+        return Int((exponential * Double.random(in: 0.5...1.5)).rounded())
+    }
+
+    // MARK: Registration
+
+    private func settleRegistration(_ result: Result<NodeRegisterReplyData, Error>) {
+        guard case .pending = registrationState else { return }
+        switch result {
+        case .success(let data):
+            registrationState = .resolved(data)
+        case .failure(let error):
+            registrationState = .rejected(error)
+        }
+        let waiters = registrationWaiters
+        registrationWaiters = []
+        for waiter in waiters {
+            switch result {
+            case .success(let data): waiter.resume(returning: data)
+            case .failure(let error): waiter.resume(throwing: error)
+            }
+        }
+    }
+
+    private func sendRegister() async throws -> NodeRegisterReplyData {
+        let data = try await request(registerFrame())
+        let reply = try NodeRegisterReplyData.parse(data)
+        let rejected = reply.acceptedCapabilities.filter { !$0.accepted }
+        guard rejected.isEmpty else {
+            let detail = rejected
+                .map { capability -> String in
+                    guard let reason = capability.reason else { return capability.name }
+                    return "\(capability.name) (\(reason))"
+                }
+                .joined(separator: ", ")
+            throw NodeRegistrationError(code: "capabilities_rejected", message: "Capabilities rejected: \(detail)")
+        }
+        return reply
+    }
+
+    private func registerFrame() -> [String: JSONValue] {
+        var fields: [String: JSONValue] = [
+            "type": .string("node.register"),
+            "name": .string(nodeName),
+            "node_id": .string(nodeID),
+            "provider": .object(["name": .string(providerName), "instance_id": .string(instanceID ?? "")]),
+            "capabilities": capabilitiesFrameValue(),
+            "max_agents": .int(maxAgents),
+            "tags": .array(tags.map(JSONValue.string)),
+            "version": .string(version),
+            "resume_cursor": .null
+        ]
+        if let machineID { fields["machine_id"] = .string(machineID) }
+        return fields
+    }
+
+    private func capabilitiesFrameValue() -> JSONValue {
+        .array(capabilityOrder.compactMap { name -> JSONValue? in
+            guard let cap = capabilityHandlers[name] else { return nil }
+            var obj: [String: JSONValue] = ["name": .string(name)]
+            if let kind = cap.kind { obj["kind"] = .string(kind.rawValue) }
+            if cap.global { obj["global"] = .bool(true) }
+            if cap.queue { obj["queue"] = .bool(true) }
+            if let metadata = cap.metadata { obj["metadata"] = .object(metadata) }
+            return .object(obj)
+        })
+    }
+
+    // MARK: Heartbeat / deregister
+
+    private func startHeartbeat() {
+        stopHeartbeat()
+        let intervalNanoseconds = UInt64(heartbeatIntervalMilliseconds) * 1_000_000
+        heartbeatTask = Task { [weak self] in
+            while !Task.isCancelled {
+                try? await Task.sleep(nanoseconds: intervalNanoseconds)
+                if Task.isCancelled { return }
+                await self?.sendHeartbeat()
+            }
+        }
+    }
+
+    private func stopHeartbeat() {
+        heartbeatTask?.cancel()
+        heartbeatTask = nil
+    }
+
+    private func sendHeartbeat() async {
+        guard let transport, registered, let instanceID else { return }
+        let payload: [String: JSONValue] = [
+            "v": .int(1),
+            "type": .string("node.heartbeat"),
+            "provider": .object(["name": .string(providerName), "instance_id": .string(instanceID)]),
+            "load": .int(0),
+            "active_agents": .int(0),
+            "handlers_live": .bool(true)
+        ]
+        guard let text = try? encodeFrame(payload) else { return }
+        try? await transport.send(text)
+    }
+
+    private func sendDeregister(using transport: NodeTransport) async {
+        guard registered, let instanceID else { return }
+        let payload: [String: JSONValue] = [
+            "v": .int(1),
+            "type": .string("node.deregister"),
+            "provider": .object(["name": .string(providerName), "instance_id": .string(instanceID)])
+        ]
+        guard let text = try? encodeFrame(payload) else { return }
+        try? await transport.send(text)
+    }
+
+    // MARK: Frame handling / dispatch
+
+    private func handleFrame(_ text: String) {
+        guard let frame = NodeProvider.parseFrame(text) else { return }
+        switch frame {
+        case .reply(let id, let data):
+            resumePending(id: id, result: .success(data))
+        case .error(let id, let code, let message):
+            resumePending(id: id, result: .failure(NodeRegistrationError(code: code, message: message)))
+        case .actionInvoke(let invocationID, let action, let input):
+            Task { [weak self] in
+                await self?.dispatchInvoke(invocationID: invocationID, action: action, input: input)
+            }
+        case .other:
+            break
+        }
+    }
+
+    private func dispatchInvoke(invocationID: String, action: String, input: JSONValue) async {
+        guard let cap = capabilityHandlers[action] else {
+            sendActionResult(invocationID: invocationID, error: "No handler registered for action \"\(action)\"")
+            return
+        }
+        let ctx = makeContext(invocationID: invocationID)
+        do {
+            let output = try await cap.handler(input, ctx)
+            sendActionResult(invocationID: invocationID, output: output)
+        } catch {
+            sendActionResult(invocationID: invocationID, error: errorMessage(error))
+        }
+    }
+
+    private func sendActionResult(invocationID: String, output: JSONValue) {
+        sendFrame(["type": .string("action.result"), "invocation_id": .string(invocationID), "output": output])
+    }
+
+    private func sendActionResult(invocationID: String, error: String) {
+        sendFrame(["type": .string("action.result"), "invocation_id": .string(invocationID), "error": .string(error)])
+    }
+
+    private func sendFrame(_ fields: [String: JSONValue]) {
+        guard let transport else { return }
+        var payload = fields
+        payload["v"] = .int(1)
+        guard let text = try? encodeFrame(payload) else { return }
+        Task { try? await transport.send(text) }
+    }
+
+    // MARK: Handler context
+
+    private func makeContext(invocationID: String) -> NodeHandlerContext {
+        NodeHandlerContext(
+            node: .init(name: nodeName, capabilities: capabilityOrder),
+            invocationID: invocationID,
+            sendMessageImpl: { [weak self] to, from, text, threadID, mode, data in
+                guard let self else { throw NodeProviderError.stopped }
+                return try await self.sendMessageFrame(to: to, from: from, text: text, threadID: threadID, mode: mode, data: data)
+            },
+            spawnAgentImpl: { [weak self] input in
+                guard let self else { throw NodeProviderError.stopped }
+                return try await self.spawnAgentFrame(input)
+            }
+        )
+    }
+
+    private func sendMessageFrame(
+        to: String,
+        from: String,
+        text: String,
+        threadID: String?,
+        mode: NodeMessageMode?,
+        data: [String: JSONValue]?
+    ) async throws -> JSONValue {
+        var payload: [String: JSONValue] = [
+            "type": .string("node.message"),
+            "to": .string(to),
+            "from": .string(from),
+            "text": .string(text)
+        ]
+        if let threadID { payload["thread_id"] = .string(threadID) }
+        if let mode { payload["mode"] = .string(mode.rawValue) }
+        if let data { payload["data"] = .object(data) }
+        return try await request(payload)
+    }
+
+    private func spawnAgentFrame(_ input: JSONValue) async throws -> JSONValue {
+        try await request([
+            "type": .string("node.spawn"),
+            "input": input,
+            "target_node_id": .string(nodeID)
+        ])
+    }
+
+    // MARK: Request / reply
+
+    private func request(_ fields: [String: JSONValue]) async throws -> JSONValue {
+        guard let transport else { throw NodeProviderError.notConnected }
+        let id = randomNodeProviderID()
+        var payload = fields
+        payload["id"] = .string(id)
+        payload["v"] = .int(1)
+        let text = try encodeFrame(payload)
+
+        return try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<JSONValue, Error>) in
+            pending[id] = continuation
+            Task { [weak self, transport] in
+                do {
+                    try await transport.send(text)
+                } catch {
+                    await self?.resumePending(id: id, result: .failure(error))
+                }
+            }
+        }
+    }
+
+    private func resumePending(id: String, result: Result<JSONValue, Error>) {
+        guard let continuation = pending.removeValue(forKey: id) else { return }
+        switch result {
+        case .success(let value): continuation.resume(returning: value)
+        case .failure(let error): continuation.resume(throwing: error)
+        }
+    }
+
+    private func rejectAllPending(_ error: Error) {
+        let waiters = pending
+        pending.removeAll()
+        for (_, continuation) in waiters {
+            continuation.resume(throwing: error)
+        }
+    }
+
+    private func reportError(_ error: Error) {
+        onError?(error)
+    }
+
+    // MARK: URL / encoding helpers
+
+    private static func webSocketURL(baseURL: String, token: String) -> URL {
+        let fallback = URL(string: "wss://cast.agentrelay.com/v1/node/ws")!
+        let trimmed = baseURL
+            .trimmingCharacters(in: CharacterSet(charactersIn: "/"))
+            .replacingOccurrences(of: "https://", with: "wss://")
+            .replacingOccurrences(of: "http://", with: "ws://")
+
+        guard var components = URLComponents(string: "\(trimmed)/v1/node/ws") else {
+            return fallback
+        }
+        components.queryItems = [
+            URLQueryItem(name: "token", value: token),
+            URLQueryItem(name: "origin_client", value: RelaycastOrigin.client),
+            URLQueryItem(name: "origin_version", value: RelaycastOrigin.version)
+        ]
+        return components.url ?? fallback
+    }
+
+    private enum InboundFrame {
+        case reply(id: String, data: JSONValue)
+        case error(id: String, code: String, message: String)
+        case actionInvoke(invocationID: String, action: String, input: JSONValue)
+        case other
+    }
+
+    private static func parseFrame(_ text: String) -> InboundFrame? {
+        guard let data = text.data(using: .utf8),
+              let value = try? JSONDecoder().decode(JSONValue.self, from: data),
+              case .object(let obj) = value,
+              case .string(let type)? = obj["type"]
+        else {
+            return nil
+        }
+
+        switch type {
+        case "reply":
+            guard case .string(let id)? = obj["id"] else { return nil }
+            return .reply(id: id, data: obj["data"] ?? .null)
+        case "error":
+            guard case .string(let id)? = obj["id"],
+                  case .string(let code)? = obj["code"],
+                  case .string(let message)? = obj["message"]
+            else { return nil }
+            return .error(id: id, code: code, message: message)
+        case "action.invoke":
+            guard case .string(let invocationID)? = obj["invocation_id"],
+                  case .string(let action)? = obj["action"]
+            else { return nil }
+            return .actionInvoke(invocationID: invocationID, action: action, input: obj["input"] ?? .object([:]))
+        default:
+            return .other
+        }
+    }
+}
+
+private func encodeFrame(_ fields: [String: JSONValue]) throws -> String {
+    let data = try JSONEncoder().encode(fields)
+    guard let text = String(data: data, encoding: .utf8) else {
+        throw NodeProviderError.encodingFailed
+    }
+    return text
+}
+
+private func randomNodeProviderID() -> String {
+    UUID().uuidString
+}
+
+private func errorMessage(_ error: Error) -> String {
+    if let localized = error as? LocalizedError, let description = localized.errorDescription {
+        return description
+    }
+    return String(describing: error)
+}

--- a/packages/sdk-swift/Sources/Relaycast/NodeProvider.swift
+++ b/packages/sdk-swift/Sources/Relaycast/NodeProvider.swift
@@ -54,13 +54,13 @@ public struct NodeHandlerContext: Sendable {
     public let invocationID: String
 
     private let sendMessageImpl: @Sendable (String, String, String, NodeMessageMode?, [String: JSONValue]?) async throws -> JSONValue
-    private let spawnAgentImpl: @Sendable (JSONValue) async throws -> JSONValue
+    private let spawnAgentImpl: @Sendable ([String: JSONValue]) async throws -> JSONValue
 
     init(
         node: NodeInfo,
         invocationID: String,
         sendMessageImpl: @escaping @Sendable (String, String, String, NodeMessageMode?, [String: JSONValue]?) async throws -> JSONValue,
-        spawnAgentImpl: @escaping @Sendable (JSONValue) async throws -> JSONValue
+        spawnAgentImpl: @escaping @Sendable ([String: JSONValue]) async throws -> JSONValue
     ) {
         self.node = node
         self.invocationID = invocationID
@@ -83,9 +83,10 @@ public struct NodeHandlerContext: Sendable {
 
     /// Spawn an agent through the node's capacity executor. Capacity-direct: it
     /// never re-enters action dispatch, so a `spawn:<harness>` shadow handler
-    /// that delegates cannot recurse into itself. Resolves with the spawn
-    /// placement.
-    public func spawnAgent(_ input: JSONValue) async throws -> JSONValue {
+    /// that delegates cannot recurse into itself. The spawn spec is a JSON
+    /// object (the engine's `node.spawn` input is object-typed). Resolves with
+    /// the spawn placement.
+    public func spawnAgent(_ input: [String: JSONValue]) async throws -> JSONValue {
         try await spawnAgentImpl(input)
     }
 }
@@ -109,25 +110,33 @@ public struct NodeRegisterReplyData: Equatable, Sendable {
     public let raw: JSONValue
 
     static func parse(_ json: JSONValue) throws -> NodeRegisterReplyData {
+        // A malformed reply is a deterministic registration failure (thrown as a
+        // NodeRegistrationError so it hard-fails rather than being retried as a
+        // transient drop).
         guard case .object(let obj) = json,
               case .object(let providerObj)? = obj["provider"],
               case .string(let name)? = providerObj["name"],
               case .string(let instanceID)? = providerObj["instance_id"]
         else {
-            throw NodeProviderError.invalidRegisterReply
+            throw NodeRegistrationError(code: "invalid_register_reply", message: "node.register reply is malformed")
         }
 
-        var acceptedCapabilities: [NodeCapabilityAcceptance] = []
-        if case .array(let items)? = obj["accepted_capabilities"] {
-            acceptedCapabilities = items.compactMap { item -> NodeCapabilityAcceptance? in
-                guard case .object(let capObj) = item,
-                      case .string(let capName)? = capObj["name"],
-                      case .bool(let accepted)? = capObj["accepted"]
-                else { return nil }
-                let kind: String = { if case .string(let k)? = capObj["kind"] { return k } else { return "action" } }()
-                let reason: String? = { if case .string(let r)? = capObj["reason"] { return r } else { return nil } }()
-                return NodeCapabilityAcceptance(name: capName, kind: kind, accepted: accepted, reason: reason)
+        // The reply must carry a well-formed acceptance list (the engine always
+        // does). A missing/corrupt list means acceptance can't be confirmed, so
+        // fail registration rather than assume success.
+        guard case .array(let items)? = obj["accepted_capabilities"] else {
+            throw NodeRegistrationError(code: "invalid_register_reply", message: "node.register reply is missing accepted_capabilities")
+        }
+        let acceptedCapabilities: [NodeCapabilityAcceptance] = items.map { item -> NodeCapabilityAcceptance in
+            // A malformed entry can't be confirmed accepted — count it as
+            // rejected (fail-safe) rather than dropping it.
+            guard case .object(let capObj) = item, case .string(let capName)? = capObj["name"] else {
+                return NodeCapabilityAcceptance(name: "<unknown>", kind: "action", accepted: false, reason: "malformed acceptance entry")
             }
+            let accepted: Bool = { if case .bool(let a)? = capObj["accepted"] { return a } else { return false } }()
+            let kind: String = { if case .string(let k)? = capObj["kind"] { return k } else { return "action" } }()
+            let reason: String? = { if case .string(let r)? = capObj["reason"] { return r } else { return nil } }()
+            return NodeCapabilityAcceptance(name: capName, kind: kind, accepted: accepted, reason: reason)
         }
 
         return NodeRegisterReplyData(providerName: name, instanceID: instanceID, acceptedCapabilities: acceptedCapabilities, raw: json)
@@ -682,12 +691,12 @@ public actor NodeProvider {
         return try await request(payload)
     }
 
-    private func spawnAgentFrame(_ input: JSONValue) async throws -> JSONValue {
+    private func spawnAgentFrame(_ input: [String: JSONValue]) async throws -> JSONValue {
         // Capacity-direct: the engine always targets this connection's own node,
         // so the frame carries no node target.
         try await request([
             "type": .string("node.spawn"),
-            "input": input
+            "input": .object(input)
         ])
     }
 

--- a/packages/sdk-swift/Sources/Relaycast/NodeProvider.swift
+++ b/packages/sdk-swift/Sources/Relaycast/NodeProvider.swift
@@ -53,13 +53,13 @@ public struct NodeHandlerContext: Sendable {
     /// The invocation being handled.
     public let invocationID: String
 
-    private let sendMessageImpl: @Sendable (String, String, String, String?, NodeMessageMode?, [String: JSONValue]?) async throws -> JSONValue
+    private let sendMessageImpl: @Sendable (String, String, String, NodeMessageMode?, [String: JSONValue]?) async throws -> JSONValue
     private let spawnAgentImpl: @Sendable (JSONValue) async throws -> JSONValue
 
     init(
         node: NodeInfo,
         invocationID: String,
-        sendMessageImpl: @escaping @Sendable (String, String, String, String?, NodeMessageMode?, [String: JSONValue]?) async throws -> JSONValue,
+        sendMessageImpl: @escaping @Sendable (String, String, String, NodeMessageMode?, [String: JSONValue]?) async throws -> JSONValue,
         spawnAgentImpl: @escaping @Sendable (JSONValue) async throws -> JSONValue
     ) {
         self.node = node
@@ -68,17 +68,17 @@ public struct NodeHandlerContext: Sendable {
         self.spawnAgentImpl = spawnAgentImpl
     }
 
-    /// Post a channel message, attributed to `from` (an agent name resolved in
-    /// the workspace). Resolves with the posted message.
+    /// Post a top-level channel message, attributed to `from` (an agent name
+    /// resolved in the workspace). Resolves with the posted message. Thread
+    /// replies are not part of this surface.
     public func sendMessage(
         to: String,
         from: String,
         text: String,
-        threadID: String? = nil,
         mode: NodeMessageMode? = nil,
         data: [String: JSONValue]? = nil
     ) async throws -> JSONValue {
-        try await sendMessageImpl(to, from, text, threadID, mode, data)
+        try await sendMessageImpl(to, from, text, mode, data)
     }
 
     /// Spawn an agent through the node's capacity executor. Capacity-direct: it
@@ -653,9 +653,9 @@ public actor NodeProvider {
         NodeHandlerContext(
             node: .init(name: nodeName, capabilities: capabilityOrder),
             invocationID: invocationID,
-            sendMessageImpl: { [weak self] to, from, text, threadID, mode, data in
+            sendMessageImpl: { [weak self] to, from, text, mode, data in
                 guard let self else { throw NodeProviderError.stopped }
-                return try await self.sendMessageFrame(to: to, from: from, text: text, threadID: threadID, mode: mode, data: data)
+                return try await self.sendMessageFrame(to: to, from: from, text: text, mode: mode, data: data)
             },
             spawnAgentImpl: { [weak self] input in
                 guard let self else { throw NodeProviderError.stopped }
@@ -668,7 +668,6 @@ public actor NodeProvider {
         to: String,
         from: String,
         text: String,
-        threadID: String?,
         mode: NodeMessageMode?,
         data: [String: JSONValue]?
     ) async throws -> JSONValue {
@@ -678,7 +677,6 @@ public actor NodeProvider {
             "from": .string(from),
             "text": .string(text)
         ]
-        if let threadID { payload["thread_id"] = .string(threadID) }
         if let mode { payload["mode"] = .string(mode.rawValue) }
         if let data { payload["data"] = .object(data) }
         return try await request(payload)

--- a/packages/sdk-swift/Sources/Relaycast/NodeProvider.swift
+++ b/packages/sdk-swift/Sources/Relaycast/NodeProvider.swift
@@ -705,10 +705,12 @@ public actor NodeProvider {
         request.httpBody = try JSONEncoder().encode(payload)
 
         let (respData, response) = try await httpSession.data(for: request)
-        let status = (response as? HTTPURLResponse)?.statusCode ?? 0
+        guard let http = response as? HTTPURLResponse else {
+            throw NodeProviderError.messageFailed(code: "invalid_response", message: "sendMessage response was not HTTP")
+        }
         let decoded = try? JSONDecoder().decode(JSONValue.self, from: respData)
-        if status >= 300 {
-            var code = "http_\(status)"
+        if http.statusCode >= 300 {
+            var code = "http_\(http.statusCode)"
             var message = "sendMessage to \"\(to)\" failed"
             if case .object(let obj)? = decoded, case .object(let err)? = obj["error"] {
                 if case .string(let c)? = err["code"] { code = c }
@@ -716,15 +718,28 @@ public actor NodeProvider {
             }
             throw NodeProviderError.messageFailed(code: code, message: message)
         }
-        if case .object(let obj)? = decoded, let dataVal = obj["data"] {
-            return dataVal
+        // A 2xx must carry a decodable `{ ok, data }` envelope; anything else is
+        // a malformed success and should surface, not silently return null.
+        guard case .object(let obj)? = decoded, let dataVal = obj["data"] else {
+            throw NodeProviderError.messageFailed(code: "invalid_response", message: "sendMessage response was not a valid message envelope")
         }
-        return decoded ?? .null
+        return dataVal
     }
 
     private static func channelMessageURL(baseURL: String, channel: String) -> URL? {
-        let trimmed = baseURL.hasSuffix("/") ? String(baseURL.dropLast()) : baseURL
-        let encoded = channel.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? channel
+        // The HTTP base may be given as ws(s):// (also accepted by the socket);
+        // normalize it back to http(s):// for the REST call.
+        var httpBase = baseURL
+        if httpBase.hasPrefix("wss://") {
+            httpBase = "https://" + httpBase.dropFirst("wss://".count)
+        } else if httpBase.hasPrefix("ws://") {
+            httpBase = "http://" + httpBase.dropFirst("ws://".count)
+        }
+        let trimmed = httpBase.hasSuffix("/") ? String(httpBase.dropLast()) : httpBase
+        // Encode the channel as a single path segment — `/` must be escaped.
+        var segment = CharacterSet.urlPathAllowed
+        segment.remove(charactersIn: "/")
+        let encoded = channel.addingPercentEncoding(withAllowedCharacters: segment) ?? channel
         return URL(string: "\(trimmed)/v1/channels/\(encoded)/messages")
     }
 

--- a/packages/sdk-swift/Sources/Relaycast/NodeProvider.swift
+++ b/packages/sdk-swift/Sources/Relaycast/NodeProvider.swift
@@ -165,6 +165,7 @@ public enum NodeProviderError: Error, LocalizedError, Sendable, Equatable {
     case reconnectAttemptsExhausted
     case encodingFailed
     case invalidRegisterReply
+    case messageFailed(code: String, message: String)
 
     public var errorDescription: String? {
         switch self {
@@ -174,6 +175,7 @@ public enum NodeProviderError: Error, LocalizedError, Sendable, Equatable {
         case .reconnectAttemptsExhausted: return "node provider exhausted reconnect attempts"
         case .encodingFailed: return "failed to encode node provider frame"
         case .invalidRegisterReply: return "node provider received an invalid node.register reply"
+        case .messageFailed(let code, let message): return "sendMessage failed (\(code)): \(message)"
         }
     }
 }
@@ -271,6 +273,7 @@ public actor NodeProvider {
     private let maxReconnectAttempts: Int
     private let onError: (@Sendable (Error) -> Void)?
     private let makeTransport: @Sendable () -> NodeTransport
+    private let httpSession: URLSession
 
     private var capabilityOrder: [String] = []
     private var capabilityHandlers: [String: RegisteredCapability] = [:]
@@ -325,6 +328,7 @@ public actor NodeProvider {
         self.maxReconnectAttempts = maxReconnectAttempts
         self.onError = onError
 
+        self.httpSession = session
         if let transportFactory {
             self.makeTransport = transportFactory
         } else {
@@ -664,7 +668,7 @@ public actor NodeProvider {
             invocationID: invocationID,
             sendMessageImpl: { [weak self] to, from, text, mode, data in
                 guard let self else { throw NodeProviderError.stopped }
-                return try await self.sendMessageFrame(to: to, from: from, text: text, mode: mode, data: data)
+                return try await self.postChannelMessage(to: to, from: from, text: text, mode: mode, data: data)
             },
             spawnAgentImpl: { [weak self] input in
                 guard let self else { throw NodeProviderError.stopped }
@@ -673,22 +677,51 @@ public actor NodeProvider {
         )
     }
 
-    private func sendMessageFrame(
+    /// Post a channel message through the canonical message route with the node
+    /// token, attributed to `from`. Node-attributed posts share the route's
+    /// delivery routing, observer events, and triggers by construction.
+    private func postChannelMessage(
         to: String,
         from: String,
         text: String,
         mode: NodeMessageMode?,
         data: [String: JSONValue]?
     ) async throws -> JSONValue {
-        var payload: [String: JSONValue] = [
-            "type": .string("node.message"),
-            "to": .string(to),
-            "from": .string(from),
-            "text": .string(text)
-        ]
+        var payload: [String: JSONValue] = ["text": .string(text), "from": .string(from)]
         if let mode { payload["mode"] = .string(mode.rawValue) }
         if let data { payload["data"] = .object(data) }
-        return try await request(payload)
+
+        guard let url = NodeProvider.channelMessageURL(baseURL: baseURL, channel: to) else {
+            throw NodeProviderError.encodingFailed
+        }
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("Bearer \(nodeToken)", forHTTPHeaderField: "Authorization")
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.httpBody = try JSONEncoder().encode(payload)
+
+        let (respData, response) = try await httpSession.data(for: request)
+        let status = (response as? HTTPURLResponse)?.statusCode ?? 0
+        let decoded = try? JSONDecoder().decode(JSONValue.self, from: respData)
+        if status >= 300 {
+            var code = "http_\(status)"
+            var message = "sendMessage to \"\(to)\" failed"
+            if case .object(let obj)? = decoded, case .object(let err)? = obj["error"] {
+                if case .string(let c)? = err["code"] { code = c }
+                if case .string(let m)? = err["message"] { message = m }
+            }
+            throw NodeProviderError.messageFailed(code: code, message: message)
+        }
+        if case .object(let obj)? = decoded, let dataVal = obj["data"] {
+            return dataVal
+        }
+        return decoded ?? .null
+    }
+
+    private static func channelMessageURL(baseURL: String, channel: String) -> URL? {
+        let trimmed = baseURL.hasSuffix("/") ? String(baseURL.dropLast()) : baseURL
+        let encoded = channel.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? channel
+        return URL(string: "\(trimmed)/v1/channels/\(encoded)/messages")
     }
 
     private func spawnAgentFrame(_ input: [String: JSONValue]) async throws -> JSONValue {

--- a/packages/sdk-swift/Sources/Relaycast/NodeProvider.swift
+++ b/packages/sdk-swift/Sources/Relaycast/NodeProvider.swift
@@ -286,6 +286,8 @@ public actor NodeProvider {
     private var reconnectAttempt = 0
     private var heartbeatTask: Task<Void, Never>?
     private var serveTask: Task<Void, Error>?
+    private var invokeSeq = 0
+    private var invokeTasks: [Int: Task<Void, Never>] = [:]
 
     private var registrationState: RegistrationState = .pending
     private var registrationWaiters: [CheckedContinuation<NodeRegisterReplyData, Error>] = []
@@ -323,7 +325,7 @@ public actor NodeProvider {
         self.machineID = machineID
         self.heartbeatIntervalMilliseconds = max(1, heartbeatIntervalMilliseconds)
         self.reconnectBaseDelayMilliseconds = max(1, reconnectBaseDelayMilliseconds)
-        self.reconnectMaxDelayMilliseconds = max(reconnectBaseDelayMilliseconds, reconnectMaxDelayMilliseconds)
+        self.reconnectMaxDelayMilliseconds = max(self.reconnectBaseDelayMilliseconds, reconnectMaxDelayMilliseconds)
         self.reconnectJitter = reconnectJitter
         self.maxReconnectAttempts = maxReconnectAttempts
         self.onError = onError
@@ -406,13 +408,31 @@ public actor NodeProvider {
     /// Gracefully deregister the provider and close the connection.
     public func stop() async {
         stopped = true
+        // Let in-flight invoke handlers finish (and send their results) before
+        // the socket closes; bound the wait so a slow handler can't hang stop.
+        let pending = Array(invokeTasks.values)
+        if !pending.isEmpty {
+            await withTaskGroup(of: Void.self) { group in
+                group.addTask { for task in pending { await task.value } }
+                group.addTask { try? await Task.sleep(nanoseconds: 5_000_000_000) }
+                await group.next()
+                group.cancelAll()
+            }
+        }
         if let transport {
             await sendDeregister(using: transport)
             await transport.close()
         }
         stopHeartbeat()
+        // A stop() before registration completed must not leave waitRegistered()
+        // hanging (settleRegistration is a no-op once it has resolved).
+        settleRegistration(.failure(NodeProviderError.stopped))
         rejectAllPending(NodeProviderError.stopped)
         serveTask?.cancel()
+    }
+
+    private func clearInvokeTask(_ id: Int) {
+        invokeTasks[id] = nil
     }
 
     // MARK: Serve loop
@@ -531,6 +551,16 @@ public actor NodeProvider {
     private func sendRegister() async throws -> NodeRegisterReplyData {
         let data = try await request(registerFrame())
         let reply = try NodeRegisterReplyData.parse(data)
+        // Every requested capability must be acknowledged; an empty/partial list
+        // cannot silently pass as success.
+        let acknowledged = Set(reply.acceptedCapabilities.map { $0.name })
+        let missing = capabilityOrder.filter { !acknowledged.contains($0) }
+        guard missing.isEmpty else {
+            throw NodeRegistrationError(
+                code: "invalid_register_reply",
+                message: "Registration reply omitted acceptance for: \(missing.joined(separator: ", "))"
+            )
+        }
         let rejected = reply.acceptedCapabilities.filter { !$0.accepted }
         guard rejected.isEmpty else {
             let detail = rejected
@@ -626,9 +656,13 @@ public actor NodeProvider {
         case .error(let id, let code, let message):
             resumePending(id: id, result: .failure(NodeRegistrationError(code: code, message: message)))
         case .actionInvoke(let invocationID, let action, let input):
-            Task { [weak self] in
+            let id = invokeSeq
+            invokeSeq += 1
+            let task = Task { [weak self] in
                 await self?.dispatchInvoke(invocationID: invocationID, action: action, input: input)
+                await self?.clearInvokeTask(id)
             }
+            invokeTasks[id] = task
         case .other:
             break
         }

--- a/packages/sdk-swift/Sources/Relaycast/NodeProvider.swift
+++ b/packages/sdk-swift/Sources/Relaycast/NodeProvider.swift
@@ -434,6 +434,10 @@ public actor NodeProvider {
                     let error = NodeProviderError.reconnectAttemptsExhausted
                     stopped = true
                     reportError(error)
+                    // If registration never completed, fail its waiter too —
+                    // otherwise waitRegistered() would hang forever after
+                    // reconnects are exhausted.
+                    settleRegistration(.failure(error))
                     throw error
                 }
                 reconnectAttempt += 1

--- a/packages/sdk-swift/Sources/Relaycast/NodeProvider.swift
+++ b/packages/sdk-swift/Sources/Relaycast/NodeProvider.swift
@@ -408,6 +408,8 @@ public actor NodeProvider {
     /// Gracefully deregister the provider and close the connection.
     public func stop() async {
         stopped = true
+        // Stop heartbeats before draining so none fire during the drain window.
+        stopHeartbeat()
         // Let in-flight invoke handlers finish (and send their results) before
         // the socket closes; bound the wait so a slow handler can't hang stop.
         let pending = Array(invokeTasks.values)
@@ -423,7 +425,6 @@ public actor NodeProvider {
             await sendDeregister(using: transport)
             await transport.close()
         }
-        stopHeartbeat()
         // A stop() before registration completed must not leave waitRegistered()
         // hanging (settleRegistration is a no-op once it has resolved).
         settleRegistration(.failure(NodeProviderError.stopped))
@@ -549,12 +550,17 @@ public actor NodeProvider {
     }
 
     private func sendRegister() async throws -> NodeRegisterReplyData {
+        // Snapshot the advertised capabilities before the await; actor
+        // reentrancy lets `capability(...)` mutate capabilityOrder while the
+        // register request is in flight, and this reply reflects only the frame
+        // that was sent.
+        let requested = capabilityOrder
         let data = try await request(registerFrame())
         let reply = try NodeRegisterReplyData.parse(data)
-        // Every requested capability must be acknowledged; an empty/partial list
-        // cannot silently pass as success.
+        // Every advertised capability must be acknowledged; an empty/partial
+        // list cannot silently pass as success.
         let acknowledged = Set(reply.acceptedCapabilities.map { $0.name })
-        let missing = capabilityOrder.filter { !acknowledged.contains($0) }
+        let missing = requested.filter { !acknowledged.contains($0) }
         guard missing.isEmpty else {
             throw NodeRegistrationError(
                 code: "invalid_register_reply",
@@ -656,6 +662,9 @@ public actor NodeProvider {
         case .error(let id, let code, let message):
             resumePending(id: id, result: .failure(NodeRegistrationError(code: code, message: message)))
         case .actionInvoke(let invocationID, let action, let input):
+            // Stop accepting new invokes once shutting down/draining; the engine
+            // reschedules an undispatched invocation when the node goes offline.
+            if stopped { break }
             let id = invokeSeq
             invokeSeq += 1
             let task = Task { [weak self] in

--- a/packages/sdk-swift/Tests/RelaycastTests/NodeProviderTests.swift
+++ b/packages/sdk-swift/Tests/RelaycastTests/NodeProviderTests.swift
@@ -578,6 +578,45 @@ final class NodeProviderTests: XCTestCase {
         try await serveTask.value
         NodeMockURLProtocol.handler = nil
     }
+
+    func testSendMessageNormalizesWsBaseAndEscapesSlashInChannel() async throws {
+        NodeMockURLProtocol.handler = { request in
+            // ws base normalized to https; the slash in the channel name escaped
+            // into a single path segment.
+            XCTAssertEqual(request.url?.absoluteString, "https://engine.test/v1/channels/team%2Falpha/messages")
+            let response = HTTPURLResponse(url: request.url!, statusCode: 201, httpVersion: nil, headerFields: nil)!
+            let data = try JSONSerialization.data(withJSONObject: ["ok": true, "data": ["id": "m-2"]])
+            return (response, data)
+        }
+
+        let factory = FakeTransportFactory()
+        let node = NodeProvider(
+            baseURL: "wss://engine.test",
+            nodeToken: baseOptions.nodeToken,
+            nodeID: baseOptions.nodeID,
+            nodeName: baseOptions.nodeName,
+            provider: (name: "py", instanceID: nil),
+            session: makeNodeMockSession(),
+            transport: { factory.make() }
+        )
+        await node.capability("run-etl") { _, ctx in
+            try await ctx.sendMessage(to: "team/alpha", from: "reporter", text: "hi")
+        }
+
+        let serveTask = Task { try await node.serve() }
+        let transport = try await registerAndAccept(node: node, factory: factory)
+        await transport.emit([
+            "v": .int(1), "type": .string("action.invoke"),
+            "invocation_id": .string("inv-2"), "action": .string("run-etl"), "input": .object([:])
+        ])
+        await waitUntil { await !transport.sentOfType("action.result").isEmpty }
+        let result = await transport.sentOfType("action.result").last!
+        XCTAssertEqual(result["output"], .object(["id": .string("m-2")]))
+
+        await node.stop()
+        try await serveTask.value
+        NodeMockURLProtocol.handler = nil
+    }
 }
 
 private final class NodeMockURLProtocol: URLProtocol {

--- a/packages/sdk-swift/Tests/RelaycastTests/NodeProviderTests.swift
+++ b/packages/sdk-swift/Tests/RelaycastTests/NodeProviderTests.swift
@@ -527,13 +527,26 @@ final class NodeProviderTests: XCTestCase {
         try await serveTask.value
     }
 
-    func testSendMessageSendsANodeMessageFrameAndResolvesWithTheReply() async throws {
+    func testSendMessagePostsToTheCanonicalChannelRoute() async throws {
+        NodeMockURLProtocol.handler = { request in
+            XCTAssertEqual(request.url?.absoluteString, "https://engine.test/v1/channels/ops/messages")
+            XCTAssertEqual(request.value(forHTTPHeaderField: "Authorization"), "Bearer nt_live_test")
+            let json = (try? JSONSerialization.jsonObject(with: nodeRequestBody(request) ?? Data())) as? [String: Any]
+            XCTAssertEqual(json?["text"] as? String, "done")
+            XCTAssertEqual(json?["from"] as? String, "reporter")
+            let response = HTTPURLResponse(url: request.url!, statusCode: 201, httpVersion: nil, headerFields: nil)!
+            let data = try JSONSerialization.data(withJSONObject: ["ok": true, "data": ["id": "m-1", "text": "done"]])
+            return (response, data)
+        }
+
         let factory = FakeTransportFactory()
         let node = NodeProvider(
+            baseURL: "https://engine.test",
             nodeToken: baseOptions.nodeToken,
             nodeID: baseOptions.nodeID,
             nodeName: baseOptions.nodeName,
             provider: (name: "py", instanceID: nil),
+            session: makeNodeMockSession(),
             transport: { factory.make() }
         )
         await node.capability("run-etl") { _, ctx in
@@ -551,26 +564,67 @@ final class NodeProviderTests: XCTestCase {
             "input": .object([:])
         ])
 
-        await waitUntil { await !transport.sentOfType("node.message").isEmpty }
-        let message = await transport.sentOfType("node.message").last!
-        XCTAssertEqual(message["to"], .string("ops"))
-        XCTAssertEqual(message["from"], .string("reporter"))
-        XCTAssertEqual(message["text"], .string("done"))
-
-        await transport.emit([
-            "id": message["id"] ?? .null,
-            "type": .string("reply"),
-            "ok": .bool(true),
-            "data": .object(["id": .string("m-1"), "text": .string("done")])
-        ])
-
+        // The handler returns sendMessage's result, so the action.result output
+        // is the posted message `data` envelope unwrapped.
         await waitUntil { await !transport.sentOfType("action.result").isEmpty }
         let result = await transport.sentOfType("action.result").last!
         XCTAssertEqual(result["output"], .object(["id": .string("m-1"), "text": .string("done")]))
 
+        // No node.message frame over the socket — posting is HTTP now.
+        let messageFrames = await transport.sentOfType("node.message")
+        XCTAssertTrue(messageFrames.isEmpty)
+
         await node.stop()
         try await serveTask.value
+        NodeMockURLProtocol.handler = nil
     }
+}
+
+private final class NodeMockURLProtocol: URLProtocol {
+    nonisolated(unsafe) static var handler: ((URLRequest) throws -> (HTTPURLResponse, Data))?
+
+    override class func canInit(with request: URLRequest) -> Bool { true }
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+    override func startLoading() {
+        guard let handler = Self.handler else {
+            client?.urlProtocol(self, didFailWithError: URLError(.badServerResponse))
+            return
+        }
+        do {
+            let (response, data) = try handler(request)
+            client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+            client?.urlProtocol(self, didLoad: data)
+            client?.urlProtocolDidFinishLoading(self)
+        } catch {
+            client?.urlProtocol(self, didFailWithError: error)
+        }
+    }
+
+    override func stopLoading() {}
+}
+
+private func makeNodeMockSession() -> URLSession {
+    let configuration = URLSessionConfiguration.ephemeral
+    configuration.protocolClasses = [NodeMockURLProtocol.self]
+    return URLSession(configuration: configuration)
+}
+
+private func nodeRequestBody(_ request: URLRequest) -> Data? {
+    if let body = request.httpBody { return body }
+    guard let stream = request.httpBodyStream else { return nil }
+    stream.open()
+    defer { stream.close() }
+    var data = Data()
+    let bufferSize = 1024
+    let buffer = UnsafeMutablePointer<UInt8>.allocate(capacity: bufferSize)
+    defer { buffer.deallocate() }
+    while stream.hasBytesAvailable {
+        let read = stream.read(buffer, maxLength: bufferSize)
+        if read <= 0 { break }
+        data.append(buffer, count: read)
+    }
+    return data
 }
 
 /// Waits for the (first) transport to be created, sends `node.register`, and

--- a/packages/sdk-swift/Tests/RelaycastTests/NodeProviderTests.swift
+++ b/packages/sdk-swift/Tests/RelaycastTests/NodeProviderTests.swift
@@ -538,6 +538,7 @@ final class NodeProviderTests: XCTestCase {
             let data = try JSONSerialization.data(withJSONObject: ["ok": true, "data": ["id": "m-1", "text": "done"]])
             return (response, data)
         }
+        defer { NodeMockURLProtocol.handler = nil }
 
         let factory = FakeTransportFactory()
         let node = NodeProvider(
@@ -576,7 +577,6 @@ final class NodeProviderTests: XCTestCase {
 
         await node.stop()
         try await serveTask.value
-        NodeMockURLProtocol.handler = nil
     }
 
     func testSendMessageNormalizesWsBaseAndEscapesSlashInChannel() async throws {
@@ -588,6 +588,7 @@ final class NodeProviderTests: XCTestCase {
             let data = try JSONSerialization.data(withJSONObject: ["ok": true, "data": ["id": "m-2"]])
             return (response, data)
         }
+        defer { NodeMockURLProtocol.handler = nil }
 
         let factory = FakeTransportFactory()
         let node = NodeProvider(
@@ -615,7 +616,6 @@ final class NodeProviderTests: XCTestCase {
 
         await node.stop()
         try await serveTask.value
-        NodeMockURLProtocol.handler = nil
     }
 }
 

--- a/packages/sdk-swift/Tests/RelaycastTests/NodeProviderTests.swift
+++ b/packages/sdk-swift/Tests/RelaycastTests/NodeProviderTests.swift
@@ -1,0 +1,543 @@
+import XCTest
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+@testable import Relaycast
+
+/// A fake node-ws transport: captures frames the client sends and lets the
+/// test drive replies/invokes without any real socket. Mirrors the engine's
+/// request/reply-over-node-socket contract.
+actor FakeNodeTransport: NodeTransport {
+    nonisolated let incoming: AsyncStream<String>
+    private let continuation: AsyncStream<String>.Continuation
+    private var sentFrames: [[String: JSONValue]] = []
+    private(set) var closed = false
+
+    init() {
+        let (stream, continuation) = AsyncStream<String>.makeStream(of: String.self)
+        self.incoming = stream
+        self.continuation = continuation
+    }
+
+    func send(_ text: String) async throws {
+        guard let data = text.data(using: .utf8),
+              let value = try? JSONDecoder().decode(JSONValue.self, from: data),
+              case .object(let obj) = value
+        else { return }
+        sentFrames.append(obj)
+    }
+
+    func close() async {
+        closed = true
+        continuation.finish()
+    }
+
+    func sent() -> [[String: JSONValue]] {
+        sentFrames
+    }
+
+    func sentOfType(_ type: String) -> [[String: JSONValue]] {
+        sentFrames.filter {
+            if case .string(let t)? = $0["type"] { return t == type }
+            return false
+        }
+    }
+
+    func lastRegister() -> [String: JSONValue]? {
+        sentOfType("node.register").last
+    }
+
+    /// Push a frame to the client as if the engine sent it.
+    func emit(_ frame: [String: JSONValue]) {
+        guard let data = try? JSONEncoder().encode(frame), let text = String(data: data, encoding: .utf8) else { return }
+        continuation.yield(text)
+    }
+
+    /// Simulate an unexpected drop (no `close()` from the client side).
+    func drop() {
+        continuation.finish()
+    }
+}
+
+/// Creates a fresh `FakeNodeTransport` per connection attempt and keeps every
+/// instance around so tests can inspect each connection epoch (mirrors the TS
+/// suite's `MockWebSocket.instances`).
+final class FakeTransportFactory: @unchecked Sendable {
+    private let lock = NSLock()
+    private var _instances: [FakeNodeTransport] = []
+
+    func make() -> NodeTransport {
+        let transport = FakeNodeTransport()
+        lock.lock()
+        _instances.append(transport)
+        lock.unlock()
+        return transport
+    }
+
+    var instances: [FakeNodeTransport] {
+        lock.lock()
+        defer { lock.unlock() }
+        return _instances
+    }
+}
+
+private func acceptAllReply(_ register: [String: JSONValue]) -> [String: JSONValue] {
+    var capabilities: [JSONValue] = []
+    if case .array(let items)? = register["capabilities"] {
+        capabilities = items.map { item -> JSONValue in
+            guard case .object(let obj) = item, case .string(let name)? = obj["name"] else { return item }
+            let kind = obj["kind"] ?? .string("action")
+            return .object(["name": .string(name), "kind": kind, "accepted": .bool(true)])
+        }
+    }
+    return [
+        "id": register["id"] ?? .null,
+        "type": .string("reply"),
+        "ok": .bool(true),
+        "data": .object([
+            "provider": register["provider"] ?? .object([:]),
+            "accepted_capabilities": .array(capabilities),
+            "name": register["name"] ?? .null
+        ])
+    ]
+}
+
+private func instanceID(_ register: [String: JSONValue]) -> String? {
+    guard case .object(let provider)? = register["provider"], case .string(let id)? = provider["instance_id"] else {
+        return nil
+    }
+    return id
+}
+
+@discardableResult
+private func waitUntil(
+    timeout: TimeInterval = 3.0,
+    file: StaticString = #filePath,
+    line: UInt = #line,
+    _ condition: () async -> Bool
+) async -> Bool {
+    let deadline = Date().addingTimeInterval(timeout)
+    while Date() < deadline {
+        if await condition() { return true }
+        try? await Task.sleep(nanoseconds: 5_000_000)
+    }
+    XCTFail("condition not met before timeout", file: file, line: line)
+    return false
+}
+
+private let baseOptions: (nodeToken: String, nodeID: String, nodeName: String) = (
+    nodeToken: "nt_live_test",
+    nodeID: "node_a",
+    nodeName: "alpha"
+)
+
+final class NodeProviderTests: XCTestCase {
+    func testRegistersAndAcceptsCapabilities() async throws {
+        let factory = FakeTransportFactory()
+        let node = NodeProvider(
+            nodeToken: baseOptions.nodeToken,
+            nodeID: baseOptions.nodeID,
+            nodeName: baseOptions.nodeName,
+            provider: (name: "py", instanceID: nil),
+            transport: { factory.make() }
+        )
+        await node.capability("run-etl") { input, _ in input }
+
+        let serveTask = Task { try await node.serve() }
+
+        await waitUntil { factory.instances.count == 1 }
+        let transport = factory.instances[0]
+
+        await waitUntil { await !transport.sentOfType("node.register").isEmpty }
+        let register = await transport.lastRegister()!
+        XCTAssertEqual(register["type"], .string("node.register"))
+        XCTAssertEqual(register["name"], .string("alpha"))
+        XCTAssertEqual(register["node_id"], .string("node_a"))
+        XCTAssertEqual(register["capabilities"], .array([.object(["name": .string("run-etl")])]))
+        guard case .object(let provider)? = register["provider"] else { return XCTFail("missing provider") }
+        XCTAssertEqual(provider["name"], .string("py"))
+        XCTAssertFalse(instanceID(register)?.isEmpty ?? true)
+
+        await transport.emit(acceptAllReply(register))
+
+        let reply = try await node.waitRegistered()
+        XCTAssertEqual(reply.providerName, "py")
+        let connected = await node.connected
+        XCTAssertTrue(connected)
+
+        await node.stop()
+        try await serveTask.value
+    }
+
+    func testHardFailsRegistrationWhenCapabilityRejected() async throws {
+        let factory = FakeTransportFactory()
+        let node = NodeProvider(
+            nodeToken: baseOptions.nodeToken,
+            nodeID: baseOptions.nodeID,
+            nodeName: baseOptions.nodeName,
+            provider: (name: "py", instanceID: nil),
+            transport: { factory.make() }
+        )
+        await node.capability("run-etl") { input, _ in input }
+
+        let serveTask = Task { try await node.serve() }
+
+        await waitUntil { factory.instances.count == 1 }
+        let transport = factory.instances[0]
+        await waitUntil { await !transport.sentOfType("node.register").isEmpty }
+        let register = await transport.lastRegister()!
+
+        await transport.emit([
+            "id": register["id"] ?? .null,
+            "type": .string("reply"),
+            "ok": .bool(true),
+            "data": .object([
+                "provider": register["provider"] ?? .object([:]),
+                "accepted_capabilities": .array([
+                    .object(["name": .string("run-etl"), "kind": .string("action"), "accepted": .bool(false), "reason": .string("duplicate action name")])
+                ])
+            ])
+        ])
+
+        do {
+            _ = try await node.waitRegistered()
+            XCTFail("expected waitRegistered() to throw")
+        } catch let error as NodeRegistrationError {
+            XCTAssertEqual(error.code, "capabilities_rejected")
+            XCTAssertTrue(error.message.contains("run-etl"))
+            XCTAssertTrue(error.message.contains("duplicate action name"))
+        }
+
+        do {
+            try await serveTask.value
+            XCTFail("expected serve() to throw")
+        } catch {
+            // expected: serve() surfaces the same hard rejection.
+        }
+    }
+
+    func testHardFailsRegistrationOnEngineErrorFrame() async throws {
+        let factory = FakeTransportFactory()
+        let node = NodeProvider(
+            nodeToken: baseOptions.nodeToken,
+            nodeID: baseOptions.nodeID,
+            nodeName: baseOptions.nodeName,
+            provider: (name: "py", instanceID: nil),
+            transport: { factory.make() }
+        )
+
+        let serveTask = Task { try await node.serve() }
+
+        await waitUntil { factory.instances.count == 1 }
+        let transport = factory.instances[0]
+        await waitUntil { await !transport.sentOfType("node.register").isEmpty }
+        let register = await transport.lastRegister()!
+
+        await transport.emit([
+            "id": register["id"] ?? .null,
+            "type": .string("error"),
+            "ok": .bool(false),
+            "code": .string("provider_instance_conflict"),
+            "message": .string("already connected")
+        ])
+
+        do {
+            _ = try await node.waitRegistered()
+            XCTFail("expected waitRegistered() to throw")
+        } catch let error as NodeRegistrationError {
+            XCTAssertEqual(error.code, "provider_instance_conflict")
+        }
+
+        do {
+            try await serveTask.value
+            XCTFail("expected serve() to throw")
+        } catch let error as NodeRegistrationError {
+            XCTAssertEqual(error.code, "provider_instance_conflict")
+        }
+    }
+
+    func testRunsHandlerOnInvokeAndRepliesWithOutput() async throws {
+        let factory = FakeTransportFactory()
+        let node = NodeProvider(
+            nodeToken: baseOptions.nodeToken,
+            nodeID: baseOptions.nodeID,
+            nodeName: baseOptions.nodeName,
+            provider: (name: "py", instanceID: nil),
+            transport: { factory.make() }
+        )
+        await node.capability("run-etl") { input, _ in .object(["echoed": input]) }
+
+        let serveTask = Task { try await node.serve() }
+        let transport = try await registerAndAccept(node: node, factory: factory)
+
+        await transport.emit([
+            "v": .int(1),
+            "type": .string("action.invoke"),
+            "invocation_id": .string("inv-1"),
+            "action": .string("run-etl"),
+            "input": .object(["rows": .int(3)])
+        ])
+
+        await waitUntil { await !transport.sentOfType("action.result").isEmpty }
+        let result = await transport.sentOfType("action.result").last!
+        XCTAssertEqual(result["invocation_id"], .string("inv-1"))
+        XCTAssertEqual(result["output"], .object(["echoed": .object(["rows": .int(3)])]))
+        XCTAssertNil(result["error"])
+
+        await node.stop()
+        try await serveTask.value
+    }
+
+    func testTurnsHandlerThrowIntoErrorResultAndNeverDropsTheInvocation() async throws {
+        struct Boom: Error, LocalizedError {
+            var errorDescription: String? { "boom" }
+        }
+        let factory = FakeTransportFactory()
+        let node = NodeProvider(
+            nodeToken: baseOptions.nodeToken,
+            nodeID: baseOptions.nodeID,
+            nodeName: baseOptions.nodeName,
+            provider: (name: "py", instanceID: nil),
+            transport: { factory.make() }
+        )
+        await node.capability("run-etl") { _, _ in throw Boom() }
+
+        let serveTask = Task { try await node.serve() }
+        let transport = try await registerAndAccept(node: node, factory: factory)
+
+        await transport.emit([
+            "v": .int(1),
+            "type": .string("action.invoke"),
+            "invocation_id": .string("inv-err"),
+            "action": .string("run-etl"),
+            "input": .object([:])
+        ])
+
+        await waitUntil { await !transport.sentOfType("action.result").isEmpty }
+        let result = await transport.sentOfType("action.result").last!
+        XCTAssertEqual(result["invocation_id"], .string("inv-err"))
+        XCTAssertEqual(result["error"], .string("boom"))
+        XCTAssertNil(result["output"])
+
+        await node.stop()
+        try await serveTask.value
+    }
+
+    func testErrorsAnInvokeForUnknownActionRatherThanDroppingIt() async throws {
+        let factory = FakeTransportFactory()
+        let node = NodeProvider(
+            nodeToken: baseOptions.nodeToken,
+            nodeID: baseOptions.nodeID,
+            nodeName: baseOptions.nodeName,
+            provider: (name: "py", instanceID: nil),
+            transport: { factory.make() }
+        )
+        await node.capability("run-etl") { input, _ in input }
+
+        let serveTask = Task { try await node.serve() }
+        let transport = try await registerAndAccept(node: node, factory: factory)
+
+        await transport.emit([
+            "v": .int(1),
+            "type": .string("action.invoke"),
+            "invocation_id": .string("inv-x"),
+            "action": .string("nope"),
+            "input": .object([:])
+        ])
+
+        await waitUntil { await !transport.sentOfType("action.result").isEmpty }
+        let result = await transport.sentOfType("action.result").last!
+        XCTAssertEqual(result["invocation_id"], .string("inv-x"))
+        guard case .string(let message)? = result["error"] else { return XCTFail("expected an error message") }
+        XCTAssertTrue(message.contains("nope"))
+
+        await node.stop()
+        try await serveTask.value
+    }
+
+    func testSendsProviderScopedHeartbeatsWhileServing() async throws {
+        let factory = FakeTransportFactory()
+        let node = NodeProvider(
+            nodeToken: baseOptions.nodeToken,
+            nodeID: baseOptions.nodeID,
+            nodeName: baseOptions.nodeName,
+            provider: (name: "py", instanceID: nil),
+            heartbeatIntervalMilliseconds: 30,
+            transport: { factory.make() }
+        )
+
+        let serveTask = Task { try await node.serve() }
+        let transport = try await registerAndAccept(node: node, factory: factory)
+
+        await waitUntil { await !transport.sentOfType("node.heartbeat").isEmpty }
+        let heartbeat = await transport.sentOfType("node.heartbeat").last!
+        guard case .object(let provider)? = heartbeat["provider"] else { return XCTFail("missing provider") }
+        XCTAssertEqual(provider["name"], .string("py"))
+        XCTAssertEqual(heartbeat["load"], .int(0))
+        XCTAssertEqual(heartbeat["active_agents"], .int(0))
+        XCTAssertEqual(heartbeat["handlers_live"], .bool(true))
+        XCTAssertNil(heartbeat["last_heartbeat_at"])
+
+        await node.stop()
+        try await serveTask.value
+    }
+
+    func testReconnectsWithANewInstanceIDAfterAnUnexpectedDrop() async throws {
+        let factory = FakeTransportFactory()
+        let node = NodeProvider(
+            nodeToken: baseOptions.nodeToken,
+            nodeID: baseOptions.nodeID,
+            nodeName: baseOptions.nodeName,
+            provider: (name: "py", instanceID: nil),
+            reconnectBaseDelayMilliseconds: 20,
+            reconnectMaxDelayMilliseconds: 100,
+            reconnectJitter: false,
+            transport: { factory.make() }
+        )
+
+        let serveTask = Task { try await node.serve() }
+        let first = try await registerAndAccept(node: node, factory: factory)
+        let firstRegister = await first.lastRegister()!
+        let firstInstanceID = instanceID(firstRegister)
+
+        await first.drop()
+
+        await waitUntil { factory.instances.count == 2 }
+        let second = factory.instances[1]
+        await waitUntil { await !second.sentOfType("node.register").isEmpty }
+        let secondRegister = await second.lastRegister()!
+        XCTAssertEqual(secondRegister["name"], .string("alpha"))
+        let secondInstanceID = instanceID(secondRegister)
+        XCTAssertNotNil(secondInstanceID)
+        XCTAssertNotEqual(secondInstanceID, firstInstanceID)
+
+        await second.emit(acceptAllReply(secondRegister))
+        await waitUntil { await node.connected }
+
+        await node.stop()
+        try await serveTask.value
+    }
+
+    func testDeregistersTheProviderOnGracefulStop() async throws {
+        let factory = FakeTransportFactory()
+        let node = NodeProvider(
+            nodeToken: baseOptions.nodeToken,
+            nodeID: baseOptions.nodeID,
+            nodeName: baseOptions.nodeName,
+            provider: (name: "py", instanceID: nil),
+            transport: { factory.make() }
+        )
+
+        let serveTask = Task { try await node.serve() }
+        let transport = try await registerAndAccept(node: node, factory: factory)
+
+        await node.stop()
+        try await serveTask.value
+
+        let deregister = await transport.sentOfType("node.deregister").last
+        XCTAssertNotNil(deregister)
+        guard case .object(let provider)? = deregister?["provider"] else { return XCTFail("missing provider") }
+        XCTAssertEqual(provider["name"], .string("py"))
+    }
+
+    func testSpawnAgentSendsACapacityDirectNodeSpawnFrameAndResolvesWithTheReply() async throws {
+        let factory = FakeTransportFactory()
+        let node = NodeProvider(
+            nodeToken: baseOptions.nodeToken,
+            nodeID: baseOptions.nodeID,
+            nodeName: baseOptions.nodeName,
+            provider: (name: "py", instanceID: nil),
+            transport: { factory.make() }
+        )
+        await node.capability("spawn:claude") { _, ctx in
+            try await ctx.spawnAgent(.object(["cli": .string("claude"), "name": .string("worker-1")]))
+        }
+
+        let serveTask = Task { try await node.serve() }
+        let transport = try await registerAndAccept(node: node, factory: factory)
+
+        await transport.emit([
+            "v": .int(1),
+            "type": .string("action.invoke"),
+            "invocation_id": .string("inv-spawn"),
+            "action": .string("spawn:claude"),
+            "input": .object([:])
+        ])
+
+        await waitUntil { await !transport.sentOfType("node.spawn").isEmpty }
+        let spawn = await transport.sentOfType("node.spawn").last!
+        XCTAssertEqual(spawn["input"], .object(["cli": .string("claude"), "name": .string("worker-1")]))
+        XCTAssertEqual(spawn["target_node_id"], .string("node_a"))
+
+        await transport.emit([
+            "id": spawn["id"] ?? .null,
+            "type": .string("reply"),
+            "ok": .bool(true),
+            "data": .object(["invocation_id": .string("spawned-1"), "status": .string("dispatched")])
+        ])
+
+        await waitUntil { await !transport.sentOfType("action.result").isEmpty }
+        let result = await transport.sentOfType("action.result").last!
+        XCTAssertEqual(result["output"], .object(["invocation_id": .string("spawned-1"), "status": .string("dispatched")]))
+
+        await node.stop()
+        try await serveTask.value
+    }
+
+    func testSendMessageSendsANodeMessageFrameAndResolvesWithTheReply() async throws {
+        let factory = FakeTransportFactory()
+        let node = NodeProvider(
+            nodeToken: baseOptions.nodeToken,
+            nodeID: baseOptions.nodeID,
+            nodeName: baseOptions.nodeName,
+            provider: (name: "py", instanceID: nil),
+            transport: { factory.make() }
+        )
+        await node.capability("run-etl") { _, ctx in
+            try await ctx.sendMessage(to: "ops", from: "reporter", text: "done")
+        }
+
+        let serveTask = Task { try await node.serve() }
+        let transport = try await registerAndAccept(node: node, factory: factory)
+
+        await transport.emit([
+            "v": .int(1),
+            "type": .string("action.invoke"),
+            "invocation_id": .string("inv-msg"),
+            "action": .string("run-etl"),
+            "input": .object([:])
+        ])
+
+        await waitUntil { await !transport.sentOfType("node.message").isEmpty }
+        let message = await transport.sentOfType("node.message").last!
+        XCTAssertEqual(message["to"], .string("ops"))
+        XCTAssertEqual(message["from"], .string("reporter"))
+        XCTAssertEqual(message["text"], .string("done"))
+
+        await transport.emit([
+            "id": message["id"] ?? .null,
+            "type": .string("reply"),
+            "ok": .bool(true),
+            "data": .object(["id": .string("m-1"), "text": .string("done")])
+        ])
+
+        await waitUntil { await !transport.sentOfType("action.result").isEmpty }
+        let result = await transport.sentOfType("action.result").last!
+        XCTAssertEqual(result["output"], .object(["id": .string("m-1"), "text": .string("done")]))
+
+        await node.stop()
+        try await serveTask.value
+    }
+}
+
+/// Waits for the (first) transport to be created, sends `node.register`, and
+/// accepts it, returning the transport once the provider is registered.
+private func registerAndAccept(node: NodeProvider, factory: FakeTransportFactory) async throws -> FakeNodeTransport {
+    await waitUntil { !factory.instances.isEmpty }
+    let transport = factory.instances[factory.instances.count - 1]
+    await waitUntil { await !transport.sentOfType("node.register").isEmpty }
+    let register = await transport.lastRegister()!
+    await transport.emit(acceptAllReply(register))
+    _ = try await node.waitRegistered()
+    return transport
+}

--- a/packages/sdk-swift/Tests/RelaycastTests/NodeProviderTests.swift
+++ b/packages/sdk-swift/Tests/RelaycastTests/NodeProviderTests.swift
@@ -467,7 +467,9 @@ final class NodeProviderTests: XCTestCase {
         await waitUntil { await !transport.sentOfType("node.spawn").isEmpty }
         let spawn = await transport.sentOfType("node.spawn").last!
         XCTAssertEqual(spawn["input"], .object(["cli": .string("claude"), "name": .string("worker-1")]))
-        XCTAssertEqual(spawn["target_node_id"], .string("node_a"))
+        // Capacity-direct: the frame carries no node target; the engine uses the
+        // connection's own node.
+        XCTAssertNil(spawn["target_node_id"])
 
         await transport.emit([
             "id": spawn["id"] ?? .null,

--- a/packages/sdk-swift/Tests/RelaycastTests/NodeProviderTests.swift
+++ b/packages/sdk-swift/Tests/RelaycastTests/NodeProviderTests.swift
@@ -216,6 +216,47 @@ final class NodeProviderTests: XCTestCase {
         }
     }
 
+    func testHardFailsRegistrationWhenReplyOmitsAcceptedCapabilities() async throws {
+        let factory = FakeTransportFactory()
+        let node = NodeProvider(
+            nodeToken: baseOptions.nodeToken,
+            nodeID: baseOptions.nodeID,
+            nodeName: baseOptions.nodeName,
+            provider: (name: "py", instanceID: nil),
+            transport: { factory.make() }
+        )
+        await node.capability("run-etl") { input, _ in input }
+
+        let serveTask = Task { try await node.serve() }
+
+        await waitUntil { factory.instances.count == 1 }
+        let transport = factory.instances[0]
+        await waitUntil { await !transport.sentOfType("node.register").isEmpty }
+        let register = await transport.lastRegister()!
+
+        // A reply that confirms nothing about capability acceptance is not success.
+        await transport.emit([
+            "id": register["id"] ?? .null,
+            "type": .string("reply"),
+            "ok": .bool(true),
+            "data": .object(["provider": register["provider"] ?? .object([:])])
+        ])
+
+        do {
+            _ = try await node.waitRegistered()
+            XCTFail("expected waitRegistered() to throw")
+        } catch let error as NodeRegistrationError {
+            XCTAssertEqual(error.code, "invalid_register_reply")
+        }
+
+        do {
+            try await serveTask.value
+            XCTFail("expected serve() to throw")
+        } catch {
+            // expected
+        }
+    }
+
     func testHardFailsRegistrationOnEngineErrorFrame() async throws {
         let factory = FakeTransportFactory()
         let node = NodeProvider(
@@ -450,7 +491,7 @@ final class NodeProviderTests: XCTestCase {
             transport: { factory.make() }
         )
         await node.capability("spawn:claude") { _, ctx in
-            try await ctx.spawnAgent(.object(["cli": .string("claude"), "name": .string("worker-1")]))
+            try await ctx.spawnAgent(["cli": .string("claude"), "name": .string("worker-1")])
         }
 
         let serveTask = Task { try await node.serve() }

--- a/packages/sdk-typescript/src/__tests__/node-provider.test.ts
+++ b/packages/sdk-typescript/src/__tests__/node-provider.test.ts
@@ -238,6 +238,23 @@ describe('NodeProviderClient', () => {
     const secondInstance = (secondRegister.provider as { instance_id: string }).instance_id;
     expect(secondRegister).toMatchObject({ name: 'alpha', provider: { name: 'py' } });
     expect(secondInstance).not.toBe(firstInstance);
+
+    // The reconnected registration completes its lifecycle: accepting it brings
+    // the provider back to connected.
+    second.emit(acceptAll(secondRegister));
+    await vi.waitFor(() => expect(node.connected).toBe(true));
+  });
+
+  it('hard-fails registration when the reply omits accepted_capabilities', async () => {
+    const node = new NodeProviderClient({ ...baseOptions, capabilities: { 'run-etl': async () => 'ok' } });
+    node.serve().catch(() => {});
+    const sock = newSocket();
+    sock.open();
+    const register = sock.lastRegister();
+    // A reply that confirms nothing about capability acceptance must not be
+    // treated as success.
+    sock.emit({ v: 1, id: register.id, type: 'reply', ok: true, data: { provider: register.provider } });
+    await expect(node.whenRegistered()).rejects.toMatchObject({ code: 'invalid_register_reply' });
   });
 
   it('reconnects after a transport drop during the register handshake', async () => {

--- a/packages/sdk-typescript/src/__tests__/node-provider.test.ts
+++ b/packages/sdk-typescript/src/__tests__/node-provider.test.ts
@@ -324,7 +324,14 @@ describe('NodeProviderClient', () => {
     expect(spawnResult).toMatchObject({ invocation_id: 'spawned-1' });
   });
 
-  it('ctx.sendMessage sends a node.message frame and resolves with the reply', async () => {
+  it('ctx.sendMessage posts to the canonical channel route with the node token', async () => {
+    const calls: { url: string; init: RequestInit }[] = [];
+    const fetchMock = vi.fn(async (url: string, init: RequestInit) => {
+      calls.push({ url, init });
+      return { ok: true, status: 201, json: async () => ({ data: { id: 'm-1', text: 'done' } }) } as unknown as Response;
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
     let posted: unknown;
     const node = new NodeProviderClient({
       ...baseOptions,
@@ -342,12 +349,15 @@ describe('NodeProviderClient', () => {
     await node.whenRegistered();
 
     sock.emit({ v: 1, type: 'action.invoke', invocation_id: 'inv-msg', action: 'run-etl', input: {} });
-    await vi.waitFor(() => expect(sock.sentOfType('node.message')).toHaveLength(1));
-    const msg = sock.sentOfType('node.message').at(-1)!;
-    expect(msg).toMatchObject({ to: 'ops', from: 'reporter', text: 'done' });
+    await vi.waitFor(() => expect(calls).toHaveLength(1));
+    const call = calls[0]!;
+    expect(call.url).toBe('https://engine.test/v1/channels/ops/messages');
+    expect((call.init.headers as Record<string, string>).authorization).toBe('Bearer nt_live_test');
+    expect(JSON.parse(call.init.body as string)).toEqual({ text: 'done', from: 'reporter' });
 
-    sock.emit({ v: 1, id: msg.id, type: 'reply', ok: true, data: { id: 'm-1', text: 'done' } });
     await vi.waitFor(() => expect(posted).toBeTruthy());
     expect(posted).toMatchObject({ id: 'm-1' });
+    // No node.message frame is sent over the socket — posting is HTTP now.
+    expect(sock.sentOfType('node.message')).toHaveLength(0);
   });
 });

--- a/packages/sdk-typescript/src/__tests__/node-provider.test.ts
+++ b/packages/sdk-typescript/src/__tests__/node-provider.test.ts
@@ -257,6 +257,33 @@ describe('NodeProviderClient', () => {
     await expect(node.whenRegistered()).rejects.toMatchObject({ code: 'invalid_register_reply' });
   });
 
+  it('hard-fails registration when the reply omits a requested capability', async () => {
+    const node = new NodeProviderClient({
+      ...baseOptions,
+      capabilities: { 'run-etl': async () => 'ok', deploy: async () => 'ok' },
+    });
+    node.serve().catch(() => {});
+    const sock = newSocket();
+    sock.open();
+    const register = sock.lastRegister();
+    // Only run-etl is acknowledged; deploy is silently missing.
+    sock.emit({
+      v: 1, id: register.id, type: 'reply', ok: true,
+      data: { provider: register.provider, accepted_capabilities: [{ name: 'run-etl', kind: 'action', accepted: true }] },
+    });
+    await expect(node.whenRegistered()).rejects.toMatchObject({ code: 'invalid_register_reply' });
+  });
+
+  it('rejects whenRegistered when stopped before registration completes', async () => {
+    const node = new NodeProviderClient(baseOptions);
+    node.serve().catch(() => {});
+    const sock = newSocket();
+    sock.open();
+    // node.register was sent but no acceptance reply has arrived yet.
+    await node.stop();
+    await expect(node.whenRegistered()).rejects.toThrow(/stopped/i);
+  });
+
   it('reconnects after a transport drop during the register handshake', async () => {
     const node = new NodeProviderClient(baseOptions);
     // A transient handshake drop must not hard-fail serve(); the reconnect below

--- a/packages/sdk-typescript/src/__tests__/node-provider.test.ts
+++ b/packages/sdk-typescript/src/__tests__/node-provider.test.ts
@@ -374,4 +374,27 @@ describe('NodeProviderClient', () => {
     // No node.message frame is sent over the socket — posting is HTTP now.
     expect(sock.sentOfType('node.message')).toHaveLength(0);
   });
+
+  it('ctx.sendMessage normalizes a ws base URL to http and encodes the channel', async () => {
+    const urls: string[] = [];
+    vi.stubGlobal('fetch', vi.fn(async (url: string) => {
+      urls.push(url);
+      return { ok: true, status: 201, json: async () => ({ data: { id: 'm' } }) } as unknown as Response;
+    }));
+
+    const node = new NodeProviderClient({
+      ...baseOptions,
+      baseUrl: 'wss://engine.test',
+      capabilities: { 'run-etl': async (_i: unknown, ctx) => ctx.sendMessage({ to: 'team/alpha', from: 'reporter', text: 'x' }) },
+    });
+    node.serve();
+    const sock = newSocket();
+    sock.open();
+    sock.emit(acceptAll(sock.lastRegister()));
+    await node.whenRegistered();
+
+    sock.emit({ v: 1, type: 'action.invoke', invocation_id: 'i', action: 'run-etl', input: {} });
+    await vi.waitFor(() => expect(urls).toHaveLength(1));
+    expect(urls[0]).toBe('https://engine.test/v1/channels/team%2Falpha/messages');
+  });
 });

--- a/packages/sdk-typescript/src/__tests__/node-provider.test.ts
+++ b/packages/sdk-typescript/src/__tests__/node-provider.test.ts
@@ -279,6 +279,20 @@ describe('NodeProviderClient', () => {
     expect(node.connected).toBe(true);
   });
 
+  it('rejects whenRegistered when reconnects are exhausted before registering', async () => {
+    const node = new NodeProviderClient({ ...baseOptions, maxReconnectAttempts: 1 });
+    node.serve().catch(() => {});
+    const first = newSocket();
+    first.open();
+    first.drop(); // dropped mid-handshake -> reconnect
+    await vi.advanceTimersByTimeAsync(50);
+    const second = newSocket();
+    second.open();
+    second.drop(); // second attempt drops -> reconnects exhausted
+    await vi.advanceTimersByTimeAsync(50);
+    await expect(node.whenRegistered()).rejects.toThrow(/exhausted/i);
+  });
+
   it('deregisters the provider on graceful stop', async () => {
     const node = new NodeProviderClient(baseOptions);
     node.serve();

--- a/packages/sdk-typescript/src/__tests__/node-provider.test.ts
+++ b/packages/sdk-typescript/src/__tests__/node-provider.test.ts
@@ -240,6 +240,28 @@ describe('NodeProviderClient', () => {
     expect(secondInstance).not.toBe(firstInstance);
   });
 
+  it('reconnects after a transport drop during the register handshake', async () => {
+    const node = new NodeProviderClient(baseOptions);
+    // A transient handshake drop must not hard-fail serve(); the reconnect below
+    // succeeding (whenRegistered resolves) is the assertion.
+    node.serve().catch(() => {});
+    const first = newSocket();
+    first.open();
+    expect(first.sentOfType('node.register')).toHaveLength(1);
+
+    // Drop before replying to node.register.
+    first.drop();
+    await vi.advanceTimersByTimeAsync(50);
+    const second = newSocket();
+    expect(second).not.toBe(first);
+    second.open();
+    expect(second.sentOfType('node.register')).toHaveLength(1);
+
+    second.emit(acceptAll(second.lastRegister()));
+    await node.whenRegistered();
+    expect(node.connected).toBe(true);
+  });
+
   it('deregisters the provider on graceful stop', async () => {
     const node = new NodeProviderClient(baseOptions);
     node.serve();

--- a/packages/sdk-typescript/src/__tests__/node-provider.test.ts
+++ b/packages/sdk-typescript/src/__tests__/node-provider.test.ts
@@ -275,7 +275,10 @@ describe('NodeProviderClient', () => {
     sock.emit({ v: 1, type: 'action.invoke', invocation_id: 'inv-spawn', action: 'spawn:claude', input: {} });
     await vi.waitFor(() => expect(sock.sentOfType('node.spawn')).toHaveLength(1));
     const spawn = sock.sentOfType('node.spawn').at(-1)!;
-    expect(spawn).toMatchObject({ input: { cli: 'claude', name: 'worker-1' }, target_node_id: 'node_a' });
+    // Capacity-direct: the frame carries no node target; the engine uses the
+    // connection's own node.
+    expect(spawn).toMatchObject({ input: { cli: 'claude', name: 'worker-1' } });
+    expect(spawn).not.toHaveProperty('target_node_id');
 
     sock.emit({ v: 1, id: spawn.id, type: 'reply', ok: true, data: { invocation_id: 'spawned-1', status: 'dispatched' } });
     await vi.waitFor(() => expect(sock.sentOfType('action.result')).toHaveLength(1));

--- a/packages/sdk-typescript/src/__tests__/node-provider.test.ts
+++ b/packages/sdk-typescript/src/__tests__/node-provider.test.ts
@@ -274,6 +274,18 @@ describe('NodeProviderClient', () => {
     await expect(node.whenRegistered()).rejects.toMatchObject({ code: 'invalid_register_reply' });
   });
 
+  it('validates registration against the capabilities sent, not later additions', async () => {
+    const node = new NodeProviderClient({ ...baseOptions, capabilities: { 'run-etl': async () => 'ok' } });
+    node.serve().catch(() => {});
+    const sock = newSocket();
+    sock.open();
+    const register = sock.lastRegister();
+    // A capability added AFTER the register frame was sent isn't in this reply.
+    node.capability('late', async () => 'ok');
+    sock.emit(acceptAll(register)); // acknowledges only run-etl (what was sent)
+    await expect(node.whenRegistered()).resolves.toBeTruthy();
+  });
+
   it('rejects whenRegistered when stopped before registration completes', async () => {
     const node = new NodeProviderClient(baseOptions);
     node.serve().catch(() => {});

--- a/packages/sdk-typescript/src/__tests__/node-provider.test.ts
+++ b/packages/sdk-typescript/src/__tests__/node-provider.test.ts
@@ -1,0 +1,311 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { NodeProviderClient } from '../node-provider.js';
+
+/**
+ * A fake node-ws server: captures frames the client sends and lets the test
+ * drive replies/invokes. Mirrors the engine's request/reply-over-node-socket
+ * contract without any network.
+ */
+class MockWebSocket {
+  static readonly OPEN = 1;
+  static readonly CLOSED = 3;
+  static instances: MockWebSocket[] = [];
+
+  url: string;
+  readyState = MockWebSocket.OPEN;
+  onopen: (() => void) | null = null;
+  onclose: (() => void) | null = null;
+  onmessage: ((event: { data: string }) => void) | null = null;
+  onerror: (() => void) | null = null;
+  sent: Record<string, unknown>[] = [];
+
+  constructor(url: string) {
+    this.url = url;
+    MockWebSocket.instances.push(this);
+  }
+
+  send(data: string): void {
+    this.sent.push(JSON.parse(data));
+  }
+
+  close(): void {
+    this.readyState = MockWebSocket.CLOSED;
+  }
+
+  open(): void {
+    this.readyState = MockWebSocket.OPEN;
+    this.onopen?.();
+  }
+
+  emit(data: unknown): void {
+    this.onmessage?.({ data: JSON.stringify(data) });
+  }
+
+  drop(): void {
+    this.readyState = MockWebSocket.CLOSED;
+    this.onclose?.();
+  }
+
+  sentOfType(type: string): Record<string, unknown>[] {
+    return this.sent.filter((f) => f.type === type);
+  }
+
+  /** The last node.register frame, for driving an acceptance reply. */
+  lastRegister(): Record<string, unknown> {
+    return this.sentOfType('node.register').at(-1)!;
+  }
+}
+
+function acceptAll(register: Record<string, unknown>) {
+  const caps = (register.capabilities as { name: string; kind?: string }[]) ?? [];
+  const provider = register.provider as { name: string; instance_id: string };
+  return {
+    v: 1,
+    id: register.id,
+    type: 'reply',
+    ok: true,
+    data: {
+      provider,
+      accepted_capabilities: caps.map((c) => ({ name: c.name, kind: c.kind ?? 'action', accepted: true })),
+      name: register.name,
+    },
+  };
+}
+
+const baseOptions = {
+  baseUrl: 'https://engine.test',
+  nodeToken: 'nt_live_test',
+  nodeId: 'node_a',
+  nodeName: 'alpha',
+  provider: { name: 'py' },
+  reconnectJitter: false,
+  reconnectBaseDelayMs: 10,
+};
+
+describe('NodeProviderClient', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    MockWebSocket.instances = [];
+    vi.stubGlobal('WebSocket', MockWebSocket);
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+  });
+
+  function newSocket(): MockWebSocket {
+    return MockWebSocket.instances.at(-1)!;
+  }
+
+  it('connects to /v1/node/ws with the node token and registers the provider', async () => {
+    const node = new NodeProviderClient({ ...baseOptions, capabilities: { 'run-etl': async () => 'ok' } });
+    node.serve();
+    const sock = newSocket();
+    const url = new URL(sock.url);
+    expect(url.origin).toBe('wss://engine.test');
+    expect(url.pathname).toBe('/v1/node/ws');
+    expect(url.searchParams.get('token')).toBe('nt_live_test');
+
+    sock.open();
+    const register = sock.lastRegister();
+    expect(register).toMatchObject({ type: 'node.register', name: 'alpha', node_id: 'node_a' });
+    expect(register.provider).toMatchObject({ name: 'py' });
+    expect((register.provider as { instance_id: string }).instance_id).toBeTruthy();
+    expect(register.capabilities).toEqual([{ name: 'run-etl' }]);
+
+    sock.emit(acceptAll(register));
+    await expect(node.whenRegistered()).resolves.toBeTruthy();
+    expect(node.connected).toBe(true);
+  });
+
+  it('hard-fails registration when a capability is rejected', async () => {
+    const node = new NodeProviderClient({ ...baseOptions, capabilities: { 'run-etl': async () => 'ok' } });
+    const served = node.serve();
+    const sock = newSocket();
+    sock.open();
+    const register = sock.lastRegister();
+    sock.emit({
+      v: 1,
+      id: register.id,
+      type: 'reply',
+      ok: true,
+      data: {
+        provider: register.provider,
+        accepted_capabilities: [{ name: 'run-etl', kind: 'action', accepted: false, reason: 'duplicate action name' }],
+      },
+    });
+    await expect(node.whenRegistered()).rejects.toThrow(/rejected.*run-etl.*duplicate action name/i);
+    // serve() surfaces the same hard rejection.
+    await expect(served).rejects.toThrow(/rejected/i);
+  });
+
+  it('hard-fails registration on an engine error frame (duplicate live instance)', async () => {
+    const node = new NodeProviderClient(baseOptions);
+    const served = node.serve();
+    const sock = newSocket();
+    sock.open();
+    const register = sock.lastRegister();
+    sock.emit({ v: 1, id: register.id, type: 'error', ok: false, code: 'provider_instance_conflict', message: 'already connected' });
+    await expect(node.whenRegistered()).rejects.toMatchObject({ code: 'provider_instance_conflict' });
+    await expect(served).rejects.toMatchObject({ code: 'provider_instance_conflict' });
+  });
+
+  it('runs a handler on action.invoke and replies with the output', async () => {
+    const node = new NodeProviderClient({
+      ...baseOptions,
+      capabilities: { 'run-etl': async (input: unknown) => ({ echoed: input }) },
+    });
+    node.serve();
+    const sock = newSocket();
+    sock.open();
+    sock.emit(acceptAll(sock.lastRegister()));
+    await node.whenRegistered();
+
+    sock.emit({ v: 1, type: 'action.invoke', invocation_id: 'inv-1', action: 'run-etl', input: { rows: 3 } });
+    await vi.waitFor(() => expect(sock.sentOfType('action.result')).toHaveLength(1));
+    expect(sock.sentOfType('action.result').at(-1)).toEqual({
+      v: 1,
+      type: 'action.result',
+      invocation_id: 'inv-1',
+      output: { echoed: { rows: 3 } },
+    });
+  });
+
+  it('turns a handler throw into an error result and never drops the invocation', async () => {
+    const node = new NodeProviderClient({
+      ...baseOptions,
+      capabilities: { 'run-etl': async () => { throw new Error('boom'); } },
+    });
+    node.serve();
+    const sock = newSocket();
+    sock.open();
+    sock.emit(acceptAll(sock.lastRegister()));
+    await node.whenRegistered();
+
+    sock.emit({ v: 1, type: 'action.invoke', invocation_id: 'inv-err', action: 'run-etl', input: {} });
+    await vi.waitFor(() => expect(sock.sentOfType('action.result')).toHaveLength(1));
+    expect(sock.sentOfType('action.result').at(-1)).toEqual({
+      v: 1,
+      type: 'action.result',
+      invocation_id: 'inv-err',
+      error: 'boom',
+    });
+  });
+
+  it('errors an invoke for an unknown action rather than dropping it', async () => {
+    const node = new NodeProviderClient({ ...baseOptions, capabilities: { 'run-etl': async () => 'ok' } });
+    node.serve();
+    const sock = newSocket();
+    sock.open();
+    sock.emit(acceptAll(sock.lastRegister()));
+    await node.whenRegistered();
+
+    sock.emit({ v: 1, type: 'action.invoke', invocation_id: 'inv-x', action: 'nope', input: {} });
+    await vi.waitFor(() => expect(sock.sentOfType('action.result')).toHaveLength(1));
+    expect(sock.sentOfType('action.result').at(-1)).toMatchObject({ invocation_id: 'inv-x', error: expect.stringContaining('nope') });
+  });
+
+  it('sends provider-scoped heartbeats while serving', async () => {
+    const node = new NodeProviderClient({ ...baseOptions, heartbeatIntervalMs: 1_000 });
+    node.serve();
+    const sock = newSocket();
+    sock.open();
+    sock.emit(acceptAll(sock.lastRegister()));
+    await node.whenRegistered();
+
+    await vi.advanceTimersByTimeAsync(1_000);
+    const hb = sock.sentOfType('node.heartbeat').at(-1)!;
+    expect(hb).toMatchObject({ provider: { name: 'py' }, load: 0, active_agents: 0, handlers_live: true });
+    expect(hb).not.toHaveProperty('last_heartbeat_at');
+  });
+
+  it('reconnects with a new instance id after an unexpected drop', async () => {
+    const node = new NodeProviderClient(baseOptions);
+    node.serve();
+    const first = newSocket();
+    first.open();
+    const firstRegister = first.lastRegister();
+    first.emit(acceptAll(firstRegister));
+    await node.whenRegistered();
+    const firstInstance = (firstRegister.provider as { instance_id: string }).instance_id;
+
+    first.drop();
+    await vi.advanceTimersByTimeAsync(50);
+    const second = newSocket();
+    expect(second).not.toBe(first);
+    second.open();
+    const secondRegister = second.lastRegister();
+    const secondInstance = (secondRegister.provider as { instance_id: string }).instance_id;
+    expect(secondRegister).toMatchObject({ name: 'alpha', provider: { name: 'py' } });
+    expect(secondInstance).not.toBe(firstInstance);
+  });
+
+  it('deregisters the provider on graceful stop', async () => {
+    const node = new NodeProviderClient(baseOptions);
+    node.serve();
+    const sock = newSocket();
+    sock.open();
+    sock.emit(acceptAll(sock.lastRegister()));
+    await node.whenRegistered();
+
+    await node.stop();
+    expect(sock.sentOfType('node.deregister').at(-1)).toMatchObject({ provider: { name: 'py' } });
+  });
+
+  it('ctx.spawnAgent sends a capacity-direct node.spawn frame and resolves with the reply', async () => {
+    let spawnResult: unknown;
+    const node = new NodeProviderClient({
+      ...baseOptions,
+      capabilities: {
+        'spawn:claude': {
+          kind: 'action',
+          handler: async (input: unknown, ctx) => {
+            spawnResult = await ctx.spawnAgent({ cli: 'claude', name: 'worker-1' });
+            return spawnResult;
+          },
+        },
+      },
+    });
+    node.serve();
+    const sock = newSocket();
+    sock.open();
+    sock.emit(acceptAll(sock.lastRegister()));
+    await node.whenRegistered();
+
+    sock.emit({ v: 1, type: 'action.invoke', invocation_id: 'inv-spawn', action: 'spawn:claude', input: {} });
+    await vi.waitFor(() => expect(sock.sentOfType('node.spawn')).toHaveLength(1));
+    const spawn = sock.sentOfType('node.spawn').at(-1)!;
+    expect(spawn).toMatchObject({ input: { cli: 'claude', name: 'worker-1' }, target_node_id: 'node_a' });
+
+    sock.emit({ v: 1, id: spawn.id, type: 'reply', ok: true, data: { invocation_id: 'spawned-1', status: 'dispatched' } });
+    await vi.waitFor(() => expect(sock.sentOfType('action.result')).toHaveLength(1));
+    expect(spawnResult).toMatchObject({ invocation_id: 'spawned-1' });
+  });
+
+  it('ctx.sendMessage sends a node.message frame and resolves with the reply', async () => {
+    let posted: unknown;
+    const node = new NodeProviderClient({
+      ...baseOptions,
+      capabilities: {
+        'run-etl': async (_input: unknown, ctx) => {
+          posted = await ctx.sendMessage({ to: 'ops', from: 'reporter', text: 'done' });
+          return posted;
+        },
+      },
+    });
+    node.serve();
+    const sock = newSocket();
+    sock.open();
+    sock.emit(acceptAll(sock.lastRegister()));
+    await node.whenRegistered();
+
+    sock.emit({ v: 1, type: 'action.invoke', invocation_id: 'inv-msg', action: 'run-etl', input: {} });
+    await vi.waitFor(() => expect(sock.sentOfType('node.message')).toHaveLength(1));
+    const msg = sock.sentOfType('node.message').at(-1)!;
+    expect(msg).toMatchObject({ to: 'ops', from: 'reporter', text: 'done' });
+
+    sock.emit({ v: 1, id: msg.id, type: 'reply', ok: true, data: { id: 'm-1', text: 'done' } });
+    await vi.waitFor(() => expect(posted).toBeTruthy());
+    expect(posted).toMatchObject({ id: 'm-1' });
+  });
+});

--- a/packages/sdk-typescript/src/index.ts
+++ b/packages/sdk-typescript/src/index.ts
@@ -51,5 +51,13 @@ export {
 export type { RegisterAgentInput, RegisterOrRotateInput, ResolvedIdentity } from './identity.js';
 export { WsClient } from './ws.js';
 export type { WsClientOptions, EventHandler } from './ws.js';
+export { NodeProviderClient, NodeRegistrationError } from './node-provider.js';
+export type {
+  NodeProviderOptions,
+  NodeCapabilityOptions,
+  NodeCapabilityHandler,
+  NodeHandlerContext,
+  NodeSendMessageInput,
+} from './node-provider.js';
 export type { Subscription } from './subscription.js';
 export type * from './types.js';

--- a/packages/sdk-typescript/src/node-provider.ts
+++ b/packages/sdk-typescript/src/node-provider.ts
@@ -145,6 +145,7 @@ export class NodeProviderClient {
 
   private readonly capabilities = new Map<string, RegisteredCapability>();
   private readonly pending = new Map<string, PendingRequest>();
+  private readonly invokeTasks = new Set<Promise<void>>();
 
   private ws: WebSocket | null = null;
   private instanceId: string | null = null;
@@ -252,9 +253,22 @@ export class NodeProviderClient {
     this.stopped = true;
     this.clearReconnect();
     this.stopHeartbeat();
+    // Let in-flight invoke handlers finish (and send their results) before the
+    // socket closes; bound the wait so a slow handler can't hang shutdown.
+    if (this.invokeTasks.size > 0) {
+      await Promise.race([
+        Promise.allSettled([...this.invokeTasks]),
+        new Promise<void>((resolve) => setTimeout(resolve, 5000)),
+      ]);
+    }
     if (this.ws && this.ws.readyState === 1 && this.registered && this.instanceId) {
       this.sendFrame({ type: 'node.deregister', provider: this.providerIdentity() });
     }
+    // A stop() before registration completed must not leave whenRegistered()
+    // hanging.
+    this.rejectRegister?.(new Error('node provider stopped'));
+    this.rejectRegister = null;
+    this.resolveRegister = null;
     this.rejectPending(new Error('node provider stopped'));
     this.closeSocket();
     this.registered = false;
@@ -362,6 +376,19 @@ export class NodeProviderClient {
       ));
       return;
     }
+    // Every requested capability must be acknowledged; an empty/partial list
+    // cannot silently pass as success.
+    const acknowledged = new Set(
+      list.filter((c): c is FleetCapabilityAcceptance => !!c && typeof c.name === 'string').map((c) => c.name),
+    );
+    const missing = [...this.capabilities.keys()].filter((name) => !acknowledged.has(name));
+    if (missing.length > 0) {
+      this.onRegisterFailed(new NodeRegistrationError(
+        `Registration reply omitted acceptance for: ${missing.join(', ')}`,
+        'invalid_register_reply',
+      ));
+      return;
+    }
     const rejected = list.filter((c: FleetCapabilityAcceptance) => !c || c.accepted !== true);
     if (rejected.length > 0) {
       const detail = rejected.map((c) => `${c?.name ?? '<unknown>'}${c?.reason ? ` (${c.reason})` : ''}`).join(', ');
@@ -426,9 +453,12 @@ export class NodeProviderClient {
         }
         return;
       }
-      case 'action.invoke':
-        void this.dispatchInvoke(message.invocation_id, message.action, message.input);
+      case 'action.invoke': {
+        const task = this.dispatchInvoke(message.invocation_id, message.action, message.input);
+        this.invokeTasks.add(task);
+        void task.finally(() => this.invokeTasks.delete(task));
         return;
+      }
       default:
         // deliver / context.update / ping carry no work for a provider client.
         return;

--- a/packages/sdk-typescript/src/node-provider.ts
+++ b/packages/sdk-typescript/src/node-provider.ts
@@ -476,7 +476,10 @@ export class NodeProviderClient {
    * delivery routing, observer events, and triggers by construction.
    */
   private async postChannelMessage(input: NodeSendMessageInput): Promise<unknown> {
-    const url = `${this.baseUrl}/v1/channels/${encodeURIComponent(input.to)}/messages`;
+    // The base may be given as ws(s):// (also accepted by the socket); normalize
+    // it back to http(s):// for the REST call.
+    const httpBase = this.baseUrl.replace(/^ws(s?):\/\//, 'http$1://');
+    const url = `${httpBase}/v1/channels/${encodeURIComponent(input.to)}/messages`;
     const res = await fetch(url, {
       method: 'POST',
       headers: { 'content-type': 'application/json', authorization: `Bearer ${this.nodeToken}` },

--- a/packages/sdk-typescript/src/node-provider.ts
+++ b/packages/sdk-typescript/src/node-provider.ts
@@ -1,0 +1,557 @@
+import {
+  parseFleetRelaycastToBrokerMessage,
+  type FleetCapability,
+  type FleetCapabilityAcceptance,
+  type FleetProviderIdentity,
+  type FleetWireJsonValue,
+  type NodeRegisterReplyData,
+} from '@relaycast/types';
+import { SDK_VERSION } from './version.js';
+
+/**
+ * A node provider client: it attaches a process to a node, registers a subset
+ * of that node's capabilities against the engine's `/v1/node/ws`, and executes
+ * their invokes. It is the language-neutral equivalent of the broker's Rust
+ * provider — connection, registration, heartbeats, invoke dispatch, and the
+ * handler-context helpers — with no local-broker dependency.
+ *
+ * Enrollment (reading the node token/URL from disk) layers on top of this in a
+ * thin wrapper; the client itself takes an explicit token and base URL.
+ */
+
+type JsonObject = Record<string, FleetWireJsonValue>;
+
+/** A capability's declaration alongside its handler. */
+export interface NodeCapabilityOptions {
+  /**
+   * `action` (default) materializes an invokable handler; `capacity`
+   * (`spawn:<harness>`, `release`) describes what the node can run and is never
+   * materialized. Omit to let the engine classify by name.
+   */
+  kind?: 'action' | 'capacity';
+  /** Claim a workspace-global alias for this action name. */
+  global?: boolean;
+  /** Queue invokes while this provider is offline instead of failing fast. */
+  queue?: boolean;
+  metadata?: JsonObject;
+}
+
+/** Context passed to every capability handler. */
+export interface NodeHandlerContext {
+  /** Informational view of the node this provider is attached to. */
+  node: { name: string; capabilities: string[] };
+  /** The invocation being handled. */
+  invocationId: string;
+  /**
+   * Post a channel message, attributed to `from` (an agent name resolved in the
+   * workspace). Resolves with the posted message.
+   */
+  sendMessage(input: NodeSendMessageInput): Promise<unknown>;
+  /**
+   * Spawn an agent through the node's capacity executor. Capacity-direct: it
+   * never re-enters action dispatch, so a `spawn:<harness>` shadow handler that
+   * delegates cannot recurse into itself. Resolves with the spawn placement.
+   */
+  spawnAgent(input: JsonObject): Promise<unknown>;
+}
+
+export interface NodeSendMessageInput {
+  to: string;
+  from: string;
+  text: string;
+  threadId?: string;
+  mode?: 'wait' | 'steer';
+  data?: JsonObject;
+}
+
+export type NodeCapabilityHandler = (
+  input: FleetWireJsonValue,
+  ctx: NodeHandlerContext,
+) => unknown | Promise<unknown>;
+
+interface RegisteredCapability {
+  options: NodeCapabilityOptions;
+  handler: NodeCapabilityHandler;
+}
+
+export interface NodeProviderOptions {
+  /** Engine base URL; defaults to `https://cast.agentrelay.com`. */
+  baseUrl?: string;
+  /** The node's shared `nt_live_` token. */
+  nodeToken: string;
+  /** The enrolled node id. */
+  nodeId: string;
+  /** The node's name (the target others address). */
+  nodeName: string;
+  /**
+   * Provider identity. `name` is stable across reconnects; `instanceId` is the
+   * connection epoch and is regenerated on every connection when omitted (the
+   * replace semantic).
+   */
+  provider: { name: string; instanceId?: string };
+  /** Capabilities and their handlers, keyed by capability name. */
+  capabilities?: Record<string, NodeCapabilityHandler | (NodeCapabilityOptions & { handler: NodeCapabilityHandler })>;
+  /** Provider-level agent capacity reported at registration. */
+  maxAgents?: number;
+  tags?: string[];
+  version?: string;
+  machineId?: string;
+  heartbeatIntervalMs?: number;
+  reconnectBaseDelayMs?: number;
+  reconnectMaxDelayMs?: number;
+  reconnectJitter?: boolean;
+  /** Max reconnect attempts after an unexpected drop; defaults to unbounded. */
+  maxReconnectAttempts?: number;
+  onError?: (err: Error) => void;
+  debug?: boolean;
+}
+
+/** Thrown when the engine rejects the provider's registration. */
+export class NodeRegistrationError extends Error {
+  constructor(message: string, readonly code: string) {
+    super(message);
+    this.name = 'NodeRegistrationError';
+  }
+}
+
+interface PendingRequest {
+  resolve: (value: unknown) => void;
+  reject: (err: Error) => void;
+}
+
+function randomId(): string {
+  const cryptoObj = (globalThis as { crypto?: { randomUUID?: () => string } }).crypto;
+  if (cryptoObj?.randomUUID) return cryptoObj.randomUUID();
+  return `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 10)}`;
+}
+
+export class NodeProviderClient {
+  private readonly baseUrl: string;
+  private readonly nodeToken: string;
+  private readonly nodeId: string;
+  private readonly nodeName: string;
+  private readonly providerName: string;
+  private readonly initialInstanceId?: string;
+  private readonly maxAgents: number;
+  private readonly tags: string[];
+  private readonly version: string;
+  private readonly machineId?: string;
+  private readonly heartbeatIntervalMs: number;
+  private readonly reconnectBaseDelayMs: number;
+  private readonly reconnectMaxDelayMs: number;
+  private readonly reconnectJitter: boolean;
+  private readonly maxReconnectAttempts: number;
+  private readonly onError?: (err: Error) => void;
+  private readonly debug: boolean;
+
+  private readonly capabilities = new Map<string, RegisteredCapability>();
+  private readonly pending = new Map<string, PendingRequest>();
+
+  private ws: WebSocket | null = null;
+  private instanceId: string | null = null;
+  private heartbeatTimer: ReturnType<typeof setInterval> | null = null;
+  private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+  private reconnectAttempt = 0;
+  private stopped = false;
+  private registered = false;
+
+  private servePromise: Promise<void> | null = null;
+  private resolveServe: (() => void) | null = null;
+  private rejectServe: ((err: Error) => void) | null = null;
+  private registerPromise: Promise<NodeRegisterReplyData> | null = null;
+  private resolveRegister: ((data: NodeRegisterReplyData) => void) | null = null;
+  private rejectRegister: ((err: Error) => void) | null = null;
+
+  constructor(options: NodeProviderOptions) {
+    this.baseUrl = (options.baseUrl ?? 'https://cast.agentrelay.com').replace(/\/+$/, '');
+    this.nodeToken = options.nodeToken;
+    this.nodeId = options.nodeId;
+    this.nodeName = options.nodeName;
+    this.providerName = options.provider.name;
+    this.initialInstanceId = options.provider.instanceId;
+    this.maxAgents = options.maxAgents ?? 0;
+    this.tags = options.tags ?? [];
+    this.version = options.version ?? SDK_VERSION;
+    this.machineId = options.machineId;
+    this.heartbeatIntervalMs = options.heartbeatIntervalMs ?? 15_000;
+    this.reconnectBaseDelayMs = options.reconnectBaseDelayMs ?? 500;
+    this.reconnectMaxDelayMs = options.reconnectMaxDelayMs ?? 30_000;
+    this.reconnectJitter = options.reconnectJitter ?? true;
+    this.maxReconnectAttempts = options.maxReconnectAttempts ?? Number.POSITIVE_INFINITY;
+    this.onError = options.onError;
+    this.debug = options.debug ?? false;
+
+    for (const [name, value] of Object.entries(options.capabilities ?? {})) {
+      if (typeof value === 'function') {
+        this.capability(name, value);
+      } else {
+        const { handler, ...opts } = value;
+        this.capability(name, opts, handler);
+      }
+    }
+  }
+
+  /** Register a capability and its handler. */
+  capability(name: string, handler: NodeCapabilityHandler): this;
+  capability(name: string, options: NodeCapabilityOptions, handler: NodeCapabilityHandler): this;
+  capability(
+    name: string,
+    optionsOrHandler: NodeCapabilityOptions | NodeCapabilityHandler,
+    handler?: NodeCapabilityHandler,
+  ): this {
+    const options = typeof optionsOrHandler === 'function' ? {} : optionsOrHandler;
+    const fn = typeof optionsOrHandler === 'function' ? optionsOrHandler : handler;
+    if (!fn) throw new Error(`capability "${name}" requires a handler`);
+    this.capabilities.set(name, { options, handler: fn });
+    return this;
+  }
+
+  get connected(): boolean {
+    return this.registered && this.ws?.readyState === 1;
+  }
+
+  /** Resolves once the provider is registered and its capabilities accepted. */
+  whenRegistered(): Promise<NodeRegisterReplyData> {
+    if (!this.registerPromise) {
+      this.registerPromise = new Promise<NodeRegisterReplyData>((resolve, reject) => {
+        this.resolveRegister = resolve;
+        this.rejectRegister = reject;
+      });
+    }
+    return this.registerPromise;
+  }
+
+  /**
+   * Connect, register, and dispatch invokes until {@link stop} is called.
+   * Reconnects with backoff on unexpected drops, re-registering with a fresh
+   * instance id. The returned promise resolves on graceful {@link stop} and
+   * rejects if the initial registration is rejected by the engine.
+   */
+  serve(): Promise<void> {
+    if (this.servePromise) return this.servePromise;
+    this.stopped = false;
+    this.servePromise = new Promise<void>((resolve, reject) => {
+      this.resolveServe = resolve;
+      this.rejectServe = reject;
+    });
+    // `whenRegistered()` mirrors the same rejection; keep it from surfacing as
+    // an unhandled rejection when a caller only awaits serve().
+    this.whenRegistered().catch(() => {});
+    this.openSocket();
+    return this.servePromise;
+  }
+
+  private settleServe(err?: Error): void {
+    if (err) this.rejectServe?.(err);
+    else this.resolveServe?.();
+    this.resolveServe = null;
+    this.rejectServe = null;
+  }
+
+  /** Gracefully deregister the provider and close the connection. */
+  async stop(): Promise<void> {
+    this.stopped = true;
+    this.clearReconnect();
+    this.stopHeartbeat();
+    if (this.ws && this.ws.readyState === 1 && this.registered && this.instanceId) {
+      this.sendFrame({ type: 'node.deregister', provider: this.providerIdentity() });
+    }
+    this.rejectPending(new Error('node provider stopped'));
+    this.closeSocket();
+    this.registered = false;
+    this.settleServe();
+  }
+
+  private providerIdentity(): FleetProviderIdentity {
+    return { name: this.providerName, instance_id: this.instanceId ?? '' };
+  }
+
+  private openSocket(): void {
+    if (this.stopped) return;
+    // A fresh instance id per connection: reconnecting with a new id replaces the
+    // previous attachment (the engine's reconnect-vs-duplicate arbitration).
+    this.instanceId = this.reconnectAttempt === 0 && this.initialInstanceId
+      ? this.initialInstanceId
+      : randomId();
+    this.registered = false;
+
+    const url = new URL('/v1/node/ws', `${this.baseUrl.replace(/^http/, 'ws')}/`);
+    url.searchParams.set('token', this.nodeToken);
+    url.searchParams.set('origin_client', '@relaycast/sdk');
+    url.searchParams.set('origin_version', SDK_VERSION);
+
+    let ws: WebSocket;
+    try {
+      ws = new WebSocket(url.toString());
+    } catch (err) {
+      this.reportError(err);
+      this.scheduleReconnect();
+      return;
+    }
+    this.ws = ws;
+
+    ws.onopen = () => {
+      if (this.ws !== ws) return;
+      this.sendRegister();
+    };
+    ws.onmessage = (event: MessageEvent) => {
+      if (this.ws !== ws) return;
+      this.handleFrame(String(event.data));
+    };
+    ws.onclose = () => {
+      if (this.ws !== ws) return;
+      this.ws = null;
+      this.stopHeartbeat();
+      const wasRegistered = this.registered;
+      this.registered = false;
+      this.rejectPending(new Error('node provider connection closed'));
+      if (this.stopped) {
+        this.settleServe();
+        return;
+      }
+      // A rejected registration is deterministic — do not reconnect into the same
+      // rejection; surface it and stop.
+      if (this.rejectRegister && !wasRegistered && this.registrationRejected) {
+        return;
+      }
+      this.scheduleReconnect();
+    };
+    ws.onerror = () => {
+      if (this.ws !== ws) return;
+      this.reportError(new Error('node provider websocket error'));
+    };
+  }
+
+  private registrationRejected = false;
+
+  private sendRegister(): void {
+    this.registrationRejected = false;
+    const id = randomId();
+    const capabilities: FleetCapability[] = [...this.capabilities.entries()].map(([name, cap]) => ({
+      name,
+      ...(cap.options.kind ? { kind: cap.options.kind } : {}),
+      ...(cap.options.global ? { global: true } : {}),
+      ...(cap.options.queue ? { queue: true } : {}),
+      ...(cap.options.metadata ? { metadata: cap.options.metadata } : {}),
+    }));
+    this.request(id, {
+      type: 'node.register',
+      name: this.nodeName,
+      node_id: this.nodeId,
+      provider: this.providerIdentity(),
+      capabilities,
+      max_agents: this.maxAgents,
+      tags: this.tags,
+      version: this.version,
+      ...(this.machineId ? { machine_id: this.machineId } : {}),
+      resume_cursor: null,
+    })
+      .then((data) => this.onRegistered(data as NodeRegisterReplyData))
+      .catch((err) => this.onRegisterFailed(err as Error));
+  }
+
+  private onRegistered(data: NodeRegisterReplyData): void {
+    const rejected = (data.accepted_capabilities ?? []).filter((c: FleetCapabilityAcceptance) => !c.accepted);
+    if (rejected.length > 0) {
+      const detail = rejected.map((c) => `${c.name}${c.reason ? ` (${c.reason})` : ''}`).join(', ');
+      this.onRegisterFailed(new NodeRegistrationError(`Capabilities rejected: ${detail}`, 'capabilities_rejected'));
+      return;
+    }
+    this.registered = true;
+    this.reconnectAttempt = 0;
+    this.startHeartbeat();
+    this.resolveRegister?.(data);
+    this.resolveRegister = null;
+    this.rejectRegister = null;
+  }
+
+  private onRegisterFailed(err: Error): void {
+    this.registrationRejected = true;
+    this.rejectRegister?.(err);
+    this.rejectRegister = null;
+    this.resolveRegister = null;
+    this.reportError(err);
+    // Close without reconnect; the onclose handler observes registrationRejected.
+    this.closeSocket();
+    if (!this.stopped) {
+      this.stopped = true;
+      this.settleServe(err);
+    }
+  }
+
+  private handleFrame(raw: string): void {
+    let message;
+    try {
+      message = parseFleetRelaycastToBrokerMessage(JSON.parse(raw));
+    } catch (err) {
+      if (this.debug) this.reportError(err);
+      return;
+    }
+    switch (message.type) {
+      case 'reply': {
+        const p = this.pending.get(message.id);
+        if (p) {
+          this.pending.delete(message.id);
+          p.resolve(message.data);
+        }
+        return;
+      }
+      case 'error': {
+        const p = this.pending.get(message.id);
+        if (p) {
+          this.pending.delete(message.id);
+          p.reject(new NodeRegistrationError(message.message, message.code));
+        }
+        return;
+      }
+      case 'action.invoke':
+        void this.dispatchInvoke(message.invocation_id, message.action, message.input);
+        return;
+      default:
+        // deliver / context.update / ping carry no work for a provider client.
+        return;
+    }
+  }
+
+  private async dispatchInvoke(invocationId: string, action: string, input: FleetWireJsonValue): Promise<void> {
+    const cap = this.capabilities.get(action);
+    if (!cap) {
+      this.sendFrame({ type: 'action.result', invocation_id: invocationId, error: `No handler registered for action "${action}"` });
+      return;
+    }
+    // A handler failure becomes an error result; the invocation is never dropped.
+    let output: unknown;
+    let handlerError: unknown;
+    try {
+      output = await cap.handler(input, this.makeContext(invocationId));
+    } catch (err) {
+      handlerError = err;
+    }
+    if (handlerError !== undefined) {
+      this.sendFrame({ type: 'action.result', invocation_id: invocationId, error: errorMessage(handlerError) });
+      return;
+    }
+    this.sendFrame({ type: 'action.result', invocation_id: invocationId, output: (output ?? null) as FleetWireJsonValue });
+  }
+
+  private makeContext(invocationId: string): NodeHandlerContext {
+    return {
+      node: { name: this.nodeName, capabilities: [...this.capabilities.keys()] },
+      invocationId,
+      sendMessage: (input) => this.request(randomId(), {
+        type: 'node.message',
+        to: input.to,
+        from: input.from,
+        text: input.text,
+        ...(input.threadId ? { thread_id: input.threadId } : {}),
+        ...(input.mode ? { mode: input.mode } : {}),
+        ...(input.data ? { data: input.data } : {}),
+      }),
+      spawnAgent: (input) => this.request(randomId(), {
+        type: 'node.spawn',
+        input,
+        target_node_id: this.nodeId,
+      }),
+    };
+  }
+
+  /** Send a request frame keyed by `id` and await its reply/error. */
+  private request(id: string, frame: Record<string, unknown>): Promise<unknown> {
+    if (!this.ws || this.ws.readyState !== 1) {
+      return Promise.reject(new Error('node provider websocket is not open'));
+    }
+    return new Promise<unknown>((resolve, reject) => {
+      this.pending.set(id, { resolve, reject });
+      try {
+        this.ws!.send(JSON.stringify({ v: 1, id, ...frame }));
+      } catch (err) {
+        this.pending.delete(id);
+        reject(err instanceof Error ? err : new Error(String(err)));
+      }
+    });
+  }
+
+  private sendFrame(frame: Record<string, unknown>): void {
+    if (!this.ws || this.ws.readyState !== 1) return;
+    try {
+      this.ws.send(JSON.stringify({ v: 1, ...frame }));
+    } catch (err) {
+      if (this.debug) this.reportError(err);
+    }
+  }
+
+  private startHeartbeat(): void {
+    this.stopHeartbeat();
+    this.heartbeatTimer = setInterval(() => {
+      this.sendFrame({
+        type: 'node.heartbeat',
+        provider: this.providerIdentity(),
+        load: 0,
+        active_agents: 0,
+        handlers_live: true,
+      });
+    }, this.heartbeatIntervalMs);
+  }
+
+  private stopHeartbeat(): void {
+    if (this.heartbeatTimer) {
+      clearInterval(this.heartbeatTimer);
+      this.heartbeatTimer = null;
+    }
+  }
+
+  private scheduleReconnect(): void {
+    if (this.stopped || this.reconnectTimer) return;
+    if (this.reconnectAttempt >= this.maxReconnectAttempts) {
+      const err = new Error('node provider exhausted reconnect attempts');
+      this.reportError(err);
+      this.stopped = true;
+      this.settleServe(err);
+      return;
+    }
+    this.reconnectAttempt += 1;
+    const exp = Math.min(this.reconnectBaseDelayMs * 2 ** (this.reconnectAttempt - 1), this.reconnectMaxDelayMs);
+    const delay = this.reconnectJitter ? Math.round(exp * (0.5 + Math.random())) : exp;
+    this.reconnectTimer = setTimeout(() => {
+      this.reconnectTimer = null;
+      this.openSocket();
+    }, delay);
+  }
+
+  private clearReconnect(): void {
+    if (this.reconnectTimer) {
+      clearTimeout(this.reconnectTimer);
+      this.reconnectTimer = null;
+    }
+  }
+
+  private rejectPending(err: Error): void {
+    for (const p of this.pending.values()) p.reject(err);
+    this.pending.clear();
+  }
+
+  private closeSocket(): void {
+    if (this.ws) {
+      this.ws.onopen = null;
+      this.ws.onmessage = null;
+      this.ws.onclose = null;
+      this.ws.onerror = null;
+      try {
+        this.ws.close();
+      } catch {
+        // already closed
+      }
+      this.ws = null;
+    }
+  }
+
+  private reportError(err: unknown): void {
+    const error = err instanceof Error ? err : new Error(String(err));
+    if (this.onError) this.onError(error);
+    else if (this.debug) console.warn('[relaycast node-provider]', error);
+  }
+}
+
+function errorMessage(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}

--- a/packages/sdk-typescript/src/node-provider.ts
+++ b/packages/sdk-typescript/src/node-provider.ts
@@ -256,10 +256,10 @@ export class NodeProviderClient {
     // Let in-flight invoke handlers finish (and send their results) before the
     // socket closes; bound the wait so a slow handler can't hang shutdown.
     if (this.invokeTasks.size > 0) {
-      await Promise.race([
-        Promise.allSettled([...this.invokeTasks]),
-        new Promise<void>((resolve) => setTimeout(resolve, 5000)),
-      ]);
+      let drainTimer: ReturnType<typeof setTimeout> | undefined;
+      const timeout = new Promise<void>((resolve) => { drainTimer = setTimeout(resolve, 5000); });
+      await Promise.race([Promise.allSettled([...this.invokeTasks]), timeout]);
+      if (drainTimer) clearTimeout(drainTimer);
     }
     if (this.ws && this.ws.readyState === 1 && this.registered && this.instanceId) {
       this.sendFrame({ type: 'node.deregister', provider: this.providerIdentity() });
@@ -359,11 +359,11 @@ export class NodeProviderClient {
       ...(this.machineId ? { machine_id: this.machineId } : {}),
       resume_cursor: null,
     })
-      .then((data) => this.onRegistered(data as NodeRegisterReplyData))
+      .then((data) => this.onRegistered(data as NodeRegisterReplyData, capabilities.map((c) => c.name)))
       .catch((err) => this.onRegisterFailed(err as Error));
   }
 
-  private onRegistered(data: NodeRegisterReplyData): void {
+  private onRegistered(data: NodeRegisterReplyData, sentNames: string[]): void {
     // The reply must carry a well-formed acceptance list (the engine always
     // does). A missing/corrupt reply (including a null `data`) means acceptance
     // can't be confirmed, so fail registration rather than assume success or
@@ -376,12 +376,13 @@ export class NodeProviderClient {
       ));
       return;
     }
-    // Every requested capability must be acknowledged; an empty/partial list
-    // cannot silently pass as success.
+    // Every capability the register frame ADVERTISED must be acknowledged.
+    // Validate against the snapshot that was sent, not the live map — a
+    // `capability()` added after the frame was sent isn't in this reply.
     const acknowledged = new Set(
       list.filter((c): c is FleetCapabilityAcceptance => !!c && typeof c.name === 'string').map((c) => c.name),
     );
-    const missing = [...this.capabilities.keys()].filter((name) => !acknowledged.has(name));
+    const missing = sentNames.filter((name) => !acknowledged.has(name));
     if (missing.length > 0) {
       this.onRegisterFailed(new NodeRegistrationError(
         `Registration reply omitted acceptance for: ${missing.join(', ')}`,
@@ -454,6 +455,9 @@ export class NodeProviderClient {
         return;
       }
       case 'action.invoke': {
+        // Stop accepting new invokes once shutting down/draining; the engine
+        // reschedules an undispatched invocation when the node goes offline.
+        if (this.stopped) return;
         const task = this.dispatchInvoke(message.invocation_id, message.action, message.input);
         this.invokeTasks.add(task);
         void task.finally(() => this.invokeTasks.delete(task));

--- a/packages/sdk-typescript/src/node-provider.ts
+++ b/packages/sdk-typescript/src/node-provider.ts
@@ -59,7 +59,6 @@ export interface NodeSendMessageInput {
   to: string;
   from: string;
   text: string;
-  threadId?: string;
   mode?: 'wait' | 'steer';
   data?: JsonObject;
 }
@@ -366,6 +365,17 @@ export class NodeProviderClient {
   }
 
   private onRegisterFailed(err: Error): void {
+    // Only a protocol rejection (a rejected capability or an engine `error`
+    // frame) is deterministic and must not be retried. A transport drop during
+    // the handshake is a normal disconnect — reconnect like any other drop.
+    if (!(err instanceof NodeRegistrationError)) {
+      this.reportError(err);
+      if (!this.stopped) {
+        this.closeSocket();
+        this.scheduleReconnect();
+      }
+      return;
+    }
     this.registrationRejected = true;
     this.rejectRegister?.(err);
     this.rejectRegister = null;
@@ -443,7 +453,6 @@ export class NodeProviderClient {
         to: input.to,
         from: input.from,
         text: input.text,
-        ...(input.threadId ? { thread_id: input.threadId } : {}),
         ...(input.mode ? { mode: input.mode } : {}),
         ...(input.data ? { data: input.data } : {}),
       }),

--- a/packages/sdk-typescript/src/node-provider.ts
+++ b/packages/sdk-typescript/src/node-provider.ts
@@ -460,14 +460,7 @@ export class NodeProviderClient {
     return {
       node: { name: this.nodeName, capabilities: [...this.capabilities.keys()] },
       invocationId,
-      sendMessage: (input) => this.request(randomId(), {
-        type: 'node.message',
-        to: input.to,
-        from: input.from,
-        text: input.text,
-        ...(input.mode ? { mode: input.mode } : {}),
-        ...(input.data ? { data: input.data } : {}),
-      }),
+      sendMessage: (input) => this.postChannelMessage(input),
       // Capacity-direct: the engine always targets this connection's own node,
       // so the frame carries no node target.
       spawnAgent: (input) => this.request(randomId(), {
@@ -475,6 +468,31 @@ export class NodeProviderClient {
         input,
       }),
     };
+  }
+
+  /**
+   * Post a channel message through the canonical message route with the node
+   * token, attributed to `input.from`. Node-attributed posts share the route's
+   * delivery routing, observer events, and triggers by construction.
+   */
+  private async postChannelMessage(input: NodeSendMessageInput): Promise<unknown> {
+    const url = `${this.baseUrl}/v1/channels/${encodeURIComponent(input.to)}/messages`;
+    const res = await fetch(url, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', authorization: `Bearer ${this.nodeToken}` },
+      body: JSON.stringify({
+        text: input.text,
+        from: input.from,
+        ...(input.mode ? { mode: input.mode } : {}),
+        ...(input.data ? { data: input.data } : {}),
+      }),
+    });
+    const body = await res.json().catch(() => ({})) as { data?: unknown; error?: { code?: string; message?: string } };
+    if (!res.ok) {
+      const code = body.error?.code ?? `http_${res.status}`;
+      throw new Error(`sendMessage to "${input.to}" failed (${code})${body.error?.message ? `: ${body.error.message}` : ''}`);
+    }
+    return body.data ?? body;
   }
 
   /** Send a request frame keyed by `id` and await its reply/error. */

--- a/packages/sdk-typescript/src/node-provider.ts
+++ b/packages/sdk-typescript/src/node-provider.ts
@@ -351,10 +351,10 @@ export class NodeProviderClient {
 
   private onRegistered(data: NodeRegisterReplyData): void {
     // The reply must carry a well-formed acceptance list (the engine always
-    // does). A missing/corrupt list means acceptance can't be confirmed, so
-    // fail registration rather than assume success; an entry missing `accepted`
-    // counts as rejected (fail-safe).
-    const list = data.accepted_capabilities;
+    // does). A missing/corrupt reply (including a null `data`) means acceptance
+    // can't be confirmed, so fail registration rather than assume success or
+    // throw; an entry missing `accepted` counts as rejected (fail-safe).
+    const list = (data ?? ({} as NodeRegisterReplyData)).accepted_capabilities;
     if (!Array.isArray(list)) {
       this.onRegisterFailed(new NodeRegistrationError(
         'Registration reply is missing accepted_capabilities',
@@ -546,6 +546,11 @@ export class NodeProviderClient {
       const err = new Error('node provider exhausted reconnect attempts');
       this.reportError(err);
       this.stopped = true;
+      // If registration never completed, reject its waiter too — otherwise
+      // whenRegistered() would hang forever after reconnects are exhausted.
+      this.rejectRegister?.(err);
+      this.rejectRegister = null;
+      this.resolveRegister = null;
       this.settleServe(err);
       return;
     }

--- a/packages/sdk-typescript/src/node-provider.ts
+++ b/packages/sdk-typescript/src/node-provider.ts
@@ -350,9 +350,21 @@ export class NodeProviderClient {
   }
 
   private onRegistered(data: NodeRegisterReplyData): void {
-    const rejected = (data.accepted_capabilities ?? []).filter((c: FleetCapabilityAcceptance) => !c.accepted);
+    // The reply must carry a well-formed acceptance list (the engine always
+    // does). A missing/corrupt list means acceptance can't be confirmed, so
+    // fail registration rather than assume success; an entry missing `accepted`
+    // counts as rejected (fail-safe).
+    const list = data.accepted_capabilities;
+    if (!Array.isArray(list)) {
+      this.onRegisterFailed(new NodeRegistrationError(
+        'Registration reply is missing accepted_capabilities',
+        'invalid_register_reply',
+      ));
+      return;
+    }
+    const rejected = list.filter((c: FleetCapabilityAcceptance) => !c || c.accepted !== true);
     if (rejected.length > 0) {
-      const detail = rejected.map((c) => `${c.name}${c.reason ? ` (${c.reason})` : ''}`).join(', ');
+      const detail = rejected.map((c) => `${c?.name ?? '<unknown>'}${c?.reason ? ` (${c.reason})` : ''}`).join(', ');
       this.onRegisterFailed(new NodeRegistrationError(`Capabilities rejected: ${detail}`, 'capabilities_rejected'));
       return;
     }

--- a/packages/sdk-typescript/src/node-provider.ts
+++ b/packages/sdk-typescript/src/node-provider.ts
@@ -447,10 +447,11 @@ export class NodeProviderClient {
         ...(input.mode ? { mode: input.mode } : {}),
         ...(input.data ? { data: input.data } : {}),
       }),
+      // Capacity-direct: the engine always targets this connection's own node,
+      // so the frame carries no node target.
       spawnAgent: (input) => this.request(randomId(), {
         type: 'node.spawn',
         input,
-        target_node_id: this.nodeId,
       }),
     };
   }

--- a/packages/types/src/fleet-wire.ts
+++ b/packages/types/src/fleet-wire.ts
@@ -181,9 +181,10 @@ export const FleetNodeSpawnMessageSchema = z
 export type FleetNodeSpawnMessage = z.infer<typeof FleetNodeSpawnMessageSchema>;
 
 /**
- * `node.message` — a provider's handler context posting a channel message. The
- * message is attributed to `from` (an agent name resolved in the workspace);
- * the engine posts it and fans out to observers and node-hosted recipients.
+ * `node.message` — a provider's handler context posting a top-level channel
+ * message. The message is attributed to `from` (an agent name resolved in the
+ * workspace); the engine posts it and fans out to observers. Thread replies are
+ * not part of this surface.
  */
 export const FleetNodeMessageMessageSchema = z
   .object({
@@ -192,7 +193,6 @@ export const FleetNodeMessageMessageSchema = z
     to: z.string(),
     from: z.string(),
     text: z.string(),
-    thread_id: z.string().optional(),
     mode: FleetDeliveryModeSchema.optional(),
     data: z.record(z.string(), FleetWireJsonValueSchema).optional(),
   })

--- a/packages/types/src/fleet-wire.ts
+++ b/packages/types/src/fleet-wire.ts
@@ -180,25 +180,6 @@ export const FleetNodeSpawnMessageSchema = z
   .strict();
 export type FleetNodeSpawnMessage = z.infer<typeof FleetNodeSpawnMessageSchema>;
 
-/**
- * `node.message` — a provider's handler context posting a top-level channel
- * message. The message is attributed to `from` (an agent name resolved in the
- * workspace); the engine posts it and fans out to observers. Thread replies are
- * not part of this surface.
- */
-export const FleetNodeMessageMessageSchema = z
-  .object({
-    ...FleetRequestEnvelopeFields,
-    type: z.literal('node.message'),
-    to: z.string(),
-    from: z.string(),
-    text: z.string(),
-    mode: FleetDeliveryModeSchema.optional(),
-    data: z.record(z.string(), FleetWireJsonValueSchema).optional(),
-  })
-  .strict();
-export type FleetNodeMessageMessage = z.infer<typeof FleetNodeMessageMessageSchema>;
-
 export const FleetAgentRegisterMessageSchema = z
   .object({
     ...FleetRequestEnvelopeFields,
@@ -377,7 +358,6 @@ export const FleetBrokerToRelaycastNonActionResultMessageSchema = z.discriminate
   FleetNodeHeartbeatMessageSchema,
   FleetNodeDeregisterMessageSchema,
   FleetNodeSpawnMessageSchema,
-  FleetNodeMessageMessageSchema,
   FleetAgentRegisterMessageSchema,
   FleetAgentDeregisterMessageSchema,
   FleetDeliveryAckMessageSchema,

--- a/packages/types/src/fleet-wire.ts
+++ b/packages/types/src/fleet-wire.ts
@@ -163,6 +163,41 @@ export const FleetNodeDeregisterMessageSchema = z
   .strict();
 export type FleetNodeDeregisterMessage = z.infer<typeof FleetNodeDeregisterMessageSchema>;
 
+/**
+ * `node.spawn` — a provider's handler context delegating a spawn to the node's
+ * capacity executor (the broker provider). Capacity-direct: the engine bypasses
+ * action dispatch, so a `spawn:<harness>` shadow handler that delegates cannot
+ * re-enter itself. `target_node_id` defaults to the connection's own node.
+ */
+export const FleetNodeSpawnMessageSchema = z
+  .object({
+    ...FleetRequestEnvelopeFields,
+    type: z.literal('node.spawn'),
+    input: z.record(z.string(), FleetWireJsonValueSchema),
+    target_node_id: z.string().optional(),
+  })
+  .strict();
+export type FleetNodeSpawnMessage = z.infer<typeof FleetNodeSpawnMessageSchema>;
+
+/**
+ * `node.message` — a provider's handler context posting a channel message. The
+ * message is attributed to `from` (an agent name resolved in the workspace);
+ * the engine posts it and fans out to observers and node-hosted recipients.
+ */
+export const FleetNodeMessageMessageSchema = z
+  .object({
+    ...FleetRequestEnvelopeFields,
+    type: z.literal('node.message'),
+    to: z.string(),
+    from: z.string(),
+    text: z.string(),
+    thread_id: z.string().optional(),
+    mode: FleetDeliveryModeSchema.optional(),
+    data: z.record(z.string(), FleetWireJsonValueSchema).optional(),
+  })
+  .strict();
+export type FleetNodeMessageMessage = z.infer<typeof FleetNodeMessageMessageSchema>;
+
 export const FleetAgentRegisterMessageSchema = z
   .object({
     ...FleetRequestEnvelopeFields,
@@ -340,6 +375,8 @@ export const FleetBrokerToRelaycastNonActionResultMessageSchema = z.discriminate
   FleetNodeRegisterMessageSchema,
   FleetNodeHeartbeatMessageSchema,
   FleetNodeDeregisterMessageSchema,
+  FleetNodeSpawnMessageSchema,
+  FleetNodeMessageMessageSchema,
   FleetAgentRegisterMessageSchema,
   FleetAgentDeregisterMessageSchema,
   FleetDeliveryAckMessageSchema,

--- a/packages/types/src/fleet-wire.ts
+++ b/packages/types/src/fleet-wire.ts
@@ -164,17 +164,18 @@ export const FleetNodeDeregisterMessageSchema = z
 export type FleetNodeDeregisterMessage = z.infer<typeof FleetNodeDeregisterMessageSchema>;
 
 /**
- * `node.spawn` — a provider's handler context delegating a spawn to the node's
- * capacity executor (the broker provider). Capacity-direct: the engine bypasses
- * action dispatch, so a `spawn:<harness>` shadow handler that delegates cannot
- * re-enter itself. `target_node_id` defaults to the connection's own node.
+ * `node.spawn` — a provider's handler context delegating a spawn to its own
+ * node's capacity executor (the broker provider). Capacity-direct: the engine
+ * bypasses action dispatch, so a `spawn:<harness>` shadow handler that delegates
+ * cannot re-enter itself. The target is always the connection's node — a node
+ * credential cannot direct a spawn at another node (that is workspace-level
+ * placement, which uses agent/workspace credentials).
  */
 export const FleetNodeSpawnMessageSchema = z
   .object({
     ...FleetRequestEnvelopeFields,
     type: z.literal('node.spawn'),
     input: z.record(z.string(), FleetWireJsonValueSchema),
-    target_node_id: z.string().optional(),
   })
   .strict();
 export type FleetNodeSpawnMessage = z.infer<typeof FleetNodeSpawnMessageSchema>;


### PR DESCRIPTION
Stacked on `node-providers-engine` (#242) — step 2 of the node-providers spec. Its diff is only the SDK client layer plus the two node-WS frames those clients need.

## What this adds

A **node provider client** in each relaycast SDK — TypeScript (`@relaycast/sdk`), Python (`relaycast-sdk`), and Swift (`Relaycast`). Given an explicit `{ baseUrl, nodeToken, node identity, provider, capabilities, handlers }`, it:

- Connects to `/v1/node/ws`, sends `node.register` with the provider identity and capability set, and surfaces per-capability acceptance — hard-failing on a rejected capability or an engine `error` frame (`provider_instance_conflict`, `action_name_conflict`) with a clear error.
- Runs a provider-scoped heartbeat loop (`load`, `active_agents`, `handlers_live`).
- Receives `action.invoke`, runs the registered handler, and replies `action.result` — a handler throw becomes an error result and an unknown action name becomes an error result; an invocation is never dropped.
- Reconnects with exponential backoff and full re-registration, minting a **new `instance_id` per connection** (the engine's replace semantic).
- Sends a provider-scoped `node.deregister` on graceful shutdown.
- Exposes a handler context with `sendMessage` and `spawnAgent` (spec §4).

The constructor takes an explicit token and base URL. Enrollment-file logic (`from_enrollment`, `fleet-enrollments.json`) is deliberately out of scope — it layers on top of this client in the relay repo (step 3).

## Handler-context surface (`ctx.spawnAgent` / `ctx.sendMessage`)

- **`ctx.spawnAgent`** is a node-WS `node.spawn` request frame answered by the engine, routing the already-implemented `dispatchCapacitySpawn` — capacity-direct, `bypassShadow`, always targeting the connection's own node (the frame carries no node target), so a `spawn:<harness>` shadow handler that delegates cannot re-enter itself and a node credential cannot direct a spawn at another node. This is the only engine frame added here (`dispatchCapacitySpawn` duplicates no existing surface, so it has no parity problem), with a conformance test.

- **`ctx.sendMessage`** posts through the **canonical** message route — `POST /v1/channels/:name/messages` — which now accepts a node token (a new `sender` auth requirement alongside agent/workspace) with a **required `from`**: an agent name resolved strictly within the node token's workspace, so a node credential can never attribute a message to another workspace. Delivery routing, observer events, webhooks, triggers, and idempotency come free because it is the one posting path (spec §5.3: registration, invocation, and events are shared; only the hosting connection differs). There is no parallel node-message posting path. In all three SDKs `ctx.sendMessage` is an HTTP call to that route with the node token.

Engine changes on this branch (for the engine-branch owner): the `node.spawn` frame, and the message route's `sender` auth + `from` attribution. Conformance covers node-token posting end to end: delivery to node-hosted recipients, required `from`, unknown-agent and cross-workspace rejection, and `from` rejected on an agent token.

## Parity

The three clients expose the same semantics, named per language (TS camelCase, Python snake_case, Swift Swift-style). Divergences, all intentional:

- **Python**: `send_message(from_=...)` and `capability(global_=...)` avoid the `from`/`global` keyword clash; the wire fields stay `from`/`global`.
- **Swift**: `NodeProvider` is an `actor` (the rest of the SDK uses `@unchecked Sendable` class + `NSLock`) — chosen for correctness across the many `await` points in register/heartbeat/reconnect/invoke bookkeeping. Constructor `capabilities` is handler-only; per-capability `kind`/`global`/`queue`/`metadata` go through the `capability(...)` builder. Adds `session`/`transport` params for test injection.
- All three connect with `?token=` (server-side clients could use `Authorization: Bearer`, but query-param matches the existing SDK WS clients and the engine accepts both).

## Tests

- **Engine** (`nodeProviders.test.ts`): `node.spawn` routes to the connection's own node capacity (never crossing to another node); node-token posting via the canonical route — delivery to a node-hosted recipient, required `from`, unknown-agent and cross-workspace rejection, and `from` rejected on an agent token. Full engine suite green (426).
- **TS** (11), **Python** (12), **Swift** (11) unit tests each against an in-process fake transport — no real sockets or runtimes. Coverage: register + acceptance rejection, invoke → result (success and handler-error), unknown action, reconnect re-register with a new `instance_id`, heartbeat shape, deregister, `spawnAgent`, `sendMessage`.
- End-to-end interop verified separately: the built TS client registering against the in-process engine, a REST invoke completing through the handler, and `ctx.sendMessage` posting to a channel.


## Follow-ups

- **WS auth header.** The three clients authenticate the socket with `?token=` (matching the existing SDK WS clients and keeping the TypeScript client isomorphic with the browser `WebSocket`, which cannot set headers). Server-side transports (Python/Swift, and Node via a header-capable WS) could prefer an `Authorization: Bearer` header to avoid token-in-URL leakage into intermediary logs; the engine already accepts both. Deferred to keep the clients consistent and the TS build isomorphic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/AgentWorkforce/relaycast/pull/243?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->




