### PR TITLE
engine: export node-control provider-disconnect + fix dropped-provider aggregate leak

### DIFF
--- a/packages/engine/src/__tests__/conformance/nodeControlExports.test.ts
+++ b/packages/engine/src/__tests__/conformance/nodeControlExports.test.ts
@@ -27,7 +27,14 @@ describe('node-control provider-disconnect exports', () => {
     expect(res.status).toBe(201);
   }
 
-  async function attachProvider(workspaceId: string, nodeId: string, nodeName: string, providerName: string, capability: string) {
+  async function attachProvider(
+    workspaceId: string,
+    nodeId: string,
+    nodeName: string,
+    providerName: string,
+    capability: string,
+    activeAgents = 0,
+  ) {
     const provider = { name: providerName, instance_id: `${providerName}-i1` };
     const sock = new FakeSocket();
     const handle = stack.runtime.realtime.attachNodeSocket(workspaceId, nodeId, sock);
@@ -44,8 +51,35 @@ describe('node-control provider-disconnect exports', () => {
       version: 'v1',
       resume_cursor: null,
     }));
-    await handle.handleMessage(JSON.stringify({ v: 1, type: 'node.heartbeat', provider, load: 0, active_agents: 0, handlers_live: true }));
+    await heartbeat(handle, providerName, activeAgents);
     return { sock, handle };
+  }
+
+  function heartbeat(handle: { handleMessage(raw: string): Promise<void> }, providerName: string, activeAgents: number) {
+    return handle.handleMessage(JSON.stringify({
+      v: 1,
+      type: 'node.heartbeat',
+      provider: { name: providerName, instance_id: `${providerName}-i1` },
+      load: 0,
+      active_agents: activeAgents,
+      handlers_live: true,
+    }));
+  }
+
+  function nodeActiveAgents(workspaceId: string, nodeId: string) {
+    return db()
+      .select({ activeAgents: nodes.activeAgents })
+      .from(nodes)
+      .where(and(eq(nodes.workspaceId, workspaceId), eq(nodes.id, nodeId)))
+      .then((rows) => rows[0]?.activeAgents);
+  }
+
+  function providerActiveAgents(workspaceId: string, nodeId: string, name: string) {
+    return db()
+      .select({ activeAgents: nodeProviders.activeAgents })
+      .from(nodeProviders)
+      .where(and(eq(nodeProviders.workspaceId, workspaceId), eq(nodeProviders.nodeId, nodeId), eq(nodeProviders.name, name)))
+      .then((rows) => rows[0]?.activeAgents);
   }
 
   function providerStatuses(workspaceId: string, nodeId: string) {
@@ -97,5 +131,39 @@ describe('node-control provider-disconnect exports', () => {
 
     expect(await providerStatuses(ws.workspaceId, 'node_a')).toEqual({ py: 'offline', rb: 'offline' });
     expect(await nodeStatus(ws.workspaceId, 'node_a')).toBe('offline');
+  });
+
+  it('drops a disconnected provider from the node aggregate, and restores it on reconnect', async () => {
+    const ws = await createWorkspace(stack.app, 'exp-aggregate');
+    await enrollNode(ws, 'node_a', 'alpha');
+    const py = await attachProvider(ws.workspaceId, 'node_a', 'alpha', 'py', 'run-etl', 2);
+    await attachProvider(ws.workspaceId, 'node_a', 'alpha', 'rb', 'build', 3);
+    // The node aggregate sums both providers' active agents.
+    expect(await nodeActiveAgents(ws.workspaceId, 'node_a')).toBe(5);
+
+    // py drops (others remain): its agents are gone, so the node aggregate must
+    // no longer count them — recomputeNodeAggregate would resurrect them if the
+    // provider row kept its stale activeAgents.
+    await handleProviderDisconnect(db(), stack.runtime.realtime, ws.workspaceId, 'node_a', 'py', true);
+    expect(await providerActiveAgents(ws.workspaceId, 'node_a', 'py')).toBe(0);
+    expect(await nodeActiveAgents(ws.workspaceId, 'node_a')).toBe(3);
+
+    // Symmetric restore: py's next heartbeat repopulates its count.
+    await heartbeat(py.handle, 'py', 2);
+    expect(await providerActiveAgents(ws.workspaceId, 'node_a', 'py')).toBe(2);
+    expect(await nodeActiveAgents(ws.workspaceId, 'node_a')).toBe(5);
+  });
+
+  it('markNodeOffline zeros every provider active-agent count', async () => {
+    const ws = await createWorkspace(stack.app, 'exp-node-offline-aggregate');
+    await enrollNode(ws, 'node_a', 'alpha');
+    await attachProvider(ws.workspaceId, 'node_a', 'alpha', 'py', 'run-etl', 2);
+    await attachProvider(ws.workspaceId, 'node_a', 'alpha', 'rb', 'build', 3);
+
+    await markNodeOffline(db(), stack.runtime.realtime, ws.workspaceId, 'node_a');
+
+    expect(await providerActiveAgents(ws.workspaceId, 'node_a', 'py')).toBe(0);
+    expect(await providerActiveAgents(ws.workspaceId, 'node_a', 'rb')).toBe(0);
+    expect(await nodeActiveAgents(ws.workspaceId, 'node_a')).toBe(0);
   });
 });

--- a/packages/engine/src/__tests__/conformance/nodeControlExports.test.ts
+++ b/packages/engine/src/__tests__/conformance/nodeControlExports.test.ts
@@ -12,7 +12,9 @@ import { nodeProviders, nodes } from '../../db/schema.js';
 describe('node-control provider-disconnect exports', () => {
   let stack: TestStack;
   beforeEach(() => { stack = makeNodeStack({ ttlMs: 60_000 }); });
-  afterEach(() => stack.close());
+  // Optional-chain so a failed beforeEach (undefined stack) surfaces its real
+  // error instead of a TypeError from teardown.
+  afterEach(() => stack?.close());
 
   const db = () => stack.runtime.handle.db;
 

--- a/packages/engine/src/__tests__/conformance/nodeControlExports.test.ts
+++ b/packages/engine/src/__tests__/conformance/nodeControlExports.test.ts
@@ -34,13 +34,14 @@ describe('node-control provider-disconnect exports', () => {
     providerName: string,
     capability: string,
     activeAgents = 0,
+    instanceId = `${providerName}-i1`,
   ) {
-    const provider = { name: providerName, instance_id: `${providerName}-i1` };
+    const provider = { name: providerName, instance_id: instanceId };
     const sock = new FakeSocket();
     const handle = stack.runtime.realtime.attachNodeSocket(workspaceId, nodeId, sock);
     await handle.handleMessage(JSON.stringify({
       v: 1,
-      id: `reg-${providerName}`,
+      id: `reg-${instanceId}`,
       type: 'node.register',
       name: nodeName,
       node_id: nodeId,
@@ -51,15 +52,20 @@ describe('node-control provider-disconnect exports', () => {
       version: 'v1',
       resume_cursor: null,
     }));
-    await heartbeat(handle, providerName, activeAgents);
+    await heartbeat(handle, providerName, activeAgents, instanceId);
     return { sock, handle };
   }
 
-  function heartbeat(handle: { handleMessage(raw: string): Promise<void> }, providerName: string, activeAgents: number) {
+  function heartbeat(
+    handle: { handleMessage(raw: string): Promise<void> },
+    providerName: string,
+    activeAgents: number,
+    instanceId = `${providerName}-i1`,
+  ) {
     return handle.handleMessage(JSON.stringify({
       v: 1,
       type: 'node.heartbeat',
-      provider: { name: providerName, instance_id: `${providerName}-i1` },
+      provider: { name: providerName, instance_id: instanceId },
       load: 0,
       active_agents: activeAgents,
       handlers_live: true,
@@ -141,15 +147,16 @@ describe('node-control provider-disconnect exports', () => {
     // The node aggregate sums both providers' active agents.
     expect(await nodeActiveAgents(ws.workspaceId, 'node_a')).toBe(5);
 
-    // py drops (others remain): its agents are gone, so the node aggregate must
-    // no longer count them — recomputeNodeAggregate would resurrect them if the
-    // provider row kept its stale activeAgents.
-    await handleProviderDisconnect(db(), stack.runtime.realtime, ws.workspaceId, 'node_a', 'py', true);
+    // py's socket drops (others remain): its agents are gone, so the node
+    // aggregate must no longer count them — recomputeNodeAggregate would resurrect
+    // them if the provider row kept its stale activeAgents.
+    await py.handle.handleClose();
     expect(await providerActiveAgents(ws.workspaceId, 'node_a', 'py')).toBe(0);
     expect(await nodeActiveAgents(ws.workspaceId, 'node_a')).toBe(3);
 
-    // Symmetric restore: py's next heartbeat repopulates its count.
-    await heartbeat(py.handle, 'py', 2);
+    // Symmetric restore through a real reconnect: a fresh socket registers py
+    // (new instance) and heartbeats, repopulating its count.
+    await attachProvider(ws.workspaceId, 'node_a', 'alpha', 'py', 'run-etl', 2, 'py-i2');
     expect(await providerActiveAgents(ws.workspaceId, 'node_a', 'py')).toBe(2);
     expect(await nodeActiveAgents(ws.workspaceId, 'node_a')).toBe(5);
   });

--- a/packages/engine/src/__tests__/conformance/nodeControlExports.test.ts
+++ b/packages/engine/src/__tests__/conformance/nodeControlExports.test.ts
@@ -1,0 +1,99 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { and, eq } from 'drizzle-orm';
+import { handleProviderDisconnect, markNodeOffline } from '../../node-control.js';
+import { makeNodeStack, createWorkspace, FakeSocket, type TestStack } from './harness.js';
+import { nodeProviders, nodes } from '../../db/schema.js';
+
+// The provider-disconnect lifecycle is exported from @relaycast/engine/node-control
+// so an out-of-process socket owner — the relaycast-cloud NodeDO — drives it on
+// socket close instead of hand-rolling the SQL (the mirror the node-providers spec
+// is removing). These assert the public exports produce the same DB liveness the
+// in-process adapter's own close path produces.
+describe('node-control provider-disconnect exports', () => {
+  let stack: TestStack;
+  beforeEach(() => { stack = makeNodeStack({ ttlMs: 60_000 }); });
+  afterEach(() => stack.close());
+
+  const db = () => stack.runtime.handle.db;
+
+  async function enrollNode(ws: { workspaceKey: string }, nodeId: string, name: string) {
+    const res = await stack.app.request('/v1/nodes', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', authorization: `Bearer ${ws.workspaceKey}` },
+      body: JSON.stringify({ node_id: nodeId, name, role: 'broker', capabilities: [], max_agents: 4, tags: ['test'], version: 'v0' }),
+    });
+    expect(res.status).toBe(201);
+  }
+
+  async function attachProvider(workspaceId: string, nodeId: string, nodeName: string, providerName: string, capability: string) {
+    const provider = { name: providerName, instance_id: `${providerName}-i1` };
+    const sock = new FakeSocket();
+    const handle = stack.runtime.realtime.attachNodeSocket(workspaceId, nodeId, sock);
+    await handle.handleMessage(JSON.stringify({
+      v: 1,
+      id: `reg-${providerName}`,
+      type: 'node.register',
+      name: nodeName,
+      node_id: nodeId,
+      provider,
+      capabilities: [{ name: capability, kind: 'action' }],
+      max_agents: 4,
+      tags: ['test'],
+      version: 'v1',
+      resume_cursor: null,
+    }));
+    await handle.handleMessage(JSON.stringify({ v: 1, type: 'node.heartbeat', provider, load: 0, active_agents: 0, handlers_live: true }));
+    return { sock, handle };
+  }
+
+  function providerStatuses(workspaceId: string, nodeId: string) {
+    return db()
+      .select({ name: nodeProviders.name, status: nodeProviders.status })
+      .from(nodeProviders)
+      .where(and(eq(nodeProviders.workspaceId, workspaceId), eq(nodeProviders.nodeId, nodeId)))
+      .then((rows) => Object.fromEntries(rows.map((r) => [r.name, r.status])));
+  }
+
+  function nodeStatus(workspaceId: string, nodeId: string) {
+    return db()
+      .select({ status: nodes.status })
+      .from(nodes)
+      .where(and(eq(nodes.workspaceId, workspaceId), eq(nodes.id, nodeId)))
+      .then((rows) => rows[0]?.status);
+  }
+
+  it('handleProviderDisconnect (remaining connections) flips only that provider offline; node stays online', async () => {
+    const ws = await createWorkspace(stack.app, 'exp-provider-remaining');
+    await enrollNode(ws, 'node_a', 'alpha');
+    await attachProvider(ws.workspaceId, 'node_a', 'alpha', 'py', 'run-etl');
+    await attachProvider(ws.workspaceId, 'node_a', 'alpha', 'rb', 'build');
+
+    await handleProviderDisconnect(db(), stack.runtime.realtime, ws.workspaceId, 'node_a', 'py', true);
+
+    expect(await providerStatuses(ws.workspaceId, 'node_a')).toEqual({ py: 'offline', rb: 'online' });
+    expect(await nodeStatus(ws.workspaceId, 'node_a')).toBe('online');
+  });
+
+  it('handleProviderDisconnect (no remaining connections) marks the whole node offline', async () => {
+    const ws = await createWorkspace(stack.app, 'exp-provider-last');
+    await enrollNode(ws, 'node_a', 'alpha');
+    await attachProvider(ws.workspaceId, 'node_a', 'alpha', 'py', 'run-etl');
+
+    await handleProviderDisconnect(db(), stack.runtime.realtime, ws.workspaceId, 'node_a', 'py', false);
+
+    expect(await providerStatuses(ws.workspaceId, 'node_a')).toEqual({ py: 'offline' });
+    expect(await nodeStatus(ws.workspaceId, 'node_a')).toBe('offline');
+  });
+
+  it('markNodeOffline flips the node and every provider offline', async () => {
+    const ws = await createWorkspace(stack.app, 'exp-node-offline');
+    await enrollNode(ws, 'node_a', 'alpha');
+    await attachProvider(ws.workspaceId, 'node_a', 'alpha', 'py', 'run-etl');
+    await attachProvider(ws.workspaceId, 'node_a', 'alpha', 'rb', 'build');
+
+    await markNodeOffline(db(), stack.runtime.realtime, ws.workspaceId, 'node_a');
+
+    expect(await providerStatuses(ws.workspaceId, 'node_a')).toEqual({ py: 'offline', rb: 'offline' });
+    expect(await nodeStatus(ws.workspaceId, 'node_a')).toBe('offline');
+  });
+});

--- a/packages/engine/src/engine/node.ts
+++ b/packages/engine/src/engine/node.ts
@@ -471,10 +471,11 @@ export async function markNodeOffline(
     .where(and(eq(nodes.workspaceId, workspaceId), eq(nodes.id, nodeId)));
 
   // Provider capability sets persist (offline nodes still show their manifest);
-  // only their liveness flips.
+  // only their liveness flips. Zero activeAgents too, so a later
+  // recomputeNodeAggregate never resurrects a dropped provider's agent count.
   await db
     .update(nodeProviders)
-    .set({ status: 'offline', handlersLive: false, load: 0, lastHeartbeatAt: new Date() })
+    .set({ status: 'offline', handlersLive: false, load: 0, activeAgents: 0, lastHeartbeatAt: new Date() })
     .where(and(eq(nodeProviders.workspaceId, workspaceId), eq(nodeProviders.nodeId, nodeId)));
 
   await db

--- a/packages/engine/src/engine/nodeProvider.ts
+++ b/packages/engine/src/engine/nodeProvider.ts
@@ -154,9 +154,12 @@ export async function heartbeatProvider(
 }
 
 export async function markProviderOffline(db: Db, workspaceId: string, nodeId: string, name: string): Promise<void> {
+  // A disconnected provider hosts no live agents; zero its activeAgents so
+  // recomputeNodeAggregate (which sums across all providers) stops counting them
+  // on the node. A reconnect/heartbeat repopulates it from the provider's report.
   await db
     .update(nodeProviders)
-    .set({ status: 'offline', handlersLive: false, load: 0, lastHeartbeatAt: new Date() })
+    .set({ status: 'offline', handlersLive: false, load: 0, activeAgents: 0, lastHeartbeatAt: new Date() })
     .where(and(
       eq(nodeProviders.workspaceId, workspaceId),
       eq(nodeProviders.nodeId, nodeId),

--- a/packages/engine/src/node-control.ts
+++ b/packages/engine/src/node-control.ts
@@ -1,5 +1,16 @@
 export {
   handleNodeControlMessage,
+  // Node-offline lifecycle for out-of-process socket owners (e.g. the
+  // relaycast-cloud NodeDO): when a provider's control socket drops, drive
+  // `handleProviderDisconnect` — it flips only that provider (and its agents)
+  // offline while the node stays online, or, when it was the node's last
+  // connection, marks the whole node offline. `markNodeOffline` is the node-wide
+  // marker for the other lifecycle triggers a socket owner controls (a liveness
+  // alarm lapse, an operator disconnect). Both encapsulate the provider-row,
+  // agent, aggregate, and invocation-reschedule effects so a host never
+  // hand-rolls them.
+  handleProviderDisconnect,
+  markNodeOffline,
   type HandleNodeControlMessageArgs,
   type NodeSocketLike,
 } from './engine/node.js';


### PR DESCRIPTION
Two changes on the node-control provider-disconnect path: expose it to
out-of-process socket owners, and fix an aggregate-count leak in it.

## 1. Export the provider-disconnect lifecycle

`@relaycast/engine/node-control` re-exports `handleProviderDisconnect` and
`markNodeOffline` alongside `handleNodeControlMessage`.

An out-of-process node-control socket owner — the relaycast-cloud `NodeDO`, which
holds the `/v1/node/ws` sockets in a Durable Object — owns its sockets but drives
the engine for everything else. On socket close it must flip the correct
liveness:

- one provider's socket drops while others stay connected → only that provider
  (and its agents) goes offline, the node stays online;
- the node's last connection drops (or a liveness-alarm lapse / operator
  disconnect) → the whole node, its providers, and its agents go offline.

That logic already lives in `engine/node.ts` (`handleProviderDisconnect`,
`markNodeOffline`) — what the in-process adapter calls on its own socket close —
but it was not exported from `node-control`, so the DO had to hand-roll a SQL
mirror of it. Multi-provider nodes turned that one mirror into several. Both
functions encapsulate the full effect (provider row, hosted agents, node
aggregate, invocation reschedule), so a host never reassembles them.

## 2. Fix the dropped-provider aggregate leak

`markProviderOffline` and `markNodeOffline` left `node_providers.active_agents`
at its last value, but `recomputeNodeAggregate` sums `active_agents` across ALL
providers (online and offline). So after a provider's socket dropped with others
still connected, `nodes.active_agents` kept counting the dropped provider's now-
offline agents until it reconnected. Both markers now zero `active_agents` on
offline; a reconnect / heartbeat repopulates it from the provider's own report.
This is in the exact function the export above exposes, so it ships here rather
than as a separate follow-up.

## Test

`nodeControlExports.test.ts` drives the public exports against the in-memory
engine: provider-scoped offline (node stays online), last-connection offline, and
node-wide offline; plus the aggregate correction — the node total drops a dropped
provider's agents and restores them on the next heartbeat, and `markNodeOffline`
zeros every provider's count.

Full engine suite green (414).

## Ships with

The consumer is relaycast-cloud#27 (NodeDO multi-provider sockets), which deletes
its hand-rolled `node/registration.ts` mirror and delegates to these exports.
Both ride the same next `@relaycast/engine` release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
