### PR TITLE
ci(observer): fix ERESOLVE in dashboard deploy from wrangler peer bump

### DIFF
--- a/.github/actions/deploy-observer-dashboard/action.yml
+++ b/.github/actions/deploy-observer-dashboard/action.yml
@@ -58,8 +58,12 @@ runs:
       run: |
         set -euo pipefail
         cd packages/observer-dashboard
-        npx @cloudflare/next-on-pages@1
+        npx @cloudflare/next-on-pages@1.13.16
         npx wrangler pages deploy .vercel/output/static --project-name="${{ inputs.project-name }}" --branch="${{ inputs.branch }}"
       env:
         CLOUDFLARE_API_TOKEN: ${{ inputs.cloudflare-api-token }}
         CLOUDFLARE_ACCOUNT_ID: ${{ inputs.cloudflare-account-id }}
+        # next-on-pages peers on @cloudflare/workers-types@^4, but the wrangler it
+        # transitively resolves now peers on ^5; tolerate that optional-peer mismatch
+        # so the ephemeral npx install can resolve. See CI ERESOLVE on wrangler 4.108.0.
+        NPM_CONFIG_LEGACY_PEER_DEPS: "true"


### PR DESCRIPTION
## Problem

The `deploy observer-dashboard` CI job started failing ([run 28955432937](https://github.com/AgentWorkforce/relaycast/actions/runs/28955432937/job/85913488878)). Build and tests pass — the failure is in the **Deploy dashboard** step:

```
npx @cloudflare/next-on-pages@1
→ npm error code ERESOLVE — unable to resolve dependency tree
  peerOptional @cloudflare/workers-types@"^5.20260706.1" from wrangler@4.108.0
  Found: @cloudflare/workers-types@4.20260702.1 (peer of next-on-pages)
```

Nothing in our code changed. Cloudflare published `wrangler@4.108.0`, which bumped its peer dependency to `@cloudflare/workers-types@^5`. The ephemeral `npx @cloudflare/next-on-pages@1` install resolves that latest wrangler, but `next-on-pages` itself peers on `@cloudflare/workers-types@^4`. npm can't satisfy both v4 and v5 in one tree, so it aborts.

## Fix

In `.github/actions/deploy-observer-dashboard/action.yml`:

- **Pin** `npx @cloudflare/next-on-pages@1` → `@1.13.16`, so a future next-on-pages release can't silently drift the deploy tree again.
- Add `NPM_CONFIG_LEGACY_PEER_DEPS: "true"` to the deploy step env so npm tolerates the optional-peer mismatch — exactly what npm's error output recommends.

The other `npx wrangler …` steps install wrangler standalone and were never affected.

## Testing

Config-only change to a composite action; verified by re-running the workflow (the ERESOLVE was in the ephemeral npx install, which this addresses directly).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DatJJXxGLYDdgTWzT9zncq)_

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/AgentWorkforce/relaycast/pull/245?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

