### PR TITLE
ci: bump pinned Node to 22.22.2 to fix npm@latest EBADENGINE

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -78,7 +78,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "22.14.0"
+          node-version: "22.22.2"
           cache: "npm"
           cache-dependency-path: package-lock.json
           registry-url: "https://registry.npmjs.org"
@@ -205,7 +205,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "22.14.0"
+          node-version: "22.22.2"
           registry-url: "https://registry.npmjs.org"
 
       - name: Download build artifacts
@@ -244,7 +244,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "22.14.0"
+          node-version: "22.22.2"
           registry-url: "https://registry.npmjs.org"
 
       - name: Download build artifacts

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -78,7 +78,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "22.22.2"
+          node-version: "22.22.3"
           cache: "npm"
           cache-dependency-path: package-lock.json
           registry-url: "https://registry.npmjs.org"
@@ -205,7 +205,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "22.22.2"
+          node-version: "22.22.3"
           registry-url: "https://registry.npmjs.org"
 
       - name: Download build artifacts
@@ -244,7 +244,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "22.22.2"
+          node-version: "22.22.3"
           registry-url: "https://registry.npmjs.org"
 
       - name: Download build artifacts


### PR DESCRIPTION
## What

Bumps the pinned Node version in `.github/workflows/publish-npm.yml` from `22.14.0` to `22.22.2` (all three `setup-node` steps).

## Why

The [publish workflow run](https://github.com/AgentWorkforce/relaycast/actions/runs/28985193410) failed on every publish job at the `Update npm for OIDC support` step:

```
npm error code EBADENGINE
npm error engine Not compatible with your version of node/npm: npm@12.0.0
npm error notsup Required: {"node":"^22.22.2 || ^24.15.0 || >=26.0.0"}
npm error notsup Actual:   {"npm":"10.9.2","node":"v22.14.0"}
```

`npm install -g npm@latest` now resolves to **npm@12.0.0**, whose `engines` field requires Node `^22.22.2 || ^24.15.0 || >=26`. The workflow pinned Node `22.14.0`, which is below the new 22.x floor, so npm refused to install with `EBADENGINE`. Nothing in the source changed — a new npm major raised its minimum Node requirement.

## Fix

Bumping the Node pin to `22.22.2` satisfies npm 12's engine requirement while keeping `npm@latest` (needed for OIDC provenance / trusted publishing). This stays within the same Node 22.x major line, so it's a low-risk change. Two alternatives — pinning `npm@11` or dropping the upgrade step — were rejected because the step deliberately wants a recent npm for OIDC support.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01X4h6iYSAmtDjNuDn3wXaGj)_

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/AgentWorkforce/relaycast/pull/246?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

