### PR TITLE
ci: drop destructive npm self-upgrade in publish workflow

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -214,9 +214,6 @@ jobs:
           name: build-output
           path: .
 
-      - name: Update npm for OIDC support
-        run: npm install -g npm@latest
-
       - name: Dry run check
         if: github.event.inputs.dry_run == 'true'
         working-directory: packages/${{ matrix.package }}
@@ -252,9 +249,6 @@ jobs:
         with:
           name: build-output
           path: .
-
-      - name: Update npm for OIDC support
-        run: npm install -g npm@latest
 
       - name: Dry run check
         if: github.event.inputs.dry_run == 'true'


### PR DESCRIPTION
## What

Removes the `Update npm for OIDC support` step (`npm install -g npm@latest`) from both the `publish-packages` and `publish-single` jobs in `.github/workflows/publish-npm.yml`.

## Why

Follow-up to #246 (which bumped the pinned Node to 22.22.3). With the npm-upgrade step now able to run, the next publish [failed at the actual publish step](https://github.com/AgentWorkforce/relaycast/actions/runs/28987711626/job/86020757553):

```
npm error code MODULE_NOT_FOUND
npm error Cannot find module 'sigstore'
npm error - .../npm/node_modules/libnpmpublish/lib/provenance.js
```

Root cause: `npm install -g npm@latest` self-upgrades npm over its own bundled copy and prunes packages it still needs — the log shows `removed 71 packages, and changed 85 packages`. The resulting npm can no longer `require('sigstore')` during `npm publish --provenance`. This is the known destructive-self-upgrade behavior (npm/cli#2736, npm/cli#3175), and the same corruption class that produced the earlier `promise-retry` failure.

## Fix

Drop the self-upgrade step entirely and use the npm bundled with Node 22.22.3 (**npm 10.9.8**). The step was never required for this workflow:

- The workflow already grants `id-token: write` (line 59) and publishes with `--provenance`.
- Provenance / OIDC id-token attestation has been supported since **npm 9.5**, so 10.9.8 is sufficient.
- Pinning a specific `npm@x` version wouldn't help — it still self-upgrades over the bundled npm and can corrupt the tree the same way.

Removing the step eliminates the entire self-install corruption class (`promise-retry`, `sigstore`) and the `npm@latest` moving-target engine breakage.

> Note: this workflow is `workflow_dispatch`-only and its `dry_run` path uses `npm publish --dry-run` *without* `--provenance`, so a dry run won't exercise the provenance code path — only a real publish fully validates it. The fix is sound by construction (the bundled npm's `libnpmpublish` ships an intact `sigstore`), but a real publish is the definitive confirmation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01X4h6iYSAmtDjNuDn3wXaGj)_

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/AgentWorkforce/relaycast/pull/247?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

