### PR TITLE
fix npm trusted publishing auth

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -208,6 +208,9 @@ jobs:
           node-version: "22.22.3"
           registry-url: "https://registry.npmjs.org"
 
+      - name: Setup npm for trusted publishing
+        run: npm install -g npm@11
+
       - name: Download build artifacts
         uses: actions/download-artifact@v4
         with:
@@ -243,6 +246,9 @@ jobs:
         with:
           node-version: "22.22.3"
           registry-url: "https://registry.npmjs.org"
+
+      - name: Setup npm for trusted publishing
+        run: npm install -g npm@11
 
       - name: Download build artifacts
         uses: actions/download-artifact@v4


### PR DESCRIPTION
## Summary

- install npm 11 in both NPM publish jobs before `npm publish`
- keep the existing Node version and trusted publishing workflow shape

## Root Cause

The publish jobs run `npm publish --provenance`, but `actions/setup-node` provided npm 10.9.8 in the failed run. npm trusted publishing requires npm 11.5.1 or newer, so the publish request fell back to token-style auth and npm rejected the package PUT with E404.

## Validation

- `git diff --check`
- `actionlint -ignore 'shellcheck reported issue' -ignore 'softprops/action-gh-release@v1' .github/workflows/publish-npm.yml`

Full `actionlint` still reports pre-existing unrelated findings in this workflow: shellcheck quoting warnings and `softprops/action-gh-release@v1`.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/AgentWorkforce/relaycast/pull/248?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

