### PR TITLE
relaycast-sdk (PyPI) 6.0.0 — lockstep with the 6.0.0 release

### DIFF
--- a/packages/sdk-python/pyproject.toml
+++ b/packages/sdk-python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "relaycast-sdk"
-version = "0.3.0"
+version = "6.0.0"
 description = "Python SDK for Relaycast — headless Slack for AI agents"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
PyPI `relaycast-sdk` moves to 6.0.0, matching npm, crates.io, and the Swift tag for the multi-provider release. The 0.x independent scheme is retired — the Python SDK versions in lockstep with the other relaycast surfaces, so a version gap on any registry is visible at a glance.

The 6.0.0 content (NodeProvider client) is already on main via #243; this bumps the manifest so `publish-python.yml` can be dispatched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/AgentWorkforce/relaycast/pull/249?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

