### PR TITLE
engine: fix provider-attach race dropping a provider's capabilities at node up

### DIFF
--- a/packages/engine/src/__tests__/conformance/providerAttachRace.test.ts
+++ b/packages/engine/src/__tests__/conformance/providerAttachRace.test.ts
@@ -1,0 +1,123 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { and, eq } from 'drizzle-orm';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { createEngine } from '../../engine.js';
+import { createNodeRuntime, type NodeRuntime } from '../../adapters/node/index.js';
+import { nodeProviders, nodes } from '../../db/schema.js';
+import { FakeSocket, createWorkspace } from './harness.js';
+
+// File-backed so runAtomic uses isolated transactions like production (not the
+// shared :memory: connection). This is what lets a concurrent register and
+// teardown expose the per-node race — before the serialization fix the register's
+// isolated transaction deadlocks the teardown's write, and on async backends the
+// teardown's recompute clobbers the register's aggregate.
+function fileStack() {
+  const dir = mkdtempSync(join(tmpdir(), 'relaycast-attach-race-'));
+  const runtime: NodeRuntime = createNodeRuntime({
+    dbPath: join(dir, 'test.db'),
+    baseUrl: 'http://localhost:0',
+    migrate: true,
+    config: { environment: 'test' },
+    presence: { ttlMs: 60_000, sweepIntervalMs: 0 },
+  });
+  const app = createEngine(runtime.deps);
+  return { app, runtime, close: () => { runtime.close(); rmSync(dir, { recursive: true, force: true }); } };
+}
+
+function registerFrame(nodeId: string, name: string, provider: { name: string; instance_id: string }, caps: Array<{ name: string; kind: string }>) {
+  return JSON.stringify({
+    v: 1, id: `reg-${provider.name}`, type: 'node.register', name, node_id: nodeId,
+    provider, capabilities: caps, max_agents: 4, tags: ['t'], version: 'v1', resume_cursor: null,
+  });
+}
+
+describe('provider attach race', () => {
+  let stack: ReturnType<typeof fileStack>;
+  beforeEach(() => { stack = fileStack(); });
+  afterEach(() => stack.close());
+
+  async function enroll(wsKey: string, nodeId: string, name: string) {
+    const res = await stack.app.request('/v1/nodes', {
+      method: 'POST', headers: { 'content-type': 'application/json', authorization: `Bearer ${wsKey}` },
+      body: JSON.stringify({ node_id: nodeId, name, role: 'broker', capabilities: [], max_agents: 4, tags: ['t'], version: 'v0' }),
+    });
+    expect(res.status).toBe(201);
+  }
+  async function nodeCapNames(workspaceId: string, nodeId: string): Promise<string[]> {
+    const [row] = await stack.runtime.handle.db
+      .select({ caps: nodes.capabilities })
+      .from(nodes)
+      .where(and(eq(nodes.workspaceId, workspaceId), eq(nodes.id, nodeId)));
+    return (row?.caps ?? []).map((c) => c.name).sort();
+  }
+  async function providerNames(workspaceId: string, nodeId: string): Promise<string[]> {
+    const rows = await stack.runtime.handle.db
+      .select({ name: nodeProviders.name })
+      .from(nodeProviders)
+      .where(and(eq(nodeProviders.workspaceId, workspaceId), eq(nodeProviders.nodeId, nodeId)));
+    return rows.map((r) => r.name).sort();
+  }
+
+  it('keeps both providers in the node aggregate when two attach concurrently', async () => {
+    for (let i = 0; i < 25; i++) {
+      const ws = await createWorkspace(stack.app, `attach-${i}`);
+      const nodeId = `node_${i}`;
+      await enroll(ws.workspaceKey, nodeId, `alpha${i}`);
+      const a = new FakeSocket(); const ha = stack.runtime.realtime.attachNodeSocket(ws.workspaceId, nodeId, a);
+      const b = new FakeSocket(); const hb = stack.runtime.realtime.attachNodeSocket(ws.workspaceId, nodeId, b);
+      await Promise.all([
+        ha.handleMessage(registerFrame(nodeId, `alpha${i}`, { name: 'broker', instance_id: 'b1' }, [{ name: 'spawn:claude', kind: 'capacity' }])),
+        hb.handleMessage(registerFrame(nodeId, `alpha${i}`, { name: 'py', instance_id: 'p1' }, [{ name: 'run-etl', kind: 'action' }])),
+      ]);
+      expect(await providerNames(ws.workspaceId, nodeId)).toEqual(['broker', 'py']);
+      expect(await nodeCapNames(ws.workspaceId, nodeId)).toEqual(['run-etl', 'spawn:claude']);
+    }
+  });
+
+  it('keeps a stable aggregate when a register races another provider disconnecting', async () => {
+    for (let i = 0; i < 25; i++) {
+      const ws = await createWorkspace(stack.app, `disc-${i}`);
+      const nodeId = `node_${i}`;
+      await enroll(ws.workspaceKey, nodeId, `alpha${i}`);
+      const a = new FakeSocket(); const ha = stack.runtime.realtime.attachNodeSocket(ws.workspaceId, nodeId, a);
+      await ha.handleMessage(registerFrame(nodeId, `alpha${i}`, { name: 'broker', instance_id: 'b1' }, [{ name: 'spawn:claude', kind: 'capacity' }]));
+      const b = new FakeSocket(); const hb = stack.runtime.realtime.attachNodeSocket(ws.workspaceId, nodeId, b);
+      // The broker disconnects at the same instant the py provider registers.
+      await Promise.all([
+        hb.handleMessage(registerFrame(nodeId, `alpha${i}`, { name: 'py', instance_id: 'p1' }, [{ name: 'run-etl', kind: 'action' }])),
+        ha.handleClose(),
+      ]);
+      // The broker's row persists offline (manifest), py is online; neither cap
+      // set is clobbered out of the aggregate.
+      expect(await providerNames(ws.workspaceId, nodeId)).toEqual(['broker', 'py']);
+      expect(await nodeCapNames(ws.workspaceId, nodeId)).toEqual(['run-etl', 'spawn:claude']);
+    }
+  });
+
+  it('resolves two providers claiming the same name deterministically, without silent cap loss', async () => {
+    const winners = new Set<string>();
+    for (let i = 0; i < 25; i++) {
+      const ws = await createWorkspace(stack.app, `dup-${i}`);
+      const nodeId = `node_${i}`;
+      await enroll(ws.workspaceKey, nodeId, `alpha${i}`);
+      const a = new FakeSocket(); const ha = stack.runtime.realtime.attachNodeSocket(ws.workspaceId, nodeId, a);
+      const b = new FakeSocket(); const hb = stack.runtime.realtime.attachNodeSocket(ws.workspaceId, nodeId, b);
+      await Promise.all([
+        ha.handleMessage(registerFrame(nodeId, `alpha${i}`, { name: 'dup', instance_id: 'a1' }, [{ name: 'spawn:claude', kind: 'capacity' }])),
+        hb.handleMessage(registerFrame(nodeId, `alpha${i}`, { name: 'dup', instance_id: 'b1' }, [{ name: 'run-etl', kind: 'action' }])),
+      ]);
+      // Exactly one provider row survives; the loser is rejected loudly (not a
+      // silent overwrite), and the winner's caps are intact.
+      expect(await providerNames(ws.workspaceId, nodeId)).toEqual(['dup']);
+      const caps = await nodeCapNames(ws.workspaceId, nodeId);
+      expect(caps.length).toBe(1);
+      winners.add(caps[0]);
+      const errors = [...a.ofType('error'), ...b.ofType('error')];
+      expect(errors.some((e) => e.code === 'provider_instance_conflict')).toBe(true);
+    }
+    // Deterministic across runs: the first registrant always wins (no ~50% flip).
+    expect(winners).toEqual(new Set(['spawn:claude']));
+  });
+});

--- a/packages/engine/src/engine/node.ts
+++ b/packages/engine/src/engine/node.ts
@@ -1368,14 +1368,15 @@ export async function handleNodeControlMessage(args: HandleNodeControlMessageArg
     return;
   }
 
-  // Serialize all control operations for a node so a concurrent register and
-  // teardown (or two providers attaching at once) can't race the duplicate
-  // check, the provider-row upsert, or the aggregate recompute.
-  return serializeNodeOp(args.workspaceId, args.nodeId, async () => {
   // A provider binds its name to the connection at node.register; later frames
   // (heartbeat, deregister, agent.register, results) resolve it from the
   // connection. Absent a bound provider (or when driven without a registry
   // connection), fall back to the synthetic `default` provider.
+  //
+  // Resolve this at frame ARRIVAL, before entering the per-node queue: if the
+  // socket closes while this frame is queued, `onNodeConnectionClose` clears the
+  // connection's provider binding synchronously, and a lookup inside the callback
+  // would then fall back to `default` and act on the wrong provider.
   const boundProviderName = args.connectionId
     ? args.registry.providerNameForConnection?.(args.connectionId)
     : undefined;
@@ -1386,6 +1387,10 @@ export async function handleNodeControlMessage(args: HandleNodeControlMessageArg
     ?? ('provider' in message && message.provider ? message.provider.name : undefined)
     ?? DEFAULT_PROVIDER_NAME;
 
+  // Serialize all control operations for a node so a concurrent register and
+  // teardown (or two providers attaching at once) can't race the duplicate
+  // check, the provider-row upsert, or the aggregate recompute.
+  return serializeNodeOp(args.workspaceId, args.nodeId, async () => {
   try {
     switch (message.type) {
       case 'node.register': {

--- a/packages/engine/src/engine/node.ts
+++ b/packages/engine/src/engine/node.ts
@@ -30,6 +30,7 @@ import {
   removeProvider,
   upsertProvider,
 } from './nodeProvider.js';
+import { serializeNodeOp } from './nodeLock.js';
 import {
   completeNodeInvocation,
   dispatchCapacitySpawn,
@@ -508,21 +509,26 @@ export async function handleProviderDisconnect(
   providerName: string,
   hasRemainingConnections: boolean,
 ) {
-  if (!hasRemainingConnections) {
-    await markNodeOffline(db, registry, workspaceId, nodeId);
-    return;
-  }
-  await markProviderOffline(db, workspaceId, nodeId, providerName);
-  await db
-    .update(agents)
-    .set({ status: 'offline', lastSeen: new Date() })
-    .where(and(
-      eq(agents.workspaceId, workspaceId),
-      eq(agents.locationType, 'via_node'),
-      eq(agents.locationNodeId, nodeId),
-      eq(agents.providerName, providerName),
-    ));
-  await recomputeNodeAggregate(db, workspaceId, nodeId);
+  // Serialized with node-control operations so a teardown can't race a
+  // concurrent register's provider upsert / aggregate recompute (or, on
+  // better-sqlite3, deadlock its isolated transaction).
+  return serializeNodeOp(workspaceId, nodeId, async () => {
+    if (!hasRemainingConnections) {
+      await markNodeOffline(db, registry, workspaceId, nodeId);
+      return;
+    }
+    await markProviderOffline(db, workspaceId, nodeId, providerName);
+    await db
+      .update(agents)
+      .set({ status: 'offline', lastSeen: new Date() })
+      .where(and(
+        eq(agents.workspaceId, workspaceId),
+        eq(agents.locationType, 'via_node'),
+        eq(agents.locationNodeId, nodeId),
+        eq(agents.providerName, providerName),
+      ));
+    await recomputeNodeAggregate(db, workspaceId, nodeId);
+  });
 }
 
 /**
@@ -567,7 +573,7 @@ export async function sweepOfflineNodes(db: Db, registry: NodeConnectionRegistry
   const rows = await db.select().from(nodes).where(eq(nodes.status, 'online'));
   const stale = rows.filter((node) => !isNodeLive(node));
   for (const node of stale) {
-    await markNodeOffline(db, registry, node.workspaceId, node.id);
+    await serializeNodeOp(node.workspaceId, node.id, () => markNodeOffline(db, registry, node.workspaceId, node.id));
   }
   return stale.length;
 }
@@ -1362,6 +1368,10 @@ export async function handleNodeControlMessage(args: HandleNodeControlMessageArg
     return;
   }
 
+  // Serialize all control operations for a node so a concurrent register and
+  // teardown (or two providers attaching at once) can't race the duplicate
+  // check, the provider-row upsert, or the aggregate recompute.
+  return serializeNodeOp(args.workspaceId, args.nodeId, async () => {
   // A provider binds its name to the connection at node.register; later frames
   // (heartbeat, deregister, agent.register, results) resolve it from the
   // connection. Absent a bound provider (or when driven without a registry
@@ -1514,4 +1524,5 @@ export async function handleNodeControlMessage(args: HandleNodeControlMessageArg
       message: error.message,
     });
   }
+  });
 }

--- a/packages/engine/src/engine/node.ts
+++ b/packages/engine/src/engine/node.ts
@@ -572,10 +572,22 @@ export async function deregisterProvider(
 export async function sweepOfflineNodes(db: Db, registry: NodeConnectionRegistry): Promise<number> {
   const rows = await db.select().from(nodes).where(eq(nodes.status, 'online'));
   const stale = rows.filter((node) => !isNodeLive(node));
+  let swept = 0;
   for (const node of stale) {
-    await serializeNodeOp(node.workspaceId, node.id, () => markNodeOffline(db, registry, node.workspaceId, node.id));
+    const offlined = await serializeNodeOp(node.workspaceId, node.id, async () => {
+      // Re-read under the lock: a heartbeat/register queued ahead of this sweep
+      // may have refreshed the node since the stale snapshot was taken.
+      const [current] = await db
+        .select()
+        .from(nodes)
+        .where(and(eq(nodes.workspaceId, node.workspaceId), eq(nodes.id, node.id)));
+      if (!current || current.status !== 'online' || isNodeLive(current)) return false;
+      await markNodeOffline(db, registry, node.workspaceId, node.id);
+      return true;
+    });
+    if (offlined) swept++;
   }
-  return stale.length;
+  return swept;
 }
 
 async function autoJoinGeneral(db: Db, workspaceId: string, agentId: string) {

--- a/packages/engine/src/engine/nodeLock.ts
+++ b/packages/engine/src/engine/nodeLock.ts
@@ -16,7 +16,9 @@
 const chains = new Map<string, Promise<unknown>>();
 
 export function serializeNodeOp<T>(workspaceId: string, nodeId: string, fn: () => Promise<T>): Promise<T> {
-  const key = `${workspaceId}:${nodeId}`;
+  // Collision-safe key: ids are free-form and may contain any separator, so
+  // encode the tuple rather than joining on a character.
+  const key = JSON.stringify([workspaceId, nodeId]);
   const prev = chains.get(key) ?? Promise.resolve();
   const run = prev.then(fn, fn);
   const tail = run.then(() => undefined, () => undefined);

--- a/packages/engine/src/engine/nodeLock.ts
+++ b/packages/engine/src/engine/nodeLock.ts
@@ -1,0 +1,28 @@
+/**
+ * Per-node serialization for node-control operations.
+ *
+ * Registration (duplicate-provider check + `node_providers` upsert + registry
+ * bind + node-aggregate recompute) and connection teardown both read and write
+ * the same shared node state (the provider rows and the `nodes` aggregate).
+ * `handleNodeControlMessage` and the socket-close path are async and would
+ * otherwise interleave for a single node, so two providers attaching at once can
+ * overwrite each other's row or clobber the aggregate, and on better-sqlite3 a
+ * register's isolated transaction can deadlock a concurrent teardown's write.
+ *
+ * All operations for one node run one-at-a-time through this queue. Keyed by
+ * `workspaceId:nodeId`, it is a no-op for callers that already serialize (a
+ * per-node Durable Object) and the ordering guarantee self-hosting needs.
+ */
+const chains = new Map<string, Promise<unknown>>();
+
+export function serializeNodeOp<T>(workspaceId: string, nodeId: string, fn: () => Promise<T>): Promise<T> {
+  const key = `${workspaceId}:${nodeId}`;
+  const prev = chains.get(key) ?? Promise.resolve();
+  const run = prev.then(fn, fn);
+  const tail = run.then(() => undefined, () => undefined);
+  chains.set(key, tail);
+  void tail.finally(() => {
+    if (chains.get(key) === tail) chains.delete(key);
+  });
+  return run;
+}

--- a/packages/engine/src/routes/node.ts
+++ b/packages/engine/src/routes/node.ts
@@ -15,6 +15,7 @@ import {
   parseOptionalJsonBody,
 } from '../lib/httpResponse.js';
 import * as nodeEngine from '../engine/node.js';
+import { serializeNodeOp } from '../engine/nodeLock.js';
 import * as actionEngine from '../engine/action.js';
 import { sendNodeDeliveriesToAgents } from '../engine/nodeDeliver.js';
 import { fanoutToWorkspace } from './fanout.js';
@@ -340,7 +341,11 @@ nodeRoutes.delete('/nodes/:node/providers/:name', requireWorkspaceKey, rateLimit
     if (!node) {
       return jsonNotFound(c, 'node_not_found', 'Node not found');
     }
-    await nodeEngine.deregisterProvider(db, c.get('engine').nodeConnections, workspace.id, node.id, c.req.param('name'));
+    // Serialize with node-control operations so removal can't race a concurrent
+    // register/heartbeat's aggregate recompute.
+    await serializeNodeOp(workspace.id, node.id, () =>
+      nodeEngine.deregisterProvider(db, c.get('engine').nodeConnections, workspace.id, node.id, c.req.param('name')),
+    );
     return jsonNoContent(c);
   } catch (err: unknown) {
     return errorResponse(c, err);

--- a/packages/sdk-rust/src/credentials.rs
+++ b/packages/sdk-rust/src/credentials.rs
@@ -270,7 +270,7 @@ pub async fn bootstrap_session(
     let name = config
         .preferred_name
         .or(cached_name)
-        .unwrap_or_else(|| format!("agent-{}", &uuid_v4_short()));
+        .unwrap_or_else(|| format!("agent-{}", uuid_v4_short()));
 
     let agent_type = config.agent_type.unwrap_or_else(|| "agent".into());
     let conflict_strategy = config.conflict_strategy;
@@ -372,7 +372,7 @@ pub async fn bootstrap_session(
 }
 
 async fn create_fresh_workspace(base_url: Option<&str>) -> Result<(String, Option<String>)> {
-    let ws_name = format!("relay-{}", &uuid_v4_short());
+    let ws_name = format!("relay-{}", uuid_v4_short());
     let result = RelayCast::create_workspace(&ws_name, base_url).await?;
     Ok((result.api_key, Some(result.workspace_id)))
 }


### PR DESCRIPTION
## The bug (P0)

Two providers attaching to one node concurrently — the broker plus a fleet `serveNode` at `node up` — non-deterministically drop one provider's **entire** capability set from the node roster (~50% of boots, flips which). This silently breaks placement/dispatch for the lost capabilities on every multi-provider `node up`.

## Root cause

Registration (duplicate-provider check → `node_providers` upsert → registry bind → node-aggregate recompute) and connection teardown both read and write shared node state, but node-control operations aren't serialized per node — they interleave at `await` points. Three concrete failure modes, all reproduced:

1. **Same-name overwrite.** Two registrations for the same provider name both pass `providerAttachConflict` (which reads the in-memory registry) *before* either calls `attachProvider`, then the second `upsertProvider` — keyed on `(workspace, node, name)` — overwrites the first's row. One capability set vanishes; the two providers collapse to one row. (This is why a per-node mutex around only the DB functions didn't help: serializing the calls doesn't stop the overwrite, and the conflict check is in the wrong layer.)
2. **Aggregate clobber.** A teardown's `recomputeNodeAggregate` reads the provider set before a concurrent register commits and writes it after — clobbering the newly registered provider out of `nodes.capabilities`. The provider *row* survives; the roster goes stale. This is the production (async D1) manifestation with distinct provider names.
3. **Self-host deadlock.** On better-sqlite3, the teardown's write on the main handle blocks a register's isolated-transaction write lock for the full `busy_timeout` (5s), then swallows `SQLITE_BUSY`.

## Fix

All control operations for a node run one-at-a-time through a per-node queue keyed by `workspace:node` (`serializeNodeOp`). `handleNodeControlMessage`, the socket-close path (`handleProviderDisconnect`), the offline sweep, and the provider DELETE route serialize through it. Consequences:

- Distinct providers coexist (the intended multi-provider behavior).
- Same-name duplicates resolve **deterministically** — the second is rejected loudly with `provider_instance_conflict` instead of silently overwriting the first.
- No cross-operation aggregate clobber and no isolated-transaction deadlock.
- No-op for callers that already serialize per node (a per-node Durable Object).

## Tests

`packages/engine/src/__tests__/conformance/providerAttachRace.test.ts` — a file-backed suite (isolated transactions, like production) that reproduces all three modes and asserts a stable aggregate. Verified it **fails without the fix** (the register-vs-disconnect case deadlocks/times out; the same-name case asserts the silent overwrite) and passes with it. Full engine suite (423) and types suite (161) green; lint clean.

## Coordination note

For the broker and a fleet `serveNode` to **coexist** on one node they must register under **distinct** provider names — the engine now rejects a same-name duplicate deterministically rather than losing a cap set. If `node up` currently points both at the same provider name (e.g. `default`), that needs a matching CLI change in the relay repo so serveNode uses a distinct name. Flagging for relay-impl.

Rides the v6.0.1 patch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/AgentWorkforce/relaycast/pull/251?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

