### PR TITLE
fix(engine): preserve delivery sequences across retention

### DIFF
--- a/.agentworkforce/trajectories/completed/2026-07/traj_3r3h6jisvzaq/summary.md
+++ b/.agentworkforce/trajectories/completed/2026-07/traj_3r3h6jisvzaq/summary.md
@@ -1,0 +1,32 @@
+# Trajectory: Keep delivery sequences monotonic across retention
+
+> **Status:** ✅ Completed
+> **Task:** relaycast#252
+> **Confidence:** 95%
+> **Started:** July 10, 2026 at 10:00 AM
+> **Completed:** July 10, 2026 at 10:12 AM
+
+---
+
+## Summary
+
+Fixed Relaycast #252 with a durable per-agent delivery sequence high-water, atomic trigger-backed allocation, migration repair for replay-hidden active rows, and regression coverage for retention, cascades, offline replay/ACK, migration backfill/FIFO repair, and concurrency
+
+**Approach:** Standard approach
+
+---
+
+## Key Decisions
+
+### Store delivery sequence high-water on agents and advance it with an AFTER INSERT trigger
+- **Chose:** Store delivery sequence high-water on agents and advance it with an AFTER INSERT trigger
+- **Reasoning:** A persistent counter survives both explicit delivery pruning and message-cascade deletion. The trigger makes allocation and advancement one SQLite statement across Node, D1 batch, and bare sequential adapters; migration repair renumbers all active rows for affected agents above max(ACK, existing seq) in FIFO order.
+
+---
+
+## Chapters
+
+### 1. Work
+*Agent: default*
+
+- Store delivery sequence high-water on agents and advance it with an AFTER INSERT trigger: Store delivery sequence high-water on agents and advance it with an AFTER INSERT trigger

--- a/.agentworkforce/trajectories/completed/2026-07/traj_3r3h6jisvzaq/trajectory.json
+++ b/.agentworkforce/trajectories/completed/2026-07/traj_3r3h6jisvzaq/trajectory.json
@@ -1,0 +1,57 @@
+{
+  "id": "traj_3r3h6jisvzaq",
+  "version": 1,
+  "task": {
+    "title": "Keep delivery sequences monotonic across retention",
+    "source": {
+      "system": "plain",
+      "id": "relaycast#252"
+    }
+  },
+  "status": "completed",
+  "startedAt": "2026-07-10T14:00:44.444Z",
+  "completedAt": "2026-07-10T14:12:04.064Z",
+  "agents": [
+    {
+      "name": "default",
+      "role": "lead",
+      "joinedAt": "2026-07-10T14:11:06.992Z"
+    }
+  ],
+  "chapters": [
+    {
+      "id": "chap_6kt0zjj30fer",
+      "title": "Work",
+      "agentName": "default",
+      "startedAt": "2026-07-10T14:11:06.992Z",
+      "endedAt": "2026-07-10T14:12:04.064Z",
+      "events": [
+        {
+          "ts": 1783692666993,
+          "type": "decision",
+          "content": "Store delivery sequence high-water on agents and advance it with an AFTER INSERT trigger: Store delivery sequence high-water on agents and advance it with an AFTER INSERT trigger",
+          "raw": {
+            "question": "Store delivery sequence high-water on agents and advance it with an AFTER INSERT trigger",
+            "chosen": "Store delivery sequence high-water on agents and advance it with an AFTER INSERT trigger",
+            "alternatives": [],
+            "reasoning": "A persistent counter survives both explicit delivery pruning and message-cascade deletion. The trigger makes allocation and advancement one SQLite statement across Node, D1 batch, and bare sequential adapters; migration repair renumbers all active rows for affected agents above max(ACK, existing seq) in FIFO order."
+          },
+          "significance": "high"
+        }
+      ]
+    }
+  ],
+  "retrospective": {
+    "summary": "Fixed Relaycast #252 with a durable per-agent delivery sequence high-water, atomic trigger-backed allocation, migration repair for replay-hidden active rows, and regression coverage for retention, cascades, offline replay/ACK, migration backfill/FIFO repair, and concurrency",
+    "approach": "Standard approach",
+    "confidence": 0.95
+  },
+  "commits": [],
+  "filesChanged": [],
+  "projectId": "AgentWorkforce/relaycast",
+  "tags": [],
+  "_trace": {
+    "startRef": "e905f3acfb790279ee2eb964cf711f29de87f718",
+    "endRef": "e905f3acfb790279ee2eb964cf711f29de87f718"
+  }
+}

--- a/packages/engine/CHANGELOG.md
+++ b/packages/engine/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 - Self-host (file-backed SQLite): route every write through one async gate so a raw statement write can no longer busy-wait the event loop while a transaction holds the write lock. Under concurrent node registration, this deadlocked on `busy_timeout` and silently dropped a provider's capabilities from the node aggregate (#250).
 - Node control logs a rejected `node.register`/`node.heartbeat` (e.g. `node_name_conflict`, a UNIQUE violation) at warn level with workspace/node/provider/code context, so a node left half-registered by a rejected message is no longer invisible server-side.
 - Message-trigger dispatch failures are logged at warn with trigger/action/workspace context instead of being swallowed, so a trigger whose action is missing or unroutable is diagnosable.
+- Kept per-agent delivery sequences monotonic across delivery pruning and message-retention cascades, including migration repair for active rows hidden behind an acknowledged cursor.
 
 ### Changed
 - Refactored route handlers, route response helpers, and service internals without changing the public HTTP envelopes or API behavior.

--- a/packages/engine/src/__tests__/atomicity.test.ts
+++ b/packages/engine/src/__tests__/atomicity.test.ts
@@ -6,7 +6,7 @@ import {
   registerAgent,
   type TestStack,
 } from './conformance/harness.js';
-import { channels, deliveries, files, messageAttachments, messageLogs, messages, readReceipts, channelMembers } from '../db/schema.js';
+import { agents, channels, deliveries, files, messageAttachments, messageLogs, messages, readReceipts, channelMembers } from '../db/schema.js';
 import { postMessage } from '../engine/message.js';
 import { sendDm } from '../engine/dm.js';
 import { createGroupDm, postGroupMessage } from '../engine/groupDm.js';
@@ -250,7 +250,7 @@ describe('atomic write paths', () => {
     });
 
     it('commits concurrent transactional sends without interleaving', async () => {
-      const { ws, alice, channelId, db } = await seed();
+      const { ws, alice, bob, channelId, db } = await seed();
 
       const results = await Promise.all(
         Array.from({ length: 5 }, (_, i) =>
@@ -260,8 +260,18 @@ describe('atomic write paths', () => {
 
       expect(new Set(results.map((r) => r.id)).size).toBe(5);
       expect(await db.select().from(messages)).toHaveLength(5);
-      // One delivery per message for bob, the only other member.
-      expect(await db.select().from(deliveries)).toHaveLength(5);
+      // One delivery per message for bob, the only other member. Concurrent
+      // inserts allocate distinct values and advance the durable high-water.
+      const deliveryRows = await db
+        .select({ seq: deliveries.seq })
+        .from(deliveries)
+        .where(eq(deliveries.agentId, bob.agentId));
+      expect(deliveryRows.map((row) => row.seq).sort((a, b) => a - b)).toEqual([1, 2, 3, 4, 5]);
+      const [recipient] = await db
+        .select({ deliverySeq: agents.deliverySeq })
+        .from(agents)
+        .where(eq(agents.id, bob.agentId));
+      expect(recipient.deliverySeq).toBe(5);
     });
   });
 

--- a/packages/engine/src/__tests__/conformance/delivery.test.ts
+++ b/packages/engine/src/__tests__/conformance/delivery.test.ts
@@ -14,6 +14,7 @@ import { agents, deliveries } from '../../db/schema.js';
 import * as messageEngine from '../../engine/message.js';
 import * as deliveryEngine from '../../engine/delivery.js';
 import { ensureDirectNodeForAgent } from '../../engine/node.js';
+import { pruneExpired } from '../../engine/retention.js';
 import { routeDeliveryOutcomes } from '../../routes/deliveryRouting.js';
 import { deliverPendingToNode, handleNodeReconnect } from '../../index.js';
 
@@ -639,6 +640,66 @@ describe('durable delivery api', () => {
     }));
     await new Promise((r) => setTimeout(r, 50));
     expect(reconnected.sock.ofType('deliver')).toHaveLength(0);
+  });
+
+  it('replays and acknowledges the next sequence after settled history is pruned offline', async () => {
+    const ws = await createWorkspace(stack.app, 'mailbox-node-pruned-history');
+    const alice = await registerAgent(stack.app, ws.workspaceKey, 'alice');
+    const node = await enrollAndAttachNode(ws);
+    const bob = await registerViaNode(node, 'bob');
+
+    const first = await stack.app.request('/v1/channels/general/messages', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', authorization: `Bearer ${alice.token}` },
+      body: JSON.stringify({ text: 'first' }),
+    });
+    expect(first.status).toBe(201);
+    await waitForAssertion(() => {
+      expect(deliverFramesOfType(node.sock, 'message.created').map((frame) => frame.seq)).toEqual([1]);
+    });
+
+    await node.handle.handleMessage(JSON.stringify({
+      v: 1,
+      type: 'delivery.ack',
+      agent: 'bob',
+      up_to_seq: 1,
+    }));
+    await stack.runtime.deps.db
+      .update(deliveries)
+      .set({ createdAt: new Date(Date.now() - 100 * 24 * 60 * 60 * 1000) })
+      .where(eq(deliveries.agentId, bob.agentId));
+    expect((await pruneExpired(stack.runtime.deps.db)).deliveries).toBe(1);
+
+    await node.handle.handleClose();
+    const second = await stack.app.request('/v1/channels/general/messages', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', authorization: `Bearer ${alice.token}` },
+      body: JSON.stringify({ text: 'second while offline' }),
+    });
+    expect(second.status).toBe(201);
+
+    const reconnected = await enrollAndAttachNode(ws, { id: node.id, name: node.name });
+    await reconnected.handle.handleMessage(JSON.stringify({
+      v: 1,
+      type: 'inventory.sync',
+      agents: [{ agent_id: bob.agentId, name: 'bob', session_ref: 'sess-bob' }],
+    }));
+    await waitForAssertion(() => {
+      expect(deliverFramesOfType(reconnected.sock, 'message.created').map((frame) => frame.seq)).toEqual([2]);
+    });
+
+    await reconnected.handle.handleMessage(JSON.stringify({
+      v: 1,
+      type: 'delivery.ack',
+      agent: 'bob',
+      up_to_seq: 2,
+    }));
+    const [recipient] = await stack.runtime.deps.db
+      .select({ ackSeq: agents.deliveryAckSeq, deliverySeq: agents.deliverySeq })
+      .from(agents)
+      .where(eq(agents.id, bob.agentId));
+    expect(recipient).toEqual({ ackSeq: 2, deliverySeq: 2 });
+    expect(await listDeliveries(bob.token)).toHaveLength(0);
   });
 
   it('redelivers a channel message with the same deliver payload after broker death/reconnect', async () => {

--- a/packages/engine/src/adapters/node/__tests__/database.test.ts
+++ b/packages/engine/src/adapters/node/__tests__/database.test.ts
@@ -1,0 +1,90 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import Database from 'better-sqlite3';
+
+const handles: Database.Database[] = [];
+
+afterEach(() => {
+  for (const handle of handles.splice(0)) {
+    try { handle.close(); } catch { /* already closed */ }
+  }
+});
+
+describe('delivery sequence high-water migration', () => {
+  it('repairs the full active queue above a collision-free base in FIFO order', () => {
+    const sqlite = new Database(':memory:');
+    handles.push(sqlite);
+    sqlite.exec(`
+      CREATE TABLE agents (
+        id TEXT PRIMARY KEY,
+        workspace_id TEXT NOT NULL,
+        delivery_ack_seq INTEGER NOT NULL DEFAULT 0
+      );
+      CREATE TABLE deliveries (
+        id TEXT PRIMARY KEY,
+        workspace_id TEXT NOT NULL,
+        agent_id TEXT NOT NULL,
+        status TEXT NOT NULL,
+        seq INTEGER NOT NULL,
+        created_at INTEGER NOT NULL,
+        UNIQUE(workspace_id, agent_id, seq)
+      );
+
+      INSERT INTO agents (id, workspace_id, delivery_ack_seq) VALUES
+        ('agent_affected', 'ws_1', 5),
+        ('agent_healthy', 'ws_1', 2),
+        ('agent_fully_pruned', 'ws_1', 7);
+
+      INSERT INTO deliveries (id, workspace_id, agent_id, status, seq, created_at) VALUES
+        ('terminal_collision', 'ws_1', 'agent_affected', 'acked', 10, 50),
+        ('hidden_older', 'ws_1', 'agent_affected', 'queued', 4, 100),
+        ('visible_newer', 'ws_1', 'agent_affected', 'delivered', 8, 200),
+        ('healthy_active', 'ws_1', 'agent_healthy', 'queued', 4, 100);
+    `);
+
+    const migration = readFileSync(
+      new URL('../../../db/migrations/0029_delivery_sequence_high_water.sql', import.meta.url),
+      'utf8',
+    );
+    sqlite.exec(migration);
+
+    const repaired = sqlite.prepare(`
+      SELECT id, seq
+      FROM deliveries
+      WHERE agent_id = 'agent_affected' AND status IN ('queued', 'delivered')
+      ORDER BY created_at, id
+    `).all();
+    expect(repaired).toEqual([
+      { id: 'hidden_older', seq: 11 },
+      { id: 'visible_newer', seq: 12 },
+    ]);
+    expect(sqlite.prepare(`SELECT delivery_seq FROM agents WHERE id = 'agent_affected'`).get())
+      .toEqual({ delivery_seq: 12 });
+    expect(sqlite.prepare(`SELECT seq FROM deliveries WHERE id = 'healthy_active'`).get())
+      .toEqual({ seq: 4 });
+    expect(sqlite.prepare(`SELECT delivery_seq FROM agents WHERE id = 'agent_healthy'`).get())
+      .toEqual({ delivery_seq: 4 });
+    expect(sqlite.prepare(`SELECT delivery_seq FROM agents WHERE id = 'agent_fully_pruned'`).get())
+      .toEqual({ delivery_seq: 7 });
+
+    sqlite.exec(`
+      INSERT INTO deliveries (id, workspace_id, agent_id, status, seq, created_at)
+      SELECT 'next_delivery', workspace_id, id, 'queued', delivery_seq + 1, 300
+      FROM agents
+      WHERE id = 'agent_affected';
+    `);
+    expect(sqlite.prepare(`SELECT seq FROM deliveries WHERE id = 'next_delivery'`).get())
+      .toEqual({ seq: 13 });
+    expect(sqlite.prepare(`SELECT delivery_seq FROM agents WHERE id = 'agent_affected'`).get())
+      .toEqual({ delivery_seq: 13 });
+
+    sqlite.exec(`
+      INSERT INTO deliveries (id, workspace_id, agent_id, status, seq, created_at)
+      SELECT 'after_full_prune', workspace_id, id, 'queued', delivery_seq + 1, 300
+      FROM agents
+      WHERE id = 'agent_fully_pruned';
+    `);
+    expect(sqlite.prepare(`SELECT seq FROM deliveries WHERE id = 'after_full_prune'`).get())
+      .toEqual({ seq: 8 });
+  });
+});

--- a/packages/engine/src/db/migrations/0029_delivery_sequence_high_water.sql
+++ b/packages/engine/src/db/migrations/0029_delivery_sequence_high_water.sql
@@ -1,0 +1,80 @@
+-- Keep each agent's delivery sequence monotonic even after delivery retention
+-- or a message-retention cascade removes every historical delivery row.
+
+ALTER TABLE agents ADD COLUMN delivery_seq INTEGER NOT NULL DEFAULT 0;
+
+-- Older engines could reuse a sequence after retention. If that sequence was
+-- already cumulatively acknowledged, the active row is hidden by replay's
+-- `seq > delivery_ack_seq` predicate. Repair every active row for each affected
+-- agent, not just the hidden rows, so their FIFO order remains intact. New
+-- values start above both the ACK cursor and every existing (including settled)
+-- row, avoiding collisions with the unique (workspace_id, agent_id, seq) index.
+WITH affected_agents AS MATERIALIZED (
+  SELECT
+    a.workspace_id,
+    a.id AS agent_id,
+    MAX(
+      a.delivery_ack_seq,
+      COALESCE((
+        SELECT MAX(all_deliveries.seq)
+        FROM deliveries all_deliveries
+        WHERE all_deliveries.workspace_id = a.workspace_id
+          AND all_deliveries.agent_id = a.id
+      ), 0)
+    ) AS base_seq
+  FROM agents a
+  WHERE EXISTS (
+    SELECT 1
+    FROM deliveries hidden
+    WHERE hidden.workspace_id = a.workspace_id
+      AND hidden.agent_id = a.id
+      AND hidden.status IN ('queued', 'delivered')
+      AND hidden.seq <= a.delivery_ack_seq
+  )
+),
+ranked_active AS MATERIALIZED (
+  SELECT
+    active.id,
+    affected_agents.base_seq + ROW_NUMBER() OVER (
+      PARTITION BY active.workspace_id, active.agent_id
+      ORDER BY active.created_at, active.id
+    ) AS repaired_seq
+  FROM deliveries active
+  INNER JOIN affected_agents
+    ON affected_agents.workspace_id = active.workspace_id
+   AND affected_agents.agent_id = active.agent_id
+  WHERE active.status IN ('queued', 'delivered')
+)
+UPDATE deliveries
+SET seq = (
+  SELECT ranked_active.repaired_seq
+  FROM ranked_active
+  WHERE ranked_active.id = deliveries.id
+)
+WHERE id IN (SELECT id FROM ranked_active);
+
+-- Seed both ordinary and repaired agents from all remaining history. The ACK
+-- cursor participates because retention may already have removed every row.
+UPDATE agents
+SET delivery_seq = MAX(
+  delivery_ack_seq,
+  COALESCE((
+    SELECT MAX(deliveries.seq)
+    FROM deliveries
+    WHERE deliveries.workspace_id = agents.workspace_id
+      AND deliveries.agent_id = agents.id
+  ), 0)
+);
+
+-- Production delivery inserts allocate above this high-water (and defensively
+-- above the ACK cursor). Advancing the counter from an AFTER INSERT trigger
+-- keeps allocation and advancement in the same SQLite statement, including D1
+-- and bare sequential adapters.
+CREATE TRIGGER deliveries_advance_sequence_high_water
+AFTER INSERT ON deliveries
+BEGIN
+  UPDATE agents
+  SET delivery_seq = MAX(delivery_seq, NEW.seq)
+  WHERE id = NEW.agent_id
+    AND workspace_id = NEW.workspace_id;
+END;

--- a/packages/engine/src/db/schema.ts
+++ b/packages/engine/src/db/schema.ts
@@ -76,6 +76,9 @@ export const agents = sqliteTable(
     sessionRef: text('session_ref'),
     originNodeId: text('origin_node_id').references((): AnySQLiteColumn => nodes.id, { onDelete: 'set null' }),
     deliveryAckSeq: integer('delivery_ack_seq').notNull().default(0),
+    // Durable allocation high-water. Unlike MAX(deliveries.seq), this survives
+    // settled-delivery pruning and message-retention cascades.
+    deliverySeq: integer('delivery_seq').notNull().default(0),
     createdAt: integer('created_at', { mode: 'timestamp' }).notNull().default(sql`(unixepoch())`),
     lastSeen: integer('last_seen', { mode: 'timestamp' }).notNull().default(sql`(unixepoch())`),
   },

--- a/packages/engine/src/engine/__tests__/retention.test.ts
+++ b/packages/engine/src/engine/__tests__/retention.test.ts
@@ -16,6 +16,7 @@ import {
 } from '../../db/schema.js';
 import { pruneExpired } from '../retention.js';
 import { snowflakeIdLowerBound } from '../snowflake.js';
+import { buildDirectDeliveryWrite } from '../deliveryWrites.js';
 
 const DAY_MS = 24 * 60 * 60 * 1000;
 
@@ -98,6 +99,23 @@ async function insertDelivery(
     createdAt: new Date(Date.now() - daysAgo * DAY_MS),
   });
   return id;
+}
+
+async function insertAllocatedDelivery(db: Db, base: Seeded, messageId: string): Promise<number> {
+  await buildDirectDeliveryWrite(db, {
+    workspaceId: base.ws,
+    messageId,
+    agentId: base.agent,
+    mode: 'immediate',
+    reason: 'dm',
+    ttlMs: 60_000,
+    depthCap: 1_000,
+  });
+  const [row] = await db
+    .select({ seq: deliveries.seq })
+    .from(deliveries)
+    .where(eq(deliveries.messageId, messageId));
+  return row.seq;
 }
 
 async function insertMessageLog(db: Db, base: Seeded, messageId: string, id: string): Promise<string> {
@@ -259,6 +277,47 @@ describe('pruneExpired', () => {
     expect(result.deliveries).toBe(2);
     const remaining = (await db.select({ status: deliveries.status }).from(deliveries)).map((r) => r.status);
     expect(remaining.sort()).toEqual(['acked', 'queued']);
+  });
+
+  it('does not reuse a delivery sequence after settled delivery retention', async () => {
+    const { db } = track(openDb());
+    const base = await seedWorkspace(db);
+    const oldMessage = await insertMessage(db, base, idAt(100));
+    await insertDelivery(db, base, oldMessage, 'acked', 100);
+    const [{ seq: oldSeq }] = await db
+      .select({ seq: deliveries.seq })
+      .from(deliveries)
+      .where(eq(deliveries.messageId, oldMessage));
+
+    const result = await pruneExpired(db);
+    expect(result.deliveries).toBe(1);
+    expect(await db.select().from(deliveries)).toHaveLength(0);
+
+    const newMessage = await insertMessage(db, base, idAt(1));
+    expect(await insertAllocatedDelivery(db, base, newMessage)).toBe(oldSeq + 1);
+    const [agent] = await db
+      .select({ deliverySeq: agents.deliverySeq })
+      .from(agents)
+      .where(eq(agents.id, base.agent));
+    expect(agent.deliverySeq).toBe(oldSeq + 1);
+  });
+
+  it('does not reuse a delivery sequence after message retention cascades the row', async () => {
+    const { db } = track(openDb());
+    const base = await seedWorkspace(db, { message_ttl_days: 30 });
+    const oldMessage = await insertMessage(db, base, idAt(40));
+    await insertDelivery(db, base, oldMessage, 'delivered', 40);
+    const [{ seq: oldSeq }] = await db
+      .select({ seq: deliveries.seq })
+      .from(deliveries)
+      .where(eq(deliveries.messageId, oldMessage));
+
+    const result = await pruneExpired(db);
+    expect(result.messages).toBe(1);
+    expect(await db.select().from(deliveries)).toHaveLength(0);
+
+    const newMessage = await insertMessage(db, base, idAt(1));
+    expect(await insertAllocatedDelivery(db, base, newMessage)).toBe(oldSeq + 1);
   });
 
   it('lets a workspace override or disable the operational defaults', async () => {

--- a/packages/engine/src/engine/deliveryWrites.ts
+++ b/packages/engine/src/engine/deliveryWrites.ts
@@ -77,13 +77,10 @@ function ttlSeconds(ttlMs: number): number {
   return Math.max(1, Math.ceil(ttlMs / 1000));
 }
 
-function nextSeqSql(workspaceId: string, agentId: unknown) {
-  return sql<number>`(
-    SELECT COALESCE(MAX(d.seq), 0) + 1
-    FROM deliveries d
-    WHERE d.workspace_id = ${workspaceId}
-      AND d.agent_id = ${agentId}
-  )`;
+function nextDeliverySeqSql() {
+  // deliverySeq is normally >= deliveryAckSeq. Including the cursor keeps a
+  // future/stale cumulative ACK from making the next allocation replay-hidden.
+  return sql<number>`MAX(${agents.deliverySeq}, ${agents.deliveryAckSeq}) + 1`;
 }
 
 function belowDepthCapSql(workspaceId: string, agentId: unknown, depthCap: number) {
@@ -131,7 +128,10 @@ export function buildChannelDeliveryWrite(
           priority: sql<string>`${'normal'}`,
           deadline: sql<null>`null`,
           status: sql<string>`${'queued'}`,
-          seq: nextSeqSql(input.workspaceId, channelMembers.agentId),
+          // Migration 0029 installs an AFTER INSERT trigger that advances the
+          // same agent row to this value. Allocation and high-water advancement
+          // therefore happen in one SQLite statement on every adapter.
+          seq: nextDeliverySeqSql(),
           locationType: sql<string>`CASE WHEN ${agentNodeBindings.nodeId} IS NOT NULL THEN 'via_node' ELSE ${agents.locationType} END`,
           locationNodeId: sql<string | null>`COALESCE(${agentNodeBindings.nodeId}, ${agents.locationNodeId})`,
           routeNodeId: sql<string | null>`COALESCE(${agentNodeBindings.nodeId}, ${agents.locationNodeId})`,
@@ -203,7 +203,7 @@ export function buildGroupDmDeliveryWrite(
           priority: sql<string>`${'normal'}`,
           deadline: sql<null>`null`,
           status: sql<string>`${'queued'}`,
-          seq: nextSeqSql(input.workspaceId, dmParticipants.agentId),
+          seq: nextDeliverySeqSql(),
           locationType: sql<string>`CASE WHEN ${agentNodeBindings.nodeId} IS NOT NULL THEN 'via_node' ELSE ${agents.locationType} END`,
           locationNodeId: sql<string | null>`COALESCE(${agentNodeBindings.nodeId}, ${agents.locationNodeId})`,
           routeNodeId: sql<string | null>`COALESCE(${agentNodeBindings.nodeId}, ${agents.locationNodeId})`,
@@ -276,7 +276,7 @@ export function buildDirectDeliveryWrite(
           priority: sql<string>`${'normal'}`,
           deadline: sql<null>`null`,
           status: sql<string>`${'queued'}`,
-          seq: nextSeqSql(input.workspaceId, agents.id),
+          seq: nextDeliverySeqSql(),
           locationType: sql<string>`CASE WHEN ${agentNodeBindings.nodeId} IS NOT NULL THEN 'via_node' ELSE ${agents.locationType} END`,
           locationNodeId: sql<string | null>`COALESCE(${agentNodeBindings.nodeId}, ${agents.locationNodeId})`,
           routeNodeId: sql<string | null>`COALESCE(${agentNodeBindings.nodeId}, ${agents.locationNodeId})`,

--- a/packages/engine/src/ports/database.ts
+++ b/packages/engine/src/ports/database.ts
@@ -20,8 +20,8 @@ import type * as schema from '../db/schema.js';
  * one, and otherwise falls back to plain sequential statements (the engine's
  * historical behavior). Cross-row invariants that must hold on *every*
  * adapter — not just atomicity-capable ones — still need single-statement
- * atomicity (e.g. a `... SELECT COALESCE(MAX(seq),0)+1 ...` scalar-subquery
- * insert guarded by a UNIQUE index) rather than a multi-step read-modify-write.
+ * atomicity (for example, an insert whose trigger advances a durable sequence
+ * high-water) rather than a multi-step read-modify-write.
  */
 // The engine is written against the async surface (everything is `await`ed),
 // which is exactly what the D1 driver produces, so the Cloudflare adapter's


### PR DESCRIPTION
## Summary

- persist a per-agent delivery sequence high-water independent of prunable delivery rows
- repair hidden active deliveries above the ACK cursor while preserving FIFO order
- allocate and advance delivery sequences atomically with a SQLite trigger

## Verification

- engine test suite: 424 passed
- build, typecheck, lint, and diff checks passed

Fixes #252

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/AgentWorkforce/relaycast/pull/253?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

