### PR TITLE
engine: log node teardown failures instead of swallowing them

### DIFF
--- a/packages/engine/src/__tests__/conformance/providerAttachRace.test.ts
+++ b/packages/engine/src/__tests__/conformance/providerAttachRace.test.ts
@@ -81,8 +81,10 @@ describe('provider attach race', () => {
     // that would drop a recompute). Serialization means it never fires here — so
     // assert no teardown error is logged across the loop.
     const teardownErrors: unknown[][] = [];
+    const originalConsoleError = console.error.bind(console);
     const errorSpy = vi.spyOn(console, 'error').mockImplementation((...args: unknown[]) => {
       if (typeof args[0] === 'string' && args[0].startsWith('[node.teardown]')) teardownErrors.push(args);
+      else originalConsoleError(...args); // don't swallow unrelated errors
     });
     try {
       for (let i = 0; i < 25; i++) {

--- a/packages/engine/src/__tests__/conformance/providerAttachRace.test.ts
+++ b/packages/engine/src/__tests__/conformance/providerAttachRace.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { and, eq } from 'drizzle-orm';
 import { mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
@@ -77,23 +77,35 @@ describe('provider attach race', () => {
   });
 
   it('keeps a stable aggregate when a register races another provider disconnecting', async () => {
-    for (let i = 0; i < 25; i++) {
-      const ws = await createWorkspace(stack.app, `disc-${i}`);
-      const nodeId = `node_${i}`;
-      await enroll(ws.workspaceKey, nodeId, `alpha${i}`);
-      const a = new FakeSocket(); const ha = stack.runtime.realtime.attachNodeSocket(ws.workspaceId, nodeId, a);
-      await ha.handleMessage(registerFrame(nodeId, `alpha${i}`, { name: 'broker', instance_id: 'b1' }, [{ name: 'spawn:claude', kind: 'capacity' }]));
-      const b = new FakeSocket(); const hb = stack.runtime.realtime.attachNodeSocket(ws.workspaceId, nodeId, b);
-      // The broker disconnects at the same instant the py provider registers.
-      await Promise.all([
-        hb.handleMessage(registerFrame(nodeId, `alpha${i}`, { name: 'py', instance_id: 'p1' }, [{ name: 'run-etl', kind: 'action' }])),
-        ha.handleClose(),
-      ]);
-      // The broker's row persists offline (manifest), py is online; neither cap
-      // set is clobbered out of the aggregate.
-      expect(await providerNames(ws.workspaceId, nodeId)).toEqual(['broker', 'py']);
-      expect(await nodeCapNames(ws.workspaceId, nodeId)).toEqual(['run-etl', 'spawn:claude']);
+    // The teardown path now logs failures loudly (e.g. a swallowed SQLITE_BUSY
+    // that would drop a recompute). Serialization means it never fires here — so
+    // assert no teardown error is logged across the loop.
+    const teardownErrors: unknown[][] = [];
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation((...args: unknown[]) => {
+      if (typeof args[0] === 'string' && args[0].startsWith('[node.teardown]')) teardownErrors.push(args);
+    });
+    try {
+      for (let i = 0; i < 25; i++) {
+        const ws = await createWorkspace(stack.app, `disc-${i}`);
+        const nodeId = `node_${i}`;
+        await enroll(ws.workspaceKey, nodeId, `alpha${i}`);
+        const a = new FakeSocket(); const ha = stack.runtime.realtime.attachNodeSocket(ws.workspaceId, nodeId, a);
+        await ha.handleMessage(registerFrame(nodeId, `alpha${i}`, { name: 'broker', instance_id: 'b1' }, [{ name: 'spawn:claude', kind: 'capacity' }]));
+        const b = new FakeSocket(); const hb = stack.runtime.realtime.attachNodeSocket(ws.workspaceId, nodeId, b);
+        // The broker disconnects at the same instant the py provider registers.
+        await Promise.all([
+          hb.handleMessage(registerFrame(nodeId, `alpha${i}`, { name: 'py', instance_id: 'p1' }, [{ name: 'run-etl', kind: 'action' }])),
+          ha.handleClose(),
+        ]);
+        // The broker's row persists offline (manifest), py is online; neither cap
+        // set is clobbered out of the aggregate.
+        expect(await providerNames(ws.workspaceId, nodeId)).toEqual(['broker', 'py']);
+        expect(await nodeCapNames(ws.workspaceId, nodeId)).toEqual(['run-etl', 'spawn:claude']);
+      }
+    } finally {
+      errorSpy.mockRestore();
     }
+    expect(teardownErrors).toEqual([]);
   });
 
   it('resolves two providers claiming the same name deterministically, without silent cap loss', async () => {

--- a/packages/engine/src/adapters/node/realtime.ts
+++ b/packages/engine/src/adapters/node/realtime.ts
@@ -452,11 +452,28 @@ export class InProcessRealtime implements RealtimeBus, ConnectionRegistry, NodeC
       this.nodeQueues.delete(this.providerQueueKey(nodeKey, providerName));
     }
     const hasRemaining = this.isNodeConnected(workspaceId, nodeId);
+    // A teardown failure (e.g. SQLITE_BUSY) must be loud, not swallowed: if it
+    // silently dropped the provider-offline / aggregate recompute the node roster
+    // would keep stale capabilities with no signal. Log it; a close still must
+    // not throw.
     if (providerName) {
-      await handleProviderDisconnect(this.db, this, workspaceId, nodeId, providerName, hasRemaining).catch(() => {});
+      await handleProviderDisconnect(this.db, this, workspaceId, nodeId, providerName, hasRemaining).catch((err) => {
+        console.error('[node.teardown] provider disconnect failed', {
+          workspace_id: workspaceId,
+          node_id: nodeId,
+          provider: providerName,
+          error: err instanceof Error ? err.message : String(err),
+        });
+      });
     } else if (!hasRemaining) {
       // Connection dropped before it bound a provider and it was the node's last.
-      await markNodeOffline(this.db, this, workspaceId, nodeId).catch(() => {});
+      await markNodeOffline(this.db, this, workspaceId, nodeId).catch((err) => {
+        console.error('[node.teardown] mark node offline failed', {
+          workspace_id: workspaceId,
+          node_id: nodeId,
+          error: err instanceof Error ? err.message : String(err),
+        });
+      });
     }
   }
 

--- a/packages/engine/src/adapters/node/realtime.ts
+++ b/packages/engine/src/adapters/node/realtime.ts
@@ -458,21 +458,13 @@ export class InProcessRealtime implements RealtimeBus, ConnectionRegistry, NodeC
     // not throw.
     if (providerName) {
       await handleProviderDisconnect(this.db, this, workspaceId, nodeId, providerName, hasRemaining).catch((err) => {
-        console.error('[node.teardown] provider disconnect failed', {
-          workspace_id: workspaceId,
-          node_id: nodeId,
-          provider: providerName,
-          error: err instanceof Error ? err.message : String(err),
-        });
+        // Pass the error object so the runtime logs its stack, not just the message.
+        console.error('[node.teardown] provider disconnect failed', { workspace_id: workspaceId, node_id: nodeId, provider: providerName }, err);
       });
     } else if (!hasRemaining) {
       // Connection dropped before it bound a provider and it was the node's last.
       await markNodeOffline(this.db, this, workspaceId, nodeId).catch((err) => {
-        console.error('[node.teardown] mark node offline failed', {
-          workspace_id: workspaceId,
-          node_id: nodeId,
-          error: err instanceof Error ? err.message : String(err),
-        });
+        console.error('[node.teardown] mark node offline failed', { workspace_id: workspaceId, node_id: nodeId }, err);
       });
     }
   }


### PR DESCRIPTION
## What

`onNodeConnectionClose` no longer discards errors from `handleProviderDisconnect` / `markNodeOffline`. The two `.catch(() => {})` now log the failure (`[node.teardown] …` with workspace / node / provider / error). A close still must not throw, so it logs rather than rethrows.

## Why

A failure on the teardown path — e.g. `SQLITE_BUSY` — silently dropped the provider-offline flip and the node-aggregate recompute, leaving the roster with stale capabilities and no signal. That's a lock timeout turning into invisible data loss: the exact way the provider-attach race (#251) manifested before serialization. Serialization removes the contention, so this path shouldn't hit a busy anymore — but if it ever does, it must be loud, not swallowed.

## Test

Hardens the existing `providerAttachRace.test.ts`: the register-vs-disconnect loop spies on `console.error` and asserts zero `[node.teardown]` errors across the loop — turning the swallow into a regression tripwire for the serialization itself. Full engine (423) + types (161) green, lint clean.

Follow-up hardening on top of #251. Not required for the v6.0.1 publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/AgentWorkforce/relaycast/pull/256?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

