### PR TITLE
engine: gate self-host SQLite writes so a raw write can't deadlock a transaction

### DIFF
--- a/packages/engine/CHANGELOG.md
+++ b/packages/engine/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 ## [Unreleased]
 
 ### Fixed
-- Self-host (file-backed SQLite): route every write through one async gate so a raw statement write can no longer busy-wait the event loop while a transaction holds the write lock. Under concurrent node registration this deadlocked on `busy_timeout` and silently dropped a provider's capabilities from the node aggregate (#250).
+- Self-host (file-backed SQLite): route every write through one async gate so a raw statement write can no longer busy-wait the event loop while a transaction holds the write lock. Under concurrent node registration, this deadlocked on `busy_timeout` and silently dropped a provider's capabilities from the node aggregate (#250).
 
 ### Changed
 - Refactored route handlers, route response helpers, and service internals without changing the public HTTP envelopes or API behavior.

--- a/packages/engine/CHANGELOG.md
+++ b/packages/engine/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+### Fixed
+- Self-host (file-backed SQLite): route every write through one async gate so a raw statement write can no longer busy-wait the event loop while a transaction holds the write lock. Under concurrent node registration this deadlocked on `busy_timeout` and silently dropped a provider's capabilities from the node aggregate (#250).
+
 ### Changed
 - Refactored route handlers, route response helpers, and service internals without changing the public HTTP envelopes or API behavior.
 - Split engine internals into focused modules for background jobs, migrations, node adapters, websocket handling, and shared route utilities.

--- a/packages/engine/src/__tests__/conformance/twoNodeWriteContention.test.ts
+++ b/packages/engine/src/__tests__/conformance/twoNodeWriteContention.test.ts
@@ -1,0 +1,115 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { and, eq } from 'drizzle-orm';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { createEngine } from '../../engine.js';
+import { createNodeRuntime, type NodeRuntime } from '../../adapters/node/index.js';
+import { nodes } from '../../db/schema.js';
+import { enqueueEvent, sweepPendingEvents } from '../../engine/eventQueue.js';
+import { FakeSocket, createWorkspace } from './harness.js';
+
+// File-backed so transactions run on isolated connections like production
+// self-host (not the shared :memory: connection). Two nodes registering at
+// once open write transactions on separate connections while the node
+// event-queue poll issues raw, non-transactional writes on the main
+// connection. On synchronous better-sqlite3 a raw write that finds the file
+// locked busy-waits and freezes the event loop, so the lock-holding
+// transaction can never commit — it times out with SQLITE_BUSY and the losing
+// write rolls back, silently dropping a provider's registration. This is the
+// residual self-host deadlock (issue #250) that the single-node
+// providerAttachRace suite cannot surface because it has no second node to
+// contend the writer and no concurrent raw-write traffic.
+function fileStack() {
+  const dir = mkdtempSync(join(tmpdir(), 'relaycast-two-node-'));
+  const runtime: NodeRuntime = createNodeRuntime({
+    dbPath: join(dir, 'test.db'),
+    baseUrl: 'http://localhost:0',
+    migrate: true,
+    config: { environment: 'test' },
+    presence: { ttlMs: 60_000, sweepIntervalMs: 0 },
+  });
+  const app = createEngine(runtime.deps);
+  return { app, runtime, close: () => { runtime.close(); rmSync(dir, { recursive: true, force: true }); } };
+}
+
+function registerFrame(
+  nodeId: string,
+  name: string,
+  provider: { name: string; instance_id: string },
+  caps: Array<{ name: string; kind: string }>,
+) {
+  return JSON.stringify({
+    v: 1, id: `reg-${nodeId}`, type: 'node.register', name, node_id: nodeId,
+    provider, capabilities: caps, max_agents: 4, tags: ['t'], version: 'v1', resume_cursor: null,
+  });
+}
+
+describe('two-node write contention (self-host)', () => {
+  let stack: ReturnType<typeof fileStack>;
+  beforeEach(() => { stack = fileStack(); });
+  afterEach(() => stack.close());
+
+  async function enroll(wsKey: string, nodeId: string, name: string) {
+    const res = await stack.app.request('/v1/nodes', {
+      method: 'POST', headers: { 'content-type': 'application/json', authorization: `Bearer ${wsKey}` },
+      body: JSON.stringify({ node_id: nodeId, name, role: 'broker', capabilities: [], max_agents: 4, tags: ['t'], version: 'v0' }),
+    });
+    expect(res.status).toBe(201);
+  }
+
+  async function nodeCapNames(workspaceId: string, nodeId: string): Promise<string[]> {
+    const [row] = await stack.runtime.handle.db
+      .select({ caps: nodes.capabilities })
+      .from(nodes)
+      .where(and(eq(nodes.workspaceId, workspaceId), eq(nodes.id, nodeId)));
+    return (row?.caps ?? []).map((c) => c.name).sort();
+  }
+
+  // Raw, non-transactional writes on the main connection — the node
+  // event-queue poll pattern (claim increments attempts via `db.update`).
+  // These are the writes that busy-wait the event loop under the pre-fix
+  // adapter while a register transaction holds the write lock.
+  async function pollTraffic(workspaceId: string, rounds: number): Promise<void> {
+    for (let i = 0; i < rounds; i++) {
+      await enqueueEvent(stack.runtime.handle.db, workspaceId, 'contention.probe', { i });
+      await sweepPendingEvents(stack.runtime.handle.db, { leaseMs: 1 });
+    }
+  }
+
+  it('keeps both nodes\' broker providers when they register while the event-queue poll writes', async () => {
+    for (let i = 0; i < 15; i++) {
+      const ws = await createWorkspace(stack.app, `two-node-${i}`);
+      const nodeA = `node_a_${i}`;
+      const nodeB = `node_b_${i}`;
+      await enroll(ws.workspaceKey, nodeA, `alpha${i}`);
+      await enroll(ws.workspaceKey, nodeB, `beta${i}`);
+
+      const sa = new FakeSocket();
+      const ha = stack.runtime.realtime.attachNodeSocket(ws.workspaceId, nodeA, sa);
+      const sb = new FakeSocket();
+      const hb = stack.runtime.realtime.attachNodeSocket(ws.workspaceId, nodeB, sb);
+
+      // Both nodes register their broker provider in the same instant, while raw
+      // event-queue writes hammer the main connection. Pre-fix this deadlocks:
+      // one node's transaction loses the SQLITE_BUSY race and rolls back,
+      // dropping its capabilities from the aggregate (which node loses flips).
+      await Promise.all([
+        ha.handleMessage(registerFrame(nodeA, `alpha${i}`, { name: 'broker', instance_id: 'a1' }, [
+          { name: 'spawn:claude', kind: 'capacity' },
+          { name: 'release', kind: 'action' },
+        ])),
+        hb.handleMessage(registerFrame(nodeB, `beta${i}`, { name: 'broker', instance_id: 'b1' }, [
+          { name: 'spawn:codex', kind: 'capacity' },
+          { name: 'release', kind: 'action' },
+        ])),
+        pollTraffic(ws.workspaceId, 6),
+      ]);
+
+      // Neither node's registration may vanish: both keep their full broker
+      // capability set.
+      expect(await nodeCapNames(ws.workspaceId, nodeA)).toEqual(['release', 'spawn:claude']);
+      expect(await nodeCapNames(ws.workspaceId, nodeB)).toEqual(['release', 'spawn:codex']);
+    }
+  });
+});

--- a/packages/engine/src/adapters/node/__tests__/writeGate.test.ts
+++ b/packages/engine/src/adapters/node/__tests__/writeGate.test.ts
@@ -1,0 +1,106 @@
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { eq } from 'drizzle-orm';
+import { getSqliteDb, runMigrations, type SqliteDbHandle } from '../database.js';
+import { runAtomicWrites } from '../../../ports/database.js';
+import { pendingEvents, workspaces } from '../../../db/schema.js';
+
+let seq = 0;
+const handles: SqliteDbHandle[] = [];
+const dirs: string[] = [];
+
+function openMemory(): SqliteDbHandle['db'] {
+  const handle = getSqliteDb(':memory:');
+  runMigrations(handle);
+  handles.push(handle);
+  return handle.db;
+}
+
+function openFile(): SqliteDbHandle['db'] {
+  const dir = mkdtempSync(join(tmpdir(), 'relaycast-write-gate-'));
+  dirs.push(dir);
+  const handle = getSqliteDb(join(dir, 'engine.db'));
+  runMigrations(handle);
+  handles.push(handle);
+  return handle.db;
+}
+
+async function seedWorkspace(db: SqliteDbHandle['db']): Promise<string> {
+  const id = `ws_${++seq}`;
+  await db.insert(workspaces).values({ id, name: 'test', apiKeyHash: `hash_${id}` });
+  return id;
+}
+
+afterEach(() => {
+  for (const handle of handles.splice(0)) {
+    try { handle.sqlite.close(); } catch { /* already closed */ }
+  }
+  for (const dir of dirs.splice(0)) rmSync(dir, { recursive: true, force: true });
+});
+
+describe('self-host write gate', () => {
+  // A prebuilt statement is bound to the connection that built it. On the
+  // file-backed backend the transaction runs on a separate connection, so a
+  // prebuilt array cannot execute inside it — awaiting one there would queue
+  // behind the very transaction awaiting it. The gate rejects loudly instead of
+  // hanging.
+  it('rejects prebuilt atomic-write arrays inside a transaction (file-backed) rather than deadlocking', async () => {
+    const db = openFile();
+    const ws = await seedWorkspace(db);
+    const prebuilt = [
+      db.insert(pendingEvents).values({ id: `evt_${++seq}`, workspaceId: ws, eventType: 'x', payload: {} }),
+    ];
+    await expect(runAtomicWrites(db, prebuilt)).rejects.toThrow(/inside a transaction/);
+    // The failed transaction rolled back: no row leaked.
+    expect(await db.select().from(pendingEvents)).toHaveLength(0);
+  });
+
+  // The builder form rebuilds statements on the transaction handle, so it is
+  // unaffected and commits normally.
+  it('runs the builder form atomically (file-backed)', async () => {
+    const db = openFile();
+    const ws = await seedWorkspace(db);
+    const id = `evt_${++seq}`;
+    await runAtomicWrites(db, (tx) => [
+      tx.insert(pendingEvents).values({ id, workspaceId: ws, eventType: 'ok', payload: {} }),
+    ]);
+    expect(await db.select().from(pendingEvents).where(eq(pendingEvents.id, id))).toHaveLength(1);
+  });
+
+  // `:memory:` is connection-local (no isolated transaction connection), so the
+  // prebuilt array form is safe there and must keep working.
+  it('runs prebuilt atomic-write arrays on :memory:', async () => {
+    const db = openMemory();
+    const ws = await seedWorkspace(db);
+    const id = `evt_${++seq}`;
+    await runAtomicWrites(db, [
+      db.insert(pendingEvents).values({ id, workspaceId: ws, eventType: 'mem', payload: {} }),
+    ]);
+    expect(await db.select().from(pendingEvents).where(eq(pendingEvents.id, id))).toHaveLength(1);
+  });
+
+  // A prepared write executes through the gate (not a bypass) and persists.
+  it('gates prepared write statements (file-backed)', async () => {
+    const db = openFile();
+    const ws = await seedWorkspace(db);
+    const id = `evt_${++seq}`;
+    const stmt = db
+      .insert(pendingEvents)
+      .values({ id, workspaceId: ws, eventType: 'prepared', payload: {} })
+      .prepare();
+    await stmt.run();
+    expect(await db.select().from(pendingEvents).where(eq(pendingEvents.id, id))).toHaveLength(1);
+  });
+
+  // Raw SQL executed directly through the handle (`db.run`) still lands.
+  it('gates raw db.run writes (file-backed)', async () => {
+    const db = openFile();
+    const ws = await seedWorkspace(db);
+    const id = `evt_${++seq}`;
+    await db.insert(pendingEvents).values({ id, workspaceId: ws, eventType: 'raw', payload: {} });
+    const rows = await db.select().from(pendingEvents).where(eq(pendingEvents.id, id));
+    expect(rows).toHaveLength(1);
+  });
+});

--- a/packages/engine/src/adapters/node/__tests__/writeGate.test.ts
+++ b/packages/engine/src/adapters/node/__tests__/writeGate.test.ts
@@ -57,6 +57,32 @@ describe('self-host write gate', () => {
     expect(await db.select().from(pendingEvents)).toHaveLength(0);
   });
 
+  // The re-entrancy marker must not leak past the transaction. A detached async
+  // resource created inside a transaction body inherits the gate marker via
+  // AsyncLocalStorage; once the transaction commits it must be able to write
+  // normally rather than being rejected forever.
+  it('lets an async resource that outlived its transaction write normally', async () => {
+    const db = openFile();
+    const ws = await seedWorkspace(db);
+    const leakedId = `evt_${++seq}`;
+    let releaseLeaked!: () => void;
+    const gate = new Promise<void>((resolve) => { releaseLeaked = resolve; });
+    let leakedWrite!: Promise<unknown>;
+
+    await runAtomicWrites(db, (tx) => {
+      // Scheduled inside the transaction's async context, but resolves later.
+      leakedWrite = gate.then(() =>
+        db.insert(pendingEvents).values({ id: leakedId, workspaceId: ws, eventType: 'leaked', payload: {} }),
+      );
+      return [tx.insert(pendingEvents).values({ id: `evt_${++seq}`, workspaceId: ws, eventType: 'tx', payload: {} })];
+    });
+
+    // Transaction has committed; the leaked write must succeed, not reject.
+    releaseLeaked();
+    await expect(leakedWrite).resolves.toBeDefined();
+    expect(await db.select().from(pendingEvents).where(eq(pendingEvents.id, leakedId))).toHaveLength(1);
+  });
+
   // The builder form rebuilds statements on the transaction handle, so it is
   // unaffected and commits normally.
   it('runs the builder form atomically (file-backed)', async () => {

--- a/packages/engine/src/adapters/node/database.ts
+++ b/packages/engine/src/adapters/node/database.ts
@@ -1,3 +1,4 @@
+import { AsyncLocalStorage } from 'node:async_hooks';
 import { existsSync, readdirSync, readFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -106,8 +107,22 @@ function attachMemoryTransaction(db: NodeEngineDb, sqlite: Database.Database): v
  */
 function withFileWriteGate(db: NodeEngineDb, path: string): NodeEngineDb {
   let writeGate: Promise<unknown> = Promise.resolve();
+  // Marks the async context of a write that currently holds the gate. A nested
+  // gated write (e.g. a statement built from this handle awaited inside a
+  // `withTransaction` body) would queue behind the very transaction that is
+  // awaiting it — a self-deadlock. Such a write also belongs on the
+  // transaction's own connection, not this handle's; reject it loudly instead.
+  const gateHeld = new AsyncLocalStorage<true>();
   const runGated: WriteGate = (task) => {
-    const result = writeGate.then(task);
+    if (gateHeld.getStore()) {
+      return Promise.reject(
+        new Error(
+          'write issued through the engine handle inside a transaction; use the ' +
+            'transaction handle (tx) for writes inside withTransaction/runAtomic',
+        ),
+      );
+    }
+    const result = writeGate.then(() => gateHeld.run(true, task));
     // The chain must survive an individual failure so later writes still run.
     writeGate = result.then(noop, noop);
     return result;
@@ -140,18 +155,27 @@ function withFileWriteGate(db: NodeEngineDb, path: string): NodeEngineDb {
 }
 
 /**
+ * Every method on `BaseSQLiteDatabase` that executes SQL directly on the main
+ * connection — including raw statements that may carry `RETURNING` writes and
+ * drizzle's native interactive `transaction`. Each is deferred behind the gate.
+ * `insert`/`update`/`delete` are handled separately (they return lazy builders).
+ */
+const GATED_HANDLE_EXECUTORS = new Set(['run', 'all', 'get', 'values', 'transaction']);
+
+/**
  * Wrap the main-connection handle so raw statement writes route through the
  * write gate. `insert`/`update`/`delete` return lazy drizzle builders, so the
- * builder is wrapped and gated at its execution seam; `run(sql)` executes on
- * call, so the whole call is deferred behind the gate. Reads and every other
- * method run directly against the main connection.
+ * builder is wrapped and gated at its execution seam; the direct executors
+ * ({@link GATED_HANDLE_EXECUTORS}) run on call, so the whole call is deferred
+ * behind the gate. Query-builder reads (`db.select()...`) and every other member
+ * run directly against the main connection — WAL readers never block the writer.
  */
 function gateRawWrites(db: NodeEngineDb, runGated: WriteGate): NodeEngineDb {
   return new Proxy(db, {
     get(target, prop) {
       const value = Reflect.get(target, prop, target);
       if (typeof value !== 'function') return value;
-      if (prop === 'run') {
+      if (typeof prop === 'string' && GATED_HANDLE_EXECUTORS.has(prop)) {
         return (...args: unknown[]) => runGated(() => (value as DbFn).apply(target, args));
       }
       if (prop === 'insert' || prop === 'update' || prop === 'delete') {
@@ -165,18 +189,26 @@ function gateRawWrites(db: NodeEngineDb, runGated: WriteGate): NodeEngineDb {
   });
 }
 
+/** Terminal executors on a thenable drizzle statement (and on a prepared query). */
+const GATED_STATEMENT_EXECUTORS = new Set(['execute', 'run', 'all', 'get', 'values']);
+
 /**
  * Wrap a drizzle write-statement builder so its execution runs inside the write
- * gate. Drizzle builders are lazy and thenable — SQL runs only when the promise
- * protocol (`then`/`catch`/`finally`) or an explicit executor (`run`/`execute`/
- * `all`/`get`) fires. Those points are gated; chain methods (`values`/`set`/
- * `where`/`returning`/`onConflict*`) are re-wrapped so whichever stage the
- * caller finally awaits still routes through the gate.
+ * gate. Drizzle builders are lazy — SQL runs only when the promise protocol
+ * (`then`/`catch`/`finally`), an explicit executor ({@link
+ * GATED_STATEMENT_EXECUTORS}), or a `prepare()`d statement's executor fires.
+ * Every one of those seams is gated; chain methods (`set`/`where`/`returning`/
+ * `onConflict*`, and `values`/`set` on the pre-thenable builder) are re-wrapped
+ * so whichever stage the caller finally awaits still routes through the gate.
+ *
+ * `values` is ambiguous: on the pre-thenable insert builder it sets rows (a
+ * chain step); on a thenable statement it is a placeholder executor. The
+ * `targetThenable` guard routes each correctly.
  */
 function gateWriteBuilder<B extends object>(builder: B, runGated: WriteGate): B {
+  const targetThenable = isThenable(builder);
   return new Proxy(builder, {
     get(target, prop) {
-      const targetThenable = isThenable(target);
       if (targetThenable && (prop === 'then' || prop === 'catch' || prop === 'finally')) {
         // Await the raw builder inside the gate — that is where SQL executes.
         const gated = () => runGated(() => Promise.resolve(target as PromiseLike<unknown>));
@@ -191,13 +223,36 @@ function gateWriteBuilder<B extends object>(builder: B, runGated: WriteGate): B 
       }
       const value = Reflect.get(target, prop, target);
       if (typeof value !== 'function') return value;
-      if (targetThenable && (prop === 'execute' || prop === 'run' || prop === 'all' || prop === 'get')) {
+      if (targetThenable && typeof prop === 'string' && GATED_STATEMENT_EXECUTORS.has(prop)) {
         return (...args: unknown[]) => runGated(() => (value as DbFn).apply(target, args));
+      }
+      // `prepare()` returns a reusable prepared query whose own executors run
+      // SQL; gate them so a prepared write can't bypass the gate either.
+      if (prop === 'prepare') {
+        return (...args: unknown[]) =>
+          gatePreparedStatement((value as DbFn).apply(target, args) as object, runGated);
       }
       return (...args: unknown[]) => {
         const result = (value as DbFn).apply(target, args);
         return isThenable(result) ? gateWriteBuilder(result as object, runGated) : result;
       };
+    },
+  });
+}
+
+/**
+ * Wrap a drizzle prepared statement (from `statement.prepare()`) so its
+ * executors run inside the write gate, matching the un-prepared path.
+ */
+function gatePreparedStatement<P extends object>(prepared: P, runGated: WriteGate): P {
+  return new Proxy(prepared, {
+    get(target, prop) {
+      const value = Reflect.get(target, prop, target);
+      if (typeof value !== 'function') return value;
+      if (typeof prop === 'string' && GATED_STATEMENT_EXECUTORS.has(prop)) {
+        return (...args: unknown[]) => runGated(() => (value as DbFn).apply(target, args));
+      }
+      return (value as DbFn).bind(target);
     },
   });
 }

--- a/packages/engine/src/adapters/node/database.ts
+++ b/packages/engine/src/adapters/node/database.ts
@@ -112,9 +112,16 @@ function withFileWriteGate(db: NodeEngineDb, path: string): NodeEngineDb {
   // `withTransaction` body) would queue behind the very transaction that is
   // awaiting it — a self-deadlock. Such a write also belongs on the
   // transaction's own connection, not this handle's; reject it loudly instead.
-  const gateHeld = new AsyncLocalStorage<true>();
-  const runGated: WriteGate = (task) => {
-    if (gateHeld.getStore()) {
+  //
+  // The marker is a per-run token cleared when its task settles, not a bare
+  // `true`: AsyncLocalStorage propagates the store to every descendant context,
+  // so a detached async resource created inside a transaction body would inherit
+  // it forever. Keying on `active` restricts rejection to writes issued *while*
+  // the enclosing task is still running; a leaked descendant that writes after
+  // the transaction commits gates normally.
+  const gateHeld = new AsyncLocalStorage<{ active: boolean }>();
+  const runGated: WriteGate = <T>(task: () => Promise<T> | T): Promise<T> => {
+    if (gateHeld.getStore()?.active) {
       return Promise.reject(
         new Error(
           'write issued through the engine handle inside a transaction; use the ' +
@@ -122,7 +129,15 @@ function withFileWriteGate(db: NodeEngineDb, path: string): NodeEngineDb {
         ),
       );
     }
-    const result = writeGate.then(() => gateHeld.run(true, task));
+    const token = { active: true };
+    const runTask = async (): Promise<T> => {
+      try {
+        return await task();
+      } finally {
+        token.active = false;
+      }
+    };
+    const result = writeGate.then(() => gateHeld.run(token, runTask));
     // The chain must survive an individual failure so later writes still run.
     writeGate = result.then(noop, noop);
     return result;

--- a/packages/engine/src/adapters/node/database.ts
+++ b/packages/engine/src/adapters/node/database.ts
@@ -32,48 +32,174 @@ export function getSqliteDb(path: string): SqliteDbHandle {
   const sqlite = new Database(path);
   configureSqlite(sqlite, { enableWal: true });
   const db = drizzle(sqlite, { schema }) as unknown as NodeEngineDb;
-  const isolatedTransactions = path !== ':memory:';
 
-  // Attach the transaction capability (`runAtomicWrites` detects it on the
-  // handle and prefers it over a batch).
-  //
-  // Drizzle's better-sqlite3 `db.transaction()` requires a synchronous
-  // callback (better-sqlite3's native wrapper commits when the sync call
-  // returns), but engine write paths are async. For file-backed databases we
-  // therefore open the transaction on a short-lived, dedicated connection so
-  // unrelated statements on the main handle cannot join the open transaction.
-  // `:memory:` databases are connection-local, so tests keep the shared
-  // connection while still serializing transactional callers.
+  // `:memory:` databases are connection-local: a transaction and a raw write
+  // share the same connection, so there is no cross-connection lock contention
+  // and no event-loop-freezing busy-wait. Keep the shared connection and only
+  // serialize transactional callers.
+  if (path === ':memory:') {
+    attachMemoryTransaction(db, sqlite);
+    return { db, sqlite };
+  }
+
+  return { db: withFileWriteGate(db, path), sqlite };
+}
+
+/** A drizzle handle method or a built statement's executor. */
+type DbFn = (...args: unknown[]) => unknown;
+
+/** Serialize a write task onto the shared gate, resolving with its result. */
+type WriteGate = <T>(task: () => Promise<T> | T) => Promise<T>;
+
+const noop = (): void => {};
+
+function isThenable(value: unknown): value is PromiseLike<unknown> {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    typeof (value as { then?: unknown }).then === 'function'
+  );
+}
+
+/**
+ * `:memory:` transaction capability: interactive transactions on the shared
+ * connection, serialized so concurrent callers don't interleave `BEGIN`s.
+ */
+function attachMemoryTransaction(db: NodeEngineDb, sqlite: Database.Database): void {
   let txTail: Promise<unknown> = Promise.resolve();
   db.withTransaction = <T>(fn: (tx: EngineDb) => Promise<T>): Promise<T> => {
     const run = async (): Promise<T> => {
-      const txSqlite = isolatedTransactions ? new Database(path) : sqlite;
+      sqlite.exec('BEGIN IMMEDIATE');
       try {
-        if (isolatedTransactions) configureSqlite(txSqlite);
-        const txDb = (isolatedTransactions
-          ? drizzle(txSqlite, { schema })
-          : db) as unknown as EngineDb;
-
-        txSqlite.exec('BEGIN IMMEDIATE');
-        const result = await fn(txDb);
-        txSqlite.exec('COMMIT');
+        const result = await fn(db as unknown as EngineDb);
+        sqlite.exec('COMMIT');
         return result;
       } catch (err) {
-        if (txSqlite.inTransaction) txSqlite.exec('ROLLBACK');
+        if (sqlite.inTransaction) sqlite.exec('ROLLBACK');
         throw err;
-      } finally {
-        if (isolatedTransactions) txSqlite.close();
       }
     };
     const result = txTail.then(run);
-    txTail = result.then(
-      () => undefined,
-      () => undefined,
-    );
+    txTail = result.then(noop, noop);
+    return result;
+  };
+}
+
+/**
+ * File-backed transaction capability plus a single async write gate.
+ *
+ * better-sqlite3 is synchronous, so a raw write that finds the database locked
+ * blocks the entire Node event loop on `busy_timeout`. A transaction body runs
+ * async (engine write paths `await` inside it), so it holds `BEGIN IMMEDIATE`'s
+ * write lock across awaits on its own short-lived connection. If a raw write on
+ * the main connection busy-waits for that lock, the event loop freezes and the
+ * lock-holding transaction can never progress to `COMMIT` — the raw write times
+ * out with `SQLITE_BUSY` and its losing statement rolls back with the error
+ * swallowed by the caller. Under concurrency (two nodes registering at once)
+ * this silently drops a provider registration.
+ *
+ * Funnelling *every* write — raw statement writes on the main connection and
+ * transaction bodies alike — through one serialization chain guarantees that no
+ * raw write ever executes while a transaction holds the lock. Writes never
+ * contend, `busy_timeout` stops being load-bearing, and the transaction always
+ * commits. Reads stay ungated: WAL readers never block the single writer.
+ */
+function withFileWriteGate(db: NodeEngineDb, path: string): NodeEngineDb {
+  let writeGate: Promise<unknown> = Promise.resolve();
+  const runGated: WriteGate = (task) => {
+    const result = writeGate.then(task);
+    // The chain must survive an individual failure so later writes still run.
+    writeGate = result.then(noop, noop);
     return result;
   };
 
-  return { db, sqlite };
+  // Interactive transactions run on a dedicated short-lived connection so
+  // unrelated statements can't join the open transaction. `runAtomicWrites`
+  // detects this capability and prefers it over a batch.
+  db.withTransaction = <T>(fn: (tx: EngineDb) => Promise<T>): Promise<T> =>
+    runGated(async () => {
+      const txSqlite = new Database(path);
+      try {
+        configureSqlite(txSqlite);
+        const txDb = drizzle(txSqlite, { schema }) as unknown as EngineDb;
+        txSqlite.exec('BEGIN IMMEDIATE');
+        try {
+          const result = await fn(txDb);
+          txSqlite.exec('COMMIT');
+          return result;
+        } catch (err) {
+          if (txSqlite.inTransaction) txSqlite.exec('ROLLBACK');
+          throw err;
+        }
+      } finally {
+        txSqlite.close();
+      }
+    });
+
+  return gateRawWrites(db, runGated);
+}
+
+/**
+ * Wrap the main-connection handle so raw statement writes route through the
+ * write gate. `insert`/`update`/`delete` return lazy drizzle builders, so the
+ * builder is wrapped and gated at its execution seam; `run(sql)` executes on
+ * call, so the whole call is deferred behind the gate. Reads and every other
+ * method run directly against the main connection.
+ */
+function gateRawWrites(db: NodeEngineDb, runGated: WriteGate): NodeEngineDb {
+  return new Proxy(db, {
+    get(target, prop) {
+      const value = Reflect.get(target, prop, target);
+      if (typeof value !== 'function') return value;
+      if (prop === 'run') {
+        return (...args: unknown[]) => runGated(() => (value as DbFn).apply(target, args));
+      }
+      if (prop === 'insert' || prop === 'update' || prop === 'delete') {
+        return (...args: unknown[]) =>
+          gateWriteBuilder((value as DbFn).apply(target, args) as object, runGated);
+      }
+      // Binding to `target` keeps read builders and helpers running against the
+      // real handle rather than leaking the proxy into their `this`.
+      return (value as DbFn).bind(target);
+    },
+  });
+}
+
+/**
+ * Wrap a drizzle write-statement builder so its execution runs inside the write
+ * gate. Drizzle builders are lazy and thenable — SQL runs only when the promise
+ * protocol (`then`/`catch`/`finally`) or an explicit executor (`run`/`execute`/
+ * `all`/`get`) fires. Those points are gated; chain methods (`values`/`set`/
+ * `where`/`returning`/`onConflict*`) are re-wrapped so whichever stage the
+ * caller finally awaits still routes through the gate.
+ */
+function gateWriteBuilder<B extends object>(builder: B, runGated: WriteGate): B {
+  return new Proxy(builder, {
+    get(target, prop) {
+      const targetThenable = isThenable(target);
+      if (targetThenable && (prop === 'then' || prop === 'catch' || prop === 'finally')) {
+        // Await the raw builder inside the gate — that is where SQL executes.
+        const gated = () => runGated(() => Promise.resolve(target as PromiseLike<unknown>));
+        if (prop === 'then') {
+          return (onF?: (v: unknown) => unknown, onR?: (e: unknown) => unknown) =>
+            gated().then(onF, onR);
+        }
+        if (prop === 'catch') {
+          return (onR?: (e: unknown) => unknown) => gated().catch(onR);
+        }
+        return (onFinally?: () => void) => gated().finally(onFinally);
+      }
+      const value = Reflect.get(target, prop, target);
+      if (typeof value !== 'function') return value;
+      if (targetThenable && (prop === 'execute' || prop === 'run' || prop === 'all' || prop === 'get')) {
+        return (...args: unknown[]) => runGated(() => (value as DbFn).apply(target, args));
+      }
+      return (...args: unknown[]) => {
+        const result = (value as DbFn).apply(target, args);
+        return isThenable(result) ? gateWriteBuilder(result as object, runGated) : result;
+      };
+    },
+  });
 }
 
 function configureSqlite(


### PR DESCRIPTION
Fixes #250.

## What this is

On the self-host, file-backed better-sqlite3 adapter, every write — raw statement writes on the main connection and `withTransaction` bodies alike — is serialized through a single async write gate. No raw write executes while a transaction holds the write lock, so writes never contend for the file lock and `busy_timeout` is not load-bearing. Reads stay ungated; WAL readers never block the single writer. The `:memory:` adapter and the Cloudflare D1/DO paths are unchanged.

## Why

`withTransaction` runs an interactive transaction on a dedicated connection: it takes `BEGIN IMMEDIATE`'s write lock, then `await`s the async transaction body. better-sqlite3 is synchronous, so a raw, non-transactional write on the main connection that finds the file locked busy-waits and freezes the Node event loop for up to `busy_timeout`. While frozen, the lock-holding transaction can never run to `COMMIT`, so the raw write times out with `SQLITE_BUSY` and its losing statement rolls back — with the error swallowed by the caller.

Under two nodes registering their providers at the same instant (with the node event-queue poll issuing raw writes on the main connection), this deadlock drops one node's broker capabilities from the node aggregate, alternating which node loses. It is self-host only: production per-node Durable Object storage has no cross-connection writer contention. The per-node serialization from #251 is correct for the production D1-latency aggregate race and is retained.

## Test

`twoNodeWriteContention` registers both nodes' broker providers concurrently over the real `attachNodeSocket`/`handleMessage` paths on file-backed storage, with concurrent event-queue poll raw-write traffic, looped. It fails on current `main` (`SqliteError: database is locked` from the poll's raw `db.update`, each run frozen ~5.4s on `busy_timeout`) and passes with the gate (~210ms). The existing single-node `providerAttachRace` suite is unaffected. Full engine (424) and types (161) suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/AgentWorkforce/relaycast/pull/257?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

