### PR TITLE
engine: log rejected node-control messages server-side

### DIFF
--- a/packages/engine/CHANGELOG.md
+++ b/packages/engine/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ### Fixed
 - Node control logs a rejected `node.register`/`node.heartbeat` (e.g. `node_name_conflict`, a UNIQUE violation) at warn level with workspace/node/provider/code context, so a node left half-registered by a rejected message is no longer invisible server-side.
+- Message-trigger dispatch failures are logged at warn with trigger/action/workspace context instead of being swallowed, so a trigger whose action is missing or unroutable is diagnosable.
 
 ### Changed
 - Refactored route handlers, route response helpers, and service internals without changing the public HTTP envelopes or API behavior.

--- a/packages/engine/CHANGELOG.md
+++ b/packages/engine/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+### Fixed
+- Node control logs a rejected `node.register`/`node.heartbeat` (e.g. `node_name_conflict`, a UNIQUE violation) at warn level with workspace/node/provider/code context, so a node left half-registered by a rejected message is no longer invisible server-side.
+
 ### Changed
 - Refactored route handlers, route response helpers, and service internals without changing the public HTTP envelopes or API behavior.
 - Split engine internals into focused modules for background jobs, migrations, node adapters, websocket handling, and shared route utilities.

--- a/packages/engine/src/__tests__/conformance/nodeProviders.test.ts
+++ b/packages/engine/src/__tests__/conformance/nodeProviders.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { and, eq } from 'drizzle-orm';
 import {
   makeNodeStack,
@@ -89,6 +89,32 @@ describe('node providers', () => {
       .from(nodeProviders)
       .where(and(eq(nodeProviders.workspaceId, ws.workspaceId), eq(nodeProviders.nodeId, 'node_a')));
     expect(providers).toEqual([{ name: 'default' }]);
+  });
+
+  it('logs a rejected node-control message server-side, not only on the socket', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      const ws = await createWorkspace(stack.app, 'np-reject-log');
+      await enrollNode(ws, 'node_a', 'alpha');
+
+      const first = attachSocket(ws.workspaceId, 'node_a');
+      await first.handle.handleMessage(registerFrame('node_a', 'alpha', { name: 'py', instance_id: 'i1' }, [{ name: 'run-etl', kind: 'action' }]));
+
+      // A duplicate live instance is rejected. The rejection must surface
+      // server-side too, so a half-registered node is not silent.
+      const dup = attachSocket(ws.workspaceId, 'node_a');
+      await dup.handle.handleMessage(registerFrame('node_a', 'alpha', { name: 'py', instance_id: 'i2' }, [{ name: 'run-etl', kind: 'action' }]));
+
+      expect(dup.sock.ofType('error').at(-1)).toMatchObject({ code: 'provider_instance_conflict' });
+      expect(warn).toHaveBeenCalledWith('[node.control] rejected message', expect.objectContaining({
+        type: 'node.register',
+        code: 'provider_instance_conflict',
+        workspaceId: ws.workspaceId,
+        nodeId: 'node_a',
+      }));
+    } finally {
+      warn.mockRestore();
+    }
   });
 
   it('attaches, replaces on reconnect, and rejects a duplicate live instance', async () => {

--- a/packages/engine/src/__tests__/conformance/triggerDispatchLog.test.ts
+++ b/packages/engine/src/__tests__/conformance/triggerDispatchLog.test.ts
@@ -1,0 +1,49 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { makeNodeStack, createWorkspace, type TestStack } from './harness.js';
+import { createTrigger, fireMessageTriggers, type TriggerMessageInput } from '../../engine/trigger.js';
+
+// A trigger whose action can't be dispatched (missing action, no handler,
+// offline node) must not fail silently — the message already posted, so a dead
+// trigger would otherwise be invisible.
+describe('message trigger dispatch failures are logged', () => {
+  let stack: TestStack;
+  beforeEach(() => { stack = makeNodeStack({ ttlMs: 60_000 }); });
+  afterEach(() => stack.close());
+
+  function message(): TriggerMessageInput {
+    return {
+      id: 'msg_1',
+      channel_id: 'chan_general',
+      channel_name: 'general',
+      agent_id: 'agent_caller',
+      agent_name: 'caller',
+      text: 'go',
+      created_at: new Date().toISOString(),
+    };
+  }
+
+  it('logs when a trigger action cannot be dispatched instead of swallowing it', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      const ws = await createWorkspace(stack.app, 'trg-log');
+      await createTrigger(stack.runtime.handle.db, ws.workspaceId, { channel: 'general', action_name: 'no-such-action' });
+
+      const invoked = await fireMessageTriggers({
+        db: stack.runtime.handle.db,
+        nodeConnections: stack.runtime.realtime,
+        workspaceId: ws.workspaceId,
+        message: message(),
+      });
+
+      // Dispatch failed, so nothing is reported invoked — but it is logged.
+      expect(invoked).toHaveLength(0);
+      expect(warn).toHaveBeenCalledWith('[trigger] action dispatch failed', expect.objectContaining({
+        actionName: 'no-such-action',
+        code: 'action_not_found',
+        workspaceId: ws.workspaceId,
+      }));
+    } finally {
+      warn.mockRestore();
+    }
+  });
+});

--- a/packages/engine/src/engine/node.ts
+++ b/packages/engine/src/engine/node.ts
@@ -1532,12 +1532,26 @@ export async function handleNodeControlMessage(args: HandleNodeControlMessageArg
     }
   } catch (err) {
     const error = err as Error & { code?: string };
+    const code = error.code ?? 'node_control_failed';
+    // The rejection reaches the client only as the error frame below. Log it so
+    // it is not invisible server-side: a rejected node.register/node.heartbeat
+    // (e.g. node_name_conflict, a UNIQUE violation) otherwise leaves a node
+    // running half-registered with no signal to operators. Warn, not error —
+    // these are client/protocol rejections, not server faults.
+    console.warn('[node.control] rejected message', {
+      type: message.type,
+      code,
+      workspaceId: args.workspaceId,
+      nodeId: args.nodeId,
+      provider: frameProviderName,
+      message: error.message,
+    });
     sendControl(args.socket, {
       v: 1,
       id: requestId(message),
       type: 'error',
       ok: false,
-      code: error.code ?? 'node_control_failed',
+      code,
       message: error.message,
     });
   }

--- a/packages/engine/src/engine/trigger.ts
+++ b/packages/engine/src/engine/trigger.ts
@@ -198,8 +198,19 @@ export async function fireMessageTriggers(args: {
         },
       }, { nodeConnections: args.nodeConnections });
       invoked.push(row.id);
-    } catch {
-      // Trigger delivery is best-effort; message posting has already succeeded.
+    } catch (err) {
+      // Trigger delivery is best-effort — the message posting already succeeded
+      // — but swallowing the failure silently hides a broken trigger (its
+      // action is missing, has no handler, or the handling node is offline).
+      // Log it with trigger/action context so a dead trigger is diagnosable.
+      const error = err as Error & { code?: string };
+      console.warn('[trigger] action dispatch failed', {
+        triggerId: row.id,
+        actionName: row.actionName,
+        code: error.code ?? 'trigger_dispatch_failed',
+        workspaceId: args.workspaceId,
+        message: error.message,
+      });
     }
   }
 


### PR DESCRIPTION
## What this is

The node-control handler logs a rejected `node.register` / `node.heartbeat` (and any other node-control message) at warn level with workspace, node, provider, message type, and error code, before sending the client the `error` frame.

## Why

The handler's catch previously sent the rejection only as a WebSocket `error` frame and logged nothing. A node whose register/heartbeat is rejected — e.g. `node_name_conflict` when two nodes register under the same name, or the underlying `SQLITE_CONSTRAINT_UNIQUE` on `nodes.(workspace_id, name)` — then runs half-registered (dead heartbeats, absent from the roster) with no server-side signal. Diagnosing the self-host two-node boot failure required adding instrumentation just to see the rejection.

## Test

`nodeProviders.test.ts` asserts a rejected registration is logged with its code and node/workspace context, in addition to the on-socket error reply.

Refs #250.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/AgentWorkforce/relaycast/pull/259?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

