### PR TITLE
engine: supersede a stale provider binding on restart (spec §3.1)

### DIFF
--- a/packages/engine/CHANGELOG.md
+++ b/packages/engine/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+### Fixed
+- Provider-attach conflict honors spec §3.1: a restarted node instance (new `instance_id`) supersedes a stale binding instead of being rejected, while a genuinely live duplicate still rejects. The liveness window is ~2× the broker heartbeat cadence (24s) rather than the 45s node TTL, so a `node up` restarted after an unclean disconnect is no longer blocked for up to 45s.
+
 ### Changed
 - Refactored route handlers, route response helpers, and service internals without changing the public HTTP envelopes or API behavior.
 - Split engine internals into focused modules for background jobs, migrations, node adapters, websocket handling, and shared route utilities.

--- a/packages/engine/src/__tests__/conformance/nodeProviders.test.ts
+++ b/packages/engine/src/__tests__/conformance/nodeProviders.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { and, eq } from 'drizzle-orm';
 import {
   makeNodeStack,
@@ -114,6 +114,56 @@ describe('node providers', () => {
       .from(nodeProviders)
       .where(and(eq(nodeProviders.workspaceId, ws.workspaceId), eq(nodeProviders.nodeId, 'node_a'), eq(nodeProviders.name, 'py')));
     expect(provider.instanceId).toBe('i3');
+  });
+
+  it('supersedes a stale provider binding when a fresh instance restarts after an unclean disconnect', async () => {
+    // Spec §3.1: a restart (new instance_id) supersedes a stale binding. On an
+    // UNCLEAN disconnect (kill -9 / dropped socket) the old connection is never
+    // closed, so it lingers in the registry; the restart must still take over
+    // once the old instance stops framing — not be blocked for the full node
+    // TTL. Drive Date.now so the incumbent's last frame ages past the
+    // attach-liveness window (24s) but within the 45s node TTL.
+    let nowMs = Date.now();
+    const nowSpy = vi.spyOn(Date, 'now').mockImplementation(() => nowMs);
+    try {
+      const ws = await createWorkspace(stack.app, 'np-stale-supersede');
+      await enrollNode(ws, 'node_a', 'alpha');
+
+      const first = attachSocket(ws.workspaceId, 'node_a');
+      await first.handle.handleMessage(registerFrame('node_a', 'alpha', { name: 'broker', instance_id: 'epoch-1' }, [{ name: 'spawn:claude', kind: 'capacity' }]));
+      expect(first.sock.ofType('reply').at(-1)).toMatchObject({ ok: true });
+
+      // Unclean disconnect: no handleClose. Time advances past the 24s window.
+      nowMs += 30_000;
+
+      const restart = attachSocket(ws.workspaceId, 'node_a');
+      await restart.handle.handleMessage(registerFrame('node_a', 'alpha', { name: 'broker', instance_id: 'epoch-2' }, [{ name: 'spawn:claude', kind: 'capacity' }]));
+
+      expect(restart.sock.ofType('error')).toHaveLength(0);
+      expect(restart.sock.ofType('reply').at(-1)).toMatchObject({ ok: true });
+      const [row] = await stack.runtime.handle.db
+        .select({ caps: nodes.capabilities })
+        .from(nodes)
+        .where(and(eq(nodes.workspaceId, ws.workspaceId), eq(nodes.id, 'node_a')));
+      expect((row?.caps ?? []).map((c) => c.name)).toEqual(['spawn:claude']);
+    } finally {
+      nowSpy.mockRestore();
+    }
+  });
+
+  it('still rejects a different instance while the incumbent is actively heartbeating', async () => {
+    const ws = await createWorkspace(stack.app, 'np-live-dup');
+    await enrollNode(ws, 'node_a', 'alpha');
+
+    const first = attachSocket(ws.workspaceId, 'node_a');
+    await first.handle.handleMessage(registerFrame('node_a', 'alpha', { name: 'broker', instance_id: 'epoch-1' }, [{ name: 'spawn:claude', kind: 'capacity' }]));
+    expect(first.sock.ofType('reply').at(-1)).toMatchObject({ ok: true });
+
+    // A second, different instance registers immediately — the incumbent is
+    // still live (framed just now), so this is a genuine duplicate and rejects.
+    const dup = attachSocket(ws.workspaceId, 'node_a');
+    await dup.handle.handleMessage(registerFrame('node_a', 'alpha', { name: 'broker', instance_id: 'epoch-2' }, [{ name: 'spawn:claude', kind: 'capacity' }]));
+    expect(dup.sock.ofType('error').at(-1)).toMatchObject({ code: 'provider_instance_conflict' });
   });
 
   it('rejects a second provider registering an action another provider already owns on the node', async () => {

--- a/packages/engine/src/adapters/node/realtime.ts
+++ b/packages/engine/src/adapters/node/realtime.ts
@@ -12,7 +12,7 @@ import type { EngineDb } from '../../ports/database.js';
 import { observerTokens } from '../../db/schema.js';
 import { handleNodeControlMessage, handleProviderDisconnect, markNodeOffline } from '../../engine/node.js';
 import { DEFAULT_PROVIDER_NAME } from '../../engine/nodeProvider.js';
-import { NODE_LIVENESS_TTL_MS } from '../../engine/placement.js';
+import { PROVIDER_ATTACH_LIVENESS_MS } from '../../engine/placement.js';
 import { drainNodeInvocations } from '../../engine/action.js';
 import { observerAllowsEvent } from '../../engine/observerToken.js';
 import type { InvocationCompletionDeps } from '../../engine/invocationCompletion.js';
@@ -274,7 +274,7 @@ export class InProcessRealtime implements RealtimeBus, ConnectionRegistry, NodeC
     workspaceId: string,
     nodeId: string,
     providerName: string,
-    _instanceId: string,
+    instanceId: string,
     connectionId: string,
   ): { code: string; message: string } | null {
     const nodeKey = this.nodeKey(workspaceId, nodeId);
@@ -282,9 +282,15 @@ export class InProcessRealtime implements RealtimeBus, ConnectionRegistry, NodeC
     if (!existingConnId || existingConnId === connectionId) return null;
     const existing = this.nodeConnections.get(existingConnId);
     if (!existing) return null;
-    // A still-live instance owns the name (duplicate process). A dropped or
-    // silent (stale) instance is a reconnect and gets replaced on attach.
-    if (Date.now() - existing.lastSeen <= NODE_LIVENESS_TTL_MS) {
+    // Spec §3.1: a new instance_id is a reconnect/restart and supersedes the
+    // incumbent on attach; the same instance re-registering just replaces
+    // itself. Reject only a genuinely-live DUPLICATE — a different instance
+    // whose connection is still actively framing, i.e. seen within
+    // PROVIDER_ATTACH_LIVENESS_MS (~2x the broker heartbeat cadence). A killed
+    // instance stops framing, so its window lapses and the restart supersedes
+    // the stale binding instead of being blocked for the full node TTL.
+    if (existing.instanceId === instanceId) return null;
+    if (Date.now() - existing.lastSeen <= PROVIDER_ATTACH_LIVENESS_MS) {
       return {
         code: 'provider_instance_conflict',
         message: `Provider "${providerName}" is already connected on this node`,

--- a/packages/engine/src/engine/placement.ts
+++ b/packages/engine/src/engine/placement.ts
@@ -10,6 +10,19 @@ type NodeRow = typeof nodes.$inferSelect;
 
 export const NODE_LIVENESS_TTL_MS = 45_000;
 
+/**
+ * Recency window for the provider-attach duplicate check — how long a provider's
+ * last frame keeps its binding "live" for the purpose of rejecting a competing
+ * instance. Set to ~2x the broker's node-control heartbeat cadence (12s; see
+ * `crates/broker/src/node_control.rs`), so a genuinely live provider (which
+ * frames at least every 12s) is always inside it, while a killed one lapses
+ * after ~2 missed beats. A restart then supersedes the stale binding instead of
+ * being blocked for the full {@link NODE_LIVENESS_TTL_MS}. Deliberately tighter
+ * than the node-liveness TTL, which governs roster/routing rather than attach
+ * arbitration.
+ */
+export const PROVIDER_ATTACH_LIVENESS_MS = 24_000;
+
 export function isNodeLive(node: Pick<NodeRow, 'status' | 'lastHeartbeatAt'>, now = Date.now()): boolean {
   return (
     node.status === 'online' &&


### PR DESCRIPTION
## What this is

The provider-attach duplicate check is instance-aware and honors fleet spec §3.1:

- The same `instance_id` re-registering replaces itself (reconnect).
- A different `instance_id` supersedes the incumbent binding — a restart — unless the incumbent was framed within `PROVIDER_ATTACH_LIVENESS_MS` (~2× the broker's 12s node heartbeat cadence = 24s), in which case it is a genuinely live duplicate and is rejected.

## Why

The check previously rejected any second instance whose incumbent connection was seen within the 45s node-liveness TTL, ignoring `instance_id`. After an **unclean** disconnect (kill -9, dropped socket, half-open TCP) the old connection is never closed, so it lingers in the registry with a recent `lastSeen`. A `node up` restarted within 45s — which mints a fresh `instance_id` per connection epoch — was rejected before reaching the supersede handoff (`attachProvider`) and left half-registered. A clean Ctrl-C restart already worked (close unbinds the provider); this closes the unclean-disconnect gap.

Keying liveness to ~2× the heartbeat cadence (not the coarser node TTL, which governs roster/routing) means a killed instance — which stops framing immediately — lapses out of the window after ~2 missed beats, so the restart supersedes it instead of being blocked for up to 45s. A genuinely live duplicate still frames every ~12s and is still rejected deterministically.

## Tests (`nodeProviders.test.ts`)

- Unclean disconnect + fresh-instance restart within the node TTL now **supersedes** (fails against the old 45s window).
- A different instance while the incumbent is actively framing still **rejects** with `provider_instance_conflict`.
- Clean-reconnect replacement is unchanged (existing coverage).

Refs #250.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/AgentWorkforce/relaycast/pull/260?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

