### PR TITLE
engine: reschedule node-scoped actions to the owning provider, not the broker

### DIFF
--- a/packages/engine/CHANGELOG.md
+++ b/packages/engine/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+### Fixed
+- Rescheduling a node-scoped action onto a fallback node targets the provider that owns the action, not the node's default (broker) provider. Previously a crash-recovery reschedule onto a multi-provider node dispatched to the broker, which rejected it with `handler_unavailable` and looped the invocation.
+
 ### Changed
 - Refactored route handlers, route response helpers, and service internals without changing the public HTTP envelopes or API behavior.
 - Split engine internals into focused modules for background jobs, migrations, node adapters, websocket handling, and shared route utilities.

--- a/packages/engine/CHANGELOG.md
+++ b/packages/engine/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 ## [Unreleased]
 
 ### Fixed
-- Rescheduling a node-scoped action onto a fallback node targets the provider that owns the action, not the node's default (broker) provider. Previously a crash-recovery reschedule onto a multi-provider node dispatched to the broker, which rejected it with `handler_unavailable` and looped the invocation.
+- Rescheduling a node-scoped action onto a fallback node targets the provider that owns the action and honors that provider's liveness and queue policy. Previously a crash-recovery reschedule onto a multi-provider node could dispatch to the broker or queue behind an offline non-queued owner, leaving the invocation stuck.
 - Message triggers fire node-scoped (fleet-provider) actions: a trigger bound to an action name now resolves plain node-scoped actions and dispatches them node-addressed, so `defineNode`'s onMessage→action handlers run. Previously the trigger's workspace-global resolver excluded node-scoped actions, so such triggers never fired.
 - Provider-attach conflict honors spec §3.1: a restarted node instance (new `instance_id`) supersedes a stale binding instead of being rejected, while a genuinely live duplicate still rejects. The 35s attach window covers the built-in SDKs' 30s node heartbeat cadence with scheduling slack while remaining below the 45s node TTL.
 - Self-host (file-backed SQLite): route every write through one async gate so a raw statement write can no longer busy-wait the event loop while a transaction holds the write lock. Under concurrent node registration, this deadlocked on `busy_timeout` and silently dropped a provider's capabilities from the node aggregate (#250).

--- a/packages/engine/src/__tests__/conformance/rescheduleNodeProvider.test.ts
+++ b/packages/engine/src/__tests__/conformance/rescheduleNodeProvider.test.ts
@@ -1,0 +1,76 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { makeNodeStack, createWorkspace, registerAgent, FakeSocket, type TestStack } from './harness.js';
+import { rescheduleInvocationsForLostNode } from '../../engine/action.js';
+
+type Cap = { name: string; kind?: string };
+
+// When a node hosting an invoked node-scoped action dies, the engine reschedules
+// onto another node that owns the action. That dispatch must target the provider
+// that owns the action on the CHOSEN node — a multi-provider node (broker +
+// fleet) otherwise falls back to the default provider (the broker), which
+// rejects the action with handler_unavailable and loops the invocation forever.
+describe('reschedule targets the action-owning provider on the fallback node', () => {
+  let stack: TestStack;
+  beforeEach(() => { stack = makeNodeStack({ ttlMs: 60_000 }); });
+  afterEach(() => stack.close());
+
+  async function enrollNode(wsKey: string, nodeId: string, name: string) {
+    const res = await stack.app.request('/v1/nodes', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', authorization: `Bearer ${wsKey}` },
+      body: JSON.stringify({ node_id: nodeId, name, role: 'broker', capabilities: [], max_agents: 4, tags: ['test'], version: 'v0' }),
+    });
+    expect(res.status).toBe(201);
+  }
+
+  function registerFrame(nodeId: string, name: string, provider: { name: string; instance_id: string } | undefined, caps: Cap[]) {
+    return JSON.stringify({
+      v: 1, id: `reg-${provider?.name ?? 'default'}`, type: 'node.register', name, node_id: nodeId,
+      ...(provider ? { provider } : {}), capabilities: caps, max_agents: 4, tags: ['test'], version: 'v1', resume_cursor: null,
+    });
+  }
+
+  async function attachProvider(wsId: string, nodeId: string, nodeName: string, providerName: string, caps: Cap[]) {
+    const provider = { name: providerName, instance_id: `${providerName}-i1` };
+    const sock = new FakeSocket();
+    const handle = stack.runtime.realtime.attachNodeSocket(wsId, nodeId, sock);
+    await handle.handleMessage(registerFrame(nodeId, nodeName, provider, caps));
+    await handle.handleMessage(JSON.stringify({ v: 1, type: 'node.heartbeat', provider, load: 0, active_agents: 0, handlers_live: true }));
+    return { sock, handle };
+  }
+
+  it('dispatches the rescheduled action to the fleet provider, not the fallback node\'s broker', async () => {
+    const ws = await createWorkspace(stack.app, 'resched');
+    const caller = await registerAgent(stack.app, ws.workspaceKey, 'caller');
+    await enrollNode(ws.workspaceKey, 'node_a', 'alpha');
+    await enrollNode(ws.workspaceKey, 'node_b', 'beta');
+
+    // node_a owns `work` via a fleet provider.
+    const aFleet = await attachProvider(ws.workspaceId, 'node_a', 'alpha', 'fleet-a', [{ name: 'work', kind: 'action' }]);
+    // node_b is multi-provider: a default/broker provider AND a fleet provider
+    // that owns `work`.
+    const bBroker = await attachProvider(ws.workspaceId, 'node_b', 'beta', 'default', [{ name: 'spawn:claude', kind: 'capacity' }]);
+    const bFleet = await attachProvider(ws.workspaceId, 'node_b', 'beta', 'fleet-b', [{ name: 'work', kind: 'action' }]);
+
+    // Invoke `work` on node_a.
+    const res = await stack.app.request('/v1/nodes/alpha/actions/work/invoke', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', authorization: `Bearer ${caller.token}` },
+      body: JSON.stringify({ input: { job: 1 } }),
+    });
+    expect(res.status).toBe(201);
+    const invocationId = (await res.json() as { data: { invocation_id: string } }).data.invocation_id;
+    expect(aFleet.sock.ofType('action.invoke').at(-1)).toMatchObject({ invocation_id: invocationId, action: 'work' });
+
+    // node_a dies; reschedule its open invocations.
+    bFleet.sock.received.length = 0;
+    bBroker.sock.received.length = 0;
+    const rescheduled = await rescheduleInvocationsForLostNode(stack.runtime.handle.db, stack.runtime.realtime, ws.workspaceId, 'node_a');
+    expect(rescheduled).toBeGreaterThanOrEqual(1);
+
+    // The reschedule reached node_b's fleet provider (which owns `work`), not
+    // its broker/default provider.
+    expect(bFleet.sock.ofType('action.invoke').at(-1)).toMatchObject({ invocation_id: invocationId, action: 'work' });
+    expect(bBroker.sock.ofType('action.invoke')).toHaveLength(0);
+  });
+});

--- a/packages/engine/src/__tests__/conformance/rescheduleNodeProvider.test.ts
+++ b/packages/engine/src/__tests__/conformance/rescheduleNodeProvider.test.ts
@@ -1,8 +1,10 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { and, eq } from 'drizzle-orm';
 import { makeNodeStack, createWorkspace, registerAgent, FakeSocket, type TestStack } from './harness.js';
 import { rescheduleInvocationsForLostNode } from '../../engine/action.js';
+import { actionInvocations, nodes } from '../../db/schema.js';
 
-type Cap = { name: string; kind?: string };
+type Cap = { name: string; kind?: string; queue?: boolean };
 
 // When a node hosting an invoked node-scoped action dies, the engine reschedules
 // onto another node that owns the action. That dispatch must target the provider
@@ -39,6 +41,16 @@ describe('reschedule targets the action-owning provider on the fallback node', (
     return { sock, handle };
   }
 
+  async function invokeWork(callerToken: string, job: number): Promise<string> {
+    const res = await stack.app.request('/v1/nodes/alpha/actions/work/invoke', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', authorization: `Bearer ${callerToken}` },
+      body: JSON.stringify({ input: { job } }),
+    });
+    expect(res.status).toBe(201);
+    return (await res.json() as { data: { invocation_id: string } }).data.invocation_id;
+  }
+
   it('dispatches the rescheduled action to the fleet provider, not the fallback node\'s broker', async () => {
     const ws = await createWorkspace(stack.app, 'resched');
     const caller = await registerAgent(stack.app, ws.workspaceKey, 'caller');
@@ -53,13 +65,7 @@ describe('reschedule targets the action-owning provider on the fallback node', (
     const bFleet = await attachProvider(ws.workspaceId, 'node_b', 'beta', 'fleet-b', [{ name: 'work', kind: 'action' }]);
 
     // Invoke `work` on node_a.
-    const res = await stack.app.request('/v1/nodes/alpha/actions/work/invoke', {
-      method: 'POST',
-      headers: { 'content-type': 'application/json', authorization: `Bearer ${caller.token}` },
-      body: JSON.stringify({ input: { job: 1 } }),
-    });
-    expect(res.status).toBe(201);
-    const invocationId = (await res.json() as { data: { invocation_id: string } }).data.invocation_id;
+    const invocationId = await invokeWork(caller.token, 1);
     expect(aFleet.sock.ofType('action.invoke').at(-1)).toMatchObject({ invocation_id: invocationId, action: 'work' });
 
     // node_a dies; reschedule its open invocations.
@@ -72,5 +78,233 @@ describe('reschedule targets the action-owning provider on the fallback node', (
     // its broker/default provider.
     expect(bFleet.sock.ofType('action.invoke').at(-1)).toMatchObject({ invocation_id: invocationId, action: 'work' });
     expect(bBroker.sock.ofType('action.invoke')).toHaveLength(0);
+  });
+
+  it('skips an offline non-queued owner and dispatches to the next live provider', async () => {
+    const ws = await createWorkspace(stack.app, 'resched-next');
+    const caller = await registerAgent(stack.app, ws.workspaceKey, 'caller');
+    await enrollNode(ws.workspaceKey, 'node_a', 'alpha');
+    await enrollNode(ws.workspaceKey, 'node_b', 'beta');
+    await enrollNode(ws.workspaceKey, 'node_c', 'gamma');
+
+    const aFleet = await attachProvider(ws.workspaceId, 'node_a', 'alpha', 'fleet-a', [{ name: 'work', kind: 'action' }]);
+    const bBroker = await attachProvider(ws.workspaceId, 'node_b', 'beta', 'default', [{ name: 'spawn:claude', kind: 'capacity' }]);
+    const bFleet = await attachProvider(ws.workspaceId, 'node_b', 'beta', 'fleet-b', [{ name: 'work', kind: 'action' }]);
+    const cFleet = await attachProvider(ws.workspaceId, 'node_c', 'gamma', 'fleet-c', [{ name: 'work', kind: 'action' }]);
+
+    const invocationId = await invokeWork(caller.token, 2);
+    expect(aFleet.sock.ofType('action.invoke').at(-1)).toMatchObject({ invocation_id: invocationId });
+    await bFleet.handle.handleClose();
+    bBroker.sock.received.length = 0;
+    cFleet.sock.received.length = 0;
+
+    const rescheduled = await rescheduleInvocationsForLostNode(stack.runtime.handle.db, stack.runtime.realtime, ws.workspaceId, 'node_a');
+    expect(rescheduled).toBe(1);
+    expect(cFleet.sock.ofType('action.invoke').at(-1)).toMatchObject({ invocation_id: invocationId, action: 'work' });
+    expect(bBroker.sock.ofType('action.invoke')).toHaveLength(0);
+
+    const [invocation] = await stack.runtime.handle.db
+      .select({ status: actionInvocations.status, dispatchedNodeId: actionInvocations.dispatchedNodeId })
+      .from(actionInvocations)
+      .where(eq(actionInvocations.id, invocationId));
+    expect(invocation).toMatchObject({ status: 'dispatched', dispatchedNodeId: 'node_c' });
+
+    const reconnected = await attachProvider(ws.workspaceId, 'node_b', 'beta', 'fleet-b', [{ name: 'work', kind: 'action' }]);
+    expect(reconnected.sock.ofType('action.invoke')).toHaveLength(0);
+  });
+
+  it('skips a connected owner whose handlers are not live', async () => {
+    const ws = await createWorkspace(stack.app, 'resched-handler-live');
+    const caller = await registerAgent(stack.app, ws.workspaceKey, 'caller');
+    await enrollNode(ws.workspaceKey, 'node_a', 'alpha');
+    await enrollNode(ws.workspaceKey, 'node_b', 'beta');
+    await enrollNode(ws.workspaceKey, 'node_c', 'gamma');
+
+    await attachProvider(ws.workspaceId, 'node_a', 'alpha', 'fleet-a', [{ name: 'work', kind: 'action' }]);
+    const bBroker = await attachProvider(ws.workspaceId, 'node_b', 'beta', 'default', [{ name: 'spawn:claude', kind: 'capacity' }]);
+    const bFleet = await attachProvider(ws.workspaceId, 'node_b', 'beta', 'fleet-b', [{ name: 'work', kind: 'action' }]);
+    const cFleet = await attachProvider(ws.workspaceId, 'node_c', 'gamma', 'fleet-c', [{ name: 'work', kind: 'action' }]);
+    const invocationId = await invokeWork(caller.token, 3);
+
+    await bFleet.handle.handleMessage(JSON.stringify({
+      v: 1,
+      type: 'node.heartbeat',
+      provider: { name: 'fleet-b', instance_id: 'fleet-b-i1' },
+      load: 0,
+      active_agents: 0,
+      handlers_live: false,
+    }));
+    bFleet.sock.received.length = 0;
+    bBroker.sock.received.length = 0;
+    cFleet.sock.received.length = 0;
+
+    const rescheduled = await rescheduleInvocationsForLostNode(stack.runtime.handle.db, stack.runtime.realtime, ws.workspaceId, 'node_a');
+    expect(rescheduled).toBe(1);
+    expect(bFleet.sock.ofType('action.invoke')).toHaveLength(0);
+    expect(bBroker.sock.ofType('action.invoke')).toHaveLength(0);
+    expect(cFleet.sock.ofType('action.invoke').at(-1)).toMatchObject({ invocation_id: invocationId, action: 'work' });
+  });
+
+  it('queues on an offline owning provider only when the action opts in', async () => {
+    const ws = await createWorkspace(stack.app, 'resched-queue');
+    const caller = await registerAgent(stack.app, ws.workspaceKey, 'caller');
+    await enrollNode(ws.workspaceKey, 'node_a', 'alpha');
+    await enrollNode(ws.workspaceKey, 'node_b', 'beta');
+
+    await attachProvider(ws.workspaceId, 'node_a', 'alpha', 'fleet-a', [{ name: 'work', kind: 'action' }]);
+    const bBroker = await attachProvider(ws.workspaceId, 'node_b', 'beta', 'default', [{ name: 'spawn:claude', kind: 'capacity' }]);
+    const bFleet = await attachProvider(ws.workspaceId, 'node_b', 'beta', 'fleet-b', [{ name: 'work', kind: 'action', queue: true }]);
+    const invocationId = await invokeWork(caller.token, 4);
+    await bFleet.handle.handleClose();
+    bBroker.sock.received.length = 0;
+
+    const rescheduled = await rescheduleInvocationsForLostNode(stack.runtime.handle.db, stack.runtime.realtime, ws.workspaceId, 'node_a');
+    expect(rescheduled).toBe(1);
+    expect(bBroker.sock.ofType('action.invoke')).toHaveLength(0);
+
+    let [invocation] = await stack.runtime.handle.db
+      .select({
+        status: actionInvocations.status,
+        error: actionInvocations.error,
+        completedAt: actionInvocations.completedAt,
+        dispatchedNodeId: actionInvocations.dispatchedNodeId,
+      })
+      .from(actionInvocations)
+      .where(eq(actionInvocations.id, invocationId));
+    expect(invocation).toMatchObject({ status: 'pending', error: null, completedAt: null, dispatchedNodeId: 'node_b' });
+
+    const reconnected = await attachProvider(ws.workspaceId, 'node_b', 'beta', 'fleet-b', [{ name: 'work', kind: 'action', queue: true }]);
+    for (let i = 0; i < 50 && reconnected.sock.ofType('action.invoke').length === 0; i++) {
+      await new Promise((resolve) => setTimeout(resolve, 10));
+    }
+    expect(reconnected.sock.ofType('action.invoke').at(-1)).toMatchObject({ invocation_id: invocationId, action: 'work' });
+    expect(bBroker.sock.ofType('action.invoke')).toHaveLength(0);
+
+    [invocation] = await stack.runtime.handle.db
+      .select({
+        status: actionInvocations.status,
+        error: actionInvocations.error,
+        completedAt: actionInvocations.completedAt,
+        dispatchedNodeId: actionInvocations.dispatchedNodeId,
+      })
+      .from(actionInvocations)
+      .where(eq(actionInvocations.id, invocationId));
+    expect(invocation).toMatchObject({ status: 'dispatched', error: null, completedAt: null, dispatchedNodeId: 'node_b' });
+  });
+
+  it('waits for handlers_live before draining an opted-in provider queue', async () => {
+    const ws = await createWorkspace(stack.app, 'resched-handler-queue');
+    const caller = await registerAgent(stack.app, ws.workspaceKey, 'caller');
+    await enrollNode(ws.workspaceKey, 'node_a', 'alpha');
+    await enrollNode(ws.workspaceKey, 'node_b', 'beta');
+
+    await attachProvider(ws.workspaceId, 'node_a', 'alpha', 'fleet-a', [{ name: 'work', kind: 'action' }]);
+    const bBroker = await attachProvider(ws.workspaceId, 'node_b', 'beta', 'default', [{ name: 'spawn:claude', kind: 'capacity' }]);
+    const bFleet = await attachProvider(ws.workspaceId, 'node_b', 'beta', 'fleet-b', [{ name: 'work', kind: 'action', queue: true }]);
+    const invocationId = await invokeWork(caller.token, 5);
+
+    await bFleet.handle.handleMessage(JSON.stringify({
+      v: 1,
+      type: 'node.heartbeat',
+      provider: { name: 'fleet-b', instance_id: 'fleet-b-i1' },
+      load: 0,
+      active_agents: 0,
+      handlers_live: false,
+    }));
+    bFleet.sock.received.length = 0;
+    bBroker.sock.received.length = 0;
+
+    const rescheduled = await rescheduleInvocationsForLostNode(stack.runtime.handle.db, stack.runtime.realtime, ws.workspaceId, 'node_a');
+    expect(rescheduled).toBe(1);
+    expect(bFleet.sock.ofType('action.invoke')).toHaveLength(0);
+    expect(bBroker.sock.ofType('action.invoke')).toHaveLength(0);
+
+    const [pending] = await stack.runtime.handle.db
+      .select({ status: actionInvocations.status, dispatchedNodeId: actionInvocations.dispatchedNodeId })
+      .from(actionInvocations)
+      .where(eq(actionInvocations.id, invocationId));
+    expect(pending).toMatchObject({ status: 'pending', dispatchedNodeId: 'node_b' });
+
+    await bFleet.handle.handleMessage(JSON.stringify({
+      v: 1,
+      type: 'node.heartbeat',
+      provider: { name: 'fleet-b', instance_id: 'fleet-b-i1' },
+      load: 0,
+      active_agents: 0,
+      handlers_live: true,
+    }));
+    for (let i = 0; i < 50 && bFleet.sock.ofType('action.invoke').length === 0; i++) {
+      await new Promise((resolve) => setTimeout(resolve, 10));
+    }
+    expect(bFleet.sock.ofType('action.invoke').at(-1)).toMatchObject({ invocation_id: invocationId, action: 'work' });
+  });
+
+  it('releases native capacity when a spawn retry enters a provider shadow', async () => {
+    const ws = await createWorkspace(stack.app, 'resched-shadow');
+    const caller = await registerAgent(stack.app, ws.workspaceKey, 'caller');
+    await enrollNode(ws.workspaceKey, 'node_a', 'alpha');
+    await enrollNode(ws.workspaceKey, 'node_b', 'beta');
+
+    const aBroker = await attachProvider(ws.workspaceId, 'node_a', 'alpha', 'default', [{ name: 'spawn:claude', kind: 'capacity' }]);
+    const bBroker = await attachProvider(ws.workspaceId, 'node_b', 'beta', 'default', [{ name: 'spawn:claude', kind: 'capacity' }]);
+    const bPolicy = await attachProvider(ws.workspaceId, 'node_b', 'beta', 'policy', [{ name: 'spawn:claude', kind: 'action' }]);
+
+    const invoke = await stack.app.request('/v1/nodes/alpha/actions/spawn:claude/invoke', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', authorization: `Bearer ${caller.token}` },
+      body: JSON.stringify({ input: { name: 'worker-1' } }),
+    });
+    expect(invoke.status).toBe(201);
+    const invocationId = (await invoke.json() as { data: { invocation_id: string } }).data.invocation_id;
+    expect(aBroker.sock.ofType('action.invoke').at(-1)).toMatchObject({ invocation_id: invocationId, action: 'spawn:claude' });
+    bBroker.sock.received.length = 0;
+    bPolicy.sock.received.length = 0;
+
+    const rescheduled = await rescheduleInvocationsForLostNode(stack.runtime.handle.db, stack.runtime.realtime, ws.workspaceId, 'node_a');
+    expect(rescheduled).toBe(1);
+    expect(bPolicy.sock.ofType('action.invoke').at(-1)).toMatchObject({ invocation_id: invocationId, action: 'spawn:claude' });
+    expect(bBroker.sock.ofType('action.invoke')).toHaveLength(0);
+
+    const [fallback] = await stack.runtime.handle.db
+      .select({ reservedAgents: nodes.reservedAgents })
+      .from(nodes)
+      .where(and(eq(nodes.workspaceId, ws.workspaceId), eq(nodes.id, 'node_b')));
+    expect(fallback.reservedAgents).toBe(0);
+  });
+
+  it('fails once all non-queued owning providers are unavailable', async () => {
+    const ws = await createWorkspace(stack.app, 'resched-fail');
+    const caller = await registerAgent(stack.app, ws.workspaceKey, 'caller');
+    await enrollNode(ws.workspaceKey, 'node_a', 'alpha');
+    await enrollNode(ws.workspaceKey, 'node_b', 'beta');
+
+    await attachProvider(ws.workspaceId, 'node_a', 'alpha', 'fleet-a', [{ name: 'work', kind: 'action' }]);
+    const bBroker = await attachProvider(ws.workspaceId, 'node_b', 'beta', 'default', [{ name: 'spawn:claude', kind: 'capacity' }]);
+    const bFleet = await attachProvider(ws.workspaceId, 'node_b', 'beta', 'fleet-b', [{ name: 'work', kind: 'action' }]);
+    const invocationId = await invokeWork(caller.token, 6);
+    await bFleet.handle.handleClose();
+    bBroker.sock.received.length = 0;
+
+    const rescheduled = await rescheduleInvocationsForLostNode(stack.runtime.handle.db, stack.runtime.realtime, ws.workspaceId, 'node_a');
+    expect(rescheduled).toBe(0);
+    expect(bBroker.sock.ofType('action.invoke')).toHaveLength(0);
+
+    const [invocation] = await stack.runtime.handle.db
+      .select({
+        status: actionInvocations.status,
+        error: actionInvocations.error,
+        completedAt: actionInvocations.completedAt,
+        dispatchAttempts: actionInvocations.dispatchAttempts,
+        attemptedNodeIds: actionInvocations.attemptedNodeIds,
+      })
+      .from(actionInvocations)
+      .where(eq(actionInvocations.id, invocationId));
+    expect(invocation).toMatchObject({
+      status: 'failed',
+      error: 'handler_unavailable',
+      dispatchAttempts: 1,
+      attemptedNodeIds: ['node_a'],
+    });
+    expect(invocation.completedAt).toBeInstanceOf(Date);
   });
 });

--- a/packages/engine/src/adapters/node/realtime.ts
+++ b/packages/engine/src/adapters/node/realtime.ts
@@ -266,6 +266,11 @@ export class InProcessRealtime implements RealtimeBus, ConnectionRegistry, NodeC
     return !!this.providerSocket(this.nodeKey(workspaceId, nodeId), providerName);
   }
 
+  isProviderAttached(workspaceId: string, nodeId: string, providerName: string): boolean {
+    const connId = this.providerConnId(this.nodeKey(workspaceId, nodeId), providerName);
+    return !!connId && this.nodeConnections.has(connId);
+  }
+
   providerNameForConnection(connectionId: string): string | undefined {
     return this.nodeConnections.get(connectionId)?.providerName;
   }

--- a/packages/engine/src/engine/action.ts
+++ b/packages/engine/src/engine/action.ts
@@ -363,10 +363,26 @@ async function isNodeProviderLive(
   return !!provider && isProviderLive(provider);
 }
 
+async function failInvocationForUnavailableProvider(
+  db: Db,
+  workspaceId: string,
+  invocationId: string,
+): Promise<void> {
+  await db
+    .update(actionInvocations)
+    .set({ status: 'failed', error: 'handler_unavailable', completedAt: new Date(), spawnReservedAt: null })
+    .where(and(
+      eq(actionInvocations.workspaceId, workspaceId),
+      eq(actionInvocations.id, invocationId),
+      inArray(actionInvocations.status, OPEN_INVOCATION_STATUSES),
+    ));
+}
+
 /**
  * Dispatch an invoke to a specific provider on a node. When the provider is
  * offline the invoke fails fast (the invocation is failed) unless it opted into
- * the per-provider offline queue.
+ * the per-provider offline queue. Retry placement can request a non-terminal
+ * unavailable result so it can try another node before failing the invocation.
  */
 async function dispatchNodeProviderInvocation(args: {
   db: Db;
@@ -379,8 +395,11 @@ async function dispatchNodeProviderInvocation(args: {
   input: Record<string, unknown>;
   agent?: { id: string; name: string } | null;
   queue: boolean;
+  actionId?: string;
   reservationHeld?: boolean;
-}): Promise<{ accepted: boolean; pending: boolean }> {
+}, options: {
+  failIfUnavailable?: boolean;
+} = {}): Promise<{ accepted: boolean; pending: boolean; providerUnavailable?: boolean }> {
   const live = await isNodeProviderLive(args.db, args.registry, args.workspaceId, args.nodeId, args.providerName);
   if (!live) {
     if (!args.queue) {
@@ -389,17 +408,21 @@ async function dispatchNodeProviderInvocation(args: {
       if (args.reservationHeld) {
         await releaseNodeCapacity(args.db, args.workspaceId, args.nodeId);
       }
-      await args.db
-        .update(actionInvocations)
-        .set({ status: 'failed', error: 'handler_unavailable', completedAt: new Date(), spawnReservedAt: null })
-        .where(and(
-          eq(actionInvocations.workspaceId, args.workspaceId),
-          eq(actionInvocations.id, args.invocationId),
-          inArray(actionInvocations.status, OPEN_INVOCATION_STATUSES),
-        ));
+      if (options.failIfUnavailable === false) {
+        return { accepted: false, pending: false, providerUnavailable: true };
+      }
+      await failInvocationForUnavailableProvider(args.db, args.workspaceId, args.invocationId);
       throw codedError(`Provider "${args.providerName}" is offline for action "${args.action}"`, 'handler_unavailable', 503);
     }
-    return dispatchNodeInvocation({ ...args, pending: true });
+    // The DB is the authoritative offline queue. Do not call sendToProvider
+    // here: a connected provider whose heartbeat says handlers_live=false still
+    // has a socket, and sendToProvider would deliver the frame immediately.
+    const accepted = await dispatchNodeAttempt(args.db, args.workspaceId, args.invocationId, args.nodeId, {
+      pending: true,
+      reservationHeld: args.reservationHeld,
+      actionId: args.actionId,
+    });
+    return { accepted, pending: true };
   }
   return dispatchNodeInvocation({ ...args });
 }
@@ -895,6 +918,7 @@ async function dispatchNodeAttempt(
     retryAfterAt?: Date | null;
     reservationHeld?: boolean;
     skipIncrementAttempts?: boolean;
+    actionId?: string;
   } = {},
 ) {
   const stateFields = opts.pending
@@ -912,6 +936,7 @@ async function dispatchNodeAttempt(
       ...stateFields,
       dispatchedNodeId: nodeId,
       spawnReservedAt: opts.reservationHeld ? new Date() : null,
+      ...(opts.actionId ? { actionId: opts.actionId } : {}),
       ...attemptFields,
     })
     .where(and(
@@ -963,6 +988,7 @@ async function dispatchNodeInvocation(args: {
   action: string;
   input: Record<string, unknown>;
   agent?: { id: string; name: string } | null;
+  actionId?: string;
   pending?: boolean;
   retryAfterAt?: Date | null;
   reservationHeld?: boolean;
@@ -996,6 +1022,7 @@ async function dispatchNodeInvocation(args: {
       retryAfterAt: args.retryAfterAt,
       reservationHeld: args.reservationHeld,
       skipIncrementAttempts: args.skipIncrementAttempts,
+      actionId: args.actionId,
     },
   );
   return { accepted, pending };
@@ -1121,11 +1148,13 @@ export async function drainNodeInvocations(
             : DEFAULT_PROVIDER_NAME);
     const nativeSpawn = isSpawnInvocation(row.actionName) && !shadowProvider;
 
-    // Skip draining to a provider that isn't connected yet (e.g. a named
-    // provider reconnecting before it re-registers). Dispatching here would mark
-    // the frame delivered and push retryAfterAt out by the dispatch timeout,
-    // leaving it idle; leave it pending so the post-register drain re-sends it.
+    // Skip draining to a provider that is disconnected or whose heartbeat says
+    // handlers are not live. A missing provider row is a legacy single-socket
+    // node, for which connection state remains the available liveness signal.
     if (!registry.isProviderConnected(workspaceId, nodeId, providerName)) continue;
+    const provider = await getProvider(db, workspaceId, nodeId, providerName);
+    const explicitlyAttached = registry.isProviderAttached?.(workspaceId, nodeId, providerName) ?? true;
+    if (provider && explicitlyAttached && !isProviderLive(provider)) continue;
 
     let reservedForDrain = false;
     try {
@@ -1245,40 +1274,80 @@ export async function rescheduleNodeInvocation(
   const actionToSend = dispatchActionNameForInvocation(invocation.actionName, input);
   const baseExclude = Array.from(new Set([...attempted, ...current]));
   const candidates = opts.allowAttemptedFallback ? [baseExclude, []] : [baseExclude];
+  const providerRejectedNodeIds = new Set<string>();
 
-  for (const excludeNodeIds of candidates) {
-    try {
-      const placement = await selectRetryPlacement(db, invocation, excludeNodeIds);
-      if (placement.queued) {
-        await dispatchNodeAttempt(db, invocation.workspaceId, invocation.id, placement.node.id, {
-          pending: true,
-          retryAfterAt: opts.retryAfterAt ?? null,
-          reservationHeld: false,
+  for (const candidateExcludes of candidates) {
+    const excludeNodeIds = new Set([...candidateExcludes, ...providerRejectedNodeIds]);
+    while (true) {
+      try {
+        const placement = await selectRetryPlacement(db, invocation, Array.from(excludeNodeIds));
+        // Resolve the owning provider before accepting node-level queued
+        // placement. A node can be live through its broker while the named
+        // provider for this action is offline, and provider queue policy must
+        // decide whether that retry may wait.
+        const target = await fetchNodeAction(db, invocation.workspaceId, placement.node.id, actionToSend);
+        const reservationHeld = isSpawnInvocation(invocation.actionName) && !placement.queued;
+        if (target?.handlerProvider) {
+          // A spawn shadow is an action, not native capacity. claimSpawnNode
+          // reserved capacity before discovering the shadow, so release it just
+          // like the initial dispatch path does before provider dispatch.
+          if (reservationHeld) {
+            await releaseNodeCapacity(db, invocation.workspaceId, placement.node.id);
+          }
+          const dispatched = await dispatchNodeProviderInvocation({
+            db,
+            registry,
+            workspaceId: invocation.workspaceId,
+            invocationId: invocation.id,
+            nodeId: placement.node.id,
+            providerName: target.handlerProvider,
+            action: actionToSend,
+            actionId: target.id,
+            input,
+            queue: target.queue,
+            reservationHeld: false,
+          }, { failIfUnavailable: false });
+          if (dispatched.providerUnavailable) {
+            providerRejectedNodeIds.add(placement.node.id);
+            excludeNodeIds.add(placement.node.id);
+            continue;
+          }
+          return dispatched.accepted;
+        }
+
+        // No named action owner means native spawn/capacity or a legacy
+        // single-socket node; retain the node-level pending/default behavior.
+        if (placement.queued) {
+          await dispatchNodeAttempt(db, invocation.workspaceId, invocation.id, placement.node.id, {
+            pending: true,
+            retryAfterAt: opts.retryAfterAt ?? null,
+            reservationHeld: false,
+            actionId: target?.id,
+          });
+          return true;
+        }
+        const dispatched = await dispatchNodeInvocation({
+          db,
+          registry,
+          workspaceId: invocation.workspaceId,
+          invocationId: invocation.id,
+          nodeId: placement.node.id,
+          action: actionToSend,
+          actionId: target?.id,
+          input,
+          reservationHeld,
         });
-        return true;
+        return dispatched.accepted;
+      } catch {
+        // This candidate phase is exhausted; optionally retry attempted nodes.
+        break;
       }
-      // Route to the provider that owns the action on the CHOSEN node. A
-      // multi-provider node (broker + fleet) otherwise falls back to the default
-      // provider — the broker — which rejects a node-scoped action with
-      // handler_unavailable, looping the invocation. Mirrors the initial-invoke
-      // path (fetchAction -> handlerProvider). No node action row (spawn/capacity
-      // or a legacy single-socket node) keeps the default-provider fallback.
-      const target = await fetchNodeAction(db, invocation.workspaceId, placement.node.id, actionToSend);
-      const dispatched = await dispatchNodeInvocation({
-        db,
-        registry,
-        workspaceId: invocation.workspaceId,
-        invocationId: invocation.id,
-        nodeId: placement.node.id,
-        providerName: target?.handlerProvider ?? undefined,
-        action: actionToSend,
-        input,
-        reservationHeld: isSpawnInvocation(invocation.actionName) && !placement.queued,
-      });
-      return dispatched.accepted;
-    } catch {
-      // Try the next candidate set.
     }
+  }
+
+  if (providerRejectedNodeIds.size > 0) {
+    await failInvocationForUnavailableProvider(db, invocation.workspaceId, invocation.id);
+    return false;
   }
 
   await db

--- a/packages/engine/src/engine/action.ts
+++ b/packages/engine/src/engine/action.ts
@@ -1233,12 +1233,20 @@ export async function rescheduleNodeInvocation(
         });
         return true;
       }
+      // Route to the provider that owns the action on the CHOSEN node. A
+      // multi-provider node (broker + fleet) otherwise falls back to the default
+      // provider — the broker — which rejects a node-scoped action with
+      // handler_unavailable, looping the invocation. Mirrors the initial-invoke
+      // path (fetchAction -> handlerProvider). No node action row (spawn/capacity
+      // or a legacy single-socket node) keeps the default-provider fallback.
+      const target = await fetchNodeAction(db, invocation.workspaceId, placement.node.id, actionToSend);
       const dispatched = await dispatchNodeInvocation({
         db,
         registry,
         workspaceId: invocation.workspaceId,
         invocationId: invocation.id,
         nodeId: placement.node.id,
+        providerName: target?.handlerProvider ?? undefined,
         action: actionToSend,
         input,
         reservationHeld: isSpawnInvocation(invocation.actionName) && !placement.queued,

--- a/packages/engine/src/ports/realtime.ts
+++ b/packages/engine/src/ports/realtime.ts
@@ -94,6 +94,13 @@ export interface NodeConnectionRegistry {
   /** True when a specific provider currently has a connected socket. */
   isProviderConnected(workspaceId: string, nodeId: string, providerName: string): boolean;
 
+  /**
+   * True when the socket is explicitly bound to this provider. Unlike
+   * isProviderConnected, this stays false for the synthetic default provider's
+   * reconnect-before-reregister compatibility socket.
+   */
+  isProviderAttached?(workspaceId: string, nodeId: string, providerName: string): boolean;
+
   /** The provider name bound to a registry connection, once it has registered. */
   providerNameForConnection?(connectionId: string): string | undefined;
 


### PR DESCRIPTION
## What this is

When a node hosting an invoked node-scoped action dies, the crash-recovery reschedule dispatches the action to the provider that **owns** it on the chosen fallback node, instead of the node's default (broker) provider.

## Why

`rescheduleNodeInvocation`'s generic-placement branch called `dispatchNodeInvocation` with **no** `providerName`. On a multi-provider node that routes via `sendToNode` → `defaultProviderName`, which returns the `default` (broker) provider. The broker rejects a node-scoped action with `handler_unavailable`, so the invocation loops between nodes and never completes.

Concretely: a node-scoped `work` action invoked on node-a; node-a is lost; the engine reschedules `work` to node-b, which hosts both a broker and a fleet provider — the reschedule went to node-b's broker and was rejected.

The initial-invoke path (`invokeNodeAction`/`invokeAction`) and the agent-target reschedule branch already resolve their provider; only the generic-placement branch omitted it.

## Change

Resolve the chosen node's action row with `fetchNodeAction` and pass its `handlerProvider` to `dispatchNodeInvocation`. When there is no node action row (spawn/capacity or a legacy single-socket node), the provider falls back to `undefined` → the node default, preserving current behavior.

## Test

`rescheduleNodeProvider.test.ts`: `work` owned by a fleet provider on node-a; node-b is multi-provider (broker + fleet owning `work`); invoke on node-a, lose node-a, reschedule — asserts the dispatch reaches node-b's **fleet** provider and not its broker. Verified to fail without the fix.

Refs #250.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/AgentWorkforce/relaycast/pull/262?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

