### PR TITLE
Export the provider-attach arbitration policy from node-control

### DIFF
--- a/.agentworkforce/trajectories/completed/2026-07/traj_tqua9v6by7jo/summary.md
+++ b/.agentworkforce/trajectories/completed/2026-07/traj_tqua9v6by7jo/summary.md
@@ -1,0 +1,33 @@
+# Trajectory: Address review feedback on PR #263
+
+> **Status:** ✅ Completed
+> **Task:** AgentWorkforce/relaycast#263
+> **Confidence:** 98%
+> **Started:** July 13, 2026 at 12:10 PM
+> **Completed:** July 13, 2026 at 12:10 PM
+
+---
+
+## Summary
+
+Fixed unbound provider attach arbitration, added regression coverage, and validated all engine gates for PR #263
+
+**Approach:** Standard approach
+
+---
+
+## Key Decisions
+
+### Short-circuit unbound provider attach before liveness checks
+- **Chose:** Short-circuit unbound provider attach before liveness checks
+- **Reasoning:** All three unresolved review threads identify the same exported-policy bug; an undefined incumbent means no collision exists regardless of the supplied last-seen timestamp.
+
+---
+
+## Chapters
+
+### 1. Work
+*Agent: default*
+
+- Short-circuit unbound provider attach before liveness checks: Short-circuit unbound provider attach before liveness checks
+- The three unresolved threads are duplicates of one valid exported-policy edge case; the minimal guard and regression test passed focused tests, all 460 engine tests, typecheck, lint, and build.

--- a/.agentworkforce/trajectories/completed/2026-07/traj_tqua9v6by7jo/trajectory.json
+++ b/.agentworkforce/trajectories/completed/2026-07/traj_tqua9v6by7jo/trajectory.json
@@ -1,0 +1,77 @@
+{
+  "id": "traj_tqua9v6by7jo",
+  "version": 1,
+  "task": {
+    "title": "Address review feedback on PR #263",
+    "source": {
+      "system": "plain",
+      "id": "AgentWorkforce/relaycast#263"
+    }
+  },
+  "status": "completed",
+  "startedAt": "2026-07-13T16:10:44.620Z",
+  "completedAt": "2026-07-13T16:10:45.947Z",
+  "agents": [
+    {
+      "name": "default",
+      "role": "lead",
+      "joinedAt": "2026-07-13T16:10:45.016Z"
+    }
+  ],
+  "chapters": [
+    {
+      "id": "chap_25s6d8nyj0el",
+      "title": "Work",
+      "agentName": "default",
+      "startedAt": "2026-07-13T16:10:45.016Z",
+      "endedAt": "2026-07-13T16:10:45.947Z",
+      "events": [
+        {
+          "ts": 1783959045017,
+          "type": "decision",
+          "content": "Short-circuit unbound provider attach before liveness checks: Short-circuit unbound provider attach before liveness checks",
+          "raw": {
+            "question": "Short-circuit unbound provider attach before liveness checks",
+            "chosen": "Short-circuit unbound provider attach before liveness checks",
+            "alternatives": [],
+            "reasoning": "All three unresolved review threads identify the same exported-policy bug; an undefined incumbent means no collision exists regardless of the supplied last-seen timestamp."
+          },
+          "significance": "high"
+        },
+        {
+          "ts": 1783959045553,
+          "type": "reflection",
+          "content": "The three unresolved threads are duplicates of one valid exported-policy edge case; the minimal guard and regression test passed focused tests, all 460 engine tests, typecheck, lint, and build.",
+          "raw": {
+            "focalPoints": [
+              "review-thread deduplication",
+              "policy correctness",
+              "regression coverage"
+            ],
+            "confidence": 0.98
+          },
+          "significance": "high",
+          "tags": [
+            "focal:review-thread deduplication",
+            "focal:policy correctness",
+            "focal:regression coverage",
+            "confidence:0.98"
+          ]
+        }
+      ]
+    }
+  ],
+  "retrospective": {
+    "summary": "Fixed unbound provider attach arbitration, added regression coverage, and validated all engine gates for PR #263",
+    "approach": "Standard approach",
+    "confidence": 0.98
+  },
+  "commits": [],
+  "filesChanged": [],
+  "projectId": "AgentWorkforce/relaycast",
+  "tags": [],
+  "_trace": {
+    "startRef": "372ab86845bef3ee729259f02bbd96bdf68283a6",
+    "endRef": "372ab86845bef3ee729259f02bbd96bdf68283a6"
+  }
+}

--- a/packages/engine/CHANGELOG.md
+++ b/packages/engine/CHANGELOG.md
@@ -5,12 +5,13 @@ All notable changes to `@relaycast/engine` will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [Unreleased - Minor]
 
 ### Added
 - Exported the provider-attach arbitration policy from `@relaycast/engine/node-control`: `providerAttachDecision()` plus `PROVIDER_ATTACH_LIVENESS_MS`, so an out-of-process socket owner (a hosted NodeDO) mirrors the spec §3.1 decision from one source of truth instead of hand-copying the constant and logic.
 
 ### Fixed
+- Provider-attach arbitration accepts an unbound provider regardless of a caller's last-seen timestamp instead of reporting a false live-instance conflict.
 - Rescheduling a node-scoped action onto a fallback node targets the provider that owns the action and honors that provider's liveness and queue policy. Previously a crash-recovery reschedule onto a multi-provider node could dispatch to the broker or queue behind an offline non-queued owner, leaving the invocation stuck.
 - Message triggers fire node-scoped (fleet-provider) actions: a trigger bound to an action name now resolves plain node-scoped actions and dispatches them node-addressed, so `defineNode`'s onMessage→action handlers run. Previously the trigger's workspace-global resolver excluded node-scoped actions, so such triggers never fired.
 - Provider-attach conflict honors spec §3.1: a restarted node instance (new `instance_id`) supersedes a stale binding instead of being rejected, while a genuinely live duplicate still rejects. The 35s attach window covers the built-in SDKs' 30s node heartbeat cadence with scheduling slack while remaining below the 45s node TTL.

--- a/packages/engine/CHANGELOG.md
+++ b/packages/engine/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+### Added
+- Exported the provider-attach arbitration policy from `@relaycast/engine/node-control`: `providerAttachDecision()` plus `PROVIDER_ATTACH_LIVENESS_MS`, so an out-of-process socket owner (a hosted NodeDO) mirrors the spec §3.1 decision from one source of truth instead of hand-copying the constant and logic.
+
 ### Fixed
 - Rescheduling a node-scoped action onto a fallback node targets the provider that owns the action and honors that provider's liveness and queue policy. Previously a crash-recovery reschedule onto a multi-provider node could dispatch to the broker or queue behind an offline non-queued owner, leaving the invocation stuck.
 - Message triggers fire node-scoped (fleet-provider) actions: a trigger bound to an action name now resolves plain node-scoped actions and dispatches them node-addressed, so `defineNode`'s onMessage→action handlers run. Previously the trigger's workspace-global resolver excluded node-scoped actions, so such triggers never fired.

--- a/packages/engine/src/__tests__/conformance/providerAttachDecision.test.ts
+++ b/packages/engine/src/__tests__/conformance/providerAttachDecision.test.ts
@@ -1,0 +1,83 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+// Import through the public `@relaycast/engine/node-control` entrypoint (its
+// source module) — this doubles as an assertion that the policy is actually
+// exported for out-of-process socket owners like the relaycast-cloud NodeDO.
+import { providerAttachDecision, PROVIDER_ATTACH_LIVENESS_MS } from '../../node-control.js';
+import { makeNodeStack, FakeSocket, type TestStack } from './harness.js';
+
+// The exported `providerAttachDecision` policy must be the single source of truth
+// for the in-process `InProcessRealtime.providerAttachConflict` adapter — the same
+// decision the relaycast-cloud NodeDO mirrors. Drive the adapter with a bound
+// incumbent provider and assert its conflict verdict agrees with the pure policy
+// across all three spec §3.1 branches (reconnect, live duplicate, stale supersede).
+
+const WS = 'ws_attach';
+const NODE = 'node_attach';
+const PROVIDER = 'broker';
+const INCUMBENT = 'inst-A';
+const T0 = 1_700_000_000_000;
+
+describe('providerAttachDecision matches InProcessRealtime.providerAttachConflict', () => {
+  let stack: TestStack;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(T0);
+    stack = makeNodeStack();
+  });
+  afterEach(async () => {
+    // `attachNodeSocket` fires a best-effort `drainNode` (a detached DB read);
+    // let it settle on a real macrotask before closing the connection so its
+    // query can't land on a closed database.
+    vi.useRealTimers();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    stack.close();
+  });
+
+  // Bind an incumbent provider instance (lastSeen = T0), then return the id of a
+  // second, competing connection on the same node.
+  function bindIncumbentAndChallenger(): string {
+    const realtime = stack.runtime.realtime;
+    const incumbent = realtime.attachNodeSocket(WS, NODE, new FakeSocket());
+    realtime.attachProvider(WS, NODE, PROVIDER, INCUMBENT, incumbent.connectionId!);
+    const challenger = realtime.attachNodeSocket(WS, NODE, new FakeSocket());
+    return challenger.connectionId!;
+  }
+
+  // Assert the adapter's conflict result and the pure decision agree for the same
+  // incumbent (instance INCUMBENT, lastSeen T0) at clock `now`.
+  function assertAgreement(challengerConnId: string, now: number, incomingInstanceId: string) {
+    vi.setSystemTime(now);
+    const adapter = stack.runtime.realtime.providerAttachConflict(WS, NODE, PROVIDER, incomingInstanceId, challengerConnId);
+    const decision = providerAttachDecision({
+      existingInstanceId: INCUMBENT,
+      existingLastSeen: T0,
+      incomingInstanceId,
+      now,
+    });
+    expect(adapter !== null).toBe(decision.conflict);
+    if (decision.conflict) expect(adapter?.code).toBe(decision.code);
+    return { adapter, decision };
+  }
+
+  it('same instance re-registering is a reconnect, not a conflict', () => {
+    const challenger = bindIncumbentAndChallenger();
+    const { adapter, decision } = assertAgreement(challenger, T0 + 1_000, INCUMBENT);
+    expect(decision.conflict).toBe(false);
+    expect(adapter).toBeNull();
+  });
+
+  it('a different instance still framing within the window is a live duplicate', () => {
+    const challenger = bindIncumbentAndChallenger();
+    const { adapter, decision } = assertAgreement(challenger, T0 + PROVIDER_ATTACH_LIVENESS_MS - 1, 'inst-B');
+    expect(decision.conflict).toBe(true);
+    expect(adapter?.code).toBe('provider_instance_conflict');
+  });
+
+  it('a different instance silent past the window supersedes the stale binding', () => {
+    const challenger = bindIncumbentAndChallenger();
+    const { adapter, decision } = assertAgreement(challenger, T0 + PROVIDER_ATTACH_LIVENESS_MS + 1, 'inst-B');
+    expect(decision.conflict).toBe(false);
+    expect(adapter).toBeNull();
+  });
+});

--- a/packages/engine/src/__tests__/conformance/providerAttachDecision.test.ts
+++ b/packages/engine/src/__tests__/conformance/providerAttachDecision.test.ts
@@ -17,6 +17,17 @@ const PROVIDER = 'broker';
 const INCUMBENT = 'inst-A';
 const T0 = 1_700_000_000_000;
 
+describe('providerAttachDecision', () => {
+  it('accepts an unbound provider regardless of a recent last-seen timestamp', () => {
+    expect(providerAttachDecision({
+      existingInstanceId: undefined,
+      existingLastSeen: T0,
+      incomingInstanceId: 'inst-B',
+      now: T0 + 1_000,
+    })).toEqual({ conflict: false });
+  });
+});
+
 describe('providerAttachDecision matches InProcessRealtime.providerAttachConflict', () => {
   let stack: TestStack;
 

--- a/packages/engine/src/adapters/node/realtime.ts
+++ b/packages/engine/src/adapters/node/realtime.ts
@@ -12,7 +12,7 @@ import type { EngineDb } from '../../ports/database.js';
 import { observerTokens } from '../../db/schema.js';
 import { handleNodeControlMessage, handleProviderDisconnect, markNodeOffline } from '../../engine/node.js';
 import { DEFAULT_PROVIDER_NAME } from '../../engine/nodeProvider.js';
-import { PROVIDER_ATTACH_LIVENESS_MS } from '../../engine/placement.js';
+import { providerAttachDecision } from '../../engine/placement.js';
 import { drainNodeInvocations } from '../../engine/action.js';
 import { observerAllowsEvent } from '../../engine/observerToken.js';
 import type { InvocationCompletionDeps } from '../../engine/invocationCompletion.js';
@@ -302,22 +302,22 @@ export class InProcessRealtime implements RealtimeBus, ConnectionRegistry, NodeC
     if (!existingConnId || existingConnId === connectionId) return null;
     const existing = this.nodeConnections.get(existingConnId);
     if (!existing) return null;
-    // Spec §3.1: a new instance_id is a reconnect/restart and supersedes the
-    // incumbent on attach; the same instance re-registering just replaces
-    // itself. Reject only a genuinely-live DUPLICATE — a different instance
-    // whose connection is still actively framing, i.e. seen within
-    // PROVIDER_ATTACH_LIVENESS_MS. The window covers the longest built-in SDK
-    // heartbeat cadence with scheduling slack. A killed instance stops framing,
-    // so its window lapses and the restart supersedes the stale binding instead
-    // of being blocked for the full node TTL.
-    if (existing.instanceId === instanceId) return null;
-    if (Date.now() - existing.lastSeen <= PROVIDER_ATTACH_LIVENESS_MS) {
-      return {
-        code: 'provider_instance_conflict',
-        message: `Provider "${providerName}" is already connected on this node`,
-      };
-    }
-    return null;
+    // Spec §3.1 arbitration lives in the shared `providerAttachDecision` policy so
+    // this in-process adapter and out-of-process socket owners (the
+    // relaycast-cloud NodeDO) stay in lockstep: a same-instance re-register is a
+    // reconnect, a different instance still framing within
+    // PROVIDER_ATTACH_LIVENESS_MS is a live duplicate, and otherwise the incumbent
+    // is stale and the restart supersedes it.
+    const decision = providerAttachDecision({
+      existingInstanceId: existing.instanceId,
+      existingLastSeen: existing.lastSeen,
+      incomingInstanceId: instanceId,
+    });
+    if (!decision.conflict) return null;
+    return {
+      code: decision.code,
+      message: `Provider "${providerName}" is already connected on this node`,
+    };
   }
 
   attachProvider(

--- a/packages/engine/src/engine/placement.ts
+++ b/packages/engine/src/engine/placement.ts
@@ -21,6 +21,51 @@ export const NODE_LIVENESS_TTL_MS = 45_000;
  */
 export const PROVIDER_ATTACH_LIVENESS_MS = 35_000;
 
+/** The reject code for an attach that collides with a still-live provider instance. */
+export type ProviderAttachConflictCode = 'provider_instance_conflict';
+
+/** Inputs to {@link providerAttachDecision}: the incumbent binding vs. the registrant. */
+export interface ProviderAttachDecisionInput {
+  /** The incumbent binding's instance id, or `undefined` when nothing is bound. */
+  existingInstanceId: string | undefined;
+  /** Epoch-ms of the incumbent's last inbound frame. */
+  existingLastSeen: number;
+  /** The registering connection's instance id. */
+  incomingInstanceId: string;
+  /** Comparison clock; defaults to `Date.now()`. */
+  now?: number;
+}
+
+/** The arbitration outcome for a provider attach. */
+export type ProviderAttachDecision =
+  | { conflict: false }
+  | { conflict: true; code: ProviderAttachConflictCode };
+
+/**
+ * Provider-attach arbitration policy (spec §3.1). Given the incumbent binding's
+ * instance id and last-frame time and the registrant's instance id, decide
+ * whether the incoming attach collides with a still-live duplicate instance:
+ *
+ * - Same instance id — a reconnect/re-register, never a conflict.
+ * - Different instance framed within {@link PROVIDER_ATTACH_LIVENESS_MS} — a live
+ *   duplicate; reject with `provider_instance_conflict`.
+ * - Different instance silent past the window — a stale binding the restart
+ *   supersedes; not a conflict.
+ *
+ * The single source of truth for both the in-process `InProcessRealtime` adapter
+ * and out-of-process socket owners (the relaycast-cloud NodeDO) that mirror the
+ * decision against their own live sockets, so the policy can never silently
+ * diverge between them.
+ */
+export function providerAttachDecision(input: ProviderAttachDecisionInput): ProviderAttachDecision {
+  const { existingInstanceId, existingLastSeen, incomingInstanceId, now = Date.now() } = input;
+  if (existingInstanceId === incomingInstanceId) return { conflict: false };
+  if (now - existingLastSeen <= PROVIDER_ATTACH_LIVENESS_MS) {
+    return { conflict: true, code: 'provider_instance_conflict' };
+  }
+  return { conflict: false };
+}
+
 export function isNodeLive(node: Pick<NodeRow, 'status' | 'lastHeartbeatAt'>, now = Date.now()): boolean {
   return (
     node.status === 'online' &&

--- a/packages/engine/src/engine/placement.ts
+++ b/packages/engine/src/engine/placement.ts
@@ -46,6 +46,7 @@ export type ProviderAttachDecision =
  * instance id and last-frame time and the registrant's instance id, decide
  * whether the incoming attach collides with a still-live duplicate instance:
  *
+ * - No incumbent binding — nothing to collide with; not a conflict.
  * - Same instance id — a reconnect/re-register, never a conflict.
  * - Different instance framed within {@link PROVIDER_ATTACH_LIVENESS_MS} — a live
  *   duplicate; reject with `provider_instance_conflict`.
@@ -59,6 +60,7 @@ export type ProviderAttachDecision =
  */
 export function providerAttachDecision(input: ProviderAttachDecisionInput): ProviderAttachDecision {
   const { existingInstanceId, existingLastSeen, incomingInstanceId, now = Date.now() } = input;
+  if (existingInstanceId === undefined) return { conflict: false };
   if (existingInstanceId === incomingInstanceId) return { conflict: false };
   if (now - existingLastSeen <= PROVIDER_ATTACH_LIVENESS_MS) {
     return { conflict: true, code: 'provider_instance_conflict' };

--- a/packages/engine/src/node-control.ts
+++ b/packages/engine/src/node-control.ts
@@ -15,3 +15,13 @@ export {
   type NodeSocketLike,
 } from './engine/node.js';
 export type { InvocationCompletionDeps } from './engine/invocationCompletion.js';
+// Provider-attach arbitration policy (spec §3.1), exported so an out-of-process
+// socket owner (the relaycast-cloud NodeDO) mirrors the decision and the liveness
+// window from one source of truth instead of hand-copying the constant + logic.
+export {
+  providerAttachDecision,
+  PROVIDER_ATTACH_LIVENESS_MS,
+  type ProviderAttachDecision,
+  type ProviderAttachDecisionInput,
+  type ProviderAttachConflictCode,
+} from './engine/placement.js';


### PR DESCRIPTION
The provider-attach arbitration policy (spec §3.1) is exported from
`@relaycast/engine/node-control` so the in-process adapter and out-of-process
socket owners share one source of truth.

## Policy

`engine/placement.ts` owns a pure `providerAttachDecision`:

```ts
providerAttachDecision({
  existingInstanceId, // incumbent binding's instance id (or undefined)
  existingLastSeen,   // epoch-ms of the incumbent's last inbound frame
  incomingInstanceId, // the registrant's instance id
  now,                // comparison clock; defaults to Date.now()
}): { conflict: false } | { conflict: true; code: 'provider_instance_conflict' }
```

- Same instance id — a reconnect/re-register, never a conflict.
- Different instance framed within `PROVIDER_ATTACH_LIVENESS_MS` (35s) — a live
  duplicate; reject with `provider_instance_conflict`.
- Different instance silent past the window — a stale binding the restart
  supersedes; not a conflict.

`InProcessRealtime.providerAttachConflict` delegates to it (keeping its own
precondition guards and the provider-scoped reject message). The window constant
`PROVIDER_ATTACH_LIVENESS_MS` and the decision are re-exported from the
`./node-control` entrypoint.

## Consumer

An out-of-process socket owner — the relaycast-cloud NodeDO — mirrors this
decision against its own live sockets. It previously hand-copied the 35s constant
and the branch logic; it can now import the policy and the window from
`@relaycast/engine/node-control`, so the two implementations can no longer
silently diverge. This resolves the "Follow-up (engine)" item recorded in
relaycast-cloud#27 (the attach-policy export, distinct from the still-open
DO-proxied delivery-readiness design question, which is out of scope here).

## Behavior

Behavior-preserving: the adapter's conflict verdict is byte-for-byte unchanged;
this extracts and exports the existing logic without altering it.

## Tests

- New conformance test (`providerAttachDecision.test.ts`): drives
  `InProcessRealtime.providerAttachConflict` with a bound incumbent provider and
  asserts its verdict agrees with the exported `providerAttachDecision` across all
  three branches — reconnect, live duplicate, and stale supersede — importing the
  policy through the public `node-control` entrypoint.
- Full engine suite green (459 tests), typecheck and lint clean.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/AgentWorkforce/relaycast/pull/263?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

