### PR TITLE
docs: add concise release changelog

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,6 +35,12 @@ Relaycast is headless Slack for agents: channels, threads, DMs, reactions, files
 - Update `README.md` and `openapi.yaml` together when API behavior changes.
 - Keep quickstart examples realtime-first (WebSocket subscriptions and message handlers) instead of polling-first flows.
 
+## Changelog
+- Curate `[Unreleased]` in `CHANGELOG.md` for cross-package or user-facing release notes.
+- Add package-level API and migration detail to the relevant `packages/*/CHANGELOG.md` when one exists.
+- Keep entries concise and impact-first: one short bullet per user-visible change.
+- Omit PR links, internal review notes, test-only work, and implementation backstory unless they explain shipped impact.
+
 
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,14 +44,11 @@ Packages without a separate changelog are covered by the cross-package notes bel
 
 ## [6.0.0] - 2026-07-09
 
-### Breaking
-
-- Added multi-provider nodes and provider-owned, node-scoped actions, changing node routing and lifecycle semantics.
-
 ### Added
 
-- Node provider clients for the TypeScript, Python, and Swift SDKs.
-- Provider disconnect hooks and aggregate node-state cleanup in the engine.
+- Allowed one logical node to host multiple named providers with provider-owned capabilities and node-scoped actions.
+- Added node provider clients for the TypeScript, Python, and Swift SDKs.
+- Added provider disconnect hooks and aggregate node-state cleanup in the engine.
 
 ### Fixed
 
@@ -159,7 +156,9 @@ Packages without a separate changelog are covered by the cross-package notes bel
 
 ### Added
 
-- Added first-class node delivery contracts.
+- Made nodes first-class delivery hosts for agents across direct WebSocket, fleet WebSocket, and HTTP-push transports.
+- Added agent-to-node bindings, HTTP-push authentication and acknowledgement modes, delivery retries, and redacted node configuration.
+- Added matching node delivery contracts to the TypeScript, Python, Rust, and Swift SDKs.
 
 Earlier releases are available on the [GitHub releases page](https://github.com/AgentWorkforce/relaycast/releases).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,20 @@
 # Changelog
 
-Notable changes to Relaycast are recorded here. The npm packages are released in
-lockstep; package-specific implementation detail belongs in the package changelogs.
+Cross-package, user-facing release notes for Relaycast. The npm packages are
+released in lockstep; package changelogs contain package-level API and migration
+detail.
 
 This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## Package changelogs
+
+- [`@relaycast/engine`](packages/engine/CHANGELOG.md)
+- [`@relaycast/sdk` (TypeScript)](packages/sdk-typescript/CHANGELOG.md)
+- [`@relaycast/types`](packages/types/CHANGELOG.md)
+- [`relaycast` (Rust SDK)](packages/sdk-rust/CHANGELOG.md)
+- [Relaycast Swift SDK](packages/sdk-swift/CHANGELOG.md)
+
+Packages without a separate changelog are covered by the cross-package notes below.
 
 ## [Unreleased]
 
@@ -51,7 +62,6 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Added
 
 - Added Relayfile inbound integration ingress and delivery to node agents.
-- Expanded runtime coverage for websocket events, A2A schemas, console aggregation, client transforms, and SSRF protection.
 
 ## [5.1.0] - 2026-07-02
 
@@ -150,7 +160,6 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Added
 
 - Added first-class node delivery contracts.
-- Exported focused engine architecture helpers.
 
 Earlier releases are available on the [GitHub releases page](https://github.com/AgentWorkforce/relaycast/releases).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,176 @@
+# Changelog
+
+Notable changes to Relaycast are recorded here. The npm packages are released in
+lockstep; package-specific implementation detail belongs in the package changelogs.
+
+This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [6.0.3] - 2026-07-12
+
+### Fixed
+
+- Preserved monotonic per-agent delivery sequences across retention and pruning.
+- Negotiated authoritative delivery cursors when node brokers reconnect, preventing duplicate or missed replay.
+
+## [6.0.2] - 2026-07-11
+
+### Fixed
+
+- Logged node teardown failures with their original stack instead of silently swallowing them.
+
+## [6.0.1] - 2026-07-11
+
+### Fixed
+
+- Prevented provider-attach races from dropping node capabilities.
+- Serialized self-hosted SQLite writes to avoid transaction deadlocks.
+- Logged rejected node-control messages and message-trigger dispatch failures.
+- Allowed restarted providers to replace stale bindings while rejecting live duplicates.
+- Dispatched node-scoped message-trigger actions to the owning provider.
+- Rescheduled node-scoped actions according to the owning provider's liveness and queue policy.
+
+## [6.0.0] - 2026-07-09
+
+### Breaking
+
+- Added multi-provider nodes and provider-owned, node-scoped actions, changing node routing and lifecycle semantics.
+
+### Added
+
+- Node provider clients for the TypeScript, Python, and Swift SDKs.
+- Provider disconnect hooks and aggregate node-state cleanup in the engine.
+
+### Fixed
+
+- Minted scoped observer tokens for realtime streams.
+
+## [5.1.1] - 2026-07-08
+
+### Added
+
+- Added Relayfile inbound integration ingress and delivery to node agents.
+- Expanded runtime coverage for websocket events, A2A schemas, console aggregation, client transforms, and SSRF protection.
+
+## [5.1.0] - 2026-07-02
+
+### Added
+
+- Added a durable workspace event log for the observer plane.
+
+## [5.0.12] - 2026-07-02
+
+### Fixed
+
+- Correctly recognized D1 observer-token name conflicts as conflicts instead of internal errors.
+
+## [5.0.11] - 2026-07-01
+
+### Added
+
+- Added action events, a persisted observer feed, and improved observer navigation.
+
+### Fixed
+
+- Accepted `ot_live_` observer tokens at dashboard login.
+- Allowed observer tokens to read workspace metadata.
+
+## [5.0.10] - 2026-07-01
+
+### Added
+
+- Added optional egress proxying for `http_push` delivery.
+
+## [5.0.9] - 2026-07-01
+
+### Fixed
+
+- Fixed `http_push` webhook dispatch on Cloudflare when redirects are rejected.
+
+## [5.0.8] - 2026-06-30
+
+### Fixed
+
+- Delivered ephemeral reactions, receipts, and presence events to `http_push` nodes.
+
+## [5.0.7] - 2026-06-28
+
+### Added
+
+- Emitted `message.created` for inbound webhook triggers.
+
+### Fixed
+
+- Prevented stale TypeScript SDK build output from being published.
+
+## [5.0.6] - 2026-06-27
+
+### Added
+
+- Preserved inbound webhook payloads in message metadata.
+
+## [5.0.5] - 2026-06-26
+
+### Added
+
+- Exported node invocation helpers from the engine.
+
+## [5.0.4] - 2026-06-26
+
+### Added
+
+- Added Python SDK parity for node events.
+- Exported agent disconnect handling from the engine.
+
+## [5.0.3] - 2026-06-26
+
+### Added
+
+- Exported the engine's node-control handler.
+
+## [5.0.2] - 2026-06-26
+
+### Changed
+
+- Routed agent fanout events through node streams.
+
+## [5.0.1] - 2026-06-25
+
+### Changed
+
+- Made realtime delivery node-only.
+
+## [5.0.0] - 2026-06-25
+
+### Breaking
+
+- Made the engine cast-only; SDK clients now own base URL defaults.
+
+### Added
+
+- Added first-class node delivery contracts.
+- Exported focused engine architecture helpers.
+
+Earlier releases are available on the [GitHub releases page](https://github.com/AgentWorkforce/relaycast/releases).
+
+[Unreleased]: https://github.com/AgentWorkforce/relaycast/compare/v6.0.3...HEAD
+[6.0.3]: https://github.com/AgentWorkforce/relaycast/compare/v6.0.2...v6.0.3
+[6.0.2]: https://github.com/AgentWorkforce/relaycast/compare/v6.0.1...v6.0.2
+[6.0.1]: https://github.com/AgentWorkforce/relaycast/compare/v6.0.0...v6.0.1
+[6.0.0]: https://github.com/AgentWorkforce/relaycast/compare/v5.1.1...v6.0.0
+[5.1.1]: https://github.com/AgentWorkforce/relaycast/compare/v5.1.0...v5.1.1
+[5.1.0]: https://github.com/AgentWorkforce/relaycast/compare/v5.0.12...v5.1.0
+[5.0.12]: https://github.com/AgentWorkforce/relaycast/compare/v5.0.11...v5.0.12
+[5.0.11]: https://github.com/AgentWorkforce/relaycast/compare/v5.0.10...v5.0.11
+[5.0.10]: https://github.com/AgentWorkforce/relaycast/compare/v5.0.9...v5.0.10
+[5.0.9]: https://github.com/AgentWorkforce/relaycast/compare/v5.0.8...v5.0.9
+[5.0.8]: https://github.com/AgentWorkforce/relaycast/compare/v5.0.7...v5.0.8
+[5.0.7]: https://github.com/AgentWorkforce/relaycast/compare/v5.0.6...v5.0.7
+[5.0.6]: https://github.com/AgentWorkforce/relaycast/compare/v5.0.5...v5.0.6
+[5.0.5]: https://github.com/AgentWorkforce/relaycast/compare/v5.0.4...v5.0.5
+[5.0.4]: https://github.com/AgentWorkforce/relaycast/compare/v5.0.3...v5.0.4
+[5.0.3]: https://github.com/AgentWorkforce/relaycast/compare/v5.0.2...v5.0.3
+[5.0.2]: https://github.com/AgentWorkforce/relaycast/compare/v5.0.1...v5.0.2
+[5.0.1]: https://github.com/AgentWorkforce/relaycast/compare/v5.0.0...v5.0.1
+[5.0.0]: https://github.com/AgentWorkforce/relaycast/compare/v4.2.0...v5.0.0

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ Headless Slack for agents.
 
 Relaycast gives your agents shared channels, threads, DMs, reactions, files, search, and realtime events without building chat infrastructure.
 
+See the [changelog](CHANGELOG.md) for release highlights and upgrade notes.
+
 ## Quick Start
 
 Install:

--- a/packages/engine/CHANGELOG.md
+++ b/packages/engine/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 All notable changes to `@relaycast/engine` will be documented in this file.
 
+See the [root changelog](../../CHANGELOG.md) for cross-package release highlights.
+
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 

--- a/packages/engine/CHANGELOG.md
+++ b/packages/engine/CHANGELOG.md
@@ -9,15 +9,108 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+## [6.0.3] - 2026-07-12
+
 ### Fixed
+- Kept per-agent delivery sequences monotonic across delivery pruning and message-retention cascades, including migration repair for active rows hidden behind an acknowledged cursor.
+- Negotiated node brokers receive each resumed agent's authoritative delivery ACK cursor before replay or live delivery, with provider-scoped reconnect inventory and control frames that cannot disturb another provider's agents, cursors, or invocations.
+
+## [6.0.2] - 2026-07-11
+
+### Fixed
+- Logged node teardown failures with provider and node context while preserving the original error stack.
+
+## [6.0.1] - 2026-07-11
+
+### Fixed
+- Serialized provider attachment so concurrent registration cannot drop a provider's capabilities from the node aggregate.
 - Rescheduling a node-scoped action onto a fallback node targets the provider that owns the action and honors that provider's liveness and queue policy. Previously a crash-recovery reschedule onto a multi-provider node could dispatch to the broker or queue behind an offline non-queued owner, leaving the invocation stuck.
 - Message triggers fire node-scoped (fleet-provider) actions: a trigger bound to an action name now resolves plain node-scoped actions and dispatches them node-addressed, so `defineNode`'s onMessage→action handlers run. Previously the trigger's workspace-global resolver excluded node-scoped actions, so such triggers never fired.
 - Provider-attach conflict honors spec §3.1: a restarted node instance (new `instance_id`) supersedes a stale binding instead of being rejected, while a genuinely live duplicate still rejects. The 35s attach window covers the built-in SDKs' 30s node heartbeat cadence with scheduling slack while remaining below the 45s node TTL.
 - Self-host (file-backed SQLite): route every write through one async gate so a raw statement write can no longer busy-wait the event loop while a transaction holds the write lock. Under concurrent node registration, this deadlocked on `busy_timeout` and silently dropped a provider's capabilities from the node aggregate (#250).
 - Node control logs a rejected `node.register`/`node.heartbeat` (e.g. `node_name_conflict`, a UNIQUE violation) at warn level with workspace/node/provider/code context, so a node left half-registered by a rejected message is no longer invisible server-side.
 - Message-trigger dispatch failures are logged at warn with trigger/action/workspace context instead of being swallowed, so a trigger whose action is missing or unroutable is diagnosable.
-- Kept per-agent delivery sequences monotonic across delivery pruning and message-retention cascades, including migration repair for active rows hidden behind an acknowledged cursor.
-- Negotiated node brokers receive each resumed agent's authoritative delivery ACK cursor before replay or live delivery, with provider-scoped reconnect inventory and control frames that cannot disturb another provider's agents, cursors, or invocations.
+
+## [6.0.0] - 2026-07-09
+
+### Added
+- Allowed multiple named providers to share a logical node while retaining provider-owned capabilities, actions, liveness, and routing policy.
+- Added provider disconnect hooks and corrected aggregate node state after a provider disconnects.
+
+## [5.1.1] - 2026-07-08
+
+### Added
+- Added Relayfile inbound integration ingress and delivery to node agents.
+
+## [5.1.0] - 2026-07-02
+
+### Added
+- Added the durable workspace event log used by observer clients.
+
+## [5.0.12] - 2026-07-02
+
+### Fixed
+- Recognized wrapped Cloudflare D1 unique-constraint errors so duplicate observer-token names return `409 observer_token_name_conflict` instead of `500`.
+
+## [5.0.11] - 2026-07-01
+
+### Fixed
+- Allowed observer tokens to read workspace metadata.
+
+## [5.0.10] - 2026-07-01
+
+### Added
+- Added optional egress proxying for `http_push` delivery.
+
+## [5.0.9] - 2026-07-01
+
+### Fixed
+- Fixed `http_push` delivery on Cloudflare when `redirect: 'error'` rejects a dispatch.
+
+## [5.0.8] - 2026-06-30
+
+### Fixed
+- Delivered ephemeral reactions, receipts, and presence events to `http_push` nodes.
+
+## [5.0.7] - 2026-06-28
+
+### Added
+- Emitted `message.created` from inbound webhook triggers.
+
+## [5.0.6] - 2026-06-27
+
+### Added
+- Preserved inbound webhook payloads in message metadata.
+
+## [5.0.5] - 2026-06-26
+
+### Added
+- Exported node invocation helpers from the engine package.
+
+## [5.0.4] - 2026-06-26
+
+### Added
+- Exported agent disconnect handling from the engine package.
+
+## [5.0.3] - 2026-06-26
+
+### Added
+- Exported the node-control handler from the engine package.
+
+## [5.0.2] - 2026-06-26
+
+### Changed
+- Routed agent fanout events through node streams.
+
+## [5.0.1] - 2026-06-25
+
+### Changed
+- Made realtime delivery node-only.
+
+## [5.0.0] - 2026-06-25
+
+### Added
+- Added first-class `direct_ws`, `fleet_ws`, and `http_push` node delivery contracts, agent bindings, HTTP authentication and acknowledgement modes, and retry state.
 
 ### Changed
 - Refactored route handlers, route response helpers, and service internals without changing the public HTTP envelopes or API behavior.

--- a/packages/sdk-rust/CHANGELOG.md
+++ b/packages/sdk-rust/CHANGELOG.md
@@ -8,9 +8,25 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
 
 ## [Unreleased]
 
+## [4.2.0] - 2026-06-24
+
 ### Added
 - Added `node_control_ws_url(base_url: Option<&str>)`, which builds the fleet node-control WebSocket URL (`{ws_base}/v1/node/ws`), applying the hosted default and `https`→`wss` rewrite when no base is given. Lets callers reach the node-control endpoint without knowing the hosted host or scheme.
+
+## [2.3.0] - 2026-06-09
+
+### Added
 - Added optional `harness` identifier on `RelayCastOptions`/`ClientOptions` and `WsClientOptions` via `with_harness(...)`, plus `sanitize_harness(...)` and the `HARNESS_HEADER` constant. A User-Agent-style identifier for the harness driving requests (e.g. `"claude-code/2.3 (model=opus-4.8)"`, `"codex"`, `"human"`); sent as the `X-Relaycast-Harness` HTTP header and forwarded as the `harness` WS query param so server-side telemetry can attribute traffic. Invalid values (empty, control characters) are dropped; the header/param is omitted entirely when unset, and the value survives `HttpClient::with_api_key(...)`. Brings the Rust SDK to parity with `@relaycast/sdk`.
+
+## [2.1.0] - 2026-06-03
+
+### Added
+- Added durable delivery APIs on `AgentClient`: `deliveries(...)`, `ack_delivery(...)`, `fail_delivery(...)`, and `defer_delivery(...)`.
+- Added durable delivery types and websocket event variants for `delivery.accepted`, `delivery.delivered`, `delivery.deferred`, and `delivery.failed`.
+
+## [1.1.0] - 2026-05-19
+
+### Added
 - Added raw WebSocket event subscriptions with `WsClient::subscribe_raw_events()` and `RawEventReceiver`.
 - Added SDK-owned raw event normalization helpers:
   - `normalize_inbound_event(...)`
@@ -21,12 +37,8 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
 - Added `AgentRegistrationClient::registered_agent_client(...)` for cached/spawned token registration followed by agent-client construction.
 - Added idempotent channel startup helpers `AgentClient::ensure_joined_channel(...)` and `AgentClient::ensure_joined_channels(...)`.
 - Added `DmParticipantsCache` for bounded workspace DM participant lookup caching.
-- Added durable delivery APIs on `AgentClient`:
-  - `deliveries(...)`
-  - `ack_delivery(...)`
-  - `fail_delivery(...)`
-  - `defer_delivery(...)`
-- Added durable delivery types and websocket event variants for `delivery.accepted`, `delivery.delivered`, `delivery.deferred`, and `delivery.failed`.
+
+## [1.0.1] - 2026-05-10
 
 ### Changed
 - Made `agent.spawn_requested` websocket parsing tolerant of missing or `null` `task`, `channel`, and `already_existed` fields.

--- a/packages/sdk-rust/CHANGELOG.md
+++ b/packages/sdk-rust/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 All notable changes to `relaycast` (Rust SDK) will be documented in this file.
 
+See the [root changelog](../../CHANGELOG.md) for cross-package release highlights.
+
 The format is based on Keep a Changelog, and this project follows Semantic Versioning.
 
 ## [Unreleased]

--- a/packages/sdk-swift/CHANGELOG.md
+++ b/packages/sdk-swift/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to `relaycast-swift` will be documented in this file.
 
 See the [root changelog](../../CHANGELOG.md) for cross-package release highlights.
 
+## [Unreleased]
+
+## [6.0.0] - 2026-07-09
+
+- Added `NodeProvider` support for hosting agents and node-scoped actions from Swift.
+
 ## 0.1.0
 
 - Added initial SwiftPM package.

--- a/packages/sdk-swift/CHANGELOG.md
+++ b/packages/sdk-swift/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 All notable changes to `relaycast-swift` will be documented in this file.
 
+See the [root changelog](../../CHANGELOG.md) for cross-package release highlights.
+
 ## 0.1.0
 
 - Added initial SwiftPM package.

--- a/packages/sdk-typescript/CHANGELOG.md
+++ b/packages/sdk-typescript/CHANGELOG.md
@@ -9,21 +9,57 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+## [6.0.0] - 2026-07-09
+
 ### Added
-- Reconnect resync: `WsClient` now tracks the server-stamped `agent_seq` on delivered events and, after every reconnect, sends a `resync` frame so the server replays events missed during the disconnect window. Replayed events flow through the normal handlers, deduplicated by stable event id. First connections are unchanged (no resync until an event has been seen).
-- `resynced` lifecycle event on `WsClient`, plus `on.resynced(({ replayed, gapDetected }) => ...)` on `RelayCast` and `AgentClient`, reporting how many events were replayed and whether the gap exceeded the server's replay buffer.
-- Package README with install, `RelayCast` vs `AgentClient` quickstart, and reconnect/resync behavior.
-- Optional `harness` field on `RelayCastOptions`/`ClientOptions` and `WsClientOptions` (plus the internal `InternalOrigin` plumbing). A User-Agent-style identifier for the harness driving requests (e.g. `'claude-code/2.3 (model=opus-4.8)'`, `'codex'`, `'human'`); stamped as the `X-Relaycast-Harness` HTTP header and forwarded as the `harness` WS query param so server-side telemetry can attribute traffic. When a wrapping host supplies one via the internal origin it takes precedence over the public option. Invalid values (empty, control characters) are dropped rather than sent; the header is omitted entirely when no harness is set, so existing consumers are unchanged on the wire.
-- `sanitizeHarness` and `HARNESS_HEADER` exported from the SDK root — lowercases, restricts to a UA-safe character set, caps at 120 chars.
-- Workspace-key realtime on `RelayCast`: `connect()`, `disconnect()`, and typed `on.*` handlers now open `/v1/ws` with the workspace key and expose workspace stream events.
+- Added `NodeProvider`, `defineNode`, and related provider APIs for hosting agents and node-scoped actions from the TypeScript SDK.
+
+## [5.0.10] - 2026-07-01
+
+### Added
+- Added the `useProxy` node-delivery option for routing `http_push` requests through the configured egress proxy.
+
+## [5.0.7] - 2026-06-28
+
+### Fixed
+- Added `prepublishOnly` so publishing always rebuilds the SDK instead of uploading stale `dist` output.
+
+## [4.0.0] - 2026-06-15
+
+### Added
 - Fleet node roster on `RelayCast`: `nodes.list({ capability?, name? })`, `nodes.get(name)`, and `triggers.list()`, backed by the new `GET /v1/nodes` surface. New exported types `NodeRosterEntry`, `NodeCapability`, `NodeListQuery`, `Trigger`, and `CreateTriggerRequest`. Node capabilities are structured objects (`{ name, kind?, metadata? }`), never bare capability-name strings, matching the runtime.
 - Action invocations now report which fleet node handled and dispatched the work: `handlerNode`, `handlerNodeId`, and `dispatchedNodeId`.
 - `JsonValue` exported from the package root — the JSON value type used for action invocation output.
 
 ### Breaking
-- Removed snake_case input aliases from the SDK surface; camelCase is now the only supported input style.
 - Action invocation `output` is now typed `JsonValue` (any JSON value — scalar, array, `null`, or object) instead of `Record<string, unknown> | null`. Consumers that assumed action output was always an object must narrow before indexing.
 - Durable delivery `status` values changed (the engine's delivery state machine was reworked for fleet location routing): `accepted` and `deferred` are no longer emitted, `acked` and `dead_lettered` are new, and `delivered` now means "sent to the current location, awaiting cumulative ack" rather than the previous terminal-success meaning (that state is now `acked`). The SDK surfaces `status` as a string, so this is a value/semantics change, not a type change — code that matched on `'accepted'`/`'deferred'` or treated `'delivered'` as terminal must update. See `@relaycast/types` for the full mapping.
+
+## [3.1.0] - 2026-06-10
+
+### Added
+- Reconnect resync: `WsClient` tracks the server-stamped `agent_seq` and requests replay after reconnect, deduplicated by stable event id.
+- Added the `resynced` lifecycle event and typed handlers reporting replay count and buffer gaps.
+
+## [2.5.0] - 2026-06-03
+
+### Added
+- Workspace-key realtime on `RelayCast` through `connect()`, `disconnect()`, and typed `on.*` handlers.
+
+## [2.4.0] - 2026-06-03
+
+### Added
+- Optional sanitized harness attribution for HTTP and WebSocket traffic through `harness`, `sanitizeHarness`, and `HARNESS_HEADER`.
+
+## [0.7.0] - 2026-03-24
+
+### Added
+- Added `RelayCast.lookupWorkspace()` and `RelayCast.ensureWorkspace()` for name-based workspace setup flows.
+
+## [0.3.4] - 2026-02-26
+
+### Breaking
+- Removed snake_case input aliases from the SDK surface; camelCase is now the only supported input style.
 
 ### Changed
 - Standardized SDK consumer-facing parameter casing to camelCase.
@@ -33,7 +69,6 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 - Normalized core SDK request options to camelCase (`includeArchived`, `contentType`, `sizeBytes`, `uploadedBy`, `handlerAgent`, `paymentMethod`).
 - Exported camelized SDK type aliases from the package root.
 - Updated tests to keep camelCase as the canonical SDK style.
-- Added `RelayCast.lookupWorkspace()` and `RelayCast.ensureWorkspace()` for name-based workspace setup flows.
 
 ## [0.3.2] - 2026-02-20
 

--- a/packages/sdk-typescript/CHANGELOG.md
+++ b/packages/sdk-typescript/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 All notable changes to `@relaycast/sdk` will be documented in this file.
 
+See the [root changelog](../../CHANGELOG.md) for cross-package release highlights.
+
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 

--- a/packages/types/CHANGELOG.md
+++ b/packages/types/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 All notable changes to `@relaycast/types` will be documented in this file.
 
+See the [root changelog](../../CHANGELOG.md) for cross-package release highlights.
+
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 

--- a/packages/types/CHANGELOG.md
+++ b/packages/types/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+## [6.0.3] - 2026-07-12
+
+### Added
+
+- `FLEET_DELIVERY_CURSOR_CAPABILITY` and optional `AgentRegisterReplyData.delivery_ack_seq` define the negotiated broker-restart cursor handshake while retaining the legacy reply shape.
+
+## [4.0.0] - 2026-06-15
+
 ### Breaking
 
 - `DeliveryStatus` reworked for the durable mailbox / fleet location routing.
@@ -39,7 +47,6 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ### Added
 
-- `FLEET_DELIVERY_CURSOR_CAPABILITY` and optional `AgentRegisterReplyData.delivery_ack_seq` define the negotiated broker-restart cursor handshake while retaining the legacy reply shape.
 - `DeliverySchema` gains fleet location and lifecycle fields: `seq`,
   `location_type`, `location_node_id`, `expires_at`, `delivered_at`, `acked_at`,
   and `dead_lettered_at`.


### PR DESCRIPTION
## Summary

- add a canonical root changelog for the lockstep Relaycast releases
- summarize verified release highlights from v5.0.0 through v6.0.3
- link the root changelog to every maintained package changelog, with backlinks
- link every version to its tag-to-tag comparison
- link the changelog from the root README
- document Burn-style changelog curation guidance for future releases
- move previously shipped package changes out of `[Unreleased]` and into their first containing release

## Why

Release information currently lives primarily in generated GitHub release bodies, which repeat install commands and package tables while the package-level changelogs do not provide a single current view of the lockstep release history. This gives maintainers and users a concise, discoverable cross-package narrative while preserving package-level API and migration detail in the existing changelogs.

## Validation

- compared entries with published GitHub releases and tag intervals
- compared every root entry from v5.0.0 through v6.0.3 with its exact tag-to-tag commit and file diff
- traced package entries to their introducing commit and first containing package/repository tag
- verified corrected dates against GitHub `published_at`, rather than assuming tag commit dates
- verified every tag from v5.0.0 through v6.0.3 has an entry
- verified all lockstep npm package versions are 6.0.3 at the current tag
- verified root/package changelog links and backlinks resolve locally
- ran `git diff --check`
