### PR TITLE
fix(engine): bound delivery expiry batches

### DIFF
--- a/.agentworkforce/trajectories/completed/2026-07/traj_aub02nr1ot5z/summary.md
+++ b/.agentworkforce/trajectories/completed/2026-07/traj_aub02nr1ot5z/summary.md
@@ -1,0 +1,33 @@
+# Trajectory: Decouple delivery expiry cleanup from inbox reads
+
+> **Status:** ✅ Completed
+> **Task:** PR #266
+> **Confidence:** 95%
+> **Started:** July 13, 2026 at 10:18 AM
+> **Completed:** July 13, 2026 at 10:22 AM
+
+---
+
+## Summary
+
+Decoupled delivery expiry from inbox reads, added a bounded global scheduled sweeper for Node and cron adapters, documented the contract, and verified cleanup failures cannot break reads
+
+**Approach:** Standard approach
+
+---
+
+## Key Decisions
+
+### Make scheduled maintenance the sole owner of delivery expiry transitions
+- **Chose:** Make scheduled maintenance the sole owner of delivery expiry transitions
+- **Reasoning:** Mailbox reads must remain latency- and failure-independent from cleanup; default reads filter unswept expired rows while a bounded global sweep preserves dead-letter state and sender notices
+
+---
+
+## Chapters
+
+### 1. Work
+*Agent: default*
+
+- Make scheduled maintenance the sole owner of delivery expiry transitions: Make scheduled maintenance the sole owner of delivery expiry transitions
+- Read paths are now pure, Node schedules expiry every 15 seconds, cron adapters receive an exported sweep helper, and failure-isolation plus 121-row D1 regressions pass

--- a/.agentworkforce/trajectories/completed/2026-07/traj_aub02nr1ot5z/summary.md
+++ b/.agentworkforce/trajectories/completed/2026-07/traj_aub02nr1ot5z/summary.md
@@ -31,3 +31,10 @@ Decoupled delivery expiry from inbox reads, added a bounded global scheduled swe
 
 - Make scheduled maintenance the sole owner of delivery expiry transitions: Make scheduled maintenance the sole owner of delivery expiry transitions
 - Read paths are now pure, Node schedules expiry every 15 seconds, cron adapters receive an exported sweep helper, and failure-isolation plus 121-row D1 regressions pass
+
+---
+
+## Artifacts
+
+**Commits:** b136358
+**Files changed:** 11

--- a/.agentworkforce/trajectories/completed/2026-07/traj_aub02nr1ot5z/trajectory.json
+++ b/.agentworkforce/trajectories/completed/2026-07/traj_aub02nr1ot5z/trajectory.json
@@ -68,12 +68,26 @@
     "approach": "Standard approach",
     "confidence": 0.95
   },
-  "commits": [],
-  "filesChanged": [],
+  "commits": [
+    "b136358"
+  ],
+  "filesChanged": [
+    "CHANGELOG.md",
+    "README.md",
+    "openapi.yaml",
+    "packages/engine/CHANGELOG.md",
+    "packages/engine/src/__tests__/conformance/delivery.test.ts",
+    "packages/engine/src/adapters/node/index.ts",
+    "packages/engine/src/engine/delivery.ts",
+    "packages/engine/src/index.ts",
+    "packages/engine/src/routes/delivery.ts",
+    "packages/engine/src/routes/deliveryRouting.ts",
+    "packages/engine/src/routes/inbox.ts"
+  ],
   "projectId": "AgentWorkforce/relaycast",
   "tags": [],
   "_trace": {
     "startRef": "59bf55634eed4d334e1d0e6c7ad495b67f829294",
-    "endRef": "59bf55634eed4d334e1d0e6c7ad495b67f829294"
+    "endRef": "b136358a23e7dbc843473305f3dceefbd3816808"
   }
 }

--- a/.agentworkforce/trajectories/completed/2026-07/traj_aub02nr1ot5z/trajectory.json
+++ b/.agentworkforce/trajectories/completed/2026-07/traj_aub02nr1ot5z/trajectory.json
@@ -1,0 +1,79 @@
+{
+  "id": "traj_aub02nr1ot5z",
+  "version": 1,
+  "task": {
+    "title": "Decouple delivery expiry cleanup from inbox reads",
+    "source": {
+      "system": "plain",
+      "id": "PR #266"
+    }
+  },
+  "status": "completed",
+  "startedAt": "2026-07-13T14:18:39.838Z",
+  "completedAt": "2026-07-13T14:22:58.612Z",
+  "agents": [
+    {
+      "name": "default",
+      "role": "lead",
+      "joinedAt": "2026-07-13T14:22:57.885Z"
+    }
+  ],
+  "chapters": [
+    {
+      "id": "chap_w80gn0li6ckn",
+      "title": "Work",
+      "agentName": "default",
+      "startedAt": "2026-07-13T14:22:57.885Z",
+      "endedAt": "2026-07-13T14:22:58.612Z",
+      "events": [
+        {
+          "ts": 1783952577886,
+          "type": "decision",
+          "content": "Make scheduled maintenance the sole owner of delivery expiry transitions: Make scheduled maintenance the sole owner of delivery expiry transitions",
+          "raw": {
+            "question": "Make scheduled maintenance the sole owner of delivery expiry transitions",
+            "chosen": "Make scheduled maintenance the sole owner of delivery expiry transitions",
+            "alternatives": [],
+            "reasoning": "Mailbox reads must remain latency- and failure-independent from cleanup; default reads filter unswept expired rows while a bounded global sweep preserves dead-letter state and sender notices"
+          },
+          "significance": "high"
+        },
+        {
+          "ts": 1783952578235,
+          "type": "reflection",
+          "content": "Read paths are now pure, Node schedules expiry every 15 seconds, cron adapters receive an exported sweep helper, and failure-isolation plus 121-row D1 regressions pass",
+          "raw": {
+            "focalPoints": [
+              "read isolation",
+              "scheduled ownership",
+              "D1 bounds",
+              "failure behavior"
+            ],
+            "confidence": 0.95
+          },
+          "significance": "high",
+          "tags": [
+            "focal:read isolation",
+            "focal:scheduled ownership",
+            "focal:D1 bounds",
+            "focal:failure behavior",
+            "confidence:0.95"
+          ]
+        }
+      ]
+    }
+  ],
+  "retrospective": {
+    "summary": "Decoupled delivery expiry from inbox reads, added a bounded global scheduled sweeper for Node and cron adapters, documented the contract, and verified cleanup failures cannot break reads",
+    "approach": "Standard approach",
+    "confidence": 0.95
+  },
+  "commits": [],
+  "filesChanged": [],
+  "projectId": "AgentWorkforce/relaycast",
+  "tags": [],
+  "_trace": {
+    "startRef": "59bf55634eed4d334e1d0e6c7ad495b67f829294",
+    "endRef": "59bf55634eed4d334e1d0e6c7ad495b67f829294"
+  }
+}

--- a/.agentworkforce/trajectories/completed/2026-07/traj_aze7f88nht39.trace.json
+++ b/.agentworkforce/trajectories/completed/2026-07/traj_aze7f88nht39.trace.json
@@ -1,0 +1,64 @@
+{
+  "version": "1.0.0",
+  "id": "49b74b3a-0bdc-426c-b0c5-7bf64a2902ec",
+  "timestamp": "2026-07-13T14:58:18.870Z",
+  "trajectory": "traj_aze7f88nht39",
+  "files": [
+    {
+      "path": "AGENTS.md",
+      "conversations": [
+        {
+          "contributor": {
+            "type": "ai"
+          },
+          "ranges": [
+            {
+              "start_line": 36,
+              "end_line": 47,
+              "revision": "0e21508c677a61d98b7e9b1daf5c66bc82a10631"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "path": "CHANGELOG.md",
+      "conversations": [
+        {
+          "contributor": {
+            "type": "ai"
+          },
+          "ranges": [
+            {
+              "start_line": 16,
+              "end_line": 22,
+              "revision": "0e21508c677a61d98b7e9b1daf5c66bc82a10631"
+            },
+            {
+              "start_line": 166,
+              "end_line": 172,
+              "revision": "0e21508c677a61d98b7e9b1daf5c66bc82a10631"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "path": "packages/engine/CHANGELOG.md",
+      "conversations": [
+        {
+          "contributor": {
+            "type": "ai"
+          },
+          "ranges": [
+            {
+              "start_line": 7,
+              "end_line": 13,
+              "revision": "0e21508c677a61d98b7e9b1daf5c66bc82a10631"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/.agentworkforce/trajectories/completed/2026-07/traj_aze7f88nht39/summary.md
+++ b/.agentworkforce/trajectories/completed/2026-07/traj_aze7f88nht39/summary.md
@@ -1,0 +1,39 @@
+# Trajectory: Define changelog release-level headings
+
+> **Status:** ✅ Completed
+> **Task:** PR #266 follow-up
+> **Confidence:** 98%
+> **Started:** July 13, 2026 at 10:56 AM
+> **Completed:** July 13, 2026 at 10:58 AM
+
+---
+
+## Summary
+
+Defined monotonic Unreleased Patch/Minor/Major changelog headings, documented release reset behavior, and marked PR #266 pending notes as Patch.
+
+**Approach:** Standard approach
+
+---
+
+## Key Decisions
+
+### Use monotonic unreleased release-level headings
+- **Chose:** Use monotonic unreleased release-level headings
+- **Reasoning:** The highest pending SemVer impact must remain visible for manual releases; later lower-impact changes cannot downgrade the selected release level, and completed releases reset to an empty plain Unreleased heading.
+
+---
+
+## Chapters
+
+### 1. Work
+*Agent: default*
+
+- Use monotonic unreleased release-level headings: Use monotonic unreleased release-level headings
+
+---
+
+## Artifacts
+
+**Commits:** 0e21508
+**Files changed:** 3

--- a/.agentworkforce/trajectories/completed/2026-07/traj_aze7f88nht39/trajectory.json
+++ b/.agentworkforce/trajectories/completed/2026-07/traj_aze7f88nht39/trajectory.json
@@ -1,0 +1,64 @@
+{
+  "id": "traj_aze7f88nht39",
+  "version": 1,
+  "task": {
+    "title": "Define changelog release-level headings",
+    "source": {
+      "system": "plain",
+      "id": "PR #266 follow-up"
+    }
+  },
+  "status": "completed",
+  "startedAt": "2026-07-13T14:56:43.388Z",
+  "completedAt": "2026-07-13T14:58:18.780Z",
+  "agents": [
+    {
+      "name": "default",
+      "role": "lead",
+      "joinedAt": "2026-07-13T14:57:50.142Z"
+    }
+  ],
+  "chapters": [
+    {
+      "id": "chap_udpf801t2uuy",
+      "title": "Work",
+      "agentName": "default",
+      "startedAt": "2026-07-13T14:57:50.142Z",
+      "endedAt": "2026-07-13T14:58:18.780Z",
+      "events": [
+        {
+          "ts": 1783954670143,
+          "type": "decision",
+          "content": "Use monotonic unreleased release-level headings: Use monotonic unreleased release-level headings",
+          "raw": {
+            "question": "Use monotonic unreleased release-level headings",
+            "chosen": "Use monotonic unreleased release-level headings",
+            "alternatives": [],
+            "reasoning": "The highest pending SemVer impact must remain visible for manual releases; later lower-impact changes cannot downgrade the selected release level, and completed releases reset to an empty plain Unreleased heading."
+          },
+          "significance": "high"
+        }
+      ]
+    }
+  ],
+  "retrospective": {
+    "summary": "Defined monotonic Unreleased Patch/Minor/Major changelog headings, documented release reset behavior, and marked PR #266 pending notes as Patch.",
+    "approach": "Standard approach",
+    "confidence": 0.98
+  },
+  "commits": [
+    "0e21508"
+  ],
+  "filesChanged": [
+    "AGENTS.md",
+    "CHANGELOG.md",
+    "packages/engine/CHANGELOG.md"
+  ],
+  "projectId": "AgentWorkforce/relaycast",
+  "tags": [],
+  "_trace": {
+    "startRef": "5a7f449dedfaa120401d1a1109f70e2116a59283",
+    "endRef": "0e21508c677a61d98b7e9b1daf5c66bc82a10631",
+    "traceId": "49b74b3a-0bdc-426c-b0c5-7bf64a2902ec"
+  }
+}

--- a/.agentworkforce/trajectories/completed/2026-07/traj_de003w7rysjo/summary.md
+++ b/.agentworkforce/trajectories/completed/2026-07/traj_de003w7rysjo/summary.md
@@ -30,3 +30,10 @@ Addressed PR #266 review feedback by hiding unswept expired rows from default de
 *Agent: default*
 
 - Filter unswept expired rows from default active delivery lists: Filter unswept expired rows from default active delivery lists
+
+---
+
+## Artifacts
+
+**Commits:** 59bf556
+**Files changed:** 2

--- a/.agentworkforce/trajectories/completed/2026-07/traj_de003w7rysjo/summary.md
+++ b/.agentworkforce/trajectories/completed/2026-07/traj_de003w7rysjo/summary.md
@@ -1,0 +1,32 @@
+# Trajectory: Address PR #266 review feedback
+
+> **Status:** ✅ Completed
+> **Task:** PR #266
+> **Confidence:** 95%
+> **Started:** July 13, 2026 at 10:11 AM
+> **Completed:** July 13, 2026 at 10:12 AM
+
+---
+
+## Summary
+
+Addressed PR #266 review feedback by hiding unswept expired rows from default delivery lists and extending the large-backlog regression across multiple recipients
+
+**Approach:** Standard approach
+
+---
+
+## Key Decisions
+
+### Filter unswept expired rows from default active delivery lists
+- **Chose:** Filter unswept expired rows from default active delivery lists
+- **Reasoning:** A bounded workspace sweep can consume its batch on another agent, so storage cleanup and caller-visible queue semantics must remain independent
+
+---
+
+## Chapters
+
+### 1. Work
+*Agent: default*
+
+- Filter unswept expired rows from default active delivery lists: Filter unswept expired rows from default active delivery lists

--- a/.agentworkforce/trajectories/completed/2026-07/traj_de003w7rysjo/trajectory.json
+++ b/.agentworkforce/trajectories/completed/2026-07/traj_de003w7rysjo/trajectory.json
@@ -1,0 +1,57 @@
+{
+  "id": "traj_de003w7rysjo",
+  "version": 1,
+  "task": {
+    "title": "Address PR #266 review feedback",
+    "source": {
+      "system": "plain",
+      "id": "PR #266"
+    }
+  },
+  "status": "completed",
+  "startedAt": "2026-07-13T14:11:20.453Z",
+  "completedAt": "2026-07-13T14:12:01.197Z",
+  "agents": [
+    {
+      "name": "default",
+      "role": "lead",
+      "joinedAt": "2026-07-13T14:12:00.847Z"
+    }
+  ],
+  "chapters": [
+    {
+      "id": "chap_ye2kl3in3h4i",
+      "title": "Work",
+      "agentName": "default",
+      "startedAt": "2026-07-13T14:12:00.847Z",
+      "endedAt": "2026-07-13T14:12:01.197Z",
+      "events": [
+        {
+          "ts": 1783951920848,
+          "type": "decision",
+          "content": "Filter unswept expired rows from default active delivery lists: Filter unswept expired rows from default active delivery lists",
+          "raw": {
+            "question": "Filter unswept expired rows from default active delivery lists",
+            "chosen": "Filter unswept expired rows from default active delivery lists",
+            "alternatives": [],
+            "reasoning": "A bounded workspace sweep can consume its batch on another agent, so storage cleanup and caller-visible queue semantics must remain independent"
+          },
+          "significance": "high"
+        }
+      ]
+    }
+  ],
+  "retrospective": {
+    "summary": "Addressed PR #266 review feedback by hiding unswept expired rows from default delivery lists and extending the large-backlog regression across multiple recipients",
+    "approach": "Standard approach",
+    "confidence": 0.95
+  },
+  "commits": [],
+  "filesChanged": [],
+  "projectId": "AgentWorkforce/relaycast",
+  "tags": [],
+  "_trace": {
+    "startRef": "65c36c7d2ab7db627dbbe285b75571d4e580c399",
+    "endRef": "65c36c7d2ab7db627dbbe285b75571d4e580c399"
+  }
+}

--- a/.agentworkforce/trajectories/completed/2026-07/traj_de003w7rysjo/trajectory.json
+++ b/.agentworkforce/trajectories/completed/2026-07/traj_de003w7rysjo/trajectory.json
@@ -46,12 +46,17 @@
     "approach": "Standard approach",
     "confidence": 0.95
   },
-  "commits": [],
-  "filesChanged": [],
+  "commits": [
+    "59bf556"
+  ],
+  "filesChanged": [
+    "packages/engine/src/__tests__/conformance/delivery.test.ts",
+    "packages/engine/src/engine/delivery.ts"
+  ],
   "projectId": "AgentWorkforce/relaycast",
   "tags": [],
   "_trace": {
     "startRef": "65c36c7d2ab7db627dbbe285b75571d4e580c399",
-    "endRef": "65c36c7d2ab7db627dbbe285b75571d4e580c399"
+    "endRef": "59bf55634eed4d334e1d0e6c7ad495b67f829294"
   }
 }

--- a/.agentworkforce/trajectories/completed/2026-07/traj_hkcaas6ntnwv.trace.json
+++ b/.agentworkforce/trajectories/completed/2026-07/traj_hkcaas6ntnwv.trace.json
@@ -1,0 +1,159 @@
+{
+  "version": "1.0.0",
+  "id": "aaaff677-e82d-4a63-b5e0-ac618bcccd56",
+  "timestamp": "2026-07-13T14:06:33.735Z",
+  "trajectory": "traj_hkcaas6ntnwv",
+  "files": [
+    {
+      "path": "AGENTS.md",
+      "conversations": [
+        {
+          "contributor": {
+            "type": "ai"
+          },
+          "ranges": [
+            {
+              "start_line": 35,
+              "end_line": 46,
+              "revision": "65f0e6a6321c2de647350e8c4501cf864d9c72a3"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "path": "CHANGELOG.md",
+      "conversations": [
+        {
+          "contributor": {
+            "type": "ai"
+          },
+          "ranges": [
+            {
+              "start_line": 1,
+              "end_line": 184,
+              "revision": "65f0e6a6321c2de647350e8c4501cf864d9c72a3"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "path": "README.md",
+      "conversations": [
+        {
+          "contributor": {
+            "type": "ai"
+          },
+          "ranges": [
+            {
+              "start_line": 4,
+              "end_line": 11,
+              "revision": "65f0e6a6321c2de647350e8c4501cf864d9c72a3"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "path": "packages/engine/CHANGELOG.md",
+      "conversations": [
+        {
+          "contributor": {
+            "type": "ai"
+          },
+          "ranges": [
+            {
+              "start_line": 2,
+              "end_line": 116,
+              "revision": "65f0e6a6321c2de647350e8c4501cf864d9c72a3"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "path": "packages/sdk-rust/CHANGELOG.md",
+      "conversations": [
+        {
+          "contributor": {
+            "type": "ai"
+          },
+          "ranges": [
+            {
+              "start_line": 2,
+              "end_line": 32,
+              "revision": "65f0e6a6321c2de647350e8c4501cf864d9c72a3"
+            },
+            {
+              "start_line": 37,
+              "end_line": 44,
+              "revision": "65f0e6a6321c2de647350e8c4501cf864d9c72a3"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "path": "packages/sdk-swift/CHANGELOG.md",
+      "conversations": [
+        {
+          "contributor": {
+            "type": "ai"
+          },
+          "ranges": [
+            {
+              "start_line": 2,
+              "end_line": 15,
+              "revision": "65f0e6a6321c2de647350e8c4501cf864d9c72a3"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "path": "packages/sdk-typescript/CHANGELOG.md",
+      "conversations": [
+        {
+          "contributor": {
+            "type": "ai"
+          },
+          "ranges": [
+            {
+              "start_line": 2,
+              "end_line": 66,
+              "revision": "65f0e6a6321c2de647350e8c4501cf864d9c72a3"
+            },
+            {
+              "start_line": 69,
+              "end_line": 74,
+              "revision": "65f0e6a6321c2de647350e8c4501cf864d9c72a3"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "path": "packages/types/CHANGELOG.md",
+      "conversations": [
+        {
+          "contributor": {
+            "type": "ai"
+          },
+          "ranges": [
+            {
+              "start_line": 2,
+              "end_line": 22,
+              "revision": "65f0e6a6321c2de647350e8c4501cf864d9c72a3"
+            },
+            {
+              "start_line": 47,
+              "end_line": 52,
+              "revision": "65f0e6a6321c2de647350e8c4501cf864d9c72a3"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/.agentworkforce/trajectories/completed/2026-07/traj_hkcaas6ntnwv.trace.json
+++ b/.agentworkforce/trajectories/completed/2026-07/traj_hkcaas6ntnwv.trace.json
@@ -5,51 +5,15 @@
   "trajectory": "traj_hkcaas6ntnwv",
   "files": [
     {
-      "path": "AGENTS.md",
-      "conversations": [
-        {
-          "contributor": {
-            "type": "ai"
-          },
-          "ranges": [
-            {
-              "start_line": 35,
-              "end_line": 46,
-              "revision": "65f0e6a6321c2de647350e8c4501cf864d9c72a3"
-            }
-          ]
-        }
-      ]
-    },
-    {
       "path": "CHANGELOG.md",
       "conversations": [
         {
-          "contributor": {
-            "type": "ai"
-          },
+          "contributor": { "type": "ai" },
           "ranges": [
             {
-              "start_line": 1,
-              "end_line": 184,
-              "revision": "65f0e6a6321c2de647350e8c4501cf864d9c72a3"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "path": "README.md",
-      "conversations": [
-        {
-          "contributor": {
-            "type": "ai"
-          },
-          "ranges": [
-            {
-              "start_line": 4,
-              "end_line": 11,
-              "revision": "65f0e6a6321c2de647350e8c4501cf864d9c72a3"
+              "start_line": 21,
+              "end_line": 24,
+              "revision": "65c36c7d2ab7db627dbbe285b75571d4e580c399"
             }
           ]
         }
@@ -59,97 +23,52 @@
       "path": "packages/engine/CHANGELOG.md",
       "conversations": [
         {
-          "contributor": {
-            "type": "ai"
-          },
+          "contributor": { "type": "ai" },
           "ranges": [
             {
-              "start_line": 2,
-              "end_line": 116,
-              "revision": "65f0e6a6321c2de647350e8c4501cf864d9c72a3"
+              "start_line": 12,
+              "end_line": 14,
+              "revision": "65c36c7d2ab7db627dbbe285b75571d4e580c399"
             }
           ]
         }
       ]
     },
     {
-      "path": "packages/sdk-rust/CHANGELOG.md",
+      "path": "packages/engine/src/__tests__/conformance/delivery.test.ts",
       "conversations": [
         {
-          "contributor": {
-            "type": "ai"
-          },
+          "contributor": { "type": "ai" },
           "ranges": [
             {
-              "start_line": 2,
-              "end_line": 32,
-              "revision": "65f0e6a6321c2de647350e8c4501cf864d9c72a3"
+              "start_line": 14,
+              "end_line": 14,
+              "revision": "65c36c7d2ab7db627dbbe285b75571d4e580c399"
             },
             {
-              "start_line": 37,
-              "end_line": 44,
-              "revision": "65f0e6a6321c2de647350e8c4501cf864d9c72a3"
+              "start_line": 1564,
+              "end_line": 1635,
+              "revision": "65c36c7d2ab7db627dbbe285b75571d4e580c399"
             }
           ]
         }
       ]
     },
     {
-      "path": "packages/sdk-swift/CHANGELOG.md",
+      "path": "packages/engine/src/engine/delivery.ts",
       "conversations": [
         {
-          "contributor": {
-            "type": "ai"
-          },
+          "contributor": { "type": "ai" },
           "ranges": [
             {
-              "start_line": 2,
-              "end_line": 15,
-              "revision": "65f0e6a6321c2de647350e8c4501cf864d9c72a3"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "path": "packages/sdk-typescript/CHANGELOG.md",
-      "conversations": [
-        {
-          "contributor": {
-            "type": "ai"
-          },
-          "ranges": [
-            {
-              "start_line": 2,
-              "end_line": 66,
-              "revision": "65f0e6a6321c2de647350e8c4501cf864d9c72a3"
+              "start_line": 44,
+              "end_line": 47,
+              "revision": "65c36c7d2ab7db627dbbe285b75571d4e580c399"
             },
             {
-              "start_line": 69,
-              "end_line": 74,
-              "revision": "65f0e6a6321c2de647350e8c4501cf864d9c72a3"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "path": "packages/types/CHANGELOG.md",
-      "conversations": [
-        {
-          "contributor": {
-            "type": "ai"
-          },
-          "ranges": [
-            {
-              "start_line": 2,
-              "end_line": 22,
-              "revision": "65f0e6a6321c2de647350e8c4501cf864d9c72a3"
-            },
-            {
-              "start_line": 47,
-              "end_line": 52,
-              "revision": "65f0e6a6321c2de647350e8c4501cf864d9c72a3"
+              "start_line": 465,
+              "end_line": 467,
+              "revision": "65c36c7d2ab7db627dbbe285b75571d4e580c399"
             }
           ]
         }

--- a/.agentworkforce/trajectories/completed/2026-07/traj_hkcaas6ntnwv/summary.md
+++ b/.agentworkforce/trajectories/completed/2026-07/traj_hkcaas6ntnwv/summary.md
@@ -1,0 +1,40 @@
+# Trajectory: Fix GitHub issue #265 and deliver mergeable PR
+
+> **Status:** ✅ Completed
+> **Task:** #265
+> **Confidence:** 95%
+> **Started:** July 13, 2026 at 10:01 AM
+> **Completed:** July 13, 2026 at 10:06 AM
+
+---
+
+## Summary
+
+Bounded delivery TTL expiry to D1-safe batches, added large-backlog route and notice regression coverage, and updated changelogs
+
+**Approach:** Standard approach
+
+---
+
+## Key Decisions
+
+### Bound expiry cleanup to one oldest-first batch of 50 rows per read
+- **Chose:** Bound expiry cleanup to one oldest-first batch of 50 rows per read
+- **Reasoning:** D1 limits statements to 100 bound parameters; 50 IDs leaves room for update and predicate bindings while bounding inbox latency and preserving per-transition notices
+
+---
+
+## Chapters
+
+### 1. Work
+*Agent: default*
+
+- Bound expiry cleanup to one oldest-first batch of 50 rows per read: Bound expiry cleanup to one oldest-first batch of 50 rows per read
+- Implemented oldest-first 50-row expiry batches with a D1-like 100-placeholder regression; focused, engine, and monorepo gates are green
+
+---
+
+## Artifacts
+
+**Commits:** 65f0e6a
+**Files changed:** 8

--- a/.agentworkforce/trajectories/completed/2026-07/traj_hkcaas6ntnwv/summary.md
+++ b/.agentworkforce/trajectories/completed/2026-07/traj_hkcaas6ntnwv/summary.md
@@ -36,5 +36,5 @@ Bounded delivery TTL expiry to D1-safe batches, added large-backlog route and no
 
 ## Artifacts
 
-**Commits:** 65f0e6a
-**Files changed:** 8
+**Commits:** 65c36c7
+**Files changed:** 4

--- a/.agentworkforce/trajectories/completed/2026-07/traj_hkcaas6ntnwv/trajectory.json
+++ b/.agentworkforce/trajectories/completed/2026-07/traj_hkcaas6ntnwv/trajectory.json
@@ -69,23 +69,19 @@
     "confidence": 0.95
   },
   "commits": [
-    "65f0e6a"
+    "65c36c7"
   ],
   "filesChanged": [
-    "AGENTS.md",
     "CHANGELOG.md",
-    "README.md",
     "packages/engine/CHANGELOG.md",
-    "packages/sdk-rust/CHANGELOG.md",
-    "packages/sdk-swift/CHANGELOG.md",
-    "packages/sdk-typescript/CHANGELOG.md",
-    "packages/types/CHANGELOG.md"
+    "packages/engine/src/__tests__/conformance/delivery.test.ts",
+    "packages/engine/src/engine/delivery.ts"
   ],
   "projectId": "AgentWorkforce/relaycast",
   "tags": [],
   "_trace": {
-    "startRef": "a29b3eccc1b9ef11dc6f5351a7d626357d8833d1",
-    "endRef": "65f0e6a6321c2de647350e8c4501cf864d9c72a3",
+    "startRef": "65f0e6a6321c2de647350e8c4501cf864d9c72a3",
+    "endRef": "65c36c7d2ab7db627dbbe285b75571d4e580c399",
     "traceId": "aaaff677-e82d-4a63-b5e0-ac618bcccd56"
   }
 }

--- a/.agentworkforce/trajectories/completed/2026-07/traj_hkcaas6ntnwv/trajectory.json
+++ b/.agentworkforce/trajectories/completed/2026-07/traj_hkcaas6ntnwv/trajectory.json
@@ -1,0 +1,91 @@
+{
+  "id": "traj_hkcaas6ntnwv",
+  "version": 1,
+  "task": {
+    "title": "Fix GitHub issue #265 and deliver mergeable PR",
+    "source": {
+      "system": "plain",
+      "id": "#265"
+    }
+  },
+  "status": "completed",
+  "startedAt": "2026-07-13T14:01:52.700Z",
+  "completedAt": "2026-07-13T14:06:33.628Z",
+  "agents": [
+    {
+      "name": "default",
+      "role": "lead",
+      "joinedAt": "2026-07-13T14:04:01.485Z"
+    }
+  ],
+  "chapters": [
+    {
+      "id": "chap_segpnu8klhmx",
+      "title": "Work",
+      "agentName": "default",
+      "startedAt": "2026-07-13T14:04:01.485Z",
+      "endedAt": "2026-07-13T14:06:33.628Z",
+      "events": [
+        {
+          "ts": 1783951441486,
+          "type": "decision",
+          "content": "Bound expiry cleanup to one oldest-first batch of 50 rows per read: Bound expiry cleanup to one oldest-first batch of 50 rows per read",
+          "raw": {
+            "question": "Bound expiry cleanup to one oldest-first batch of 50 rows per read",
+            "chosen": "Bound expiry cleanup to one oldest-first batch of 50 rows per read",
+            "alternatives": [],
+            "reasoning": "D1 limits statements to 100 bound parameters; 50 IDs leaves room for update and predicate bindings while bounding inbox latency and preserving per-transition notices"
+          },
+          "significance": "high"
+        },
+        {
+          "ts": 1783951593294,
+          "type": "reflection",
+          "content": "Implemented oldest-first 50-row expiry batches with a D1-like 100-placeholder regression; focused, engine, and monorepo gates are green",
+          "raw": {
+            "focalPoints": [
+              "D1 parameter safety",
+              "bounded latency",
+              "notice idempotency",
+              "regression coverage"
+            ],
+            "confidence": 0.95
+          },
+          "significance": "high",
+          "tags": [
+            "focal:D1 parameter safety",
+            "focal:bounded latency",
+            "focal:notice idempotency",
+            "focal:regression coverage",
+            "confidence:0.95"
+          ]
+        }
+      ]
+    }
+  ],
+  "retrospective": {
+    "summary": "Bounded delivery TTL expiry to D1-safe batches, added large-backlog route and notice regression coverage, and updated changelogs",
+    "approach": "Standard approach",
+    "confidence": 0.95
+  },
+  "commits": [
+    "65f0e6a"
+  ],
+  "filesChanged": [
+    "AGENTS.md",
+    "CHANGELOG.md",
+    "README.md",
+    "packages/engine/CHANGELOG.md",
+    "packages/sdk-rust/CHANGELOG.md",
+    "packages/sdk-swift/CHANGELOG.md",
+    "packages/sdk-typescript/CHANGELOG.md",
+    "packages/types/CHANGELOG.md"
+  ],
+  "projectId": "AgentWorkforce/relaycast",
+  "tags": [],
+  "_trace": {
+    "startRef": "a29b3eccc1b9ef11dc6f5351a7d626357d8833d1",
+    "endRef": "65f0e6a6321c2de647350e8c4501cf864d9c72a3",
+    "traceId": "aaaff677-e82d-4a63-b5e0-ac618bcccd56"
+  }
+}

--- a/.agentworkforce/trajectories/completed/2026-07/traj_v1t0lx7bolpc.trace.json
+++ b/.agentworkforce/trajectories/completed/2026-07/traj_v1t0lx7bolpc.trace.json
@@ -1,0 +1,132 @@
+{
+  "version": "1.0.0",
+  "id": "11ad3a6d-5c1e-4dd8-96f3-f204fe4c85d4",
+  "timestamp": "2026-07-13T14:40:46.256Z",
+  "trajectory": "traj_v1t0lx7bolpc",
+  "files": [
+    {
+      "path": "packages/engine/src/__tests__/conformance/delivery.test.ts",
+      "conversations": [
+        {
+          "contributor": {
+            "type": "ai"
+          },
+          "ranges": [
+            {
+              "start_line": 1596,
+              "end_line": 1612,
+              "revision": "9b5913eca2cf93f91cf5ac56ab0e45e03b81346d"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "path": "packages/engine/src/adapters/node/__tests__/delivery-maintenance.test.ts",
+      "conversations": [
+        {
+          "contributor": {
+            "type": "ai"
+          },
+          "ranges": [
+            {
+              "start_line": 1,
+              "end_line": 68,
+              "revision": "9b5913eca2cf93f91cf5ac56ab0e45e03b81346d"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "path": "packages/engine/src/adapters/node/delivery-maintenance.ts",
+      "conversations": [
+        {
+          "contributor": {
+            "type": "ai"
+          },
+          "ranges": [
+            {
+              "start_line": 1,
+              "end_line": 50,
+              "revision": "9b5913eca2cf93f91cf5ac56ab0e45e03b81346d"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "path": "packages/engine/src/adapters/node/index.ts",
+      "conversations": [
+        {
+          "contributor": {
+            "type": "ai"
+          },
+          "ranges": [
+            {
+              "start_line": 16,
+              "end_line": 22,
+              "revision": "9b5913eca2cf93f91cf5ac56ab0e45e03b81346d"
+            },
+            {
+              "start_line": 161,
+              "end_line": 172,
+              "revision": "9b5913eca2cf93f91cf5ac56ab0e45e03b81346d"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "path": "packages/engine/src/db/migrations/0031_delivery_active_expiry_index.sql",
+      "conversations": [
+        {
+          "contributor": {
+            "type": "ai"
+          },
+          "ranges": [
+            {
+              "start_line": 1,
+              "end_line": 6,
+              "revision": "9b5913eca2cf93f91cf5ac56ab0e45e03b81346d"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "path": "packages/engine/src/db/schema.ts",
+      "conversations": [
+        {
+          "contributor": {
+            "type": "ai"
+          },
+          "ranges": [
+            {
+              "start_line": 948,
+              "end_line": 956,
+              "revision": "9b5913eca2cf93f91cf5ac56ab0e45e03b81346d"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "path": "packages/engine/src/engine/delivery.ts",
+      "conversations": [
+        {
+          "contributor": {
+            "type": "ai"
+          },
+          "ranges": [
+            {
+              "start_line": 468,
+              "end_line": 477,
+              "revision": "9b5913eca2cf93f91cf5ac56ab0e45e03b81346d"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/.agentworkforce/trajectories/completed/2026-07/traj_v1t0lx7bolpc/summary.md
+++ b/.agentworkforce/trajectories/completed/2026-07/traj_v1t0lx7bolpc/summary.md
@@ -1,0 +1,44 @@
+# Trajectory: Address final PR #266 maintenance review
+
+> **Status:** ✅ Completed
+> **Task:** PR #266
+> **Confidence:** 95%
+> **Started:** July 13, 2026 at 10:37 AM
+> **Completed:** July 13, 2026 at 10:40 AM
+
+---
+
+## Summary
+
+Added a planner-verified global partial index for active expiry batches and serialized Node HTTP-push/TTL maintenance with overlap coalescing and failure-isolation coverage.
+
+**Approach:** Standard approach
+
+---
+
+## Key Decisions
+
+### Added a global partial active-expiry index
+- **Chose:** Added a global partial active-expiry index
+- **Reasoning:** The scheduler sweeps across workspaces; the existing workspace-leading index cannot serve oldest-first global batches. Literal active statuses keep the SQLite partial-index predicate planner-visible.
+
+### Serialized Node delivery maintenance
+- **Chose:** Serialized Node delivery maintenance
+- **Reasoning:** HTTP push dispatch must finish before TTL expiry, and overlapping timer ticks are coalesced so a slow POST cannot race a later expiry cycle.
+
+---
+
+## Chapters
+
+### 1. Work
+*Agent: default*
+
+- Added a global partial active-expiry index: Added a global partial active-expiry index
+- Serialized Node delivery maintenance: Serialized Node delivery maintenance
+
+---
+
+## Artifacts
+
+**Commits:** 9b5913e
+**Files changed:** 7

--- a/.agentworkforce/trajectories/completed/2026-07/traj_v1t0lx7bolpc/trajectory.json
+++ b/.agentworkforce/trajectories/completed/2026-07/traj_v1t0lx7bolpc/trajectory.json
@@ -1,0 +1,80 @@
+{
+  "id": "traj_v1t0lx7bolpc",
+  "version": 1,
+  "task": {
+    "title": "Address final PR #266 maintenance review",
+    "source": {
+      "system": "plain",
+      "id": "PR #266"
+    }
+  },
+  "status": "completed",
+  "startedAt": "2026-07-13T14:37:14.308Z",
+  "completedAt": "2026-07-13T14:40:46.185Z",
+  "agents": [
+    {
+      "name": "default",
+      "role": "lead",
+      "joinedAt": "2026-07-13T14:39:20.452Z"
+    }
+  ],
+  "chapters": [
+    {
+      "id": "chap_y13g9l4mz7ib",
+      "title": "Work",
+      "agentName": "default",
+      "startedAt": "2026-07-13T14:39:20.452Z",
+      "endedAt": "2026-07-13T14:40:46.185Z",
+      "events": [
+        {
+          "ts": 1783953560453,
+          "type": "decision",
+          "content": "Added a global partial active-expiry index: Added a global partial active-expiry index",
+          "raw": {
+            "question": "Added a global partial active-expiry index",
+            "chosen": "Added a global partial active-expiry index",
+            "alternatives": [],
+            "reasoning": "The scheduler sweeps across workspaces; the existing workspace-leading index cannot serve oldest-first global batches. Literal active statuses keep the SQLite partial-index predicate planner-visible."
+          },
+          "significance": "high"
+        },
+        {
+          "ts": 1783953560805,
+          "type": "decision",
+          "content": "Serialized Node delivery maintenance: Serialized Node delivery maintenance",
+          "raw": {
+            "question": "Serialized Node delivery maintenance",
+            "chosen": "Serialized Node delivery maintenance",
+            "alternatives": [],
+            "reasoning": "HTTP push dispatch must finish before TTL expiry, and overlapping timer ticks are coalesced so a slow POST cannot race a later expiry cycle."
+          },
+          "significance": "high"
+        }
+      ]
+    }
+  ],
+  "retrospective": {
+    "summary": "Added a planner-verified global partial index for active expiry batches and serialized Node HTTP-push/TTL maintenance with overlap coalescing and failure-isolation coverage.",
+    "approach": "Standard approach",
+    "confidence": 0.95
+  },
+  "commits": [
+    "9b5913e"
+  ],
+  "filesChanged": [
+    "packages/engine/src/__tests__/conformance/delivery.test.ts",
+    "packages/engine/src/adapters/node/__tests__/delivery-maintenance.test.ts",
+    "packages/engine/src/adapters/node/delivery-maintenance.ts",
+    "packages/engine/src/adapters/node/index.ts",
+    "packages/engine/src/db/migrations/0031_delivery_active_expiry_index.sql",
+    "packages/engine/src/db/schema.ts",
+    "packages/engine/src/engine/delivery.ts"
+  ],
+  "projectId": "AgentWorkforce/relaycast",
+  "tags": [],
+  "_trace": {
+    "startRef": "e0208de5b6e4b3b01540169811d8275b396a34c6",
+    "endRef": "9b5913eca2cf93f91cf5ac56ab0e45e03b81346d",
+    "traceId": "11ad3a6d-5c1e-4dd8-96f3-f204fe4c85d4"
+  }
+}

--- a/.agentworkforce/trajectories/completed/2026-07/traj_x5kqmdgiomzn.trace.json
+++ b/.agentworkforce/trajectories/completed/2026-07/traj_x5kqmdgiomzn.trace.json
@@ -1,0 +1,25 @@
+{
+  "version": "1.0.0",
+  "id": "c4d19ec4-339b-4355-9ee0-e37ef85090f1",
+  "timestamp": "2026-07-13T14:45:28.493Z",
+  "trajectory": "traj_x5kqmdgiomzn",
+  "files": [
+    {
+      "path": "packages/engine/src/adapters/node/__tests__/delivery-maintenance.test.ts",
+      "conversations": [
+        {
+          "contributor": {
+            "type": "ai"
+          },
+          "ranges": [
+            {
+              "start_line": 65,
+              "end_line": 87,
+              "revision": "0a8324157924b110528d79723b3c86b95088952b"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/.agentworkforce/trajectories/completed/2026-07/traj_x5kqmdgiomzn/summary.md
+++ b/.agentworkforce/trajectories/completed/2026-07/traj_x5kqmdgiomzn/summary.md
@@ -1,0 +1,22 @@
+# Trajectory: Add expiry maintenance failure regression
+
+> **Status:** ✅ Completed
+> **Task:** PR #266 review
+> **Confidence:** 98%
+> **Started:** July 13, 2026 at 10:45 AM
+> **Completed:** July 13, 2026 at 10:45 AM
+
+---
+
+## Summary
+
+Added the requested regression proving expiry sweep failures are captured and do not reject the Node maintenance cycle.
+
+**Approach:** Standard approach
+
+---
+
+## Artifacts
+
+**Commits:** 0a83241
+**Files changed:** 1

--- a/.agentworkforce/trajectories/completed/2026-07/traj_x5kqmdgiomzn/trajectory.json
+++ b/.agentworkforce/trajectories/completed/2026-07/traj_x5kqmdgiomzn/trajectory.json
@@ -1,0 +1,34 @@
+{
+  "id": "traj_x5kqmdgiomzn",
+  "version": 1,
+  "task": {
+    "title": "Add expiry maintenance failure regression",
+    "source": {
+      "system": "plain",
+      "id": "PR #266 review"
+    }
+  },
+  "status": "completed",
+  "startedAt": "2026-07-13T14:45:00.016Z",
+  "completedAt": "2026-07-13T14:45:28.431Z",
+  "agents": [],
+  "chapters": [],
+  "retrospective": {
+    "summary": "Added the requested regression proving expiry sweep failures are captured and do not reject the Node maintenance cycle.",
+    "approach": "Standard approach",
+    "confidence": 0.98
+  },
+  "commits": [
+    "0a83241"
+  ],
+  "filesChanged": [
+    "packages/engine/src/adapters/node/__tests__/delivery-maintenance.test.ts"
+  ],
+  "projectId": "AgentWorkforce/relaycast",
+  "tags": [],
+  "_trace": {
+    "startRef": "08248f9e8e8287ea6fc1d196b086c0cd0f6273d6",
+    "endRef": "0a8324157924b110528d79723b3c86b95088952b",
+    "traceId": "c4d19ec4-339b-4355-9ee0-e37ef85090f1"
+  }
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,8 +36,12 @@ Relaycast is headless Slack for agents: channels, threads, DMs, reactions, files
 - Keep quickstart examples realtime-first (WebSocket subscriptions and message handlers) instead of polling-first flows.
 
 ## Changelog
-- Curate `[Unreleased]` in `CHANGELOG.md` for cross-package or user-facing release notes.
+- Curate the unreleased section in `CHANGELOG.md` for cross-package or user-facing release notes.
+- An empty post-release changelog starts at `[Unreleased]`. The first pending user-visible change must set the heading to `[Unreleased - Patch]`, `[Unreleased - Minor]`, or `[Unreleased - Major]` according to its SemVer impact.
+- The pending release level is monotonic: `Patch < Minor < Major`. Raise the heading when a higher-impact change arrives; never lower it for a later lower-impact change, and leave it unchanged for another change at the same level.
+- When a release is cut, move the pending entries under the released version and restore an empty `[Unreleased]` heading with no release level.
 - Add package-level API and migration detail to the relevant `packages/*/CHANGELOG.md` when one exists.
+- Apply the same release-level heading rules to any package changelog that receives a pending entry.
 - Keep entries concise and impact-first: one short bullet per user-visible change.
 - Omit PR links, internal review notes, test-only work, and implementation backstory unless they explain shipped impact.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 Packages without a separate changelog are covered by the cross-package notes below.
 
-## [Unreleased]
+## [Unreleased - Patch]
 
 ### Fixed
 
@@ -166,7 +166,7 @@ Packages without a separate changelog are covered by the cross-package notes bel
 
 Earlier releases are available on the [GitHub releases page](https://github.com/AgentWorkforce/relaycast/releases).
 
-[Unreleased]: https://github.com/AgentWorkforce/relaycast/compare/v6.0.3...HEAD
+[Unreleased - Patch]: https://github.com/AgentWorkforce/relaycast/compare/v6.0.3...HEAD
 [6.0.3]: https://github.com/AgentWorkforce/relaycast/compare/v6.0.2...v6.0.3
 [6.0.2]: https://github.com/AgentWorkforce/relaycast/compare/v6.0.1...v6.0.2
 [6.0.1]: https://github.com/AgentWorkforce/relaycast/compare/v6.0.0...v6.0.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ Packages without a separate changelog are covered by the cross-package notes bel
 
 ### Fixed
 
-- Kept inbox and delivery reads available while large expired-delivery backlogs drain in bounded batches.
+- Kept inbox and delivery reads independent from scheduled cleanup while large expired-delivery backlogs drain in bounded batches.
 
 ## [6.0.3] - 2026-07-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ Packages without a separate changelog are covered by the cross-package notes bel
 
 ## [Unreleased]
 
+### Fixed
+
+- Kept inbox and delivery reads available while large expired-delivery backlogs drain in bounded batches.
+
 ## [6.0.3] - 2026-07-12
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -465,6 +465,9 @@ messages can filter on the `X-Relaycast-Event` header.
 Queue/cron-backed deployments must call `sweepDueHttpPushDeliveries` from a scheduled
 handler to retry queued HTTP push deliveries whose `next_attempt_at` is due; the Node
 self-host adapter runs that sweep on its local maintenance timer.
+They must also call `sweepExpiredDeliveries` to transition expired mailbox rows in
+bounded D1-safe batches and emit sender failure notices. Inbox and delivery reads do
+not run maintenance; they remain available if a scheduled cleanup attempt fails.
 Adapters that terminate `/v1/node/ws` outside the engine request handler should delegate
 node control frames to `handleNodeControlMessage` from `@relaycast/engine/node-control`:
 the handler only needs `{ db, registry, workspaceId, nodeId, socket, raw }`, where

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -3191,7 +3191,8 @@ paths:
         List durable delivery items queued for the calling agent. Defaults to
         the non-terminal queue (`queued` + `delivered`) so an offline consumer
         can replay what it missed after reconnect, oldest first. Each item
-        carries the message payload.
+        carries the message payload. Expired rows awaiting scheduled cleanup
+        are excluded from the default active queue.
       tags:
         - Deliveries
       security:

--- a/packages/engine/CHANGELOG.md
+++ b/packages/engine/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+### Fixed
+- Bounded delivery TTL expiry work so large backlogs drain across D1-safe batches without breaking inbox reads or duplicating sender failure notices.
+
 ## [6.0.3] - 2026-07-12
 
 ### Fixed

--- a/packages/engine/CHANGELOG.md
+++ b/packages/engine/CHANGELOG.md
@@ -7,7 +7,7 @@ See the [root changelog](../../CHANGELOG.md) for cross-package release highlight
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [Unreleased - Patch]
 
 ### Fixed
 - Moved delivery TTL expiry out of inbox reads into bounded scheduled D1-safe batches, keeping reads available through cleanup failures without duplicating sender failure notices.

--- a/packages/engine/CHANGELOG.md
+++ b/packages/engine/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 ## [Unreleased]
 
 ### Fixed
-- Bounded delivery TTL expiry work so large backlogs drain across D1-safe batches without breaking inbox reads or duplicating sender failure notices.
+- Moved delivery TTL expiry out of inbox reads into bounded scheduled D1-safe batches, keeping reads available through cleanup failures without duplicating sender failure notices.
 
 ## [6.0.3] - 2026-07-12
 

--- a/packages/engine/src/__tests__/conformance/delivery.test.ts
+++ b/packages/engine/src/__tests__/conformance/delivery.test.ts
@@ -11,7 +11,7 @@ import {
   contextUpdatesOfType,
   type TestStack,
 } from './harness.js';
-import { agents, deliveries } from '../../db/schema.js';
+import { agents, deliveries, messages } from '../../db/schema.js';
 import * as messageEngine from '../../engine/message.js';
 import * as deliveryEngine from '../../engine/delivery.js';
 import { ensureDirectNodeForAgent } from '../../engine/node.js';
@@ -1559,6 +1559,78 @@ describe('durable delivery api', () => {
         expect.objectContaining({ reason: 'ttl_expired', retryable: false }),
       ]));
     });
+  });
+
+  it('drains a large expiry backlog in D1-safe batches without duplicate notices', async () => {
+    const { ws, alice, bob, messageId } = await seed();
+    const { sock: aliceSock } = await attachDirectNodeSocket(stack, ws.workspaceId, alice);
+    const [seedMessage] = await stack.runtime.deps.db
+      .select({ channelId: messages.channelId })
+      .from(messages)
+      .where(eq(messages.id, messageId));
+    const expiredAt = new Date(Date.now() - 60_000);
+    const extraCount = 120;
+
+    await stack.runtime.deps.db.insert(messages).values(Array.from({ length: extraCount }, (_, index) => ({
+      id: `expiry-message-${index}`,
+      workspaceId: ws.workspaceId,
+      channelId: seedMessage.channelId,
+      agentId: alice.agentId,
+      body: `expired ${index}`,
+    })));
+    await stack.runtime.deps.db.insert(deliveries).values(Array.from({ length: extraCount }, (_, index) => ({
+      id: `expiry-delivery-${index}`,
+      workspaceId: ws.workspaceId,
+      messageId: `expiry-message-${index}`,
+      agentId: bob.agentId,
+      status: 'queued',
+      seq: index + 2,
+      expiresAt: expiredAt,
+    })));
+    await stack.runtime.deps.db
+      .update(deliveries)
+      .set({ expiresAt: expiredAt })
+      .where(eq(deliveries.messageId, messageId));
+
+    // Emulate D1's documented ceiling against the real SQL emitted by Drizzle.
+    // The regression used to put all 121 delivery IDs in one UPDATE and trip this guard.
+    const sqlite = stack.runtime.handle.sqlite;
+    const prepare = sqlite.prepare.bind(sqlite);
+    sqlite.prepare = ((source: string) => {
+      const parameterCount = (source.match(/\?/g) ?? []).length;
+      if (parameterCount > 100) {
+        throw new Error(`D1_ERROR: too many SQL variables at offset 100 (${parameterCount})`);
+      }
+      return prepare(source);
+    }) as typeof sqlite.prepare;
+
+    const deadLetteredCount = async () => (await stack.runtime.deps.db
+      .select({ id: deliveries.id })
+      .from(deliveries)
+      .where(eq(deliveries.status, 'dead_lettered'))).length;
+
+    const inbox = await stack.app.request('/v1/inbox', {
+      headers: { authorization: `Bearer ${bob.token}` },
+    });
+    expect(inbox.status).toBe(200);
+    expect(await deadLetteredCount()).toBe(50);
+
+    expect(await listDeliveries(bob.token)).toHaveLength(21);
+    expect(await deadLetteredCount()).toBe(100);
+    expect(await listDeliveries(bob.token)).toHaveLength(0);
+    expect(await deadLetteredCount()).toBe(121);
+
+    await waitForAssertion(() => {
+      const notices = contextUpdatesOfType(aliceSock, 'delivery.failed')
+        .filter((event) => event.data && (event.data as Record<string, unknown>).reason === 'ttl_expired');
+      expect(notices).toHaveLength(121);
+      expect(new Set(notices.map((event) => (event.data as Record<string, unknown>).delivery_id)).size).toBe(121);
+    });
+
+    expect(await listDeliveries(bob.token)).toHaveLength(0);
+    await new Promise((resolve) => setTimeout(resolve, 25));
+    expect(contextUpdatesOfType(aliceSock, 'delivery.failed')
+      .filter((event) => event.data && (event.data as Record<string, unknown>).reason === 'ttl_expired')).toHaveLength(121);
   });
 
   it('rejects new deliveries over the depth cap and sends feedback to the sender', async () => {

--- a/packages/engine/src/__tests__/conformance/delivery.test.ts
+++ b/packages/engine/src/__tests__/conformance/delivery.test.ts
@@ -1563,13 +1563,16 @@ describe('durable delivery api', () => {
 
   it('drains a large expiry backlog in D1-safe batches without duplicate notices', async () => {
     const { ws, alice, bob, messageId } = await seed();
+    const charlie = await registerAgent(stack.app, ws.workspaceKey, 'charlie');
     const { sock: aliceSock } = await attachDirectNodeSocket(stack, ws.workspaceId, alice);
     const [seedMessage] = await stack.runtime.deps.db
       .select({ channelId: messages.channelId })
       .from(messages)
       .where(eq(messages.id, messageId));
-    const expiredAt = new Date(Date.now() - 60_000);
+    const bobExpiredAt = new Date(Date.now() - 60_000);
+    const charlieExpiredAt = new Date(Date.now() - 120_000);
     const extraCount = 120;
+    const charlieCount = 60;
 
     await stack.runtime.deps.db.insert(messages).values(Array.from({ length: extraCount }, (_, index) => ({
       id: `expiry-message-${index}`,
@@ -1582,14 +1585,14 @@ describe('durable delivery api', () => {
       id: `expiry-delivery-${index}`,
       workspaceId: ws.workspaceId,
       messageId: `expiry-message-${index}`,
-      agentId: bob.agentId,
+      agentId: index < charlieCount ? charlie.agentId : bob.agentId,
       status: 'queued',
-      seq: index + 2,
-      expiresAt: expiredAt,
+      seq: index < charlieCount ? index + 1 : index - charlieCount + 2,
+      expiresAt: index < charlieCount ? charlieExpiredAt : bobExpiredAt,
     })));
     await stack.runtime.deps.db
       .update(deliveries)
-      .set({ expiresAt: expiredAt })
+      .set({ expiresAt: bobExpiredAt })
       .where(eq(deliveries.messageId, messageId));
 
     // Emulate D1's documented ceiling against the real SQL emitted by Drizzle.
@@ -1615,7 +1618,9 @@ describe('durable delivery api', () => {
     expect(inbox.status).toBe(200);
     expect(await deadLetteredCount()).toBe(50);
 
-    expect(await listDeliveries(bob.token)).toHaveLength(21);
+    // The second sweep dead-letters Charlie's remaining 10 rows and Bob's oldest
+    // 40. Bob's 21 still-unswept expired rows must not leak through the active list.
+    expect(await listDeliveries(bob.token)).toHaveLength(0);
     expect(await deadLetteredCount()).toBe(100);
     expect(await listDeliveries(bob.token)).toHaveLength(0);
     expect(await deadLetteredCount()).toBe(121);

--- a/packages/engine/src/__tests__/conformance/delivery.test.ts
+++ b/packages/engine/src/__tests__/conformance/delivery.test.ts
@@ -18,7 +18,7 @@ import { ensureDirectNodeForAgent } from '../../engine/node.js';
 import { sendNodeDeliveriesToAgents } from '../../engine/nodeDeliver.js';
 import type { NodeConnectionRegistry } from '../../ports/realtime.js';
 import { pruneExpired } from '../../engine/retention.js';
-import { routeDeliveryOutcomes } from '../../routes/deliveryRouting.js';
+import { routeDeliveryOutcomes, sweepExpiredDeliveries } from '../../routes/deliveryRouting.js';
 import { deliverPendingToNode, handleNodeReconnect } from '../../index.js';
 
 /**
@@ -1552,6 +1552,7 @@ describe('durable delivery api', () => {
 
     await new Promise((r) => setTimeout(r, 1100));
     expect(await listDeliveries(bob.token)).toHaveLength(0);
+    expect(await sweepExpiredDeliveries(stack.runtime.deps, { workspaceId: ws.workspaceId })).toBe(1);
     expect(await listDeliveries(bob.token, '?status=dead_lettered')).toHaveLength(1);
     await new Promise((r) => setTimeout(r, 50));
     await waitForAssertion(() => {
@@ -1561,7 +1562,7 @@ describe('durable delivery api', () => {
     });
   });
 
-  it('drains a large expiry backlog in D1-safe batches without duplicate notices', async () => {
+  it('scheduled expiry drains a large backlog in D1-safe batches without affecting reads', async () => {
     const { ws, alice, bob, messageId } = await seed();
     const charlie = await registerAgent(stack.app, ws.workspaceKey, 'charlie');
     const { sock: aliceSock } = await attachDirectNodeSocket(stack, ws.workspaceId, alice);
@@ -1616,13 +1617,20 @@ describe('durable delivery api', () => {
       headers: { authorization: `Bearer ${bob.token}` },
     });
     expect(inbox.status).toBe(200);
+    expect(await listDeliveries(bob.token)).toHaveLength(0);
+    // Reads filter expired active rows but do not mutate them or depend on cleanup.
+    expect(await deadLetteredCount()).toBe(0);
+
+    expect(await sweepExpiredDeliveries(stack.runtime.deps)).toBe(50);
     expect(await deadLetteredCount()).toBe(50);
 
-    // The second sweep dead-letters Charlie's remaining 10 rows and Bob's oldest
-    // 40. Bob's 21 still-unswept expired rows must not leak through the active list.
+    expect(await sweepExpiredDeliveries(stack.runtime.deps)).toBe(50);
+    // Charlie's remaining 10 rows and Bob's oldest 40 transitioned. Bob's 21
+    // still-unswept expired rows must not leak through the active list.
     expect(await listDeliveries(bob.token)).toHaveLength(0);
     expect(await deadLetteredCount()).toBe(100);
-    expect(await listDeliveries(bob.token)).toHaveLength(0);
+
+    expect(await sweepExpiredDeliveries(stack.runtime.deps)).toBe(21);
     expect(await deadLetteredCount()).toBe(121);
 
     await waitForAssertion(() => {
@@ -1632,10 +1640,41 @@ describe('durable delivery api', () => {
       expect(new Set(notices.map((event) => (event.data as Record<string, unknown>).delivery_id)).size).toBe(121);
     });
 
-    expect(await listDeliveries(bob.token)).toHaveLength(0);
+    expect(await sweepExpiredDeliveries(stack.runtime.deps)).toBe(0);
     await new Promise((resolve) => setTimeout(resolve, 25));
     expect(contextUpdatesOfType(aliceSock, 'delivery.failed')
       .filter((event) => event.data && (event.data as Record<string, unknown>).reason === 'ttl_expired')).toHaveLength(121);
+  });
+
+  it('keeps inbox and delivery reads available when scheduled expiry fails', async () => {
+    const { ws, bob, messageId } = await seed();
+    await stack.runtime.deps.db
+      .update(deliveries)
+      .set({ expiresAt: new Date(Date.now() - 60_000) })
+      .where(eq(deliveries.messageId, messageId));
+
+    const sqlite = stack.runtime.handle.sqlite;
+    const prepare = sqlite.prepare.bind(sqlite);
+    sqlite.prepare = ((source: string) => {
+      if (source.startsWith('update "deliveries"') && source.includes('"dead_lettered_at"')) {
+        throw new Error('simulated scheduled expiry failure');
+      }
+      return prepare(source);
+    }) as typeof sqlite.prepare;
+
+    await expect(sweepExpiredDeliveries(stack.runtime.deps, { workspaceId: ws.workspaceId }))
+      .rejects.toThrow('simulated scheduled expiry failure');
+
+    const inbox = await stack.app.request('/v1/inbox', {
+      headers: { authorization: `Bearer ${bob.token}` },
+    });
+    expect(inbox.status).toBe(200);
+    expect(await listDeliveries(bob.token)).toHaveLength(0);
+    const [stored] = await stack.runtime.deps.db
+      .select({ status: deliveries.status })
+      .from(deliveries)
+      .where(eq(deliveries.messageId, messageId));
+    expect(stored.status).toBe('queued');
   });
 
   it('rejects new deliveries over the depth cap and sends feedback to the sender', async () => {

--- a/packages/engine/src/__tests__/conformance/delivery.test.ts
+++ b/packages/engine/src/__tests__/conformance/delivery.test.ts
@@ -1596,6 +1596,17 @@ describe('durable delivery api', () => {
       .set({ expiresAt: bobExpiredAt })
       .where(eq(deliveries.messageId, messageId));
 
+    const expiryPlan = stack.runtime.handle.sqlite
+      .prepare(`EXPLAIN QUERY PLAN
+        SELECT id FROM deliveries
+        WHERE status IN ('queued', 'delivered')
+          AND expires_at IS NOT NULL
+          AND expires_at <= ?
+        ORDER BY expires_at, id
+        LIMIT 50`)
+      .all(Math.floor(Date.now() / 1000)) as Array<{ detail: string }>;
+    expect(expiryPlan.some((step) => step.detail.includes('idx_deliveries_active_expiry'))).toBe(true);
+
     // Emulate D1's documented ceiling against the real SQL emitted by Drizzle.
     // The regression used to put all 121 delivery IDs in one UPDATE and trip this guard.
     const sqlite = stack.runtime.handle.sqlite;

--- a/packages/engine/src/adapters/node/__tests__/delivery-maintenance.test.ts
+++ b/packages/engine/src/adapters/node/__tests__/delivery-maintenance.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { EngineDeps } from '../../../ports/index.js';
+import { createDeliveryMaintenanceRunner } from '../delivery-maintenance.js';
+
+function deferred(): { promise: Promise<void>; resolve: () => void } {
+  let resolve!: () => void;
+  const promise = new Promise<void>((done) => {
+    resolve = done;
+  });
+  return { promise, resolve };
+}
+
+describe('Node delivery maintenance', () => {
+  it('serializes HTTP push and expiry and coalesces overlapping cycles', async () => {
+    const pushFinished = deferred();
+    const order: string[] = [];
+    const sweepHttpPush = vi.fn(async () => {
+      order.push('push:start');
+      await pushFinished.promise;
+      order.push('push:end');
+    });
+    const sweepExpiry = vi.fn(async () => {
+      order.push('expiry');
+    });
+    const deps = {
+      telemetry: { captureException: vi.fn() },
+    } as unknown as EngineDeps;
+    const run = createDeliveryMaintenanceRunner(deps, { sweepHttpPush, sweepExpiry });
+
+    const first = run();
+    const overlapping = run();
+
+    expect(overlapping).toBe(first);
+    expect(sweepHttpPush).toHaveBeenCalledTimes(1);
+    expect(sweepExpiry).not.toHaveBeenCalled();
+
+    pushFinished.resolve();
+    await first;
+
+    expect(order).toEqual(['push:start', 'push:end', 'expiry']);
+    expect(sweepExpiry).toHaveBeenCalledTimes(1);
+
+    await run();
+    expect(sweepHttpPush).toHaveBeenCalledTimes(2);
+    expect(sweepExpiry).toHaveBeenCalledTimes(2);
+  });
+
+  it('still runs expiry when the HTTP push sweep fails', async () => {
+    const error = new Error('push sweep failed');
+    const captureException = vi.fn();
+    const sweepExpiry = vi.fn(async () => {});
+    const deps = {
+      telemetry: { captureException },
+    } as unknown as EngineDeps;
+    const run = createDeliveryMaintenanceRunner(deps, {
+      sweepHttpPush: vi.fn(async () => { throw error; }),
+      sweepExpiry,
+    });
+
+    await expect(run()).resolves.toBeUndefined();
+
+    expect(sweepExpiry).toHaveBeenCalledTimes(1);
+    expect(captureException).toHaveBeenCalledWith(error, {
+      source: 'node.maintenance',
+      op: 'http_push_delivery',
+    });
+  });
+});

--- a/packages/engine/src/adapters/node/__tests__/delivery-maintenance.test.ts
+++ b/packages/engine/src/adapters/node/__tests__/delivery-maintenance.test.ts
@@ -65,4 +65,23 @@ describe('Node delivery maintenance', () => {
       op: 'http_push_delivery',
     });
   });
+
+  it('captures expiry failures without rejecting the maintenance cycle', async () => {
+    const error = new Error('expiry sweep failed');
+    const captureException = vi.fn();
+    const deps = {
+      telemetry: { captureException },
+    } as unknown as EngineDeps;
+    const run = createDeliveryMaintenanceRunner(deps, {
+      sweepHttpPush: vi.fn(async () => {}),
+      sweepExpiry: vi.fn(async () => { throw error; }),
+    });
+
+    await expect(run()).resolves.toBeUndefined();
+
+    expect(captureException).toHaveBeenCalledWith(error, {
+      source: 'node.maintenance',
+      op: 'delivery_expiry',
+    });
+  });
 });

--- a/packages/engine/src/adapters/node/delivery-maintenance.ts
+++ b/packages/engine/src/adapters/node/delivery-maintenance.ts
@@ -1,0 +1,50 @@
+import type { EngineDeps } from '../../ports/index.js';
+import { sweepDueHttpPushDeliveries, sweepExpiredDeliveries } from '../../routes/deliveryRouting.js';
+
+interface DeliveryMaintenanceOperations {
+  sweepHttpPush: (deps: EngineDeps) => Promise<unknown>;
+  sweepExpiry: (deps: EngineDeps) => Promise<unknown>;
+}
+
+/**
+ * Serialize delivery maintenance so an in-flight HTTP push cannot be expired
+ * while its POST is still pending. Calls made while a cycle is running share
+ * that cycle rather than queueing an unbounded maintenance backlog.
+ */
+export function createDeliveryMaintenanceRunner(
+  deps: EngineDeps,
+  operations: DeliveryMaintenanceOperations = {
+    sweepHttpPush: sweepDueHttpPushDeliveries,
+    sweepExpiry: sweepExpiredDeliveries,
+  },
+): () => Promise<void> {
+  let running: Promise<void> | undefined;
+
+  return () => {
+    if (running) return running;
+
+    const cycle = (async () => {
+      try {
+        await operations.sweepHttpPush(deps);
+      } catch (err) {
+        deps.telemetry.captureException(err, {
+          source: 'node.maintenance',
+          op: 'http_push_delivery',
+        });
+      }
+
+      try {
+        await operations.sweepExpiry(deps);
+      } catch (err) {
+        deps.telemetry.captureException(err, {
+          source: 'node.maintenance',
+          op: 'delivery_expiry',
+        });
+      }
+    })();
+    running = cycle.finally(() => {
+      running = undefined;
+    });
+    return running;
+  };
+}

--- a/packages/engine/src/adapters/node/index.ts
+++ b/packages/engine/src/adapters/node/index.ts
@@ -16,7 +16,7 @@ import { LocalFileStorage, createFileRouteHandler, FILE_ROUTE_PREFIX } from './f
 import { sweepOfflineNodes } from '../../engine/node.js';
 import { sweepTimedOutInvocations } from '../../engine/action.js';
 import { sendNodePresenceContext } from '../../engine/nodeContext.js';
-import { sweepDueHttpPushDeliveries } from '../../routes/deliveryRouting.js';
+import { sweepDueHttpPushDeliveries, sweepExpiredDeliveries } from '../../routes/deliveryRouting.js';
 
 export {
   InProcessRealtime,
@@ -165,6 +165,9 @@ export function createNodeRuntime(options: NodeRuntimeOptions): NodeRuntime {
     void sweepOfflineNodes(db, realtime).catch(() => {});
     void sweepTimedOutInvocations(db, realtime).catch(() => {});
     void sweepDueHttpPushDeliveries(deps).catch(() => {});
+    void sweepExpiredDeliveries(deps).catch((err) => {
+      telemetry.captureException(err, { source: 'node.maintenance', op: 'delivery_expiry' });
+    });
   }, 15_000);
   (sweepTimer as { unref?: () => void }).unref?.();
 

--- a/packages/engine/src/adapters/node/index.ts
+++ b/packages/engine/src/adapters/node/index.ts
@@ -16,7 +16,7 @@ import { LocalFileStorage, createFileRouteHandler, FILE_ROUTE_PREFIX } from './f
 import { sweepOfflineNodes } from '../../engine/node.js';
 import { sweepTimedOutInvocations } from '../../engine/action.js';
 import { sendNodePresenceContext } from '../../engine/nodeContext.js';
-import { sweepDueHttpPushDeliveries, sweepExpiredDeliveries } from '../../routes/deliveryRouting.js';
+import { createDeliveryMaintenanceRunner } from './delivery-maintenance.js';
 
 export {
   InProcessRealtime,
@@ -161,13 +161,12 @@ export function createNodeRuntime(options: NodeRuntimeOptions): NodeRuntime {
 
   realtime.setNodeCompletionDeps(deps);
 
+  const runDeliveryMaintenance = createDeliveryMaintenanceRunner(deps);
+
   const sweepTimer = setInterval(() => {
     void sweepOfflineNodes(db, realtime).catch(() => {});
     void sweepTimedOutInvocations(db, realtime).catch(() => {});
-    void sweepDueHttpPushDeliveries(deps).catch(() => {});
-    void sweepExpiredDeliveries(deps).catch((err) => {
-      telemetry.captureException(err, { source: 'node.maintenance', op: 'delivery_expiry' });
-    });
+    void runDeliveryMaintenance();
   }, 15_000);
   (sweepTimer as { unref?: () => void }).unref?.();
 

--- a/packages/engine/src/db/migrations/0031_delivery_active_expiry_index.sql
+++ b/packages/engine/src/db/migrations/0031_delivery_active_expiry_index.sql
@@ -1,0 +1,6 @@
+-- The scheduled expiry sweep is global, so its oldest-first query needs an
+-- index that does not begin with workspace_id. Restrict it to the two active
+-- statuses to keep the index small as delivery history accumulates.
+CREATE INDEX IF NOT EXISTS idx_deliveries_active_expiry
+  ON deliveries(expires_at, id)
+  WHERE status IN ('queued', 'delivered') AND expires_at IS NOT NULL;

--- a/packages/engine/src/db/schema.ts
+++ b/packages/engine/src/db/schema.ts
@@ -948,6 +948,9 @@ export const deliveries = sqliteTable(
     index('idx_deliveries_agent').on(table.agentId, table.createdAt),
     index('idx_deliveries_agent_status_seq').on(table.workspaceId, table.agentId, table.status, table.seq),
     index('idx_deliveries_expires').on(table.workspaceId, table.status, table.expiresAt),
+    index('idx_deliveries_active_expiry')
+      .on(table.expiresAt, table.id)
+      .where(sql`${table.status} IN ('queued', 'delivered') AND ${table.expiresAt} IS NOT NULL`),
     index('idx_deliveries_status').on(table.workspaceId, table.status, table.createdAt),
     index('idx_deliveries_http_push_due').on(table.workspaceId, table.routeNodeKind, table.status, table.nextAttemptAt),
   ],

--- a/packages/engine/src/engine/delivery.ts
+++ b/packages/engine/src/engine/delivery.ts
@@ -468,7 +468,10 @@ export async function expireDueDeliveries(
     .innerJoin(agents, eq(deliveries.agentId, agents.id))
     .where(and(
       workspaceId ? eq(deliveries.workspaceId, workspaceId) : undefined,
-      inArray(deliveries.status, [...ACTIVE_DELIVERY_STATUSES]),
+      // Keep these literals aligned with idx_deliveries_active_expiry. SQLite
+      // can only select a partial index when its predicate is visible while
+      // planning; parameterizing the two statuses would hide that implication.
+      sql`${deliveries.status} IN ('queued', 'delivered')`,
       sql`${deliveries.expiresAt} IS NOT NULL AND ${deliveries.expiresAt} <= ${nowSeconds}`,
     ))
     .orderBy(asc(deliveries.expiresAt), asc(deliveries.id))

--- a/packages/engine/src/engine/delivery.ts
+++ b/packages/engine/src/engine/delivery.ts
@@ -96,6 +96,12 @@ export async function listDeliveries(
   const statusFilter = opts.status
     ? eq(deliveries.status, opts.status)
     : inArray(deliveries.status, [...ACTIVE_DELIVERY_STATUSES]);
+  // A bounded workspace sweep may spend its batch on another agent's older
+  // backlog. Never expose this agent's still-unswept expired rows through the
+  // default active queue; explicit status queries continue to reflect stored state.
+  const activeExpiryFilter = opts.status
+    ? undefined
+    : sql`(${deliveries.expiresAt} IS NULL OR ${deliveries.expiresAt} > ${Math.floor(Date.now() / 1000)})`;
 
   const rows = await db
     .select()
@@ -105,6 +111,7 @@ export async function listDeliveries(
         eq(deliveries.workspaceId, workspaceId),
         eq(deliveries.agentId, agentId),
         statusFilter,
+        activeExpiryFilter,
       ),
     )
     .orderBy(asc(deliveries.createdAt), asc(deliveries.id))

--- a/packages/engine/src/engine/delivery.ts
+++ b/packages/engine/src/engine/delivery.ts
@@ -439,6 +439,7 @@ export async function markDeliveriesDelivered(
 }
 
 export interface DeliveryFailureNotice {
+  workspace_id: string;
   delivery_id: string;
   message_id: string;
   sender_agent_id: string;
@@ -452,7 +453,7 @@ export interface DeliveryFailureNotice {
 
 export async function expireDueDeliveries(
   db: Db,
-  workspaceId: string,
+  workspaceId: string | undefined,
   now: Date = new Date(),
 ): Promise<DeliveryFailureNotice[]> {
   const nowSeconds = Math.floor(now.getTime() / 1000);
@@ -466,7 +467,7 @@ export async function expireDueDeliveries(
     .innerJoin(messages, eq(deliveries.messageId, messages.id))
     .innerJoin(agents, eq(deliveries.agentId, agents.id))
     .where(and(
-      eq(deliveries.workspaceId, workspaceId),
+      workspaceId ? eq(deliveries.workspaceId, workspaceId) : undefined,
       inArray(deliveries.status, [...ACTIVE_DELIVERY_STATUSES]),
       sql`${deliveries.expiresAt} IS NOT NULL AND ${deliveries.expiresAt} <= ${nowSeconds}`,
     ))
@@ -486,7 +487,7 @@ export async function expireDueDeliveries(
       updatedAt: now,
     })
     .where(and(
-      eq(deliveries.workspaceId, workspaceId),
+      workspaceId ? eq(deliveries.workspaceId, workspaceId) : undefined,
       inArray(deliveries.id, ids),
       notInArray(deliveries.status, ['acked', 'dead_lettered', 'failed']),
     ))
@@ -496,6 +497,7 @@ export async function expireDueDeliveries(
   return due
     .filter((row) => row.senderAgentId && updatedIds.has(row.delivery.id))
     .map((row) => ({
+      workspace_id: row.delivery.workspaceId,
       delivery_id: row.delivery.id,
       message_id: row.delivery.messageId,
       sender_agent_id: row.senderAgentId,

--- a/packages/engine/src/engine/delivery.ts
+++ b/packages/engine/src/engine/delivery.ts
@@ -41,6 +41,10 @@ export interface RoutableDeliveryEvent {
 
 const ACTIVE_DELIVERY_STATUSES = ['queued', 'delivered'] as const;
 const TERMINAL_SUCCESS_STATUS = 'acked';
+// Keep expiry work bounded per request and leave ample room under D1's
+// 100-parameter ceiling for the UPDATE's SET and status/workspace predicates.
+// A larger backlog drains oldest-first across subsequent inbox/delivery reads.
+const DELIVERY_EXPIRY_BATCH_SIZE = 50;
 
 function serializeDelivery(row: DeliveryRow & { channelId?: string }) {
   return {
@@ -458,7 +462,9 @@ export async function expireDueDeliveries(
       eq(deliveries.workspaceId, workspaceId),
       inArray(deliveries.status, [...ACTIVE_DELIVERY_STATUSES]),
       sql`${deliveries.expiresAt} IS NOT NULL AND ${deliveries.expiresAt} <= ${nowSeconds}`,
-    ));
+    ))
+    .orderBy(asc(deliveries.expiresAt), asc(deliveries.id))
+    .limit(DELIVERY_EXPIRY_BATCH_SIZE);
 
   if (due.length === 0) return [];
 

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -53,6 +53,7 @@ export { runA2aHealthChecks } from './engine/a2a-health.js';
 // `next_attempt_at` is due. The Node adapter wires the same helper to its local
 // maintenance interval for self-hosted runtimes.
 export { sweepDueHttpPushDeliveries } from './routes/deliveryRouting.js';
+export { sweepExpiredDeliveries } from './routes/deliveryRouting.js';
 export { deliverPendingToNode } from './engine/delivery.js';
 export { handleNodeReconnect } from './node-reconnect.js';
 export { handleAgentDisconnect } from './agent-disconnect.js';

--- a/packages/engine/src/routes/delivery.ts
+++ b/packages/engine/src/routes/delivery.ts
@@ -4,7 +4,6 @@ import { requireAgentToken } from '../middleware/auth.js';
 import { rateLimit } from '../middleware/rateLimit.js';
 import * as deliveryEngine from '../engine/delivery.js';
 import { fanoutToAgents } from './fanout.js';
-import { notifyDeliveryFailures } from './deliveryRouting.js';
 import { runInBackground } from './background.js';
 import { errorResponse } from '../lib/httpError.js';
 import {
@@ -34,10 +33,6 @@ deliveryRoutes.get(
       const db = c.get('db');
       const workspace = c.get('workspace');
       const agent = c.get('agent');
-      const expired = await deliveryEngine.expireDueDeliveries(db, workspace.id);
-      if (expired.length > 0) {
-        runInBackground(c, notifyDeliveryFailures(c, expired), 'fanout delivery expired');
-      }
       const result = await deliveryEngine.listDeliveries(db, workspace.id, agent!.id, parsed.data);
       return jsonOk(c, result);
     } catch (err: unknown) {

--- a/packages/engine/src/routes/deliveryRouting.ts
+++ b/packages/engine/src/routes/deliveryRouting.ts
@@ -494,6 +494,50 @@ export async function sweepDueHttpPushDeliveries(
   return due.length;
 }
 
+async function notifyDeliveryFailuresForContext(
+  ctx: RoutingContext,
+  notices: deliveryEngine.DeliveryFailureNotice[],
+): Promise<void> {
+  for (const notice of notices) {
+    await fanoutToAgentsForContext(ctx, [notice.sender_agent_id], 'delivery.failed', {
+      delivery_id: notice.delivery_id,
+      message_id: notice.message_id,
+      target_agent_id: notice.target_agent_id,
+      target_agent_name: notice.target_agent_name,
+      seq: notice.seq,
+      reason: notice.reason,
+      error: notice.error,
+      retryable: notice.retryable,
+    });
+  }
+}
+
+/**
+ * Scheduled TTL expiry maintenance. Each workspace advances by at most one
+ * D1-safe delivery batch per invocation; adapters call this on a cadence rather
+ * than coupling mailbox reads to cleanup work.
+ */
+export async function sweepExpiredDeliveries(
+  engine: EngineDeps,
+  opts: { workspaceId?: string; now?: Date } = {},
+): Promise<number> {
+  const now = opts.now ?? new Date();
+  const notices = await deliveryEngine.expireDueDeliveries(engine.db, opts.workspaceId, now);
+  const byWorkspace = new Map<string, deliveryEngine.DeliveryFailureNotice[]>();
+  for (const notice of notices) {
+    const workspaceNotices = byWorkspace.get(notice.workspace_id) ?? [];
+    workspaceNotices.push(notice);
+    byWorkspace.set(notice.workspace_id, workspaceNotices);
+  }
+  for (const [workspaceId, workspaceNotices] of byWorkspace) {
+    await notifyDeliveryFailuresForContext(
+      { db: engine.db, workspaceId, engine },
+      workspaceNotices,
+    );
+  }
+  return notices.length;
+}
+
 export async function notifyDeliveryRejections(
   c: HonoContext,
   senderAgentId: string,
@@ -509,25 +553,6 @@ export async function notifyDeliveryRejections(
       reason: rejection.reason,
       error: rejection.error,
       retryable: rejection.retryable,
-    });
-  }
-}
-
-export async function notifyDeliveryFailures(
-  c: HonoContext,
-  notices: deliveryEngine.DeliveryFailureNotice[],
-): Promise<void> {
-  if (notices.length === 0) return;
-  for (const notice of notices) {
-    await fanoutToAgents(c, [notice.sender_agent_id], 'delivery.failed', {
-      delivery_id: notice.delivery_id,
-      message_id: notice.message_id,
-      target_agent_id: notice.target_agent_id,
-      target_agent_name: notice.target_agent_name,
-      seq: notice.seq,
-      reason: notice.reason,
-      error: notice.error,
-      retryable: notice.retryable,
     });
   }
 }

--- a/packages/engine/src/routes/inbox.ts
+++ b/packages/engine/src/routes/inbox.ts
@@ -3,9 +3,6 @@ import type { AppEnv } from '../env.js';
 import { requireAgentToken } from '../middleware/auth.js';
 import { rateLimit } from '../middleware/rateLimit.js';
 import * as inboxEngine from '../engine/inbox.js';
-import * as deliveryEngine from '../engine/delivery.js';
-import { notifyDeliveryFailures } from './deliveryRouting.js';
-import { runInBackground } from './background.js';
 import { errorResponse } from '../lib/httpError.js';
 import { jsonOk } from '../lib/httpResponse.js';
 
@@ -21,10 +18,6 @@ inboxRoutes.get(
       const db = c.get('db');
       const workspace = c.get('workspace');
       const agent = c.get('agent');
-      const expired = await deliveryEngine.expireDueDeliveries(db, workspace.id);
-      if (expired.length > 0) {
-        runInBackground(c, notifyDeliveryFailures(c, expired), 'fanout delivery expired');
-      }
       const result = await inboxEngine.getInbox(db, workspace.id, agent!.id);
       return jsonOk(c, result);
     } catch (err: unknown) {


### PR DESCRIPTION
## Summary

- cap TTL expiry cleanup at 50 deliveries per scheduled sweep
- run expiry from Node maintenance and export a helper for cron-backed adapters
- remove expiry mutation from inbox and delivery reads
- drain the oldest expired deliveries first across subsequent sweeps
- add a global partial active-expiry index for efficient oldest-first scheduling
- serialize Node HTTP-push and TTL maintenance, coalescing overlapping timer cycles
- exclude still-unswept expired rows from default active delivery lists
- preserve failure notices only for rows transitioned by the current batch
- add D1-limit, query-plan, read-isolation, maintenance-ordering, and failure-isolation regressions
- document monotonic `Unreleased - Patch/Minor/Major` changelog headings and mark this pending release as Patch

## Root cause

`expireDueDeliveries()` selected every expired delivery in a workspace, then bound all returned IDs into one `UPDATE ... IN (...)`. A backlog above the D1 parameter limit caused `GET /v1/inbox` and `GET /v1/deliveries` to fail before returning mailbox data.

## Impact

Inbox and delivery reads remain available even when scheduled cleanup fails. Large expiry backlogs drain in bounded global batches using a planner-verified active-expiry index, expired rows cannot leak into active queue responses, and sender failure notifications remain limited to rows transitioned by each sweep. Node maintenance waits for HTTP-push dispatch before expiring deliveries, preventing contradictory success/failure outcomes.

The changelog now records the highest pending SemVer level for manual releases and resets to plain `Unreleased` after a release.

## Validation

- `npm test --workspace=@relaycast/engine` (461 tests)
- `npm run typecheck --workspace=@relaycast/engine`
- `npm run lint --workspace=@relaycast/engine`
- `npx turbo build lint test` (build/lint passed; the sandbox-only localhost bind test was rerun successfully outside the sandbox)
- changelog heading/link consistency and Markdown whitespace checks

Closes #265