### PR TITLE
fix(swift): decode hosted agent lifecycle statuses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Packages without a separate changelog are covered by the cross-package notes bel
 
 ### Fixed
 
+- Allowed Swift clients to decode hosted agent lifecycle statuses and complete realtime connections.
 - Kept inbox and delivery reads independent from scheduled cleanup while large expired-delivery backlogs drain in bounded batches.
 
 ## [6.0.3] - 2026-07-12

--- a/packages/sdk-swift/CHANGELOG.md
+++ b/packages/sdk-swift/CHANGELOG.md
@@ -4,7 +4,9 @@ All notable changes to `relaycast-swift` will be documented in this file.
 
 See the [root changelog](../../CHANGELOG.md) for cross-package release highlights.
 
-## [Unreleased]
+## [Unreleased - Patch]
+
+- Allowed agent models to decode the hosted lifecycle statuses used during realtime connection setup.
 
 ## [6.0.0] - 2026-07-09
 

--- a/packages/sdk-swift/Sources/Relaycast/Models.swift
+++ b/packages/sdk-swift/Sources/Relaycast/Models.swift
@@ -268,6 +268,10 @@ public enum AgentType: String, Codable, Sendable {
 }
 
 public enum AgentStatus: String, Codable, Sendable {
+    case active
+    case idle
+    case blocked
+    case waiting
     case online
     case offline
     case away

--- a/packages/sdk-swift/Tests/RelaycastTests/RelaycastTests.swift
+++ b/packages/sdk-swift/Tests/RelaycastTests/RelaycastTests.swift
@@ -10,6 +10,13 @@ final class RelaycastTests: XCTestCase {
         super.tearDown()
     }
 
+    func testAgentStatusDecodesHostedLifecycleStatuses() throws {
+        for status in ["active", "idle", "blocked", "waiting", "offline"] {
+            let decoded = try JSONDecoder().decode(AgentStatus.self, from: Data("\"\(status)\"".utf8))
+            XCTAssertEqual(decoded.rawValue, status)
+        }
+    }
+
     func testHttpClientEncodesSnakeCaseAndOriginHeaders() async throws {
         let session = makeMockSession()
         let client = try HttpClient(


### PR DESCRIPTION
## Summary

- add the hosted `active`, `idle`, `blocked`, and `waiting` lifecycle values to Swift's `AgentStatus`
- retain the legacy `online`, `offline`, and `away` cases for source compatibility
- add regression coverage for decoding every hosted lifecycle status
- document the fix in the root and Swift SDK changelogs

## Root cause and impact

`AgentClient.connect()` decodes `GET /v1/agent` before configuring its implicit direct-node WebSocket. The hosted API returns statuses such as `active`, but the Swift enum previously accepted only `online`, `offline`, and `away`, so decoding failed and realtime connection setup never reached the socket.

With the hosted lifecycle values represented in the SDK, valid agent responses decode successfully and connection setup can continue.

Fixes #267.

## Validation

- `swift test` — 28 tests passed


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/AgentWorkforce/relaycast/pull/268?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

