### PR TITLE
fix(engine): fire triggers for inbound webhook messages

### DIFF
--- a/packages/engine/src/__tests__/conformance/inboundWebhookTriggers.test.ts
+++ b/packages/engine/src/__tests__/conformance/inboundWebhookTriggers.test.ts
@@ -1,0 +1,167 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { eq } from 'drizzle-orm';
+import { triggers, webhooks } from '../../db/schema.js';
+import { createTrigger } from '../../engine/trigger.js';
+import {
+  createWorkspace,
+  FakeSocket,
+  makeNodeStack,
+  type TestStack,
+} from './harness.js';
+
+describe('inbound webhook message triggers', () => {
+  let stack: TestStack;
+
+  beforeEach(() => { stack = makeNodeStack({ ttlMs: 60_000 }); });
+  afterEach(() => stack.close());
+
+  async function enrollNode(workspaceKey: string, nodeId: string, name: string) {
+    const response = await stack.app.request('/v1/nodes', {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        authorization: `Bearer ${workspaceKey}`,
+      },
+      body: JSON.stringify({
+        node_id: nodeId,
+        name,
+        role: 'broker',
+        capabilities: [],
+        max_agents: 4,
+        tags: ['test'],
+        version: 'v0',
+      }),
+    });
+    expect(response.status).toBe(201);
+  }
+
+  async function setup(actionName: string) {
+    const workspace = await createWorkspace(stack.app, `inbound-trigger-${actionName}`);
+    const nodeId = `node_${actionName}`;
+    await enrollNode(workspace.workspaceKey, nodeId, 'local-surface');
+
+    const socket = new FakeSocket();
+    const handle = stack.runtime.realtime.attachNodeSocket(workspace.workspaceId, nodeId, socket);
+    await handle.handleMessage(JSON.stringify({
+      v: 1,
+      id: `register-${actionName}`,
+      type: 'node.register',
+      name: 'local-surface',
+      node_id: nodeId,
+      provider: { name: 'local', instance_id: `local-${actionName}` },
+      capabilities: [{ name: actionName, kind: 'action' }],
+      max_agents: 4,
+      tags: ['test'],
+      version: 'v1',
+      resume_cursor: null,
+    }));
+
+    const trigger = await createTrigger(stack.runtime.handle.db, workspace.workspaceId, {
+      channel: 'general',
+      action_name: actionName,
+    });
+    const createResponse = await stack.app.request('/v1/webhooks', {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        authorization: `Bearer ${workspace.workspaceKey}`,
+      },
+      body: JSON.stringify({ channel: 'general', name: 'provider-events' }),
+    });
+    expect(createResponse.status).toBe(201);
+    const created = await createResponse.json() as {
+      data: { webhook_id: string; token: string };
+    };
+
+    const [webhook] = await stack.runtime.handle.db
+      .select({ createdBy: webhooks.createdBy, channelId: webhooks.channelId })
+      .from(webhooks)
+      .where(eq(webhooks.id, created.data.webhook_id));
+    expect(webhook?.createdBy).toBeTruthy();
+
+    return { socket, trigger, created: created.data, webhook: webhook! };
+  }
+
+  async function waitForAction(socket: FakeSocket, actionName: string) {
+    for (let attempt = 0; attempt < 50; attempt += 1) {
+      const frame = socket.ofType('action.invoke').find((event) => event.action === actionName);
+      if (frame) return frame;
+      await new Promise((resolve) => setTimeout(resolve, 10));
+    }
+    return undefined;
+  }
+
+  it('fires a fleet trigger with the message created by the webhook route', async () => {
+    const actionName = 'run-event';
+    const { socket, trigger, created, webhook } = await setup(actionName);
+    const metadata = { provider: 'github', delivery_id: 'delivery-1' };
+
+    const response = await stack.app.request(`/v1/hooks/${created.webhook_id}`, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        authorization: `Bearer ${created.token}`,
+      },
+      body: JSON.stringify({
+        text: 'pull request opened',
+        source: 'github',
+        author: 'GitHub',
+        payload: metadata,
+      }),
+    });
+    expect(response.status).toBe(201);
+    const body = await response.json() as {
+      data: {
+        message_id: string;
+        channel: string;
+        text: string;
+        created_at: string;
+        metadata: Record<string, unknown>;
+      };
+    };
+    expect(body.data).not.toHaveProperty('agent_id');
+
+    const action = await waitForAction(socket, actionName);
+    expect(action).toBeDefined();
+    expect(action?.action).toBe(actionName);
+    expect(action?.input).toEqual({
+      trigger_id: trigger.id,
+      message: {
+        id: body.data.message_id,
+        channel_id: webhook.channelId,
+        channel_name: body.data.channel,
+        agent_id: webhook.createdBy,
+        text: body.data.text,
+        mentions: [],
+        metadata,
+        created_at: body.data.created_at,
+      },
+    });
+  });
+
+  it('does not re-fire a trigger for an action-generated webhook message', async () => {
+    const actionName = 'run-guarded-event';
+    const { socket, trigger, created } = await setup(actionName);
+
+    const response = await stack.app.request(`/v1/hooks/${created.webhook_id}`, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        authorization: `Bearer ${created.token}`,
+      },
+      body: JSON.stringify({
+        text: 'generated by an action',
+        payload: { action_generated: true },
+      }),
+    });
+    expect(response.status).toBe(201);
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    expect(socket.ofType('action.invoke')).toHaveLength(0);
+    const [storedTrigger] = await stack.runtime.handle.db
+      .select({ lastTriggeredAt: triggers.lastTriggeredAt })
+      .from(triggers)
+      .where(eq(triggers.id, trigger.id));
+    expect(storedTrigger?.lastTriggeredAt).toBeNull();
+  });
+});

--- a/packages/engine/src/__tests__/conformance/inboundWebhookTriggers.test.ts
+++ b/packages/engine/src/__tests__/conformance/inboundWebhookTriggers.test.ts
@@ -115,6 +115,7 @@ describe('inbound webhook message triggers', () => {
         message_id: string;
         channel: string;
         text: string;
+        author: string;
         created_at: string;
         metadata: Record<string, unknown>;
       };
@@ -123,6 +124,7 @@ describe('inbound webhook message triggers', () => {
 
     const action = await waitForAction(socket, actionName);
     expect(action).toBeDefined();
+    expect(socket.ofType('action.invoke').filter((event) => event.action === actionName)).toHaveLength(1);
     expect(action?.action).toBe(actionName);
     expect(action?.input).toEqual({
       trigger_id: trigger.id,
@@ -131,6 +133,7 @@ describe('inbound webhook message triggers', () => {
         channel_id: webhook.channelId,
         channel_name: body.data.channel,
         agent_id: webhook.createdBy,
+        agent_name: body.data.author,
         text: body.data.text,
         mentions: [],
         metadata,

--- a/packages/engine/src/engine/inboundWebhook.ts
+++ b/packages/engine/src/engine/inboundWebhook.ts
@@ -218,6 +218,7 @@ export async function triggerWebhook(
 
   return {
     message_id: message.id,
+    agent_id: message.agentId,
     webhook_id: webhook.id,
     workspace_id: webhook.workspaceId,
     channel_id: webhook.channelId,

--- a/packages/engine/src/routes/inboundWebhook.ts
+++ b/packages/engine/src/routes/inboundWebhook.ts
@@ -160,6 +160,7 @@ inboundWebhookRoutes.post('/hooks/:webhookId', async (c) => {
             channel_id,
             channel_name: result.channel,
             agent_id,
+            agent_name: result.author,
             text: result.text,
             mentions: [],
             metadata: result.metadata,

--- a/packages/engine/src/routes/inboundWebhook.ts
+++ b/packages/engine/src/routes/inboundWebhook.ts
@@ -5,6 +5,7 @@ import { errorResponse } from '../lib/httpError.js';
 import { requireWorkspaceKey } from '../middleware/auth.js';
 import { rateLimit } from '../middleware/rateLimit.js';
 import * as inboundWebhookEngine from '../engine/inboundWebhook.js';
+import * as triggerEngine from '../engine/trigger.js';
 import * as channelEngine from '../engine/channel.js';
 import { fanoutToChannel } from './fanout.js';
 import { runInBackground } from './background.js';
@@ -136,7 +137,7 @@ inboundWebhookRoutes.post('/hooks/:webhookId', async (c) => {
     if (!result) {
       return jsonNotFound(c, 'webhook_not_found', 'Webhook not found or inactive');
     }
-    const { workspace_id, channel_id, ...responseData } = result;
+    const { workspace_id, channel_id, agent_id, ...responseData } = result;
 
     const eventData = { ...responseData, channel_id };
     if (channel_id) {
@@ -146,6 +147,28 @@ inboundWebhookRoutes.post('/hooks/:webhookId', async (c) => {
         'fanout webhook.received',
       );
     }
+    runInBackground(
+      c,
+      (async () => {
+        const { nodeConnections } = c.get('engine');
+        await triggerEngine.fireMessageTriggers({
+          db,
+          nodeConnections,
+          workspaceId: workspace_id,
+          message: {
+            id: String(result.message_id),
+            channel_id,
+            channel_name: result.channel,
+            agent_id,
+            text: result.text,
+            mentions: [],
+            metadata: result.metadata,
+            created_at: result.created_at,
+          },
+        });
+      })(),
+      'fire message triggers',
+    );
     await sendWebhookEvent(c, {
       type: 'webhook.received',
       workspaceId: workspace_id,


### PR DESCRIPTION
## Summary

- dispatch fleet message triggers after inbound webhooks create channel messages
- preserve the public webhook response while passing the persisted sender ID into TriggerMessageInput
- cover the full HTTP-to-node action path and the existing action-generated loop guard

## Verification

- npm test --workspace @relaycast/engine (467 passed)
- npm run typecheck --workspace @relaycast/engine
- npm run lint --workspace @relaycast/engine
- npm run build --workspace @relaycast/engine
- npm test --workspace @relaycast/engine -- src/__tests__/conformance/inboundWebhookTriggers.test.ts (2 passed)

Node 22 was used for verification because better-sqlite3@11.10.0 does not build on the host default Node 25.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/AgentWorkforce/relaycast/pull/269?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

