### PR TITLE
feat(engine): opt-in message retention TTL with a self-host env knob

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,11 +16,11 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 Packages without a separate changelog are covered by the cross-package notes below.
 
-## [Unreleased - Major]
+## [Unreleased - Minor]
 
-### Changed
+### Added
 
-- Default message retention now prunes messages after 30 days instead of keeping them forever. Set `RELAYCAST_MESSAGE_TTL_DAYS=0` (self-host) or a per-workspace `retention.message_ttl_days: null` to keep history indefinitely.
+- Message retention remains opt-in (history is kept forever by default); self-host deployments can now opt in to a deployment-wide message TTL via `RELAYCAST_MESSAGE_TTL_DAYS`.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,11 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 Packages without a separate changelog are covered by the cross-package notes below.
 
-## [Unreleased - Patch]
+## [Unreleased - Major]
+
+### Changed
+
+- Default message retention now prunes messages after 30 days instead of keeping them forever. Set `RELAYCAST_MESSAGE_TTL_DAYS=0` (self-host) or a per-workspace `retention.message_ttl_days: null` to keep history indefinitely.
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -392,8 +392,12 @@ thread reply, and emits `delivery.accepted`, `delivery.delivered`, `delivery.def
 on reconnect; the ack/fail/defer endpoints are idempotent.
 Muted channel members do not receive durable delivery rows or realtime pushes for ordinary
 channel messages, so unmute does not backfill skipped queue entries. Explicit `@mentions`
-still create `mention` deliveries for muted members; full channel history remains available
-through the message history APIs.
+still create `mention` deliveries for muted members; channel history remains available
+through the message history APIs, within the workspace's message retention window.
+Messages are retained for 30 days by default; a workspace can change or disable this via
+its `retention.message_ttl_days` setting (explicit `null` keeps history forever), and
+self-host deployments can override the default with `RELAYCAST_MESSAGE_TTL_DAYS`
+(`0` disables message pruning).
 
 Canonical realtime/subscription event names are dotted and shared across WebSocket
 and outbound subscriptions: `message.created`, `message.reacted`, `message.read`,

--- a/README.md
+++ b/README.md
@@ -393,11 +393,10 @@ on reconnect; the ack/fail/defer endpoints are idempotent.
 Muted channel members do not receive durable delivery rows or realtime pushes for ordinary
 channel messages, so unmute does not backfill skipped queue entries. Explicit `@mentions`
 still create `mention` deliveries for muted members; channel history remains available
-through the message history APIs, within the workspace's message retention window.
-Messages are retained for 30 days by default; a workspace can change or disable this via
-its `retention.message_ttl_days` setting (explicit `null` keeps history forever), and
-self-host deployments can override the default with `RELAYCAST_MESSAGE_TTL_DAYS`
-(`0` disables message pruning).
+through the message history APIs, subject to the workspace's message retention.
+Messages are retained indefinitely by default; a workspace's `retention.message_ttl_days`
+setting (or a deployment-wide default — the hosted service uses 30 days; self-host:
+`RELAYCAST_MESSAGE_TTL_DAYS`) enables pruning of older messages.
 
 Canonical realtime/subscription event names are dotted and shared across WebSocket
 and outbound subscriptions: `message.created`, `message.reacted`, `message.read`,

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -63,7 +63,7 @@ Flags take precedence over environment variables.
 | `--port <n>` | `PORT` | `8787` | HTTP/WebSocket listen port. |
 | `--base-url <url>` | — | `http://localhost:<port>` | Public origin. **Set this in production** — it's embedded in signed file-upload/download URLs, so it must be the address clients actually reach. |
 | `--env <name>` | `RELAYCAST_ENV` | `production` | Environment label used in logs. |
-| — | `RELAYCAST_MESSAGE_TTL_DAYS` | `30` | Days of message history retained before pruning. `0` (or negative) keeps messages forever. Per-workspace `retention` settings override this; operational tables (deliveries, message logs) prune at 90 days regardless. |
+| — | `RELAYCAST_MESSAGE_TTL_DAYS` | unset (keep forever) | Opt in to pruning message history after this many days. Unset, `0`, or negative keeps messages forever. Per-workspace `retention` settings override this; operational tables (deliveries, message logs) prune at 90 days regardless. |
 
 **Telemetry is off by default** — self-host ships a no-op telemetry sink, so
 nothing is sent anywhere. (There is no PostHog/analytics in self-host.)

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -63,6 +63,7 @@ Flags take precedence over environment variables.
 | `--port <n>` | `PORT` | `8787` | HTTP/WebSocket listen port. |
 | `--base-url <url>` | — | `http://localhost:<port>` | Public origin. **Set this in production** — it's embedded in signed file-upload/download URLs, so it must be the address clients actually reach. |
 | `--env <name>` | `RELAYCAST_ENV` | `production` | Environment label used in logs. |
+| — | `RELAYCAST_MESSAGE_TTL_DAYS` | `30` | Days of message history retained before pruning. `0` (or negative) keeps messages forever. Per-workspace `retention` settings override this; operational tables (deliveries, message logs) prune at 90 days regardless. |
 
 **Telemetry is off by default** — self-host ships a no-op telemetry sink, so
 nothing is sent anywhere. (There is no PostHog/analytics in self-host.)

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -2339,7 +2339,11 @@ paths:
 
     get:
       summary: List messages
-      description: Get messages from a channel. Observer tokens require `messages:read`.
+      description: >-
+        Get messages from a channel. Observer tokens require `messages:read`.
+        Messages older than the workspace's retention TTL (30 days by default;
+        configurable or disabled per workspace via `retention.message_ttl_days`)
+        are pruned and will not be returned.
       tags:
         - Messages
       security:
@@ -2770,7 +2774,11 @@ paths:
   /search:
     get:
       summary: Search messages
-      description: Full-text search across messages. Observer tokens require `search:read`; DM search results require `dms:read` and DM filters.
+      description: >-
+        Full-text search across messages. Observer tokens require
+        `search:read`; DM search results require `dms:read` and DM filters.
+        Messages older than the workspace's retention TTL (30 days by default)
+        are pruned and will not appear in results.
       tags:
         - Search
       security:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -2341,9 +2341,9 @@ paths:
       summary: List messages
       description: >-
         Get messages from a channel. Observer tokens require `messages:read`.
-        Messages older than the workspace's retention TTL (30 days by default;
-        configurable or disabled per workspace via `retention.message_ttl_days`)
-        are pruned and will not be returned.
+        Messages are retained indefinitely by default; if the workspace's
+        `retention.message_ttl_days` (or a deployment default — the hosted
+        service uses 30 days) enables pruning, older messages are not returned.
       tags:
         - Messages
       security:
@@ -2777,8 +2777,9 @@ paths:
       description: >-
         Full-text search across messages. Observer tokens require
         `search:read`; DM search results require `dms:read` and DM filters.
-        Messages older than the workspace's retention TTL (30 days by default)
-        are pruned and will not appear in results.
+        Messages are retained indefinitely by default; if the workspace's
+        retention settings (or a deployment default — the hosted service uses
+        30 days) enable pruning, older messages do not appear in results.
       tags:
         - Search
       security:

--- a/packages/engine/CHANGELOG.md
+++ b/packages/engine/CHANGELOG.md
@@ -7,12 +7,10 @@ See the [root changelog](../../CHANGELOG.md) for cross-package release highlight
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased - Major]
-
-### Changed
-- `pruneExpired` now defaults `messageTtlDays` to 30 (`DEFAULT_MESSAGE_TTL_DAYS`, also exported from the package root) instead of `null`, so messages are pruned after 30 days out of the box. An explicit `messageTtlDays: null` deployment default or a per-workspace `retention.message_ttl_days: null` disables message pruning. Self-host exposes the `RELAYCAST_MESSAGE_TTL_DAYS` env knob (`0` disables).
+## [Unreleased - Minor]
 
 ### Added
+- Message retention remains opt-in (`pruneExpired` still defaults `messageTtlDays` to `null`). Self-host can now opt in to a deployment-wide message TTL: `startServer` accepts `eventQueue` (`DurableEventQueueOptions`, including `retention`), and the `relaycast-engine` CLI exposes `RELAYCAST_MESSAGE_TTL_DAYS` (positive = prune after N days; unset or `0`/negative = keep forever).
 - Exported the provider-attach arbitration policy from `@relaycast/engine/node-control`: `providerAttachDecision()` plus `PROVIDER_ATTACH_LIVENESS_MS`, so an out-of-process socket owner (a hosted NodeDO) mirrors the spec §3.1 decision from one source of truth instead of hand-copying the constant and logic.
 
 ### Fixed

--- a/packages/engine/CHANGELOG.md
+++ b/packages/engine/CHANGELOG.md
@@ -7,7 +7,10 @@ See the [root changelog](../../CHANGELOG.md) for cross-package release highlight
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased - Minor]
+## [Unreleased - Major]
+
+### Changed
+- `pruneExpired` now defaults `messageTtlDays` to 30 (`DEFAULT_MESSAGE_TTL_DAYS`, also exported from the package root) instead of `null`, so messages are pruned after 30 days out of the box. An explicit `messageTtlDays: null` deployment default or a per-workspace `retention.message_ttl_days: null` disables message pruning. Self-host exposes the `RELAYCAST_MESSAGE_TTL_DAYS` env knob (`0` disables).
 
 ### Added
 - Exported the provider-attach arbitration policy from `@relaycast/engine/node-control`: `providerAttachDecision()` plus `PROVIDER_ATTACH_LIVENESS_MS`, so an out-of-process socket owner (a hosted NodeDO) mirrors the spec §3.1 decision from one source of truth instead of hand-copying the constant and logic.

--- a/packages/engine/src/adapters/node/event-queue.ts
+++ b/packages/engine/src/adapters/node/event-queue.ts
@@ -35,9 +35,9 @@ export interface DurableEventQueueOptions {
   cleanupIntervalMs?: number;
   /**
    * Retention pruning (`pruneExpired`) options, run on the same cleanup
-   * cadence. `false` disables it. Defaults are conservative: only operational
-   * tables (settled deliveries, message logs) are pruned; message retention is
-   * opt-in per workspace via `workspaces.retention`.
+   * cadence. `false` disables it. Defaults prune `messages` after 30 days and
+   * operational tables (settled deliveries, message logs) after 90 days; a
+   * workspace can raise, lower, or disable each TTL via `workspaces.retention`.
    */
   retention?: PruneOptions | false;
 }

--- a/packages/engine/src/adapters/node/event-queue.ts
+++ b/packages/engine/src/adapters/node/event-queue.ts
@@ -35,9 +35,10 @@ export interface DurableEventQueueOptions {
   cleanupIntervalMs?: number;
   /**
    * Retention pruning (`pruneExpired`) options, run on the same cleanup
-   * cadence. `false` disables it. Defaults prune `messages` after 30 days and
-   * operational tables (settled deliveries, message logs) after 90 days; a
-   * workspace can raise, lower, or disable each TTL via `workspaces.retention`.
+   * cadence. `false` disables it. Defaults are conservative: only operational
+   * tables (settled deliveries, message logs) are pruned; message retention is
+   * opt-in per workspace via `workspaces.retention` or a deployment-wide
+   * `defaults.messageTtlDays` (self-host: `RELAYCAST_MESSAGE_TTL_DAYS`).
    */
   retention?: PruneOptions | false;
 }

--- a/packages/engine/src/bin/serve.ts
+++ b/packages/engine/src/bin/serve.ts
@@ -69,9 +69,10 @@ async function main(): Promise<void> {
     ...(num(process.env.RELAYCAST_MAILBOX_DEPTH_CAP) !== undefined ? { depthCap: num(process.env.RELAYCAST_MAILBOX_DEPTH_CAP) } : {}),
   };
 
-  // Optional override of the default message retention TTL (30 days). A positive
-  // value sets the days of message history kept; `0` or negative disables
-  // message pruning entirely (history is kept forever, mapping to `null`).
+  // Optional deployment-wide message retention TTL. Unset keeps message
+  // history forever (the engine default — pruning is opt-in). A positive value
+  // prunes messages after that many days; `0` or negative is an explicit
+  // keep-forever (maps to `null`).
   const messageTtlDays = num(process.env.RELAYCAST_MESSAGE_TTL_DAYS);
   const eventQueue =
     messageTtlDays !== undefined

--- a/packages/engine/src/bin/serve.ts
+++ b/packages/engine/src/bin/serve.ts
@@ -69,6 +69,15 @@ async function main(): Promise<void> {
     ...(num(process.env.RELAYCAST_MAILBOX_DEPTH_CAP) !== undefined ? { depthCap: num(process.env.RELAYCAST_MAILBOX_DEPTH_CAP) } : {}),
   };
 
+  // Optional override of the default message retention TTL (30 days). A positive
+  // value sets the days of message history kept; `0` or negative disables
+  // message pruning entirely (history is kept forever, mapping to `null`).
+  const messageTtlDays = num(process.env.RELAYCAST_MESSAGE_TTL_DAYS);
+  const eventQueue =
+    messageTtlDays !== undefined
+      ? { retention: { defaults: { messageTtlDays: messageTtlDays > 0 ? messageTtlDays : null } } }
+      : undefined;
+
   const running = startServer({
     dbPath: opts.db,
     port: opts.port,
@@ -77,6 +86,7 @@ async function main(): Promise<void> {
       environment: opts.environment,
       ...(Object.keys(mailbox).length > 0 ? { mailbox } : {}),
     },
+    ...(eventQueue ? { eventQueue } : {}),
   });
 
   process.stdout.write(`Relaycast self-host listening on ${baseUrl} (db: ${opts.db})\n`);

--- a/packages/engine/src/engine/__tests__/retention.test.ts
+++ b/packages/engine/src/engine/__tests__/retention.test.ts
@@ -154,14 +154,28 @@ describe('pruneExpired', () => {
     expect(await db.select().from(messageLogs)).toHaveLength(1);
   });
 
-  it('never prunes messages by default — operational tables only', async () => {
+  it('prunes messages past the 30-day default', async () => {
+    const { db } = track(openDb());
+    const base = await seedWorkspace(db);
+    const expired = await insertMessage(db, base, idAt(40));
+    const fresh = await insertMessage(db, base, idAt(10, 1));
+
+    const result = await pruneExpired(db);
+
+    expect(result.messages).toBe(1);
+    const remaining = (await db.select({ id: messages.id }).from(messages)).map((r) => r.id);
+    expect(remaining).toEqual([fresh]);
+    expect(remaining).not.toContain(expired);
+  });
+
+  it('keeps message history when the deployment default is explicitly null (operational tables still prune)', async () => {
     const { db } = track(openDb());
     const base = await seedWorkspace(db);
     const oldMsg = await insertMessage(db, base, idAt(400));
     await insertDelivery(db, base, oldMsg, 'acked', 400);
     await insertMessageLog(db, base, oldMsg, idAt(400, 1));
 
-    const result = await pruneExpired(db);
+    const result = await pruneExpired(db, { defaults: { messageTtlDays: null } });
 
     expect(result.messages).toBe(0);
     expect(result.deliveries).toBe(1);
@@ -171,21 +185,37 @@ describe('pruneExpired', () => {
     expect(await db.select().from(messageLogs)).toHaveLength(0);
   });
 
-  it('prunes messages past the workspace TTL and leaves other workspaces alone', async () => {
+  it('prunes messages past the default but respects a per-workspace opt-out', async () => {
     const { db } = track(openDb());
-    const optedIn = await seedWorkspace(db, { message_ttl_days: 30 });
-    const untouched = await seedWorkspace(db);
+    const def = await seedWorkspace(db); // inherits the 30-day default
+    const optedOut = await seedWorkspace(db, { message_ttl_days: null }); // keeps history forever
 
-    const expired = await insertMessage(db, optedIn, idAt(40));
-    const fresh = await insertMessage(db, optedIn, idAt(10));
-    const otherOld = await insertMessage(db, untouched, idAt(40, 1));
+    const expired = await insertMessage(db, def, idAt(40));
+    const fresh = await insertMessage(db, def, idAt(10));
+    const keptForever = await insertMessage(db, optedOut, idAt(400, 1));
 
     const result = await pruneExpired(db);
 
     expect(result.messages).toBe(1);
     const remaining = (await db.select({ id: messages.id }).from(messages)).map((r) => r.id);
-    expect(remaining.sort()).toEqual([fresh, otherOld].sort());
+    expect(remaining.sort()).toEqual([fresh, keptForever].sort());
     expect(remaining).not.toContain(expired);
+  });
+
+  it('lets a per-workspace message TTL override the default in both directions', async () => {
+    const { db } = track(openDb());
+    const relaxed = await seedWorkspace(db, { message_ttl_days: 90 });
+    const strict = await seedWorkspace(db, { message_ttl_days: 7 });
+
+    const relaxedKept = await insertMessage(db, relaxed, idAt(40)); // <90d -> kept despite the 30-day default
+    const strictPruned = await insertMessage(db, strict, idAt(10, 1)); // >7d -> pruned though <30d default
+
+    const result = await pruneExpired(db);
+
+    expect(result.messages).toBe(1);
+    const remaining = (await db.select({ id: messages.id }).from(messages)).map((r) => r.id);
+    expect(remaining).toEqual([relaxedKept]);
+    expect(remaining).not.toContain(strictPruned);
   });
 
   it('cascades message deletion to receipts, reactions, attachments, logs, and deliveries', async () => {
@@ -261,7 +291,9 @@ describe('pruneExpired', () => {
 
   it('prunes only settled deliveries past the TTL', async () => {
     const { db } = track(openDb());
-    const base = await seedWorkspace(db);
+    // Opt out of message pruning so the 30-day default doesn't cascade the
+    // aged messages (and their deliveries) out from under this assertion.
+    const base = await seedWorkspace(db, { message_ttl_days: null });
     const m1 = await insertMessage(db, base, idAt(100));
     const m2 = await insertMessage(db, base, idAt(100, 1));
     const m3 = await insertMessage(db, base, idAt(100, 2));
@@ -281,7 +313,8 @@ describe('pruneExpired', () => {
 
   it('does not reuse a delivery sequence after settled delivery retention', async () => {
     const { db } = track(openDb());
-    const base = await seedWorkspace(db);
+    // Opt out of message pruning to isolate settled-delivery retention.
+    const base = await seedWorkspace(db, { message_ttl_days: null });
     const oldMessage = await insertMessage(db, base, idAt(100));
     await insertDelivery(db, base, oldMessage, 'acked', 100);
     const [{ seq: oldSeq }] = await db
@@ -322,8 +355,8 @@ describe('pruneExpired', () => {
 
   it('lets a workspace override or disable the operational defaults', async () => {
     const { db } = track(openDb());
-    const disabled = await seedWorkspace(db, { delivery_ttl_days: null, message_log_ttl_days: null });
-    const aggressive = await seedWorkspace(db, { delivery_ttl_days: 7, message_log_ttl_days: 7 });
+    const disabled = await seedWorkspace(db, { message_ttl_days: null, delivery_ttl_days: null, message_log_ttl_days: null });
+    const aggressive = await seedWorkspace(db, { message_ttl_days: null, delivery_ttl_days: 7, message_log_ttl_days: 7 });
 
     const mA = await insertMessage(db, disabled, idAt(100));
     await insertDelivery(db, disabled, mA, 'acked', 100);

--- a/packages/engine/src/engine/__tests__/retention.test.ts
+++ b/packages/engine/src/engine/__tests__/retention.test.ts
@@ -154,28 +154,14 @@ describe('pruneExpired', () => {
     expect(await db.select().from(messageLogs)).toHaveLength(1);
   });
 
-  it('prunes messages past the 30-day default', async () => {
-    const { db } = track(openDb());
-    const base = await seedWorkspace(db);
-    const expired = await insertMessage(db, base, idAt(40));
-    const fresh = await insertMessage(db, base, idAt(10, 1));
-
-    const result = await pruneExpired(db);
-
-    expect(result.messages).toBe(1);
-    const remaining = (await db.select({ id: messages.id }).from(messages)).map((r) => r.id);
-    expect(remaining).toEqual([fresh]);
-    expect(remaining).not.toContain(expired);
-  });
-
-  it('keeps message history when the deployment default is explicitly null (operational tables still prune)', async () => {
+  it('never prunes messages by default — operational tables only', async () => {
     const { db } = track(openDb());
     const base = await seedWorkspace(db);
     const oldMsg = await insertMessage(db, base, idAt(400));
     await insertDelivery(db, base, oldMsg, 'acked', 400);
     await insertMessageLog(db, base, oldMsg, idAt(400, 1));
 
-    const result = await pruneExpired(db, { defaults: { messageTtlDays: null } });
+    const result = await pruneExpired(db);
 
     expect(result.messages).toBe(0);
     expect(result.deliveries).toBe(1);
@@ -185,36 +171,42 @@ describe('pruneExpired', () => {
     expect(await db.select().from(messageLogs)).toHaveLength(0);
   });
 
-  it('prunes messages past the default but respects a per-workspace opt-out', async () => {
+  it('prunes messages past the workspace TTL and leaves other workspaces alone', async () => {
     const { db } = track(openDb());
-    const def = await seedWorkspace(db); // inherits the 30-day default
-    const optedOut = await seedWorkspace(db, { message_ttl_days: null }); // keeps history forever
+    const optedIn = await seedWorkspace(db, { message_ttl_days: 30 });
+    const untouched = await seedWorkspace(db);
 
-    const expired = await insertMessage(db, def, idAt(40));
-    const fresh = await insertMessage(db, def, idAt(10));
-    const keptForever = await insertMessage(db, optedOut, idAt(400, 1));
+    const expired = await insertMessage(db, optedIn, idAt(40));
+    const fresh = await insertMessage(db, optedIn, idAt(10));
+    const otherOld = await insertMessage(db, untouched, idAt(40, 1));
 
     const result = await pruneExpired(db);
 
     expect(result.messages).toBe(1);
     const remaining = (await db.select({ id: messages.id }).from(messages)).map((r) => r.id);
-    expect(remaining.sort()).toEqual([fresh, keptForever].sort());
+    expect(remaining.sort()).toEqual([fresh, otherOld].sort());
     expect(remaining).not.toContain(expired);
   });
 
-  it('lets a per-workspace message TTL override the default in both directions', async () => {
+  it('applies a deployment-wide message TTL, with per-workspace overrides in both directions and null opt-out', async () => {
     const { db } = track(openDb());
+    const inherits = await seedWorkspace(db); // no settings -> deployment default (30d)
     const relaxed = await seedWorkspace(db, { message_ttl_days: 90 });
     const strict = await seedWorkspace(db, { message_ttl_days: 7 });
+    const optedOut = await seedWorkspace(db, { message_ttl_days: null });
 
-    const relaxedKept = await insertMessage(db, relaxed, idAt(40)); // <90d -> kept despite the 30-day default
+    const inheritsPruned = await insertMessage(db, inherits, idAt(40));
+    const inheritsKept = await insertMessage(db, inherits, idAt(10));
+    const relaxedKept = await insertMessage(db, relaxed, idAt(40, 1)); // <90d -> kept despite the 30d default
     const strictPruned = await insertMessage(db, strict, idAt(10, 1)); // >7d -> pruned though <30d default
+    const keptForever = await insertMessage(db, optedOut, idAt(400)); // explicit null -> never pruned
 
-    const result = await pruneExpired(db);
+    const result = await pruneExpired(db, { defaults: { messageTtlDays: 30 } });
 
-    expect(result.messages).toBe(1);
+    expect(result.messages).toBe(2);
     const remaining = (await db.select({ id: messages.id }).from(messages)).map((r) => r.id);
-    expect(remaining).toEqual([relaxedKept]);
+    expect(remaining.sort()).toEqual([inheritsKept, relaxedKept, keptForever].sort());
+    expect(remaining).not.toContain(inheritsPruned);
     expect(remaining).not.toContain(strictPruned);
   });
 
@@ -291,9 +283,7 @@ describe('pruneExpired', () => {
 
   it('prunes only settled deliveries past the TTL', async () => {
     const { db } = track(openDb());
-    // Opt out of message pruning so the 30-day default doesn't cascade the
-    // aged messages (and their deliveries) out from under this assertion.
-    const base = await seedWorkspace(db, { message_ttl_days: null });
+    const base = await seedWorkspace(db);
     const m1 = await insertMessage(db, base, idAt(100));
     const m2 = await insertMessage(db, base, idAt(100, 1));
     const m3 = await insertMessage(db, base, idAt(100, 2));
@@ -313,8 +303,7 @@ describe('pruneExpired', () => {
 
   it('does not reuse a delivery sequence after settled delivery retention', async () => {
     const { db } = track(openDb());
-    // Opt out of message pruning to isolate settled-delivery retention.
-    const base = await seedWorkspace(db, { message_ttl_days: null });
+    const base = await seedWorkspace(db);
     const oldMessage = await insertMessage(db, base, idAt(100));
     await insertDelivery(db, base, oldMessage, 'acked', 100);
     const [{ seq: oldSeq }] = await db
@@ -355,8 +344,8 @@ describe('pruneExpired', () => {
 
   it('lets a workspace override or disable the operational defaults', async () => {
     const { db } = track(openDb());
-    const disabled = await seedWorkspace(db, { message_ttl_days: null, delivery_ttl_days: null, message_log_ttl_days: null });
-    const aggressive = await seedWorkspace(db, { message_ttl_days: null, delivery_ttl_days: 7, message_log_ttl_days: 7 });
+    const disabled = await seedWorkspace(db, { delivery_ttl_days: null, message_log_ttl_days: null });
+    const aggressive = await seedWorkspace(db, { delivery_ttl_days: 7, message_log_ttl_days: 7 });
 
     const mA = await insertMessage(db, disabled, idAt(100));
     await insertDelivery(db, disabled, mA, 'acked', 100);

--- a/packages/engine/src/engine/retention.ts
+++ b/packages/engine/src/engine/retention.ts
@@ -16,6 +16,8 @@ type Db = ReturnType<typeof getDb>;
 
 const DAY_MS = 24 * 60 * 60 * 1000;
 
+/** Messages are user data, pruned after 30 days by default; a workspace can raise, lower, or disable this. */
+export const DEFAULT_MESSAGE_TTL_DAYS = 30;
 /** Settled deliveries are operational tracking rows, pruned after 90 days by default. */
 export const DEFAULT_DELIVERY_TTL_DAYS = 90;
 /** Message logs are operational telemetry (duplicate bodies), pruned after 90 days by default. */
@@ -41,7 +43,7 @@ const SETTLED_DELIVERY_STATUSES = ['acked', 'failed', 'dead_lettered'];
  * `workspaces.retention` settings. `null` disables pruning for that table.
  */
 export interface RetentionDefaults {
-  /** Messages are user data: no default — pruning is opt-in per workspace. */
+  /** Default {@link DEFAULT_MESSAGE_TTL_DAYS}. */
   messageTtlDays?: number | null;
   /** Default {@link DEFAULT_DELIVERY_TTL_DAYS}. */
   deliveryTtlDays?: number | null;
@@ -96,10 +98,13 @@ interface PrunePass {
  *
  * Per-workspace TTLs come from `workspaces.retention` (see
  * {@link WorkspaceRetentionSettings}); workspaces without settings inherit
- * `opts.defaults`. Out of the box only operational tables are pruned
- * (settled `deliveries` and `message_logs`, 90 days); `messages` retention is
- * strictly opt-in — no workspace loses message history unless its settings
- * (or an explicit deployment default) say so.
+ * `opts.defaults`. Out of the box `messages` are pruned after 30 days
+ * ({@link DEFAULT_MESSAGE_TTL_DAYS}) and operational tables after 90 days
+ * (settled `deliveries` and `message_logs`). A workspace can raise, lower, or
+ * disable each TTL via its `retention` settings — an explicit `null` keeps that
+ * table's history forever — and a deployment can override the message default
+ * (self-host exposes the `RELAYCAST_MESSAGE_TTL_DAYS` env knob, where `0`
+ * disables message pruning).
  *
  * What a run does, per table, oldest rows first:
  * - `messages` older than the effective TTL, leaf-first: a message still
@@ -123,7 +128,10 @@ export async function pruneExpired(db: Db, opts: PruneOptions = {}): Promise<Pru
   const batchLimit = Math.max(1, opts.batchLimit ?? DEFAULT_BATCH_LIMIT);
   const maxBatches = Math.max(1, opts.maxBatches ?? DEFAULT_MAX_BATCHES);
   const defaults: Required<RetentionDefaults> = {
-    messageTtlDays: opts.defaults?.messageTtlDays ?? null,
+    messageTtlDays:
+      opts.defaults?.messageTtlDays !== undefined
+        ? opts.defaults.messageTtlDays
+        : DEFAULT_MESSAGE_TTL_DAYS,
     deliveryTtlDays:
       opts.defaults?.deliveryTtlDays !== undefined
         ? opts.defaults.deliveryTtlDays

--- a/packages/engine/src/engine/retention.ts
+++ b/packages/engine/src/engine/retention.ts
@@ -97,7 +97,8 @@ interface PrunePass {
  * Per-workspace TTLs come from `workspaces.retention` (see
  * {@link WorkspaceRetentionSettings}); workspaces without settings inherit
  * `opts.defaults`. Out of the box only operational tables are pruned
- * (settled `deliveries` and `message_logs`, 90 days); `messages` retention is
+ * (settled `deliveries` and `message_logs`, 90 days; `workspace_events`,
+ * 30 days); `messages` retention is
  * strictly opt-in — no workspace loses message history unless its settings
  * (or an explicit deployment default) say so. Deployments can set a
  * deployment-wide message default via `defaults.messageTtlDays` (the hosted

--- a/packages/engine/src/engine/retention.ts
+++ b/packages/engine/src/engine/retention.ts
@@ -16,8 +16,6 @@ type Db = ReturnType<typeof getDb>;
 
 const DAY_MS = 24 * 60 * 60 * 1000;
 
-/** Messages are user data, pruned after 30 days by default; a workspace can raise, lower, or disable this. */
-export const DEFAULT_MESSAGE_TTL_DAYS = 30;
 /** Settled deliveries are operational tracking rows, pruned after 90 days by default. */
 export const DEFAULT_DELIVERY_TTL_DAYS = 90;
 /** Message logs are operational telemetry (duplicate bodies), pruned after 90 days by default. */
@@ -43,7 +41,7 @@ const SETTLED_DELIVERY_STATUSES = ['acked', 'failed', 'dead_lettered'];
  * `workspaces.retention` settings. `null` disables pruning for that table.
  */
 export interface RetentionDefaults {
-  /** Default {@link DEFAULT_MESSAGE_TTL_DAYS}. */
+  /** Messages are user data: no default — pruning is opt-in per workspace or via this deployment default. */
   messageTtlDays?: number | null;
   /** Default {@link DEFAULT_DELIVERY_TTL_DAYS}. */
   deliveryTtlDays?: number | null;
@@ -98,13 +96,13 @@ interface PrunePass {
  *
  * Per-workspace TTLs come from `workspaces.retention` (see
  * {@link WorkspaceRetentionSettings}); workspaces without settings inherit
- * `opts.defaults`. Out of the box `messages` are pruned after 30 days
- * ({@link DEFAULT_MESSAGE_TTL_DAYS}) and operational tables after 90 days
- * (settled `deliveries` and `message_logs`). A workspace can raise, lower, or
- * disable each TTL via its `retention` settings — an explicit `null` keeps that
- * table's history forever — and a deployment can override the message default
- * (self-host exposes the `RELAYCAST_MESSAGE_TTL_DAYS` env knob, where `0`
- * disables message pruning).
+ * `opts.defaults`. Out of the box only operational tables are pruned
+ * (settled `deliveries` and `message_logs`, 90 days); `messages` retention is
+ * strictly opt-in — no workspace loses message history unless its settings
+ * (or an explicit deployment default) say so. Deployments can set a
+ * deployment-wide message default via `defaults.messageTtlDays` (the hosted
+ * gateway uses 30 days); self-host exposes the `RELAYCAST_MESSAGE_TTL_DAYS`
+ * env knob.
  *
  * What a run does, per table, oldest rows first:
  * - `messages` older than the effective TTL, leaf-first: a message still
@@ -128,10 +126,7 @@ export async function pruneExpired(db: Db, opts: PruneOptions = {}): Promise<Pru
   const batchLimit = Math.max(1, opts.batchLimit ?? DEFAULT_BATCH_LIMIT);
   const maxBatches = Math.max(1, opts.maxBatches ?? DEFAULT_MAX_BATCHES);
   const defaults: Required<RetentionDefaults> = {
-    messageTtlDays:
-      opts.defaults?.messageTtlDays !== undefined
-        ? opts.defaults.messageTtlDays
-        : DEFAULT_MESSAGE_TTL_DAYS,
+    messageTtlDays: opts.defaults?.messageTtlDays ?? null,
     deliveryTtlDays:
       opts.defaults?.deliveryTtlDays !== undefined
         ? opts.defaults.deliveryTtlDays

--- a/packages/engine/src/entrypoints/node.ts
+++ b/packages/engine/src/entrypoints/node.ts
@@ -14,6 +14,7 @@ import type { TelemetrySink } from '../ports/telemetry.js';
 import {
   createNodeRuntime,
   FILE_ROUTE_PREFIX,
+  type DurableEventQueueOptions,
   type EngineSocket,
   type InProcessPresenceOptions,
   type NodeRuntime,
@@ -38,6 +39,8 @@ export interface StartServerOptions {
   telemetry?: TelemetrySink;
   config?: EngineConfig;
   presence?: InProcessPresenceOptions;
+  /** Durable webhook outbox + retention pruning tuning. */
+  eventQueue?: DurableEventQueueOptions;
 }
 
 export interface RunningServer {
@@ -83,6 +86,7 @@ export function startServer(options: StartServerOptions): RunningServer {
     telemetry: options.telemetry,
     config: options.config,
     presence: options.presence,
+    eventQueue: options.eventQueue,
   });
 
   const engine = createEngine(runtime.deps);

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -83,6 +83,7 @@ export type { ClaimedEvent, SweptEvent } from './engine/eventQueue.js';
 // scheduled handler.
 export {
   pruneExpired,
+  DEFAULT_MESSAGE_TTL_DAYS,
   DEFAULT_DELIVERY_TTL_DAYS,
   DEFAULT_MESSAGE_LOG_TTL_DAYS,
   DEFAULT_WORKSPACE_EVENT_TTL_DAYS,

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -83,7 +83,6 @@ export type { ClaimedEvent, SweptEvent } from './engine/eventQueue.js';
 // scheduled handler.
 export {
   pruneExpired,
-  DEFAULT_MESSAGE_TTL_DAYS,
   DEFAULT_DELIVERY_TTL_DAYS,
   DEFAULT_MESSAGE_LOG_TTL_DAYS,
   DEFAULT_WORKSPACE_EVENT_TTL_DAYS,


### PR DESCRIPTION
## Summary

Message retention stays **opt-in — the engine default is keep-forever** (`pruneExpired`'s `messageTtlDays` still defaults to `null`; no behavior change for existing deployments). This PR adds the machinery for deployments to opt in:

- A deployment-wide `defaults.messageTtlDays` remains the way to set a fleet default — the hosted gateway opts into 30 days in AgentWorkforce/relaycast-cloud#34.
- New self-host env knob `RELAYCAST_MESSAGE_TTL_DAYS` (following the `RELAYCAST_MAILBOX_*` convention): unset = keep forever, positive = prune after N days, `0`/negative = explicitly forever. Wired via a new `StartServerOptions.eventQueue` passthrough (serve.ts previously had no way to reach the queue's retention options). Documented in `docs/self-hosting.md`.
- Per-workspace `retention.message_ttl_days` overrides continue to win in both directions, and explicit `null` disables pruning.
- Operational-table defaults unchanged (settled deliveries / message logs 90d, workspace events 30d).
- README + openapi.yaml now state the retention semantics on the message list/search endpoints.

Changelogs: **Minor** (additive feature only — an earlier revision of this branch changed the default to 30 days and was reverted per review; the default-change now lives solely in the cloud deployment).

## Tests

- Kept the "does not prune messages by default" guarantee under test.
- Added coverage: deployment-default `messageTtlDays: 30` opt-in, per-workspace overrides in both directions (relaxed 90d / strict 7d), and per-workspace `null` opt-out.
- `typecheck`, `lint`, full vitest suite: **468 passed / 44 files**.

## Companion PR

AgentWorkforce/relaycast-cloud#34 wires `pruneExpired` into the cloud worker's cron (it previously never ran retention at all) and passes `messageTtlDays: 30` explicitly — the hosted 30-day default is a deployment setting, not an engine default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QfNwrgA6B6snbmtyCvVzkr