### PR TITLE
fix(engine): key node enrollment on node_id, not name

### DIFF
--- a/.agentworkforce/trajectories/completed/2026-07/traj_e8qk8ofg0e1a/summary.md
+++ b/.agentworkforce/trajectories/completed/2026-07/traj_e8qk8ofg0e1a/summary.md
@@ -1,0 +1,32 @@
+# Trajectory: Fix #258: key node enrollment on node_id, not name
+
+> **Status:** ✅ Completed
+> **Task:** relaycast#258
+> **Confidence:** 90%
+> **Started:** July 16, 2026 at 04:07 AM
+> **Completed:** July 16, 2026 at 04:08 AM
+
+---
+
+## Summary
+
+POST /v1/nodes now keys on node_id when supplied: same id rotates/renames in place, new id creates a node, and a cross-id name collision is an explicit 409 node_name_conflict (matching node.register) instead of silently rewriting the other node. Name-only enrollment still rotates by name. Added 5 conformance tests; updated openapi + changelogs.
+
+**Approach:** Standard approach
+
+---
+
+## Key Decisions
+
+### Enrollment keys on node_id when supplied; name lookup only as fallback for callers without a stable id
+- **Chose:** Enrollment keys on node_id when supplied; name lookup only as fallback for callers without a stable id
+- **Reasoning:** node_id is the stable identity; keying on name let a second enroll silently rewrite a different node. Name-keyed rotate preserved for backwards compat (existing conformance test relies on it). Cross-id name collision is now an explicit 409 node_name_conflict, matching node.register — no takeover flag until a real need appears (user-confirmed).
+
+---
+
+## Chapters
+
+### 1. Work
+*Agent: default*
+
+- Enrollment keys on node_id when supplied; name lookup only as fallback for callers without a stable id: Enrollment keys on node_id when supplied; name lookup only as fallback for callers without a stable id

--- a/.agentworkforce/trajectories/completed/2026-07/traj_e8qk8ofg0e1a/trajectory.json
+++ b/.agentworkforce/trajectories/completed/2026-07/traj_e8qk8ofg0e1a/trajectory.json
@@ -1,0 +1,57 @@
+{
+  "id": "traj_e8qk8ofg0e1a",
+  "version": 1,
+  "task": {
+    "title": "Fix #258: key node enrollment on node_id, not name",
+    "source": {
+      "system": "plain",
+      "id": "relaycast#258"
+    }
+  },
+  "status": "completed",
+  "startedAt": "2026-07-16T04:07:04.421Z",
+  "completedAt": "2026-07-16T04:08:13.953Z",
+  "agents": [
+    {
+      "name": "default",
+      "role": "lead",
+      "joinedAt": "2026-07-16T04:07:14.632Z"
+    }
+  ],
+  "chapters": [
+    {
+      "id": "chap_hxmgah13ehv7",
+      "title": "Work",
+      "agentName": "default",
+      "startedAt": "2026-07-16T04:07:14.632Z",
+      "endedAt": "2026-07-16T04:08:13.953Z",
+      "events": [
+        {
+          "ts": 1784174834634,
+          "type": "decision",
+          "content": "Enrollment keys on node_id when supplied; name lookup only as fallback for callers without a stable id: Enrollment keys on node_id when supplied; name lookup only as fallback for callers without a stable id",
+          "raw": {
+            "question": "Enrollment keys on node_id when supplied; name lookup only as fallback for callers without a stable id",
+            "chosen": "Enrollment keys on node_id when supplied; name lookup only as fallback for callers without a stable id",
+            "alternatives": [],
+            "reasoning": "node_id is the stable identity; keying on name let a second enroll silently rewrite a different node. Name-keyed rotate preserved for backwards compat (existing conformance test relies on it). Cross-id name collision is now an explicit 409 node_name_conflict, matching node.register — no takeover flag until a real need appears (user-confirmed)."
+          },
+          "significance": "high"
+        }
+      ]
+    }
+  ],
+  "retrospective": {
+    "summary": "POST /v1/nodes now keys on node_id when supplied: same id rotates/renames in place, new id creates a node, and a cross-id name collision is an explicit 409 node_name_conflict (matching node.register) instead of silently rewriting the other node. Name-only enrollment still rotates by name. Added 5 conformance tests; updated openapi + changelogs.",
+    "approach": "Standard approach",
+    "confidence": 0.9
+  },
+  "commits": [],
+  "filesChanged": [],
+  "projectId": "git/AgentWorkforce/relaycast",
+  "tags": [],
+  "_trace": {
+    "startRef": "03ab9ad113b13ce16fbdb0632b222e84c62ab5e9",
+    "endRef": "03ab9ad113b13ce16fbdb0632b222e84c62ab5e9"
+  }
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ Packages without a separate changelog are covered by the cross-package notes bel
 
 - Allowed Swift clients to decode hosted agent lifecycle statuses and complete realtime connections.
 - Kept inbox and delivery reads independent from scheduled cleanup while large expired-delivery backlogs drain in bounded batches.
+- Node enrollment (`POST /v1/nodes`) now keys on `node_id` when supplied: re-enrolling rotates (and can rename) the same node in place, and a name held by a different node is rejected with `node_name_conflict` (409) instead of silently rewriting the other node.
 
 ## [6.0.3] - 2026-07-12
 

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -3703,7 +3703,11 @@ paths:
     post:
       summary: Enroll or rotate a node token
       description: >
-        Enroll a delivery node in the workspace or rotate the token for an existing node name.
+        Enroll a delivery node in the workspace or rotate the token for an existing node.
+        When `node_id` is supplied, it is the enrollment key: a matching node is rotated
+        in place (and renamed if `name` differs), a new `node_id` creates a new node, and
+        a `name` already held by a different node is rejected with `node_name_conflict`
+        (409). Without `node_id`, an existing node with the same `name` is rotated.
         Fleet WebSocket nodes use the returned token on `/node/ws`; HTTP push nodes store a
         delivery endpoint and can host one bound agent by default.
       tags:
@@ -3721,6 +3725,7 @@ paths:
               properties:
                 node_id:
                   type: string
+                  description: Stable node identity. When supplied, enrollment keys on it — matching node rotated in place, new id creates a node — instead of resolving by name.
                 name:
                   type: string
                 kind:
@@ -3761,6 +3766,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/SuccessResponse'
+        '409':
+          description: Node name is already enrolled by a different node
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
     get:
       summary: List nodes
       description: List delivery nodes in the workspace, optionally filtered by capability or name. Observer tokens require `nodes:read`; agent filters constrain active-agent details.

--- a/packages/engine/CHANGELOG.md
+++ b/packages/engine/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 ### Fixed
 - Provider-attach arbitration accepts an unbound provider regardless of a caller's last-seen timestamp instead of reporting a false live-instance conflict.
 - Moved delivery TTL expiry out of inbox reads into bounded scheduled D1-safe batches, keeping reads available through cleanup failures without duplicating sender failure notices.
+- `createNodeToken` (`POST /v1/nodes`) resolves the target node by `node_id` when supplied instead of by name: a matching id is rotated in place (renaming if `name` differs), a new id creates a new node, and a `name` held by a different node throws `node_name_conflict` (409) — matching `node.register` — instead of silently rotating and reshaping the other node. Name-only enrollment (no `node_id`) still rotates by name.
 
 ## [6.0.3] - 2026-07-12
 

--- a/packages/engine/CHANGELOG.md
+++ b/packages/engine/CHANGELOG.md
@@ -16,7 +16,7 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 ### Fixed
 - Provider-attach arbitration accepts an unbound provider regardless of a caller's last-seen timestamp instead of reporting a false live-instance conflict.
 - Moved delivery TTL expiry out of inbox reads into bounded scheduled D1-safe batches, keeping reads available through cleanup failures without duplicating sender failure notices.
-- `createNodeToken` (`POST /v1/nodes`) resolves the target node by `node_id` when supplied instead of by name: a matching id is rotated in place (renaming if `name` differs), a new id creates a new node, and a `name` held by a different node throws `node_name_conflict` (409) — matching `node.register` — instead of silently rotating and reshaping the other node. Name-only enrollment (no `node_id`) still rotates by name.
+- `createNodeToken` (`POST /v1/nodes`) resolves the target node by `node_id` when supplied instead of by name: a matching id is rotated in place (renaming if `name` differs), a new id creates a new node, and a `name` held by a different node throws `node_name_conflict` (409) — matching `node.register` — instead of silently rotating and reshaping the other node. Name-only enrollment (no `node_id`) still rotates by name. A name that is empty or still `#`-prefixed after stripping the single reference `#` is rejected with `invalid_node_name` (400).
 
 ## [6.0.3] - 2026-07-12
 

--- a/packages/engine/src/__tests__/conformance/node.test.ts
+++ b/packages/engine/src/__tests__/conformance/node.test.ts
@@ -1788,6 +1788,25 @@ describe('node adapter conformance', () => {
       expect(collide.body.error?.code).toBe('node_name_conflict');
     });
 
+    it('rejects names that normalize to empty or stay #-prefixed', async () => {
+      const ws = await createWorkspace(stack.app, 'enroll-bad-name-ws');
+      for (const badName of ['#', '##host']) {
+        const res = await enroll(ws.workspaceKey, { node_id: 'node_a', name: badName });
+        expect(res.status).toBe(400);
+        expect(res.body.error?.code).toBe('invalid_node_name');
+      }
+      const rows = await stack.runtime.deps.db
+        .select()
+        .from(nodes)
+        .where(eq(nodes.workspaceId, ws.workspaceId));
+      expect(rows).toHaveLength(0);
+
+      // A single leading "#" is a reference prefix, not part of the name.
+      const prefixed = await enroll(ws.workspaceKey, { node_id: 'node_a', name: '#host' });
+      expect(prefixed.status).toBe(201);
+      expect(prefixed.body.data?.name).toBe('host');
+    });
+
     it('enrolling without node_id still rotates the existing node by name', async () => {
       const ws = await createWorkspace(stack.app, 'enroll-by-name-ws');
       const first = await enroll(ws.workspaceKey, { node_id: 'node_a', name: 'host' });

--- a/packages/engine/src/__tests__/conformance/node.test.ts
+++ b/packages/engine/src/__tests__/conformance/node.test.ts
@@ -1713,4 +1713,90 @@ describe('node adapter conformance', () => {
       });
     });
   });
+
+  describe('node enrollment identity', () => {
+    async function enroll(workspaceKey: string, body: Record<string, unknown>) {
+      const res = await stack.app.request('/v1/nodes', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json', authorization: `Bearer ${workspaceKey}` },
+        body: JSON.stringify(body),
+      });
+      return { status: res.status, body: await res.json() as { data?: { id: string; name: string; token: string }; error?: { code: string } } };
+    }
+
+    it('rejects enrolling a second node_id under an existing name instead of rewriting the other node', async () => {
+      const ws = await createWorkspace(stack.app, 'enroll-name-conflict-ws');
+      const first = await enroll(ws.workspaceKey, { node_id: 'node_a', name: 'host' });
+      expect(first.status).toBe(201);
+
+      const second = await enroll(ws.workspaceKey, { node_id: 'node_b', name: 'host' });
+      expect(second.status).toBe(409);
+      expect(second.body.error?.code).toBe('node_name_conflict');
+
+      // Node A keeps its identity and token; node B was never created.
+      const rows = await stack.runtime.deps.db
+        .select()
+        .from(nodes)
+        .where(eq(nodes.workspaceId, ws.workspaceId));
+      expect(rows.map((row) => row.id)).toEqual(['node_a']);
+      expect(rows[0].name).toBe('host');
+    });
+
+    it('re-enrolling the same node_id rotates the token in place', async () => {
+      const ws = await createWorkspace(stack.app, 'enroll-rotate-ws');
+      const first = await enroll(ws.workspaceKey, { node_id: 'node_a', name: 'host', version: 'v1' });
+      expect(first.status).toBe(201);
+
+      const second = await enroll(ws.workspaceKey, { node_id: 'node_a', name: 'host', version: 'v2' });
+      expect(second.status).toBe(201);
+      expect(second.body.data?.id).toBe('node_a');
+      expect(second.body.data?.token).not.toBe(first.body.data?.token);
+
+      const rows = await stack.runtime.deps.db
+        .select()
+        .from(nodes)
+        .where(eq(nodes.workspaceId, ws.workspaceId));
+      expect(rows).toHaveLength(1);
+      expect(rows[0].version).toBe('v2');
+    });
+
+    it('re-enrolling the same node_id under a new name renames the node', async () => {
+      const ws = await createWorkspace(stack.app, 'enroll-rename-ws');
+      const first = await enroll(ws.workspaceKey, { node_id: 'node_a', name: 'old-name' });
+      expect(first.status).toBe(201);
+
+      const renamed = await enroll(ws.workspaceKey, { node_id: 'node_a', name: 'new-name' });
+      expect(renamed.status).toBe(201);
+      expect(renamed.body.data?.id).toBe('node_a');
+      expect(renamed.body.data?.name).toBe('new-name');
+
+      const rows = await stack.runtime.deps.db
+        .select()
+        .from(nodes)
+        .where(eq(nodes.workspaceId, ws.workspaceId));
+      expect(rows).toHaveLength(1);
+      expect(rows[0].name).toBe('new-name');
+    });
+
+    it('rejects renaming a node onto a name held by a different node', async () => {
+      const ws = await createWorkspace(stack.app, 'enroll-rename-conflict-ws');
+      expect((await enroll(ws.workspaceKey, { node_id: 'node_a', name: 'alpha' })).status).toBe(201);
+      expect((await enroll(ws.workspaceKey, { node_id: 'node_b', name: 'beta' })).status).toBe(201);
+
+      const collide = await enroll(ws.workspaceKey, { node_id: 'node_b', name: 'alpha' });
+      expect(collide.status).toBe(409);
+      expect(collide.body.error?.code).toBe('node_name_conflict');
+    });
+
+    it('enrolling without node_id still rotates the existing node by name', async () => {
+      const ws = await createWorkspace(stack.app, 'enroll-by-name-ws');
+      const first = await enroll(ws.workspaceKey, { node_id: 'node_a', name: 'host' });
+      expect(first.status).toBe(201);
+
+      const rotated = await enroll(ws.workspaceKey, { name: 'host' });
+      expect(rotated.status).toBe(201);
+      expect(rotated.body.data?.id).toBe('node_a');
+      expect(rotated.body.data?.token).not.toBe(first.body.data?.token);
+    });
+  });
 });

--- a/packages/engine/src/engine/node.ts
+++ b/packages/engine/src/engine/node.ts
@@ -206,6 +206,12 @@ export async function createNodeToken(
   const token = `nt_live_${randomHex(24)}`;
   const tokenHash = await sha256Hex(token);
   const name = data.name.startsWith('#') ? data.name.slice(1) : data.name;
+  // Reject names that are empty or still #-prefixed after normalization: an
+  // empty name is unreachable via /v1/nodes/:name, and a residual "#" would
+  // dodge every name lookup (including the conflict check below).
+  if (!name || name.startsWith('#')) {
+    throw codedError('Node name must be non-empty and cannot begin with "#"', 'invalid_node_name', 400);
+  }
   // Enrollment keys on node_id (the stable identity) when supplied; the name
   // lookup is only a fallback for callers without a stable id. A name held by
   // a *different* node id is a conflict — mirroring node.register — never a

--- a/packages/engine/src/engine/node.ts
+++ b/packages/engine/src/engine/node.ts
@@ -205,7 +205,18 @@ export async function createNodeToken(
 ) {
   const token = `nt_live_${randomHex(24)}`;
   const tokenHash = await sha256Hex(token);
-  const existing = await getNodeByName(db, workspaceId, data.name);
+  const name = data.name.startsWith('#') ? data.name.slice(1) : data.name;
+  // Enrollment keys on node_id (the stable identity) when supplied; the name
+  // lookup is only a fallback for callers without a stable id. A name held by
+  // a *different* node id is a conflict — mirroring node.register — never a
+  // silent rewrite of the other node.
+  const existing = await resolveNodeForEnroll(db, workspaceId, data);
+  if (data.node_id !== undefined) {
+    const nameHolder = await getNodeByName(db, workspaceId, name);
+    if (nameHolder && nameHolder.id !== data.node_id) {
+      throw codedError(`Node name "${name}" is already enrolled by another node`, 'node_name_conflict', 409);
+    }
+  }
   const now = new Date();
   const existingShape = existing ? normalizeLegacyNodeShape(existing.kind, existing.role) : null;
   const normalized = normalizeLegacyNodeShape(
@@ -234,6 +245,7 @@ export async function createNodeToken(
     const [updated] = await db
       .update(nodes)
       .set({
+        name,
         tokenHash,
         kind,
         role,
@@ -256,7 +268,7 @@ export async function createNodeToken(
     .values({
       id: data.node_id ?? `node_${generateId()}`,
       workspaceId,
-      name: data.name,
+      name,
       tokenHash,
       kind,
       role,
@@ -288,6 +300,29 @@ export async function getNodeByName(db: Db, workspaceId: string, name: string) {
     .from(nodes)
     .where(and(eq(nodes.workspaceId, workspaceId), eq(nodes.name, normalized)));
   return node ?? null;
+}
+
+export async function getNodeById(db: Db, workspaceId: string, nodeId: string) {
+  const [node] = await db
+    .select()
+    .from(nodes)
+    .where(and(eq(nodes.workspaceId, workspaceId), eq(nodes.id, nodeId)));
+  return node ?? null;
+}
+
+/**
+ * Resolve the node an enroll (POST /v1/nodes) targets: by node_id when
+ * supplied, by name otherwise.
+ */
+export async function resolveNodeForEnroll(
+  db: Db,
+  workspaceId: string,
+  data: { node_id?: string; name: string },
+) {
+  if (data.node_id !== undefined) {
+    return getNodeById(db, workspaceId, data.node_id);
+  }
+  return getNodeByName(db, workspaceId, data.name);
 }
 
 export interface RegisterNodeResult {

--- a/packages/engine/src/routes/node.ts
+++ b/packages/engine/src/routes/node.ts
@@ -134,7 +134,7 @@ nodeRoutes.post('/nodes', requireWorkspaceKey, rateLimit, async (c) => {
     if (!parsed.ok) {
       return parsed.response;
     }
-    const existing = await nodeEngine.getNodeByName(c.get('db'), c.get('workspace').id, parsed.data.name);
+    const existing = await nodeEngine.resolveNodeForEnroll(c.get('db'), c.get('workspace').id, parsed.data);
     const kind = parsed.data.kind ?? (existing?.kind as z.infer<typeof nodeKindSchema> | undefined) ?? 'ws';
     const role = parsed.data.role
       ?? (existing?.role as z.infer<typeof nodeRoleSchema> | undefined)


### PR DESCRIPTION
Fixes #258

## Problem

`POST /v1/nodes` (`createNodeToken`) resolved existing nodes by **name** only. Enrolling `{node_id: B, name: "host"}` when node A already owned "host" silently rotated and reshaped **node A** — the caller got back a different node's identity, node B was never created, and the discarded id later tripped `node_name_conflict` at `node.register` with an empty capability aggregate (the "10/10 flip" from the #250/#257 two-node E2E). Meanwhile `node.register` explicitly rejects a cross-id name collision, so the two paths disagreed.

## Change

Enrollment now keys on `node_id` (the stable identity) when supplied:

- **Matching `node_id` exists** → rotate that node in place; if `name` differs, the node is renamed (conflict-checked).
- **New `node_id`** → create a new node; a `name` already held by a *different* node is an explicit `node_name_conflict` 409, matching `node.register`'s semantics.
- **No `node_id`** → unchanged: rotate-by-name is preserved for callers without a stable id (existing `nodeDeliveryContracts` rotation test still passes).

No takeover flag was added — a cross-id name collision always errors; operators resolve it by removing the stale node or renaming. (Per design review on the issue: the relay broker always sends `node_id` and surfaces non-2xx mint responses loudly, so the failure becomes explicit instead of identity-corrupting. The hostname-fallback trigger was already fixed relay-side in relay#1239.)

The route's default-derivation (`kind`/`role`/`delivery` inherited from the existing node) now resolves through the same id-first lookup so defaults come from the node actually being rotated.

## Details

- `packages/engine/src/engine/node.ts`: id-first resolution + conflict check in `createNodeToken`; new `getNodeById` / `resolveNodeForEnroll` helpers; the update path now writes the (`#`-normalized) name so renames stick and a `#`-prefixed rotate can't corrupt the stored name.
- `packages/engine/src/routes/node.ts`: `POST /v1/nodes` uses `resolveNodeForEnroll` for default derivation.
- `openapi.yaml`: documented the keying semantics, `node_id` property, and the 409 response.
- Changelogs updated (root + engine).

## Tests

5 new conformance tests in `node.test.ts` (`node enrollment identity`): cross-id name conflict leaves the original node untouched, same-id rotate, same-id rename, rename-onto-taken-name conflict, and name-only rotate fallback.

Full engine suite: **473 passed** (44 files). `turbo lint` + engine typecheck/build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01829wc4gETpiaeh7yjWUkKR

---
_Generated by [Claude Code](https://claude.ai/code/session_01829wc4gETpiaeh7yjWUkKR)_

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/AgentWorkforce/relaycast/pull/275?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

