### PR TITLE
fix(engine): make agent disconnect presence-only for node-hosted agents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,11 @@ Packages without a separate changelog are covered by the cross-package notes bel
 ### Added
 
 - Message retention remains opt-in (history is kept forever by default); self-host deployments can now opt in to a deployment-wide message TTL via `RELAYCAST_MESSAGE_TTL_DAYS`.
+- `POST /v1/agents/disconnect` accepts an optional `deregister` flag; SDK `disconnect()` and `presence.markOffline()` take `{ deregister?: boolean }` to opt into full node teardown.
+
+### Changed
+
+- Agent disconnect is presence-only by default for node-hosted agents: the node binding is kept so a still-running session keeps receiving deliveries, instead of silently re-homing to an offline direct node.
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -485,8 +485,10 @@ drains queued node invocations and replays pending node deliveries after
 `node.register`, `agent.register`, and `inventory.sync`, so adapters using it should not
 also call `handleNodeReconnect` for those same frames. If an adapter owns
 `POST /v1/agents/disconnect` outside the engine router, call `handleAgentDisconnect`
-from `@relaycast/engine/agent-disconnect` before presence cleanup so node-hosted
-agents follow the same deregistration path as an `agent.deregister` frame.
+from `@relaycast/engine/agent-disconnect` before presence cleanup. By default it is
+presence-only for node-hosted agents (the node binding is left intact so the
+still-running session keeps its deliveries); pass `{ deregister: true }` to follow the
+full `agent.deregister` teardown path that re-homes the agent to its direct node.
 
 Broker nodes can negotiate restart-safe delivery cursor recovery by including
 `{ "name": "relay:delivery-cursor-v1", "kind": "capacity" }` in every

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -2886,11 +2886,30 @@ paths:
   /agents/disconnect:
     post:
       summary: Mark agent disconnected
-      description: Explicitly mark the authenticated agent offline and release any node-hosted binding
+      description: >-
+        Explicitly mark the authenticated agent offline. For a node-hosted
+        (broker) agent this is presence-only by default: the node binding is
+        left intact so a still-running session keeps receiving deliveries. Pass
+        `deregister: true` to also tear down the node binding and re-home the
+        agent to its implicit direct node.
       tags:
         - Presence
       security:
         - agentToken: []
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                deregister:
+                  type: boolean
+                  default: false
+                  description: >-
+                    When true, deregister the node-hosted binding and re-home
+                    the agent to its implicit direct node. Defaults to false
+                    (presence-only).
       responses:
         '200':
           description: Agent disconnected

--- a/packages/engine/CHANGELOG.md
+++ b/packages/engine/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 ### Added
 - Message retention remains opt-in (`pruneExpired` still defaults `messageTtlDays` to `null`). Self-host can now opt in to a deployment-wide message TTL: `startServer` accepts `eventQueue` (`DurableEventQueueOptions`, including `retention`), and the `relaycast-engine` CLI exposes `RELAYCAST_MESSAGE_TTL_DAYS` (positive = prune after N days; unset or `0`/negative = keep forever).
 - Exported the provider-attach arbitration policy from `@relaycast/engine/node-control`: `providerAttachDecision()` plus `PROVIDER_ATTACH_LIVENESS_MS`, so an out-of-process socket owner (a hosted NodeDO) mirrors the spec §3.1 decision from one source of truth instead of hand-copying the constant and logic.
+- `handleAgentDisconnect` accepts an optional `{ deregister?: boolean }` argument, and `POST /v1/agents/disconnect` accepts an optional `{ deregister?: boolean }` body.
+
+### Changed
+- `handleAgentDisconnect` / `POST /v1/agents/disconnect` are presence-only by default for node-hosted agents: the active `agent_node_bindings` row and node slot are kept (deliveries keep flowing to the still-running session) instead of deactivating the binding and re-homing `location_node_id` to the offline direct node. Pass `deregister: true` for the previous full teardown. Skipped and re-homing paths now log at warn.
 
 ### Fixed
 - Provider-attach arbitration accepts an unbound provider regardless of a caller's last-seen timestamp instead of reporting a false live-instance conflict.

--- a/packages/engine/src/__tests__/conformance/node.test.ts
+++ b/packages/engine/src/__tests__/conformance/node.test.ts
@@ -1043,7 +1043,7 @@ describe('node adapter conformance', () => {
       });
     });
 
-    it('REST disconnect deregisters a node-hosted agent without a node socket', async () => {
+    it('REST disconnect is presence-only for a node-hosted agent by default', async () => {
       const ws = await createWorkspace(stack.app, 'agent-disconnect-helper-ws');
       const db = stack.runtime.handle.db;
       const alpha = await enrollAndAttachNode(ws, {
@@ -1076,6 +1076,93 @@ describe('node adapter conformance', () => {
       const disconnect = await stack.app.request('/v1/agents/disconnect', {
         method: 'POST',
         headers: { authorization: `Bearer ${reply.data?.token ?? ''}` },
+      });
+      expect(disconnect.status).toBe(200);
+
+      // Default disconnect is presence intent only: the node binding, slot, and
+      // location are left intact so the still-running PTY keeps its deliveries.
+      const worker = await db
+        .select({
+          locationType: agents.locationType,
+          locationNodeId: agents.locationNodeId,
+        })
+        .from(agents)
+        .where(and(eq(agents.workspaceId, ws.workspaceId), eq(agents.id, agentId)))
+        .then((rows) => rows[0]);
+      expect(worker).toMatchObject({
+        locationType: 'via_node',
+        locationNodeId: 'node_disconnect_alpha',
+      });
+
+      const activeBindings = await db
+        .select({ nodeId: agentNodeBindings.nodeId })
+        .from(agentNodeBindings)
+        .where(and(
+          eq(agentNodeBindings.workspaceId, ws.workspaceId),
+          eq(agentNodeBindings.agentId, agentId),
+          eq(agentNodeBindings.status, 'active'),
+        ));
+      expect(activeBindings).toEqual([{ nodeId: 'node_disconnect_alpha' }]);
+
+      const alphaNode = await db
+        .select({
+          id: nodes.id,
+          activeAgents: nodes.activeAgents,
+        })
+        .from(nodes)
+        .where(and(eq(nodes.workspaceId, ws.workspaceId), eq(nodes.id, 'node_disconnect_alpha')))
+        .then((rows) => rows[0]);
+      expect(alphaNode).toMatchObject({
+        id: 'node_disconnect_alpha',
+        activeAgents: 1,
+      });
+
+      // The implicit direct node is never created by a presence-only disconnect.
+      const directNode = await db
+        .select({ id: nodes.id })
+        .from(nodes)
+        .where(and(eq(nodes.workspaceId, ws.workspaceId), eq(nodes.id, `node_direct_${agentId}`)))
+        .then((rows) => rows[0]);
+      expect(directNode).toBeUndefined();
+    });
+
+    it('REST disconnect with deregister:true tears down a node-hosted agent without a node socket', async () => {
+      const ws = await createWorkspace(stack.app, 'agent-deregister-helper-ws');
+      const db = stack.runtime.handle.db;
+      const alpha = await enrollAndAttachNode(ws, {
+        id: 'node_disconnect_alpha',
+        name: 'disconnect-alpha',
+        capabilities: [],
+        maxAgents: 1,
+      });
+
+      await alpha.handle.handleMessage(JSON.stringify({
+        v: 1,
+        id: 'agent-register-disconnect',
+        type: 'agent.register',
+        name: 'disconnect-worker',
+        session_ref: 'pty://disconnect/worker',
+      }));
+      const reply = alpha.sock.ofType('reply').find((frame) => frame.id === 'agent-register-disconnect') as {
+        data?: { agent_id?: string; token?: string };
+      };
+      const agentId = reply.data?.agent_id ?? '';
+      expect(agentId.length).toBeGreaterThan(0);
+
+      const beforeNode = await db
+        .select({ activeAgents: nodes.activeAgents })
+        .from(nodes)
+        .where(and(eq(nodes.workspaceId, ws.workspaceId), eq(nodes.id, 'node_disconnect_alpha')))
+        .then((rows) => rows[0]);
+      expect(beforeNode?.activeAgents).toBe(1);
+
+      const disconnect = await stack.app.request('/v1/agents/disconnect', {
+        method: 'POST',
+        headers: {
+          authorization: `Bearer ${reply.data?.token ?? ''}`,
+          'content-type': 'application/json',
+        },
+        body: JSON.stringify({ deregister: true }),
       });
       expect(disconnect.status).toBe(200);
 

--- a/packages/engine/src/agent-disconnect.ts
+++ b/packages/engine/src/agent-disconnect.ts
@@ -3,14 +3,32 @@ import type { EngineDb } from './ports/index.js';
 import { agents } from './db/schema.js';
 import { deregisterAgentViaNode, directNodeIdForAgent } from './engine/node.js';
 
+/** Options for {@link handleAgentDisconnect}. */
+export interface HandleAgentDisconnectOptions {
+  /**
+   * When `true`, fully deregister a node-hosted agent: deactivate its active
+   * `agent_node_bindings` row, release the node slot, and re-home
+   * `location_node_id` to the implicit offline direct node. When `false`
+   * (the default), the disconnect is treated as **presence intent only** — the
+   * node binding and slot are left intact so the still-running PTY keeps
+   * receiving deliveries. See issue #272.
+   */
+  deregister?: boolean;
+}
+
 /**
  * Disconnect an agent currently hosted by an explicit node when the caller has
  * no node-control socket frame to pass through `handleNodeControlMessage`.
+ *
+ * By default this is a no-op for the node binding (presence-only): callers that
+ * genuinely intend to tear down the node hosting must pass
+ * `{ deregister: true }`.
  */
 export async function handleAgentDisconnect(
   db: EngineDb,
   workspaceId: string,
   agentId: string,
+  opts: HandleAgentDisconnectOptions = {},
 ): Promise<boolean> {
   const [agent] = await db
     .select({
@@ -28,6 +46,22 @@ export async function handleAgentDisconnect(
   ) {
     return false;
   }
+
+  if (!opts.deregister) {
+    console.warn('[agent.disconnect] presence-only disconnect; skipping node deregistration', {
+      workspaceId,
+      agentId,
+      nodeId: agent.locationNodeId,
+    });
+    return false;
+  }
+
+  console.warn('[agent.disconnect] deregistering node-hosted agent; re-homing to direct node', {
+    workspaceId,
+    agentId,
+    fromNodeId: agent.locationNodeId,
+    directNodeId: directNodeIdForAgent(agentId),
+  });
 
   const disconnected = await deregisterAgentViaNode(
     db,

--- a/packages/engine/src/routes/presence.ts
+++ b/packages/engine/src/routes/presence.ts
@@ -1,4 +1,5 @@
 import { Hono } from 'hono';
+import { z } from 'zod';
 import type { AppEnv } from '../env.js';
 import { requireWorkspaceRead, requireAgentToken } from '../middleware/auth.js';
 import { rateLimit } from '../middleware/rateLimit.js';
@@ -10,9 +11,13 @@ import {
 } from '../engine/observerToken.js';
 import { emitServerEvent } from '../lib/serverTelemetry.js';
 import { errorResponse } from '../lib/httpError.js';
-import { jsonOk, jsonSuccess } from '../lib/httpResponse.js';
+import { jsonOk, jsonSuccess, parseOptionalJsonBody } from '../lib/httpResponse.js';
 
 export const presenceRoutes = new Hono<AppEnv>();
+
+const disconnectBodySchema = z.object({
+  deregister: z.boolean().optional().default(false),
+});
 
 presenceRoutes.get('/agents/presence', requireWorkspaceRead('agents:read'), rateLimit, async (c) => {
   try {
@@ -43,7 +48,9 @@ presenceRoutes.post('/agents/heartbeat', requireAgentToken, rateLimit, async (c)
   }
 });
 
-// POST /agents/disconnect — explicitly mark agent offline.
+// POST /agents/disconnect — explicitly mark agent offline. For node-hosted
+// agents this is presence-only by default; pass `{ "deregister": true }` to
+// also tear down the node binding and re-home the agent to its direct node.
 presenceRoutes.post('/agents/disconnect', requireAgentToken, rateLimit, async (c) => {
   try {
     const db = c.get('db');
@@ -51,7 +58,12 @@ presenceRoutes.post('/agents/disconnect', requireAgentToken, rateLimit, async (c
     const workspace = c.get('workspace');
     const { presence } = c.get('engine');
 
-    await handleAgentDisconnect(db, workspace.id, agent.id);
+    const parsed = await parseOptionalJsonBody(c, disconnectBodySchema, 'invalid disconnect body');
+    if (!parsed.ok) {
+      return parsed.response;
+    }
+
+    await handleAgentDisconnect(db, workspace.id, agent.id, { deregister: parsed.data.deregister });
     await presence.disconnect(workspace.id, agent.id, agent.name);
 
     emitServerEvent(c, workspace.id, 'relaycast_server_presence_disconnected', {

--- a/packages/sdk-typescript/CHANGELOG.md
+++ b/packages/sdk-typescript/CHANGELOG.md
@@ -7,7 +7,10 @@ See the [root changelog](../../CHANGELOG.md) for cross-package release highlight
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [Unreleased - Minor]
+
+### Added
+- `AgentClient.disconnect()` and `presence.markOffline()` accept an optional `{ deregister?: boolean }`. By default the disconnect is presence-only for node-hosted agents; pass `{ deregister: true }` to tear down the node binding and re-home the agent to its direct node.
 
 ## [6.0.0] - 2026-07-09
 

--- a/packages/sdk-typescript/src/__tests__/agent-features.test.ts
+++ b/packages/sdk-typescript/src/__tests__/agent-features.test.ts
@@ -342,4 +342,57 @@ describe('AgentClient features', () => {
     });
 
   });
+
+  describe('presence.markOffline', () => {
+    it('posts to /v1/agents/disconnect with no deregister flag by default', async () => {
+      mockFetch.mockImplementation(() => mockResponse({}));
+      await me.presence.markOffline();
+
+      const [url, init] = mockFetch.mock.calls[0]!;
+      expect(url).toBe('https://cast.agentrelay.com/v1/agents/disconnect');
+      expect(init.method).toBe('POST');
+      expect(init.body).toBe(JSON.stringify({}));
+    });
+
+    it('sends { deregister: true } when opted in', async () => {
+      mockFetch.mockImplementation(() => mockResponse({}));
+      await me.presence.markOffline({ deregister: true });
+
+      const [, init] = mockFetch.mock.calls[0]!;
+      expect(init.body).toBe(JSON.stringify({ deregister: true }));
+    });
+
+    it('sends no deregister flag when deregister is false', async () => {
+      mockFetch.mockImplementation(() => mockResponse({}));
+      await me.presence.markOffline({ deregister: false });
+
+      const [, init] = mockFetch.mock.calls[0]!;
+      expect(init.body).toBe(JSON.stringify({}));
+    });
+  });
+
+  describe('disconnect', () => {
+    it('posts to /v1/agents/disconnect with no deregister flag by default', async () => {
+      mockFetch.mockImplementation(() => mockResponse({}));
+      await me.disconnect();
+
+      const disconnectCall = mockFetch.mock.calls.find(
+        ([url]) => url === 'https://cast.agentrelay.com/v1/agents/disconnect',
+      );
+      expect(disconnectCall).toBeDefined();
+      expect(disconnectCall![1].method).toBe('POST');
+      expect(disconnectCall![1].body).toBe(JSON.stringify({}));
+    });
+
+    it('sends { deregister: true } when opted in', async () => {
+      mockFetch.mockImplementation(() => mockResponse({}));
+      await me.disconnect({ deregister: true });
+
+      const disconnectCall = mockFetch.mock.calls.find(
+        ([url]) => url === 'https://cast.agentrelay.com/v1/agents/disconnect',
+      );
+      expect(disconnectCall).toBeDefined();
+      expect(disconnectCall![1].body).toBe(JSON.stringify({ deregister: true }));
+    });
+  });
 });

--- a/packages/sdk-typescript/src/agent.ts
+++ b/packages/sdk-typescript/src/agent.ts
@@ -196,6 +196,12 @@ export class AgentClient {
      */
     markOffline: async (options?: { deregister?: boolean }): Promise<void> => {
       this.stopAutoHeartbeat();
+      // Wait for any in-flight auto heartbeat to settle so the HTTP disconnect
+      // below is guaranteed to be the last presence mutation.
+      if (this.pendingHeartbeat) {
+        await this.pendingHeartbeat;
+        this.pendingHeartbeat = null;
+      }
       await this.client.post('/v1/agents/disconnect', options?.deregister ? { deregister: true } : {});
     },
   };

--- a/packages/sdk-typescript/src/agent.ts
+++ b/packages/sdk-typescript/src/agent.ts
@@ -189,9 +189,10 @@ export class AgentClient {
      * Mark this agent offline.
      *
      * By default this is a presence-only signal: a node-hosted (broker) agent
-     * keeps its node binding, so its still-running session continues to receive
-     * deliveries. Pass `{ deregister: true }` to also tear down the node
-     * binding and re-home the agent to its implicit direct node.
+     * keeps its node binding, so a session still running on its node keeps
+     * receiving deliveries through that node and the binding stays usable for
+     * later reconnection. Pass `{ deregister: true }` to also tear down the
+     * node binding and re-home the agent to its implicit direct node.
      */
     markOffline: async (options?: { deregister?: boolean }): Promise<void> => {
       this.stopAutoHeartbeat();
@@ -281,12 +282,14 @@ export class AgentClient {
   }
 
   /**
-   * Tear down the WebSocket and mark this agent offline.
+   * Tear down this client's WebSocket and mark the agent offline.
    *
    * By default the HTTP disconnect is presence-only for node-hosted (broker)
-   * agents: the node binding is left intact so a still-running session keeps
-   * receiving deliveries. Pass `{ deregister: true }` to also deregister the
-   * node binding and re-home the agent to its implicit direct node.
+   * agents: the node binding is preserved, so an agent process still running
+   * on its node keeps receiving deliveries through that node, and the binding
+   * remains usable for later reconnection. Pass `{ deregister: true }` to also
+   * deregister the node binding and re-home the agent to its implicit direct
+   * node.
    */
   async disconnect(options?: { deregister?: boolean }): Promise<void> {
     this.stopAutoHeartbeat();

--- a/packages/sdk-typescript/src/agent.ts
+++ b/packages/sdk-typescript/src/agent.ts
@@ -185,9 +185,17 @@ export class AgentClient {
     heartbeat: async (): Promise<void> => {
       await this.client.post('/v1/agents/heartbeat', {});
     },
-    markOffline: async (): Promise<void> => {
+    /**
+     * Mark this agent offline.
+     *
+     * By default this is a presence-only signal: a node-hosted (broker) agent
+     * keeps its node binding, so its still-running session continues to receive
+     * deliveries. Pass `{ deregister: true }` to also tear down the node
+     * binding and re-home the agent to its implicit direct node.
+     */
+    markOffline: async (options?: { deregister?: boolean }): Promise<void> => {
       this.stopAutoHeartbeat();
-      await this.client.post('/v1/agents/disconnect', {});
+      await this.client.post('/v1/agents/disconnect', options?.deregister ? { deregister: true } : {});
     },
   };
 
@@ -272,7 +280,15 @@ export class AgentClient {
     await this.presence.heartbeat();
   }
 
-  async disconnect(): Promise<void> {
+  /**
+   * Tear down the WebSocket and mark this agent offline.
+   *
+   * By default the HTTP disconnect is presence-only for node-hosted (broker)
+   * agents: the node binding is left intact so a still-running session keeps
+   * receiving deliveries. Pass `{ deregister: true }` to also deregister the
+   * node binding and re-home the agent to its implicit direct node.
+   */
+  async disconnect(options?: { deregister?: boolean }): Promise<void> {
     this.stopAutoHeartbeat();
     // Wait for any in-flight auto heartbeat to settle at PresenceDO so the
     // HTTP disconnect below is guaranteed to be the last presence mutation.
@@ -294,7 +310,9 @@ export class AgentClient {
     this.activeWsChannels.clear();
     // Always send the HTTP disconnect — it works even without a WS and
     // serves as the authoritative presence update.
-    await this.client.post('/v1/agents/disconnect', {}).catch(() => {});
+    await this.client
+      .post('/v1/agents/disconnect', options?.deregister ? { deregister: true } : {})
+      .catch(() => {});
   }
 
   subscribe(channels: string[]): void;

--- a/packages/sdk-typescript/src/agent.ts
+++ b/packages/sdk-typescript/src/agent.ts
@@ -210,6 +210,10 @@ export class AgentClient {
     this.stopAutoHeartbeat();
     if (this.autoHeartbeatMs === false) return;
     this.autoHeartbeatTimer = setInterval(() => {
+      // Serialize heartbeats: skip this tick while one is still in flight so
+      // pendingHeartbeat always tracks the only outstanding request — awaiting
+      // it before disconnect then guarantees no heartbeat lands afterwards.
+      if (this.pendingHeartbeat) return;
       this.pendingHeartbeat = this.presence.heartbeat()
         .catch(() => {})
         .finally(() => { this.pendingHeartbeat = null; });


### PR DESCRIPTION
Fixes #272.

## Problem

`POST /v1/agents/disconnect` always ran the full node teardown for a broker-hosted (`via_node`) agent: it deactivated the active `agent_node_bindings` row, released the node slot, and re-homed `location_node_id` to the implicit offline direct node — silently, while the agent's PTY kept running on the node. Any one-shot SDK/CLI/MCP use of the agent's token that ended with a disconnect destroyed the agent's broker routing: subsequent deliveries snapshotted the offline direct node and queued forever, while the agent could still send normally.

## Fix

- **Engine — presence-only by default.** `handleAgentDisconnect` now takes `opts: { deregister?: boolean }` (default `false`). Without the flag, a node-hosted agent's disconnect is treated as presence intent only: the node binding, slot, and `location_node_id` are left intact, and the skip is logged at warn. The gate lives inside `handleAgentDisconnect` (not just the route) so the hosted gateway — whose presence adapter delegates to this helper — inherits the fix on the next engine bump.
- **Explicit opt-in for the teardown.** The route accepts an optional JSON body `{ "deregister": true }` (zod-validated; absent/empty body means `false`) to request the previous full deregistration, and the re-homing is now logged at warn instead of happening invisibly.
- **SDK.** `disconnect(options?: { deregister?: boolean })` and `presence.markOffline(options?: { deregister?: boolean })` pass the flag through; the default remains presence-only.
- **Docs.** `openapi.yaml` operation description + request body, and the `handleAgentDisconnect` guidance in `README.md`, updated to match. Changelogs curated at `[Unreleased - Minor]` (root, engine, sdk-typescript).

## Tests

- Reworked the conformance test that encoded the old behavior: default REST disconnect now asserts the binding stays active, the slot stays held, and `location_node_id` stays on the original node; a sibling test asserts `{ deregister: true }` performs the full teardown (old assertions).
- SDK tests cover the default body (`{}`) vs opt-in (`{ deregister: true }`) for both `disconnect()` and `markOffline()`.
- `npx turbo build` 9/9, engine suite 469 tests passed, sdk suite 389 tests passed, typecheck and lint clean.

## Note

This PR and #273's PR (branch `claude/relaycast-issue-273-xa2lua`) both touch `agent-disconnect.ts`/`node.ts`; whichever merges second may need a trivial rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JQ8fa196XtLnvctQMQuUDx

---
_Generated by [Claude Code](https://claude.ai/code/session_01JQ8fa196XtLnvctQMQuUDx)_

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/AgentWorkforce/relaycast/pull/277?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

