### PR TITLE
fix(engine,types): remove raw NUL byte from source and correct deliver fixture

### DIFF
--- a/packages/engine/src/routes/deliveryRouting.ts
+++ b/packages/engine/src/routes/deliveryRouting.ts
@@ -588,7 +588,9 @@ export async function sweepDueNodeDeliveries(
       httpPushEvents.push(event);
       continue;
     }
-    const key = `${event.workspaceId} ${event.delivery.agentId}`;
+    // Collision-safe key: workspace and agent ids are free-form, so encode the
+    // tuple rather than joining on a separator (matches groupByNodeProvider).
+    const key = JSON.stringify([event.workspaceId, event.delivery.agentId]);
     if (seenWsAgents.has(key)) continue;
     seenWsAgents.add(key);
     wsAgents.push({ workspaceId: event.workspaceId, agentId: event.delivery.agentId });

--- a/packages/types/fixtures/fleet-wire/deliver.json
+++ b/packages/types/fixtures/fleet-wire/deliver.json
@@ -8,12 +8,23 @@
   "seq": 43,
   "mode": "wait",
   "payload": {
-    "channel": "general",
-    "text": "Please run the fleet fixture tests.",
-    "sender": "orchestrator",
-    "thread_id": null,
-    "metadata": {
-      "priority": "normal"
+    "type": "message.created",
+    "data": {
+      "id": "msg_01J7FLEET000000000000201",
+      "channel_id": "chn_01J7FLEET000000000000401",
+      "agent_id": "agt_01J7FLEET000000000000999",
+      "agent_name": "orchestrator",
+      "text": "Please run the fleet fixture tests.",
+      "blocks": null,
+      "metadata": {},
+      "has_attachments": false,
+      "thread_id": null,
+      "created_at": "2026-02-14T17:32:11.000Z",
+      "mentions": [],
+      "attachments": [],
+      "injection_mode": "wait",
+      "channel_name": "general",
+      "from_name": "orchestrator"
     }
   }
 }


### PR DESCRIPTION
Two fixes found during a codebase review.

## 1. A raw NUL byte was committed into engine source

`packages/engine/src/routes/deliveryRouting.ts:591` used the ws-agent dedupe key:

```ts
const key = `${event.workspaceId}<0x00>${event.delivery.agentId}`;
```

That separator was a **literal `0x00` byte**, not the two-character `\x00` escape. Consequences:

- **ripgrep/grep classified the 26KB file as binary and silently skipped it.** Code search returned `binary file matches` instead of results, so this file was invisible to content search.
- **`git diff` rendered it as an ordinary space.** Git's binary heuristic only scans the first 8000 bytes, and the NUL sits at offset 23117 — so it looked completely normal in every review.
- **It was one formatter away from a silent data bug.** Any editor or tool that strips control characters would collapse the separator to `""`, colliding keys such as `(ws "a", agent "bc")` with `(ws "ab", agent "c")` and dropping one agent's due-delivery redrive.

Replaced with the collision-safe tuple encoding already used by `groupByNodeProvider` in `nodeContext.ts`, so this follows an established in-repo pattern:

```ts
const key = JSON.stringify([event.workspaceId, event.delivery.agentId]);
```

Behavior is unchanged. `file` now reports UTF-8 text instead of `data`, and ripgrep can search the file again.

## 2. The `deliver.json` wire fixture misrepresented the payload

The fixture described a flat payload:

```jsonc
"payload": { "channel": "general", "text": "…", "sender": "orchestrator", … }
```

But `buildDeliverPayload` returns `{ type, data }`, and **both** `buildDeliverFrame` call sites (`delivery.ts:914`, `nodeDeliver.ts:153`) route through it. The fixture matched no code path.

Nothing caught it because `payload` is typed `FleetWireJsonValue`, so the round-trip test's `schema.parse` accepts any JSON. Since this fixture is the canonical cross-repo sample of the wire contract, an SDK author reading it would have built the wrong parser.

The corrected payload was derived from `buildRoutableDeliveryEvent` + `buildMessageCreatedEventData` rather than copied from the broker's copy, so all fifteen `message.created` fields are accurate. The `del_` delivery-id prefix was kept — checking `deliveryWrites.ts` and `dm.ts` confirmed relaycast had that right and the broker's copy had `dlv_` wrong.

## Test plan

- `npx turbo test` — **18/18 tasks green**, including 509 engine tests and the 162 `@relaycast/types` fixture round-trip tests.
- Verified `file` reports `UTF-8 text` (was `data`) and that ripgrep now matches inside `deliveryRouting.ts`.
- No changelog entry: the dedupe-key change is behavior-preserving and internal, and fixtures are not published (`@relaycast/types` ships `files: ["dist"]`).

## Related

AgentWorkforce/relay#(companion) aligns the broker's copy of `deliver.json` with the corrected fixture.

A third finding from the same review is **not** addressed here and needs a decision: the engine emits `context.update` frames over `ws.node.v1` (`nodeContext.ts:94`), but the broker's `ServerToNode` enum has no such variant, so every one is dropped with a warn. Either the broker should handle the frame or the engine should not send it to broker nodes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RGTSgKgcg4Aiqf4s68JGfg)_

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/AgentWorkforce/relaycast/pull/296?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

