### PR TITLE
fix(engine): clear left_at when re-resolving a 1:1 DM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,11 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 Packages without a separate changelog are covered by the cross-package notes below.
 
-## [Unreleased]
+## [Unreleased - Patch]
+
+### Fixed
+
+- Sending into a 1:1 DM whose participant is marked as departed now restores that participant, instead of resolving the conversation while its roster still shows the departure.
 
 ## [6.3.0] - 2026-07-28
 

--- a/packages/engine/CHANGELOG.md
+++ b/packages/engine/CHANGELOG.md
@@ -7,7 +7,11 @@ See the [root changelog](../../CHANGELOG.md) for cross-package release highlight
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [Unreleased - Patch]
+
+### Fixed
+
+- `sendDm` re-resolving a 1:1 conversation now clears `dm_participants.left_at` for both participants instead of no-opping on conflict. A 1:1 with a departed participant previously resolved to the same conversation while its roster still showed the departure; the conversation id is unchanged either way, since it derives only from the workspace and the sorted agent pair.
 
 ## [6.3.0] - 2026-07-28
 

--- a/packages/engine/src/engine/__tests__/dm.test.ts
+++ b/packages/engine/src/engine/__tests__/dm.test.ts
@@ -1,0 +1,172 @@
+/**
+ * 1:1 DM conversation identity and roster invariants.
+ *
+ * A 1:1 conversation id is a pure function of `(workspaceId, sorted agent pair)`,
+ * so it names the durable A<->B relationship rather than a conversation instance.
+ * Agent Relay has declared that model externally — it is the basis on which Ratify
+ * delegation certificates are scoped to a DM (see the Agent Relay Resource
+ * Identifier Profile, invariant DM-1), which means the properties asserted here
+ * are a compatibility surface, not just internal behaviour.
+ */
+
+import { afterEach, describe, expect, it } from 'vitest';
+import { and, eq, isNotNull } from 'drizzle-orm';
+
+import { getSqliteDb, runMigrations, type SqliteDbHandle } from '../../adapters/node/database.js';
+import { agents, dmConversations, dmParticipants, workspaces } from '../../db/schema.js';
+import { sendDm } from '../dm.js';
+
+type Db = SqliteDbHandle['db'];
+
+const handles: SqliteDbHandle[] = [];
+
+afterEach(() => {
+  for (const handle of handles.splice(0)) {
+    try {
+      handle.sqlite.close();
+    } catch {
+      /* already closed */
+    }
+  }
+});
+
+let seq = 0;
+
+interface Fixture {
+  db: Db;
+  ws: string;
+  alice: string;
+  bob: string;
+}
+
+function seed(): Fixture {
+  const handle = getSqliteDb(':memory:');
+  runMigrations(handle);
+  handles.push(handle);
+
+  const n = ++seq;
+  const ws = `ws_${n}`;
+  const alice = `ag_alice_${n}`;
+  const bob = `ag_bob_${n}`;
+
+  handle.db.insert(workspaces).values({ id: ws, name: `w${n}`, apiKeyHash: `hash_${n}` }).run();
+  handle.db.insert(agents).values({ id: alice, workspaceId: ws, name: 'alice', tokenHash: `tok_a_${n}` }).run();
+  handle.db.insert(agents).values({ id: bob, workspaceId: ws, name: 'bob', tokenHash: `tok_b_${n}` }).run();
+
+  return { db: handle.db, ws, alice, bob };
+}
+
+/** Mirrors `getDmPairKey` — kept independent so a change to the algorithm fails here. */
+async function expectedConversationId(ws: string, a: string, b: string): Promise<string> {
+  const [first, second] = [a, b].sort();
+  const digest = await crypto.subtle.digest(
+    'SHA-256',
+    new TextEncoder().encode(`${ws}:${first}:${second}`),
+  );
+  const hex = Array.from(new Uint8Array(digest))
+    .map((byte) => byte.toString(16).padStart(2, '0'))
+    .join('');
+  return `dm_${hex.slice(0, 24)}`;
+}
+
+describe('1:1 DM conversation identity', () => {
+  it('derives the conversation id from the workspace and the sorted agent pair', async () => {
+    const { db, ws, alice, bob } = seed();
+
+    const sent = await sendDm(db, ws, alice, { to: 'bob', text: 'hello' });
+
+    expect(sent.conversation_id).toBe(await expectedConversationId(ws, alice, bob));
+  });
+
+  it('resolves the same conversation regardless of who sends first', async () => {
+    const { db, ws, alice, bob } = seed();
+
+    const fromAlice = await sendDm(db, ws, alice, { to: 'bob', text: 'hello' });
+    const fromBob = await sendDm(db, ws, bob, { to: 'alice', text: 'hi back' });
+
+    expect(fromBob.conversation_id).toBe(fromAlice.conversation_id);
+
+    const conversations = await db.select().from(dmConversations).where(eq(dmConversations.workspaceId, ws));
+    expect(conversations).toHaveLength(1);
+  });
+
+  it('re-resolves an existing conversation without creating a second one', async () => {
+    const { db, ws, alice } = seed();
+
+    const first = await sendDm(db, ws, alice, { to: 'bob', text: 'one' });
+    const second = await sendDm(db, ws, alice, { to: 'bob', text: 'two' });
+
+    expect(second.conversation_id).toBe(first.conversation_id);
+
+    const participants = await db
+      .select()
+      .from(dmParticipants)
+      .where(eq(dmParticipants.conversationId, first.conversation_id));
+    expect(participants).toHaveLength(2);
+  });
+});
+
+describe('invariant DM-1: a 1:1 conversation never has a departed participant', () => {
+  /**
+   * The seam this pins:
+   *
+   * `resolveConversation` finds an existing 1:1 by joining `dm_participants`
+   * with `left_at IS NULL`. If a participant is ever marked departed the SELECT
+   * misses, so the create branch runs — recomputing the *same* deterministic id
+   * and re-inserting with `onConflictDoNothing()`, which no-ops against the
+   * existing conversation, channel, and participant rows. `left_at` stays set.
+   *
+   * The conversation therefore keeps resolving correctly while its roster says
+   * someone left. Nothing throws; the two just disagree from then on.
+   *
+   * Identifier stability is not what breaks — the id never consults `left_at`.
+   * What breaks is the claim that the identifier names a durable relationship
+   * with fixed membership, which is the substance of the lifecycle model Agent
+   * Relay declared to Identities AI. That is why this is an invariant and not a
+   * code comment.
+   *
+   * No current code path can set `left_at` for a 1:1 — `left_at` is written only
+   * by the group-DM code. This test reaches the state directly so the invariant
+   * is guarded before some future path can reach it accidentally.
+   */
+  it('clears a departed marker rather than resolving a conversation whose roster disagrees', async () => {
+    const { db, ws, alice, bob } = seed();
+
+    const first = await sendDm(db, ws, alice, { to: 'bob', text: 'hello' });
+    const conversationId = first.conversation_id;
+
+    // Reach the state no current code path can reach.
+    await db
+      .update(dmParticipants)
+      .set({ leftAt: new Date() })
+      .where(
+        and(eq(dmParticipants.conversationId, conversationId), eq(dmParticipants.agentId, alice)),
+      );
+
+    const second = await sendDm(db, ws, alice, { to: 'bob', text: 'again' });
+
+    // Identity holds: the id is a pure function of (workspace, sorted pair).
+    expect(second.conversation_id).toBe(conversationId);
+
+    // Exactly one conversation — the create branch must not have minted a second.
+    const conversations = await db
+      .select()
+      .from(dmConversations)
+      .where(eq(dmConversations.workspaceId, ws));
+    expect(conversations).toHaveLength(1);
+
+    // DM-1 itself: no participant of a 1:1 is left marked departed.
+    const departed = await db
+      .select()
+      .from(dmParticipants)
+      .where(and(eq(dmParticipants.conversationId, conversationId), isNotNull(dmParticipants.leftAt)));
+    expect(departed).toEqual([]);
+
+    // And the roster is still both agents.
+    const roster = await db
+      .select({ agentId: dmParticipants.agentId })
+      .from(dmParticipants)
+      .where(eq(dmParticipants.conversationId, conversationId));
+    expect(roster.map((r) => r.agentId).sort()).toEqual([alice, bob].sort());
+  });
+});

--- a/packages/engine/src/engine/dm.ts
+++ b/packages/engine/src/engine/dm.ts
@@ -78,14 +78,24 @@ async function resolveConversation(
       dmType: '1:1',
     }).onConflictDoNothing();
 
+    // Clear `left_at` rather than no-op on conflict. Reaching this branch for an
+    // id that already exists means the lookup above missed, and the only way it
+    // can miss for an existing 1:1 is a participant marked departed. Leaving the
+    // marker set would resolve the conversation while its roster disagreed —
+    // see invariant DM-1 in __tests__/dm.test.ts.
+    const rejoin = {
+      target: [dmParticipants.conversationId, dmParticipants.agentId],
+      set: { leftAt: null },
+    };
+
     await db.insert(dmParticipants).values({
       conversationId: deterministicConversationId,
       agentId: fromAgentId,
-    }).onConflictDoNothing();
+    }).onConflictDoUpdate(rejoin);
     await db.insert(dmParticipants).values({
       conversationId: deterministicConversationId,
       agentId: toAgentId,
-    }).onConflictDoNothing();
+    }).onConflictDoUpdate(rejoin);
 
     conversationId = deterministicConversationId;
   }


### PR DESCRIPTION
## What

A 1:1 DM conversation id is a pure function of `(workspaceId, sorted agent pair)`, so it names the durable A↔B relationship rather than a conversation instance.

`resolveConversation` finds an existing 1:1 by joining `dm_participants` with `left_at IS NULL`. If a participant is ever marked departed the `SELECT` misses, the create branch runs, recomputes the **same** deterministic id, and re-inserts with `onConflictDoNothing()` — which no-ops against the existing conversation, channel, and participant rows, leaving `left_at` set.

The conversation then keeps resolving correctly while its roster says someone left. Nothing throws; the two just disagree from then on.

Identifier stability is *not* what breaks — the id never consults `left_at`. What breaks is the claim that the identifier names a relationship with fixed membership.

## Why it matters outside this repo

That claim is load-bearing for the Ratify design partnership. Agent Relay has declared this lifecycle model to Identities AI as the basis on which Ratify delegation certificates are scoped to a DM — invariant **DM-1** in the Agent Relay Resource Identifier Profile. It is stated as an invariant with a test rather than left as a code comment, so it cannot change silently later.

## Change

The create branch clears `left_at` on conflict instead of no-opping. Reaching that branch for an id that already exists means the lookup missed, and for an existing 1:1 the only way it can miss is a departed participant — so re-resolution heals the roster.

Resolution semantics are otherwise unchanged. No current code path can set `left_at` for a 1:1: it is written only by the group-DM code (`groupDm.ts`). The test reaches that state directly so the invariant is guarded before some future path can reach it accidentally.

## Tests

Four tests covering the model:

- id derives from `(workspace, sorted pair)`
- either sender resolves the same conversation
- re-resolution creates no second conversation
- **DM-1**: a 1:1 conversation never has a departed participant

The DM-1 test fails against the previous behaviour, which is the point — it pins the invariant, not the current behaviour.

## Verification

- `npx turbo build && npx vitest run` in `packages/engine` — **515/515**
- `npx turbo lint` — clean
- Confirmed it is a real guard: with the one-line fix reverted, DM-1 is the only test in the engine suite whose result changes.

## Review note

This touches production message-routing code (`onConflictDoNothing` → `onConflictDoUpdate` in the 1:1 resolution path). It is one line and only fires in a branch unreachable today, but a reviewer who owns this file should confirm the conflict-target choice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/AgentWorkforce/relaycast/pull/302?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

