### PR TITLE
docs: correct the audit header to the database production actually uses

### DIFF
--- a/scripts/audit-dm-reservations.mjs
+++ b/scripts/audit-dm-reservations.mjs
@@ -17,7 +17,7 @@
  *                            path will never re-derive.
  *
  * IT ALSO EARNED ITS KEEP. Run against production it found 4 colliding pair
- * groups and 30 mismatched ids that would have aborted the deployment. All 30
+ * groups and 87 mismatched ids that would have aborted the deployment. All 87
  * were ORPHANED TWO-PARTY conversations, not self-DMs: `dm_participants.agent_id`
  * cascades on agent deletion, so an ordinary 1:1 collapses to a one-row roster
  * while its id still encodes the original pair. The backfill was reading those
@@ -30,17 +30,28 @@
  *
  * Git history says the derivation never changed — the only edit swapped node
  * crypto for web crypto with a byte-identical input string, and production
- * confirms it: 3425 two-party conversations, zero mismatches. This script exists
+ * confirms it: 2607 two-party conversations, zero mismatches. This script exists
  * because "stable in git history" and "zero rows in production disagree" are
  * different claims, and only the second one is evidence.
+ *
+ * WHICH DATABASE. Those figures are from `relaycast-cloud`, the D1 instance the
+ * production worker binds — resolve it through the SST resource
+ * `RelaycastDatabase`, never by the name that matches this repo. Two live
+ * instances carry DM data under confusingly close names and this script was
+ * first run against the wrong one; the finding replicated on both, so the
+ * conclusion held, but it held for the wrong reason until that was checked.
+ * The figures above were corrected on 2026-08-04 from the wrong-instance run
+ * (which reported 30 mismatches and 3425 two-party conversations).
  *
  * USAGE
  * ─────
  *   Self-hosted (SQLite file):
  *     node scripts/audit-dm-reservations.mjs --sqlite /path/to/relay.db
  *
- *   Hosted (Cloudflare D1) — feed it the rows, since D1 is not a local file:
- *     wrangler d1 execute <DB> --json --command \
+ *   Hosted (Cloudflare D1) — feed it the rows, since D1 is not a local file.
+ *   `--remote` is required: without it wrangler reads the LOCAL emulated
+ *   database and the audit silently reports on nothing.
+ *     wrangler d1 execute relaycast-cloud --remote --json --command \
  *       "SELECT dc.id, dc.workspace_id, dp.agent_id \
  *        FROM dm_conversations dc \
  *        JOIN dm_participants dp ON dp.conversation_id = dc.id \


### PR DESCRIPTION
## What

Comment-only correction to `scripts/audit-dm-reservations.mjs`. No behaviour change.

The header recorded **30 mismatched ids** and **3425 two-party conversations**. Those figures come from the first run of this script, which went against the pre-cutover `relaycast` D1 instance rather than `relaycast-cloud` — the one the worker actually binds. Every other record of that run (the migration record, and what was reported to the Ratify design partner) says **4 colliding pair groups, 87 mismatched ids, 2607 two-party conversations**.

The finding replicated on both instances, so the conclusion held and the deployment was correct. But the script disagreed with itself and with everything else describing the same run, and it is the artifact someone would read first.

## Also

- Names which instance the figures are from, and how to resolve it: through the SST resource `RelaycastDatabase`, never by the name matching this repo. Two live instances carry DM data under confusingly close names, which is how the wrong one got audited in the first place.
- Adds the missing `--remote` to the usage example. Without it `wrangler d1 execute` reads the **local emulated** database, so the audit silently reports on nothing — hit while re-running this against production today.

## Verification

Re-ran the script against `relaycast-cloud` today: 3078 1:1 conversations scanned, 2961 reservable, 117 skipped (101 orphaned two-party, 16 self-DM), and zero findings in all three checks. Reservation table: 0 colliding pair groups, 0 reservations without a conversation, 0 unsorted pairs, and 0 of the 2961 two-party conversations without a reservation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/AgentWorkforce/relaycast/pull/304?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

