### PR TITLE
fix(a2a): serve agent-card discovery at the standard well-known path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,11 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 Packages without a separate changelog are covered by the cross-package notes below.
 
-## [Unreleased]
+## [Unreleased - Patch]
+
+### Fixed
+
+- A2A agent-card discovery now answers the standard `GET /.well-known/agent-card.json` on a single-tenant deployment, and an explicit `/:workspace/` path selector is honoured instead of being overridden by host inference. Previously a deployment whose workspace was not named after the first label of its hostname returned `workspace_not_found` at the standard discovery URL, and the documented path route could never take effect on any authority with three or more labels. Multi-tenant deployments still fail closed, and an invalid explicit selector is never silently replaced.
 
 ## [7.0.0] - 2026-08-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ Packages without a separate changelog are covered by the cross-package notes bel
 
 ### Fixed
 
-- A2A agent-card discovery now answers the standard `GET /.well-known/agent-card.json` on a single-tenant deployment, and an explicit `/:workspace/` path selector is honoured instead of being overridden by host inference. Previously a deployment whose workspace was not named after the first label of its hostname returned `workspace_not_found` at the standard discovery URL, and the documented path route could never take effect on any authority with three or more labels. Multi-tenant deployments still fail closed, and an invalid explicit selector is never silently replaced.
+- A2A counterparties can discover a self-hosted deployment at the standard `GET /.well-known/agent-card.json`, and `/:workspace/.well-known/agent-card.json` now resolves. Deployments holding more than one workspace still require a selector.
 
 ## [7.0.0] - 2026-08-07
 

--- a/README.md
+++ b/README.md
@@ -649,7 +649,8 @@ POST   /v1/a2a/register              Register an external A2A agent
 GET    /v1/a2a/agents                List registered A2A agents
 DELETE /v1/a2a/agents/:name          Remove an A2A agent
 GET    /v1/a2a/agents/:name/card     Get agent card for a registered agent
-GET    /.well-known/agent-card.json  A2A agent card (root-level)
+GET    /.well-known/agent-card.json  A2A agent card (root-level; ?workspace= selects on multi-tenant)
+GET    /:workspace/.well-known/agent-card.json  A2A agent card for a named workspace
 POST   /a2a/rpc                      A2A JSON-RPC gateway (root-level)
 POST   /a2a/webhook/:ws/:name        Inbound webhook for relay agents
 ```

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -4801,10 +4801,69 @@ paths:
         description: Local development server
     get:
       summary: Workspace A2A agent card
+      description: >
+        Unauthenticated A2A discovery. The workspace is resolved in order:
+        Authorization header, `?workspace=` query parameter, an explicit
+        `/:workspace/` path segment, then the first host label (the hosted
+        workspace-per-subdomain convention). A deployment holding exactly one
+        workspace answers this bare path with that workspace; a deployment
+        holding more than one returns 404 unless a selector identifies it. An
+        explicit query or path selector that does not resolve always returns
+        404 rather than falling back.
       tags: [A2A]
+      parameters:
+        - in: query
+          name: workspace
+          required: false
+          schema:
+            type: string
+          description: Workspace name. Required on a deployment holding more than one workspace.
       responses:
         '200':
           description: Agent card JSON
+          content:
+            application/json:
+              schema:
+                type: object
+        '404':
+          description: >
+            `workspace_not_found` — no selector resolved a workspace, or an
+            explicit selector named one that does not exist.
+          content:
+            application/json:
+              schema:
+                type: object
+
+  /{workspace}/.well-known/agent-card.json:
+    servers:
+      - url: https://cast.agentrelay.com
+        description: Production server (root, no /v1 prefix)
+      - url: http://localhost:8787
+        description: Local development server
+    get:
+      summary: Workspace A2A agent card, path-scoped
+      description: >
+        Path-scoped form of A2A discovery. The path segment takes precedence
+        over host-label inference, so this route resolves on multi-label
+        authorities. A segment naming a workspace that does not exist returns
+        404 rather than falling back to any other workspace.
+      tags: [A2A]
+      parameters:
+        - in: path
+          name: workspace
+          required: true
+          schema:
+            type: string
+          description: Workspace name.
+      responses:
+        '200':
+          description: Agent card JSON
+          content:
+            application/json:
+              schema:
+                type: object
+        '404':
+          description: '`workspace_not_found` — the named workspace does not exist.'
           content:
             application/json:
               schema:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -4807,9 +4807,11 @@ paths:
         `/:workspace/` path segment, then the first host label (the hosted
         workspace-per-subdomain convention). A deployment holding exactly one
         workspace answers this bare path with that workspace; a deployment
-        holding more than one returns 404 unless a selector identifies it. An
-        explicit query or path selector that does not resolve always returns
-        404 rather than falling back.
+        holding more than one resolves only if one of those mechanisms names a
+        workspace — a valid workspace subdomain is sufficient on its own — and
+        otherwise returns 404. An explicit query or path selector that does not
+        resolve always returns 404 rather than falling back to any other
+        workspace.
       tags: [A2A]
       parameters:
         - in: query
@@ -4817,7 +4819,10 @@ paths:
           required: false
           schema:
             type: string
-          description: Workspace name. Required on a deployment holding more than one workspace.
+          description: >
+            Workspace name. Needed on a deployment holding more than one
+            workspace unless the request host already identifies one — a valid
+            workspace subdomain resolves without it.
       responses:
         '200':
           description: Agent card JSON

--- a/packages/engine/CHANGELOG.md
+++ b/packages/engine/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ### Fixed
 
-- `extractWorkspaceHint` consults an explicit `/:workspace/` path parameter before host-label inference, so the documented `/:workspace/.well-known/agent-card.json` route works on authorities with three or more labels instead of being unreachable. `handleWorkspaceAgentCard` falls back to the sole workspace when a deployment has exactly one and the caller supplied no explicit selector, so a single-tenant self-host answers the bare standard well-known URL. The fallback is skipped whenever a query or path selector was supplied — a misspelled selector fails rather than crossing a tenant boundary — and the candidate query is bounded to two rows so a multi-tenant deployment fails closed without scanning the table.
+- Agent-card discovery resolves the workspace from an explicit `/:workspace/` path segment before host-label inference, and serves the sole workspace when a deployment has exactly one and no selector was given. Deployments with more than one workspace, and unresolved explicit selectors, return `workspace_not_found`.
 
 ## [7.0.0] - 2026-08-07
 

--- a/packages/engine/CHANGELOG.md
+++ b/packages/engine/CHANGELOG.md
@@ -7,7 +7,11 @@ See the [root changelog](../../CHANGELOG.md) for cross-package release highlight
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [Unreleased - Patch]
+
+### Fixed
+
+- `extractWorkspaceHint` consults an explicit `/:workspace/` path parameter before host-label inference, so the documented `/:workspace/.well-known/agent-card.json` route works on authorities with three or more labels instead of being unreachable. `handleWorkspaceAgentCard` falls back to the sole workspace when a deployment has exactly one and the caller supplied no explicit selector, so a single-tenant self-host answers the bare standard well-known URL. The fallback is skipped whenever a query or path selector was supplied — a misspelled selector fails rather than crossing a tenant boundary — and the candidate query is bounded to two rows so a multi-tenant deployment fails closed without scanning the table.
 
 ## [7.0.0] - 2026-08-07
 

--- a/packages/engine/src/engine/__tests__/a2a.test.ts
+++ b/packages/engine/src/engine/__tests__/a2a.test.ts
@@ -555,6 +555,22 @@ describe('workspace agent-card discovery', () => {
     });
   });
 
+  it('serves the sole workspace even when an unresolved host label was inferred', async () => {
+    // Host-label inference is a hosted convention, not caller intent, so a
+    // label that names no workspace does not suppress the single-tenant
+    // fallback — otherwise a self-host could never answer the standard path,
+    // since a conformant authority always yields some first label. The row cap
+    // is the boundary: the multi-tenant case above 404s on this same request.
+    await createWorkspace(stack.app, 'ratify-protocol');
+
+    const response = await stack.app.request(
+      'https://relay.ratifyprotocol.com/.well-known/agent-card.json',
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({ name: 'ratify-protocol' });
+  });
+
   it('does not hide an invalid explicit workspace selector behind the sole-workspace fallback', async () => {
     await createWorkspace(stack.app, 'borealis');
 

--- a/packages/engine/src/engine/__tests__/a2a.test.ts
+++ b/packages/engine/src/engine/__tests__/a2a.test.ts
@@ -470,3 +470,101 @@ describe('getWorkspaceAgentCard', () => {
     ]);
   });
 });
+
+describe('workspace agent-card discovery', () => {
+  let stack: TestStack;
+
+  beforeEach(() => {
+    stack = makeNodeStack();
+  });
+
+  afterEach(() => stack.close());
+
+  it('serves the standard bare well-known path for a sole self-hosted workspace', async () => {
+    const ws = await createWorkspace(stack.app, 'borealis');
+    await registerAgent(stack.app, ws.workspaceKey, 'worker');
+
+    const response = await stack.app.request(
+      'https://relay.borealis.example/.well-known/agent-card.json',
+    );
+
+    expect(response.status).toBe(200);
+    const card = await response.json() as { provider?: Record<string, unknown> };
+    expect(card.provider).toMatchObject({
+      workspace_id: ws.workspaceId,
+      workspace_name: 'borealis',
+    });
+  });
+
+  it('keeps a valid hosted workspace subdomain authoritative', async () => {
+    const selected = await createWorkspace(stack.app, 'northwind');
+    await createWorkspace(stack.app, 'borealis');
+
+    const response = await stack.app.request(
+      'https://northwind.cast.example/.well-known/agent-card.json',
+    );
+
+    expect(response.status).toBe(200);
+    const card = await response.json() as { provider?: Record<string, unknown> };
+    expect(card.provider).toMatchObject({
+      workspace_id: selected.workspaceId,
+      workspace_name: 'northwind',
+    });
+  });
+
+  it('makes an explicit path workspace beat host inference on a multi-label authority', async () => {
+    const selected = await createWorkspace(stack.app, 'borealis');
+    await createWorkspace(stack.app, 'cast');
+
+    const response = await stack.app.request(
+      'https://cast.agentrelay.com/borealis/.well-known/agent-card.json',
+    );
+
+    expect(response.status).toBe(200);
+    const card = await response.json() as { provider?: Record<string, unknown> };
+    expect(card.provider).toMatchObject({
+      workspace_id: selected.workspaceId,
+      workspace_name: 'borealis',
+    });
+  });
+
+  it('does not replace an invalid path workspace with a valid host workspace', async () => {
+    await createWorkspace(stack.app, 'cast');
+
+    const response = await stack.app.request(
+      'https://cast.agentrelay.com/misspelled/.well-known/agent-card.json',
+    );
+
+    expect(response.status).toBe(404);
+    await expect(response.json()).resolves.toMatchObject({
+      error: { code: 'workspace_not_found' },
+    });
+  });
+
+  it('fails closed on a bare multi-tenant deployment instead of selecting a workspace', async () => {
+    await createWorkspace(stack.app, 'northwind');
+    await createWorkspace(stack.app, 'borealis');
+
+    const response = await stack.app.request(
+      'https://cast.agentrelay.com/.well-known/agent-card.json',
+    );
+
+    expect(response.status).toBe(404);
+    await expect(response.json()).resolves.toMatchObject({
+      error: { code: 'workspace_not_found' },
+    });
+  });
+
+  it('does not hide an invalid explicit workspace selector behind the sole-workspace fallback', async () => {
+    await createWorkspace(stack.app, 'borealis');
+
+    const response = await stack.app.request(
+      'https://relay.borealis.example/.well-known/agent-card.json?workspace=misspelled',
+    );
+
+    expect(response.status).toBe(404);
+    await expect(response.json()).resolves.toMatchObject({
+      error: { code: 'workspace_not_found' },
+    });
+  });
+});

--- a/packages/engine/src/routes/a2a.ts
+++ b/packages/engine/src/routes/a2a.ts
@@ -237,10 +237,25 @@ async function handleWorkspaceAgentCard(c: Context<AppEnv>) {
 
     // A self-hosted, single-tenant deployment must answer the standard bare
     // well-known URL without requiring a Relaycast-specific query parameter.
-    // Only use this fallback when the caller supplied no explicit workspace:
-    // a misspelled query/path selector must fail rather than silently crossing
-    // a tenant boundary. Limit to two rows so the multi-tenant case fails
-    // closed without scanning the workspace table.
+    //
+    // Two guards, and the distinction between them is deliberate:
+    //
+    // 1. An *explicit* selector is caller intent, so a misspelled `?workspace=`
+    //    or `/:workspace/` must 404 rather than silently resolving to a
+    //    different tenant. Host-label inference is not caller intent — it is a
+    //    hosted workspace-per-subdomain convention, and on any authority with
+    //    three or more labels it always produces a candidate. Treating it as an
+    //    explicit selector would mean the fallback never fires on exactly the
+    //    deployments it exists for.
+    // 2. The row cap is what makes that safe: with two or more workspaces the
+    //    fallback declines rather than guessing, so there is no tenant boundary
+    //    to cross. It is `limit(2)` rather than a count so a large table is
+    //    never scanned.
+    //
+    // Net effect: on a multi-tenant deployment an unresolved host label 404s;
+    // on a single-tenant one it serves the only workspace there is. The card is
+    // unauthenticated by design (A2A discovery), so this exposes nothing that
+    // the standard well-known path is not already meant to publish.
     if (
       !workspace
       && !c.req.query('workspace')

--- a/packages/engine/src/routes/a2a.ts
+++ b/packages/engine/src/routes/a2a.ts
@@ -62,6 +62,13 @@ function extractWorkspaceHint(c: Context<AppEnv>): string | null {
   const explicit = c.req.query('workspace');
   if (explicit) return explicit;
 
+  // An explicit path selector must beat host inference. Previously the host
+  // branch was consulted first, so on any authority with three or more labels
+  // — which the Relay identifier profile requires — the documented
+  // `/:workspace/.well-known/agent-card.json` route could never take effect.
+  const pathWorkspace = c.req.param('workspace');
+  if (pathWorkspace) return pathWorkspace;
+
   const host = c.req.header('Host') ?? new URL(c.req.url).host;
   const hostname = host.split(':')[0] ?? '';
   const hostSegments = hostname.split('.').filter(Boolean);
@@ -70,7 +77,7 @@ function extractWorkspaceHint(c: Context<AppEnv>): string | null {
     return hostSegments[0]!;
   }
 
-  return c.req.param('workspace') || null;
+  return null;
 }
 
 function extractTargetAgentName(params: Record<string, unknown> | undefined, fallbackContextId?: string): string | null {
@@ -225,6 +232,23 @@ async function handleWorkspaceAgentCard(c: Context<AppEnv>) {
           .from(workspaces)
           .where(eq(workspaces.name, workspaceHint));
         workspace = ws ?? null;
+      }
+    }
+
+    // A self-hosted, single-tenant deployment must answer the standard bare
+    // well-known URL without requiring a Relaycast-specific query parameter.
+    // Only use this fallback when the caller supplied no explicit workspace:
+    // a misspelled query/path selector must fail rather than silently crossing
+    // a tenant boundary. Limit to two rows so the multi-tenant case fails
+    // closed without scanning the workspace table.
+    if (
+      !workspace
+      && !c.req.query('workspace')
+      && !c.req.param('workspace')
+    ) {
+      const candidates = await db.select().from(workspaces).limit(2);
+      if (candidates.length === 1) {
+        workspace = candidates[0]!;
       }
     }
 

--- a/packages/types/src/__tests__/sdk-openapi-sync.test.ts
+++ b/packages/types/src/__tests__/sdk-openapi-sync.test.ts
@@ -30,6 +30,10 @@ const IGNORED_SEGMENTS = new Set([
 const NON_SDK_OPENAPI_PATHS = new Set([
   '/v1/health',
   '/v1/.well-known/agent-card.json',
+  // Path-scoped form of the same unauthenticated A2A discovery endpoint. Served
+  // for counterparties that name the workspace explicitly; like the bare form
+  // it is not an agent-SDK surface.
+  '/v1/{param}/.well-known/agent-card.json',
   '/v1/a2a/rpc',
   '/v1/a2a/webhook/{param}/{param}',
   // Provider integration endpoints are provisioned/called by relayfile-cloud,


### PR DESCRIPTION
Split out of the Phase 2 federation work (#318) so it can ship on its own — it affects any A2A counterparty, not just that engagement.

## Current production behaviour

Agent-card discovery is where A2A federation starts, and it does not work today on any deployment whose workspace is not named after the first label of its hostname. Verified against `cast.agentrelay.com`, whose workspace is actually named `rw_7ccfea89`:

```
GET /.well-known/agent-card.json                        -> 404 workspace_not_found
GET /.well-known/agent-card.json?workspace=rw_7ccfea89  -> 200
GET /rw_7ccfea89/.well-known/agent-card.json            -> 404 workspace_not_found
GET /.well-known/agent-card.json  (Authorization: Bearer …)  -> 200
```

## Two defects, one root cause

`extractWorkspaceHint` resolved **query → host label → path param**, and the unauthenticated card handler had no other source.

1. **The documented `/:workspace/.well-known/agent-card.json` route was dead** on any authority with three or more labels — host inference always answered first, so the path parameter was never read. The Relay identifier profile *requires* multi-label, non-loopback authorities, so every conformant deployment sits exactly where that escape hatch cannot work.
2. **A single-tenant self-host could not answer the bare standard URL at all** — the one an A2A counterparty tries first.

`POST /a2a/rpc` is unaffected; it authenticates and takes the workspace from the token. That is what made this narrow and misleading: discovery 404s while everything authenticated succeeds, and the error text blames agent registration.

## The fix

- An explicit path selector now beats host inference.
- The card handler falls back to the sole workspace when a deployment has exactly one.
- The fallback is **skipped whenever a query or path selector was supplied**, so a misspelled selector fails loudly instead of quietly resolving to another tenant.
- The candidate query is bounded to , so a multi-tenant deployment fails closed without scanning the workspace table.

## Regression risk, and the test that covers it

This reorders **live routing**. The test that makes it safe to ship is *"keeps a valid hosted workspace subdomain authoritative"* — hosted multitenancy behaviour is unchanged.

Six tests total; the two subtle ones assert that the fallback never papers over a caller error.

## Verification

- `packages/engine` full suite: **558 passed (558)**, 52 files — no regressions
- `a2a.test.ts`: 33/33

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/AgentWorkforce/relaycast/pull/319?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

