### PR TITLE
fix(ci): lowercase the GHCR owner in the image name

### DIFF
--- a/.github/workflows/publish-container.yml
+++ b/.github/workflows/publish-container.yml
@@ -57,6 +57,11 @@ jobs:
       # The tag must match the engine version the image actually installs.
       # Version skew between the two ends of a federation is the run-stopper a
       # dry run exists to catch, so it is checked here rather than trusted.
+      # GHCR repository names must be lowercase, and the org is "AgentWorkforce".
+      # buildx rejects the tag outright rather than normalising it.
+      - name: Lowercase the owner for the image name
+        run: echo "OWNER_LC=${GITHUB_REPOSITORY_OWNER,,}" >> "$GITHUB_ENV"
+
       - name: Verify the tag matches the pinned engine version
         env:
           TAG: ${{ inputs.tag }}
@@ -78,12 +83,12 @@ jobs:
           push: true
           build-args: RELAYCAST_ENGINE_VERSION=${{ inputs.tag }}
           tags: |
-            ghcr.io/${{ github.repository_owner }}/relaycast-self-host:${{ inputs.tag }}
-            ${{ inputs.latest && format('ghcr.io/{0}/relaycast-self-host:latest', github.repository_owner) || '' }}
+            ghcr.io/${{ env.OWNER_LC }}/relaycast-self-host:${{ inputs.tag }}
+            ${{ inputs.latest && format('ghcr.io/{0}/relaycast-self-host:latest', env.OWNER_LC) || '' }}
 
       - name: Report the immutable reference
         env:
-          OWNER: ${{ github.repository_owner }}
+          OWNER: ${{ env.OWNER_LC }}
           TAG: ${{ inputs.tag }}
           DIGEST: ${{ steps.push.outputs.digest }}
         run: |


### PR DESCRIPTION
First publish run failed at buildx:

```
invalid tag "ghcr.io/AgentWorkforce/relaycast-self-host:8.0.0": repository name must be lowercase
```

`github.repository_owner` is `AgentWorkforce`, and buildx rejects a mixed-case repository name rather than normalising it. Lowercased once into an env var, used for both tags and the run summary.

The tag-vs-pinned-version guard ran and **passed** before this point, so that check works — only the image name was wrong.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/AgentWorkforce/relaycast/pull/322?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

