### PR TITLE
fix(engine): scale DM inbox reads beyond D1 limit

### DIFF
--- a/.agentworkforce/trajectories/completed/2026-08/traj_7h85vmqpxuxa/summary.md
+++ b/.agentworkforce/trajectories/completed/2026-08/traj_7h85vmqpxuxa/summary.md
@@ -1,0 +1,37 @@
+# Trajectory: Fix relay#1471 DM inbox/list scaling
+
+> **Status:** ✅ Completed
+> **Task:** AgentWorkforce/relay#1471
+> **Confidence:** 93%
+> **Started:** August 13, 2026 at 10:56 PM
+> **Completed:** August 13, 2026 at 10:59 PM
+
+---
+
+## Summary
+
+Fixed relay#1471 by batching DM conversation and inbox enrichment queries below D1 bound-parameter limits, wiring the advertised DM-list limit through MCP/SDK/HTTP, and adding 151-conversation D1-cap regressions.
+
+**Approach:** Standard approach
+
+---
+
+## Key Decisions
+
+### Batch DM list and inbox enrichment queries in groups of 90
+- **Chose:** Batch DM list and inbox enrichment queries in groups of 90
+- **Reasoning:** Hosted Cloudflare D1 allows 100 bound parameters per statement; 90 leaves headroom for other predicates and remains safe if queries gain a few scalar bindings.
+
+### Thread the existing MCP DM-list limit through SDK and HTTP route
+- **Chose:** Thread the existing MCP DM-list limit through SDK and HTTP route
+- **Reasoning:** The public parameter was previously ignored; applying it before enrichment bounds work and makes the advertised control real, while chunking keeps unlimited reads safe.
+
+---
+
+## Chapters
+
+### 1. Work
+*Agent: default*
+
+- Batch DM list and inbox enrichment queries in groups of 90: Batch DM list and inbox enrichment queries in groups of 90
+- Thread the existing MCP DM-list limit through SDK and HTTP route: Thread the existing MCP DM-list limit through SDK and HTTP route

--- a/.agentworkforce/trajectories/completed/2026-08/traj_7h85vmqpxuxa/trajectory.json
+++ b/.agentworkforce/trajectories/completed/2026-08/traj_7h85vmqpxuxa/trajectory.json
@@ -1,0 +1,69 @@
+{
+  "id": "traj_7h85vmqpxuxa",
+  "version": 1,
+  "task": {
+    "title": "Fix relay#1471 DM inbox/list scaling",
+    "source": {
+      "system": "plain",
+      "id": "AgentWorkforce/relay#1471"
+    }
+  },
+  "status": "completed",
+  "startedAt": "2026-08-13T20:56:19.345Z",
+  "completedAt": "2026-08-13T20:59:52.744Z",
+  "agents": [
+    {
+      "name": "default",
+      "role": "lead",
+      "joinedAt": "2026-08-13T20:56:21.182Z"
+    }
+  ],
+  "chapters": [
+    {
+      "id": "chap_5inu0gx0jhgj",
+      "title": "Work",
+      "agentName": "default",
+      "startedAt": "2026-08-13T20:56:21.182Z",
+      "endedAt": "2026-08-13T20:59:52.744Z",
+      "events": [
+        {
+          "ts": 1786654581183,
+          "type": "decision",
+          "content": "Batch DM list and inbox enrichment queries in groups of 90: Batch DM list and inbox enrichment queries in groups of 90",
+          "raw": {
+            "question": "Batch DM list and inbox enrichment queries in groups of 90",
+            "chosen": "Batch DM list and inbox enrichment queries in groups of 90",
+            "alternatives": [],
+            "reasoning": "Hosted Cloudflare D1 allows 100 bound parameters per statement; 90 leaves headroom for other predicates and remains safe if queries gain a few scalar bindings."
+          },
+          "significance": "high"
+        },
+        {
+          "ts": 1786654582374,
+          "type": "decision",
+          "content": "Thread the existing MCP DM-list limit through SDK and HTTP route: Thread the existing MCP DM-list limit through SDK and HTTP route",
+          "raw": {
+            "question": "Thread the existing MCP DM-list limit through SDK and HTTP route",
+            "chosen": "Thread the existing MCP DM-list limit through SDK and HTTP route",
+            "alternatives": [],
+            "reasoning": "The public parameter was previously ignored; applying it before enrichment bounds work and makes the advertised control real, while chunking keeps unlimited reads safe."
+          },
+          "significance": "high"
+        }
+      ]
+    }
+  ],
+  "retrospective": {
+    "summary": "Fixed relay#1471 by batching DM conversation and inbox enrichment queries below D1 bound-parameter limits, wiring the advertised DM-list limit through MCP/SDK/HTTP, and adding 151-conversation D1-cap regressions.",
+    "approach": "Standard approach",
+    "confidence": 0.93
+  },
+  "commits": [],
+  "filesChanged": [],
+  "projectId": "AgentWorkforce/relaycast",
+  "tags": [],
+  "_trace": {
+    "startRef": "c69f8e687f730347e7f0358f8b21173cfbe4fa71",
+    "endRef": "c69f8e687f730347e7f0358f8b21173cfbe4fa71"
+  }
+}

--- a/.agentworkforce/trajectories/completed/2026-08/traj_d8chr9br8b8z/summary.md
+++ b/.agentworkforce/trajectories/completed/2026-08/traj_d8chr9br8b8z/summary.md
@@ -1,0 +1,37 @@
+# Trajectory: Address PR #326 review feedback
+
+> **Status:** ✅ Completed
+> **Task:** relaycast#326
+> **Confidence:** 96%
+> **Started:** August 13, 2026 at 11:51 PM
+> **Completed:** August 14, 2026 at 12:02 AM
+
+---
+
+## Summary
+
+Addressed PR #326 review findings by bounding DM conversation limits at 100 across REST/OpenAPI/MCP, using SQLite insertion rowid for deterministic same-second recency, restoring omitted-limit MCP coverage, and adding red/green regression tests. Engine and MCP full suites, builds, lint, diff check, and secret scan pass.
+
+**Approach:** Standard approach
+
+---
+
+## Key Decisions
+
+### Use SQLite dm_conversations rowid as the same-second recency tiebreaker
+- **Chose:** Use SQLite dm_conversations rowid as the same-second recency tiebreaker
+- **Reasoning:** The schema has no explicit monotonic sequence and deterministic DM ids are hashes. dm_conversations is a normal rowid table, inserts never provide rowid, and production has no conversation-delete path, so rowid preserves insertion chronology without a risky table rebuild.
+
+### Reject DM conversation limits above 100 at API and MCP validation
+- **Chose:** Reject DM conversation limits above 100 at API and MCP validation
+- **Reasoning:** A bounded Zod schema prevents oversized enrichment reads, matches the established endpoint ceiling, and keeps OpenAPI, MCP, and README contracts aligned.
+
+---
+
+## Chapters
+
+### 1. Work
+*Agent: default*
+
+- Use SQLite dm_conversations rowid as the same-second recency tiebreaker: Use SQLite dm_conversations rowid as the same-second recency tiebreaker
+- Reject DM conversation limits above 100 at API and MCP validation: Reject DM conversation limits above 100 at API and MCP validation

--- a/.agentworkforce/trajectories/completed/2026-08/traj_d8chr9br8b8z/trajectory.json
+++ b/.agentworkforce/trajectories/completed/2026-08/traj_d8chr9br8b8z/trajectory.json
@@ -1,0 +1,69 @@
+{
+  "id": "traj_d8chr9br8b8z",
+  "version": 1,
+  "task": {
+    "title": "Address PR #326 review feedback",
+    "source": {
+      "system": "plain",
+      "id": "relaycast#326"
+    }
+  },
+  "status": "completed",
+  "startedAt": "2026-08-13T21:51:08.826Z",
+  "completedAt": "2026-08-13T22:02:43.164Z",
+  "agents": [
+    {
+      "name": "default",
+      "role": "lead",
+      "joinedAt": "2026-08-13T22:00:35.629Z"
+    }
+  ],
+  "chapters": [
+    {
+      "id": "chap_9xeyo5ywzbel",
+      "title": "Work",
+      "agentName": "default",
+      "startedAt": "2026-08-13T22:00:35.629Z",
+      "endedAt": "2026-08-13T22:02:43.164Z",
+      "events": [
+        {
+          "ts": 1786658435630,
+          "type": "decision",
+          "content": "Use SQLite dm_conversations rowid as the same-second recency tiebreaker: Use SQLite dm_conversations rowid as the same-second recency tiebreaker",
+          "raw": {
+            "question": "Use SQLite dm_conversations rowid as the same-second recency tiebreaker",
+            "chosen": "Use SQLite dm_conversations rowid as the same-second recency tiebreaker",
+            "alternatives": [],
+            "reasoning": "The schema has no explicit monotonic sequence and deterministic DM ids are hashes. dm_conversations is a normal rowid table, inserts never provide rowid, and production has no conversation-delete path, so rowid preserves insertion chronology without a risky table rebuild."
+          },
+          "significance": "high"
+        },
+        {
+          "ts": 1786658440876,
+          "type": "decision",
+          "content": "Reject DM conversation limits above 100 at API and MCP validation: Reject DM conversation limits above 100 at API and MCP validation",
+          "raw": {
+            "question": "Reject DM conversation limits above 100 at API and MCP validation",
+            "chosen": "Reject DM conversation limits above 100 at API and MCP validation",
+            "alternatives": [],
+            "reasoning": "A bounded Zod schema prevents oversized enrichment reads, matches the established endpoint ceiling, and keeps OpenAPI, MCP, and README contracts aligned."
+          },
+          "significance": "high"
+        }
+      ]
+    }
+  ],
+  "retrospective": {
+    "summary": "Addressed PR #326 review findings by bounding DM conversation limits at 100 across REST/OpenAPI/MCP, using SQLite insertion rowid for deterministic same-second recency, restoring omitted-limit MCP coverage, and adding red/green regression tests. Engine and MCP full suites, builds, lint, diff check, and secret scan pass.",
+    "approach": "Standard approach",
+    "confidence": 0.96
+  },
+  "commits": [],
+  "filesChanged": [],
+  "projectId": "AgentWorkforce/relaycast",
+  "tags": [],
+  "_trace": {
+    "startRef": "d3d71877f86c6a070b7a8fcfd313a13ec3c738a7",
+    "endRef": "d3d71877f86c6a070b7a8fcfd313a13ec3c738a7"
+  }
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@ Packages without a separate changelog are covered by the cross-package notes bel
 
 - The self-host container now installs `@relaycast/engine` 8.0.0, matching the hosted deployment, and its runbook documents agent-card discovery as working on the standard well-known path rather than as a known defect.
 
+### Fixed
+
+- DM conversation and inbox reads remain available beyond 100 conversations, and the advertised DM-list limit now reaches the server instead of being ignored.
+
 ## [8.0.0] - 2026-08-10
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -402,6 +402,7 @@ POST   /channels/:name/messages
 GET    /channels/:name/messages
 POST   /messages/:id/replies
 POST   /dm
+GET    /dm/conversations?limit=<1-100>  List the agent's newest DM conversations (limit optional)
 GET    /inbox
 GET    /search
 GET    /activity

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -2758,6 +2758,13 @@ paths:
         - Direct Messages
       security:
         - agentToken: []
+      parameters:
+        - name: limit
+          in: query
+          description: Maximum number of conversations to return
+          schema:
+            type: integer
+            minimum: 1
       responses:
         '200':
           description: List of conversations

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -2765,6 +2765,7 @@ paths:
           schema:
             type: integer
             minimum: 1
+            maximum: 100
       responses:
         '200':
           description: List of conversations

--- a/packages/engine/CHANGELOG.md
+++ b/packages/engine/CHANGELOG.md
@@ -7,7 +7,11 @@ See the [root changelog](../../CHANGELOG.md) for cross-package release highlight
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [Unreleased - Patch]
+
+### Fixed
+
+- DM conversation and unread-inbox enrichment batches large identifier sets below D1's bound-parameter ceiling, so long-lived agents no longer lose both read paths after accumulating more than 100 conversations.
 
 ## [8.0.0] - 2026-08-10
 

--- a/packages/engine/src/__tests__/conformance/dmInboxScale.test.ts
+++ b/packages/engine/src/__tests__/conformance/dmInboxScale.test.ts
@@ -1,0 +1,142 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { createWorkspace, makeNodeStack, registerAgent, type TestStack } from './harness.js';
+
+const CONVERSATION_COUNT = 151;
+const D1_MAX_BOUND_PARAMETERS = 100;
+
+function seedDmConversations(
+  stack: TestStack,
+  workspaceId: string,
+  agentId: string,
+  count: number,
+): void {
+  const sqlite = stack.runtime.handle.sqlite;
+  const insertAgent = sqlite.prepare(`
+    INSERT INTO agents (id, workspace_id, name, token_hash)
+    VALUES (?, ?, ?, ?)
+  `);
+  const insertChannel = sqlite.prepare(`
+    INSERT INTO channels (id, workspace_id, name, channel_type, created_by)
+    VALUES (?, ?, ?, 1, ?)
+  `);
+  const insertConversation = sqlite.prepare(`
+    INSERT INTO dm_conversations (id, workspace_id, channel_id, dm_type)
+    VALUES (?, ?, ?, '1:1')
+  `);
+  const insertParticipant = sqlite.prepare(`
+    INSERT INTO dm_participants (conversation_id, agent_id)
+    VALUES (?, ?)
+  `);
+  const insertMember = sqlite.prepare(`
+    INSERT INTO channel_members (channel_id, agent_id)
+    VALUES (?, ?)
+  `);
+  const insertMessage = sqlite.prepare(`
+    INSERT INTO messages (id, workspace_id, channel_id, agent_id, body)
+    VALUES (?, ?, ?, ?, ?)
+  `);
+
+  sqlite.transaction(() => {
+    for (let index = 0; index < count; index += 1) {
+      const suffix = String(index).padStart(3, '0');
+      const peerId = `agent_peer_${suffix}`;
+      const channelId = `channel_dm_${suffix}`;
+      const conversationId = `dm_conversation_${suffix}`;
+
+      insertAgent.run(peerId, workspaceId, `peer-${suffix}`, `token-hash-${suffix}`);
+      insertChannel.run(channelId, workspaceId, `dm-${suffix}`, agentId);
+      insertConversation.run(conversationId, workspaceId, channelId);
+      insertParticipant.run(conversationId, agentId);
+      insertParticipant.run(conversationId, peerId);
+      insertMember.run(channelId, agentId);
+      insertMember.run(channelId, peerId);
+      insertMessage.run(`message_${suffix}`, workspaceId, channelId, peerId, `message ${suffix}`);
+    }
+  })();
+}
+
+/**
+ * better-sqlite3 accepts far more parameters than hosted D1. Guard prepare()
+ * at D1's real 100-parameter ceiling so a regression cannot pass locally while
+ * still failing in production.
+ */
+function enforceD1ParameterLimit(stack: TestStack): {
+  maxObserved: () => number;
+  restore: () => void;
+} {
+  const sqlite = stack.runtime.handle.sqlite;
+  const originalPrepare = sqlite.prepare.bind(sqlite);
+  let maxObserved = 0;
+
+  sqlite.prepare = ((source: string) => {
+    const parameterCount = source.match(/\?/g)?.length ?? 0;
+    maxObserved = Math.max(maxObserved, parameterCount);
+    if (parameterCount > D1_MAX_BOUND_PARAMETERS) {
+      throw new Error(
+        `D1_ERROR: too many bound parameters (${parameterCount}; maximum ${D1_MAX_BOUND_PARAMETERS})`,
+      );
+    }
+    return originalPrepare(source);
+  }) as typeof sqlite.prepare;
+
+  return {
+    maxObserved: () => maxObserved,
+    restore: () => {
+      sqlite.prepare = originalPrepare as typeof sqlite.prepare;
+    },
+  };
+}
+
+describe('DM inbox scaling', () => {
+  let stack: TestStack;
+  let agentToken: string;
+
+  beforeEach(async () => {
+    stack = makeNodeStack();
+    const workspace = await createWorkspace(stack.app, 'dm-scale');
+    const agent = await registerAgent(stack.app, workspace.workspaceKey, 'coordinator');
+    agentToken = agent.token;
+    seedDmConversations(stack, workspace.workspaceId, agent.agentId, CONVERSATION_COUNT);
+  });
+
+  afterEach(() => stack.close());
+
+  it('lists more than 150 DM conversations without exceeding D1 parameter limits', async () => {
+    const guard = enforceD1ParameterLimit(stack);
+    try {
+      const response = await stack.app.request('/v1/dm/conversations', {
+        headers: { authorization: `Bearer ${agentToken}` },
+      });
+
+      expect(response.status).toBe(200);
+      const body = await response.json() as { data: Array<{ id: string }> };
+      expect(body.data).toHaveLength(CONVERSATION_COUNT);
+
+      const limitedResponse = await stack.app.request('/v1/dm/conversations?limit=25', {
+        headers: { authorization: `Bearer ${agentToken}` },
+      });
+      expect(limitedResponse.status).toBe(200);
+      const limitedBody = await limitedResponse.json() as { data: Array<{ id: string }> };
+      expect(limitedBody.data).toHaveLength(25);
+      expect(guard.maxObserved()).toBeLessThanOrEqual(D1_MAX_BOUND_PARAMETERS);
+    } finally {
+      guard.restore();
+    }
+  });
+
+  it('checks an inbox with more than 150 unread DMs without exceeding D1 parameter limits', async () => {
+    const guard = enforceD1ParameterLimit(stack);
+    try {
+      const response = await stack.app.request('/v1/inbox', {
+        headers: { authorization: `Bearer ${agentToken}` },
+      });
+
+      expect(response.status).toBe(200);
+      const body = await response.json() as { data: { unread_dms: Array<{ conversation_id: string }> } };
+      expect(body.data.unread_dms).toHaveLength(CONVERSATION_COUNT);
+      expect(guard.maxObserved()).toBeLessThanOrEqual(D1_MAX_BOUND_PARAMETERS);
+    } finally {
+      guard.restore();
+    }
+  });
+});

--- a/packages/engine/src/__tests__/conformance/dmInboxScale.test.ts
+++ b/packages/engine/src/__tests__/conformance/dmInboxScale.test.ts
@@ -20,8 +20,8 @@ function seedDmConversations(
     VALUES (?, ?, ?, 1, ?)
   `);
   const insertConversation = sqlite.prepare(`
-    INSERT INTO dm_conversations (id, workspace_id, channel_id, dm_type)
-    VALUES (?, ?, ?, '1:1')
+    INSERT INTO dm_conversations (id, workspace_id, channel_id, dm_type, created_at)
+    VALUES (?, ?, ?, '1:1', ?)
   `);
   const insertParticipant = sqlite.prepare(`
     INSERT INTO dm_participants (conversation_id, agent_id)
@@ -39,13 +39,14 @@ function seedDmConversations(
   sqlite.transaction(() => {
     for (let index = 0; index < count; index += 1) {
       const suffix = String(index).padStart(3, '0');
+      const reverseSuffix = String(count - index).padStart(3, '0');
       const peerId = `agent_peer_${suffix}`;
       const channelId = `channel_dm_${suffix}`;
-      const conversationId = `dm_conversation_${suffix}`;
+      const conversationId = `dm_conversation_${reverseSuffix}`;
 
       insertAgent.run(peerId, workspaceId, `peer-${suffix}`, `token-hash-${suffix}`);
       insertChannel.run(channelId, workspaceId, `dm-${suffix}`, agentId);
-      insertConversation.run(conversationId, workspaceId, channelId);
+      insertConversation.run(conversationId, workspaceId, channelId, 1_700_000_000);
       insertParticipant.run(conversationId, agentId);
       insertParticipant.run(conversationId, peerId);
       insertMember.run(channelId, agentId);
@@ -122,6 +123,27 @@ describe('DM inbox scaling', () => {
     } finally {
       guard.restore();
     }
+  });
+
+  it('rejects a DM conversation limit above 100', async () => {
+    const response = await stack.app.request('/v1/dm/conversations?limit=101', {
+      headers: { authorization: `Bearer ${agentToken}` },
+    });
+    expect(response.status).toBe(400);
+  });
+
+  it('lists same-second conversations in newest-first insertion order', async () => {
+    const response = await stack.app.request('/v1/dm/conversations?limit=25', {
+      headers: { authorization: `Bearer ${agentToken}` },
+    });
+    expect(response.status).toBe(200);
+    const body = await response.json() as { data: Array<{ id: string }> };
+    expect(body.data.map((conversation) => conversation.id)).toEqual(
+      Array.from(
+        { length: 25 },
+        (_, index) => `dm_conversation_${String(index + 1).padStart(3, '0')}`,
+      ),
+    );
   });
 
   it('checks an inbox with more than 150 unread DMs without exceeding D1 parameter limits', async () => {

--- a/packages/engine/src/engine/dm.ts
+++ b/packages/engine/src/engine/dm.ts
@@ -459,6 +459,10 @@ export async function listConversations(
   agentId: string,
   opts: { limit?: number } = {},
 ) {
+  // Conversation ids are deterministic hashes, while created_at only has
+  // second precision. SQLite's insertion rowid supplies the chronological
+  // tiebreaker for conversations created within the same second.
+  const insertionOrder = sql<number>`${dmConversations}.rowid`;
   const conversationQuery = db
     .select({
       id: dmConversations.id,
@@ -476,7 +480,10 @@ export async function listConversations(
         isNull(dmParticipants.leftAt),
       ),
     )
-    .orderBy(desc(dmConversations.createdAt), desc(dmConversations.id));
+    .orderBy(
+      desc(dmConversations.createdAt),
+      desc(insertionOrder),
+    );
   const conversationRows = opts.limit === undefined
     ? await conversationQuery
     : await conversationQuery.limit(opts.limit);

--- a/packages/engine/src/engine/dm.ts
+++ b/packages/engine/src/engine/dm.ts
@@ -1,4 +1,4 @@
-import { eq, and, sql, lt, gt, isNull, inArray } from 'drizzle-orm';
+import { eq, and, sql, lt, gt, isNull, inArray, desc } from 'drizzle-orm';
 import type { DmMessage } from '@relaycast/types';
 import type { getDb } from '../db/index.js';
 import {
@@ -24,6 +24,7 @@ import { DEFAULT_MAILBOX_DEPTH_CAP, DEFAULT_MAILBOX_TTL_MS, type MailboxConfig }
 import { codedError } from '../lib/httpError.js';
 import { fetchAttachmentsBatch, resolveSendAttachments, type AttachmentRow } from './attachments.js';
 import { publicMessageMetadata, sanitizeUserMessageMetadata } from './messageMetadata.js';
+import { queryInChunks } from '../lib/queryChunks.js';
 
 type Db = ReturnType<typeof getDb>;
 
@@ -452,8 +453,13 @@ export async function sendDm(
   };
 }
 
-export async function listConversations(db: Db, workspaceId: string, agentId: string) {
-  const conversationRows = await db
+export async function listConversations(
+  db: Db,
+  workspaceId: string,
+  agentId: string,
+  opts: { limit?: number } = {},
+) {
+  const conversationQuery = db
     .select({
       id: dmConversations.id,
       dmType: dmConversations.dmType,
@@ -469,7 +475,11 @@ export async function listConversations(db: Db, workspaceId: string, agentId: st
         eq(dmParticipants.agentId, agentId),
         isNull(dmParticipants.leftAt),
       ),
-    );
+    )
+    .orderBy(desc(dmConversations.createdAt), desc(dmConversations.id));
+  const conversationRows = opts.limit === undefined
+    ? await conversationQuery
+    : await conversationQuery.limit(opts.limit);
 
   if (conversationRows.length === 0) {
     return [];
@@ -478,7 +488,7 @@ export async function listConversations(db: Db, workspaceId: string, agentId: st
   const conversationIds = conversationRows.map((row) => row.id);
   const channelIds = conversationRows.map((row) => row.channelId);
 
-  const participantRows = await db
+  const participantRows = await queryInChunks(conversationIds, (ids) => db
     .select({
       conversationId: dmParticipants.conversationId,
       agentId: dmParticipants.agentId,
@@ -486,33 +496,31 @@ export async function listConversations(db: Db, workspaceId: string, agentId: st
     })
     .from(dmParticipants)
     .innerJoin(agents, eq(dmParticipants.agentId, agents.id))
-    .where(inArray(dmParticipants.conversationId, conversationIds));
+    .where(inArray(dmParticipants.conversationId, ids)));
 
-  const counts = await db
+  const counts = await queryInChunks(channelIds, (ids) => db
     .select({ channelId: messages.channelId, count: sql<number>`count(*)` })
     .from(messages)
-    .where(inArray(messages.channelId, channelIds))
-    .groupBy(messages.channelId);
+    .where(inArray(messages.channelId, ids))
+    .groupBy(messages.channelId));
 
-  const latestMessageIds = await db
+  const latestMessageIds = await queryInChunks(channelIds, (ids) => db
     .select({ channelId: messages.channelId, lastId: sql<string>`max(${messages.id})` })
     .from(messages)
-    .where(inArray(messages.channelId, channelIds))
-    .groupBy(messages.channelId);
+    .where(inArray(messages.channelId, ids))
+    .groupBy(messages.channelId));
 
   const lastIds = latestMessageIds.map((row) => row.lastId).filter(Boolean);
-  const lastMessages = lastIds.length > 0
-    ? await db
-      .select({
-        id: messages.id,
-        channelId: messages.channelId,
-        agentId: messages.agentId,
-        body: messages.body,
-        createdAt: messages.createdAt,
-      })
-      .from(messages)
-      .where(inArray(messages.id, lastIds))
-    : [];
+  const lastMessages = await queryInChunks(lastIds, (ids) => db
+    .select({
+      id: messages.id,
+      channelId: messages.channelId,
+      agentId: messages.agentId,
+      body: messages.body,
+      createdAt: messages.createdAt,
+    })
+    .from(messages)
+    .where(inArray(messages.id, ids)));
 
   const participantsByConversation = new Map<string, Array<{ agent_id: string; agent_name: string }>>();
   for (const row of participantRows) {

--- a/packages/engine/src/engine/inbox.ts
+++ b/packages/engine/src/engine/inbox.ts
@@ -6,6 +6,7 @@ import {
   agents,
   dmParticipants,
 } from '../db/schema.js';
+import { queryInChunks } from '../lib/queryChunks.js';
 
 type Db = ReturnType<typeof getDb>;
 
@@ -94,7 +95,7 @@ export async function getInbox(db: Db, workspaceId: string, agentId: string) {
     const conversationIds = unreadDmRows.map((row) => row.conversation_id);
     const channelIds = unreadDmRows.map((row) => row.channel_id);
 
-    const otherParticipants = await db
+    const otherParticipants = await queryInChunks(conversationIds, (ids) => db
       .select({
         conversationId: dmParticipants.conversationId,
         name: agents.name,
@@ -103,30 +104,28 @@ export async function getInbox(db: Db, workspaceId: string, agentId: string) {
       .innerJoin(agents, eq(dmParticipants.agentId, agents.id))
       .where(
         and(
-          inArray(dmParticipants.conversationId, conversationIds),
+          inArray(dmParticipants.conversationId, ids),
           ne(dmParticipants.agentId, agentId),
           isNull(dmParticipants.leftAt),
         ),
-      );
+      ));
 
-    const latestMessageIds = await db
+    const latestMessageIds = await queryInChunks(channelIds, (ids) => db
       .select({ channelId: messages.channelId, lastId: sql<string>`max(${messages.id})` })
       .from(messages)
-      .where(inArray(messages.channelId, channelIds))
-      .groupBy(messages.channelId);
+      .where(inArray(messages.channelId, ids))
+      .groupBy(messages.channelId));
 
     const lastIds = latestMessageIds.map((row) => row.lastId).filter(Boolean);
-    const lastMessages = lastIds.length > 0
-      ? await db
-        .select({
-          id: messages.id,
-          channelId: messages.channelId,
-          body: messages.body,
-          createdAt: messages.createdAt,
-        })
-        .from(messages)
-        .where(inArray(messages.id, lastIds))
-      : [];
+    const lastMessages = await queryInChunks(lastIds, (ids) => db
+      .select({
+        id: messages.id,
+        channelId: messages.channelId,
+        body: messages.body,
+        createdAt: messages.createdAt,
+      })
+      .from(messages)
+      .where(inArray(messages.id, ids)));
 
     const otherParticipantByConversation = new Map<string, string>();
     for (const participant of otherParticipants) {

--- a/packages/engine/src/lib/queryChunks.ts
+++ b/packages/engine/src/lib/queryChunks.ts
@@ -1,0 +1,23 @@
+/**
+ * Cloudflare D1 permits at most 100 bound parameters in one statement. Keep a
+ * little headroom for predicates outside an IN clause (agent id, workspace id,
+ * status, and future additions) instead of coupling a query to the exact cap.
+ */
+export const D1_SAFE_IN_QUERY_CHUNK_SIZE = 90;
+
+/** Run an IN-based lookup in D1-safe chunks and preserve every returned row. */
+export async function queryInChunks<TValue, TRow>(
+  values: readonly TValue[],
+  query: (chunk: TValue[]) => PromiseLike<TRow[]> | TRow[],
+  chunkSize = D1_SAFE_IN_QUERY_CHUNK_SIZE,
+): Promise<TRow[]> {
+  if (!Number.isInteger(chunkSize) || chunkSize < 1) {
+    throw new RangeError('chunkSize must be a positive integer');
+  }
+
+  const rows: TRow[] = [];
+  for (let index = 0; index < values.length; index += chunkSize) {
+    rows.push(...await query(values.slice(index, index + chunkSize)));
+  }
+  return rows;
+}

--- a/packages/engine/src/routes/dm.ts
+++ b/packages/engine/src/routes/dm.ts
@@ -14,8 +14,8 @@ import { runInBackground } from './background.js';
 import { sendWebhookEvent } from './webhookOutbox.js';
 import { emitServerEvent } from '../lib/serverTelemetry.js';
 import { errorResponse } from '../lib/httpError.js';
-import { jsonError, jsonOk, parseJsonBody } from '../lib/httpResponse.js';
-import { parsePaginationQuery } from '../lib/httpQuery.js';
+import { jsonError, jsonOk, parseJsonBody, parseQueryParams } from '../lib/httpResponse.js';
+import { LimitQuerySchema, parsePaginationQuery } from '../lib/httpQuery.js';
 
 export const dmRoutes = new Hono<AppEnv>();
 
@@ -152,6 +152,10 @@ dmRoutes.get(
   rateLimit,
   async (c) => {
     try {
+      const query = parseQueryParams(c, LimitQuerySchema, 'Invalid DM conversation query');
+      if (!query.ok) {
+        return query.response;
+      }
       const db = c.get('db');
       const workspace = c.get('workspace');
       const agent = c.get('agent');
@@ -159,6 +163,7 @@ dmRoutes.get(
         db,
         workspace.id,
         agent!.id,
+        { limit: query.data.limit },
       );
       return jsonOk(c, conversations);
     } catch (err: unknown) {

--- a/packages/engine/src/routes/dm.ts
+++ b/packages/engine/src/routes/dm.ts
@@ -15,7 +15,7 @@ import { sendWebhookEvent } from './webhookOutbox.js';
 import { emitServerEvent } from '../lib/serverTelemetry.js';
 import { errorResponse } from '../lib/httpError.js';
 import { jsonError, jsonOk, parseJsonBody, parseQueryParams } from '../lib/httpResponse.js';
-import { LimitQuerySchema, parsePaginationQuery } from '../lib/httpQuery.js';
+import { parsePaginationQuery, positiveIntQueryParam } from '../lib/httpQuery.js';
 
 export const dmRoutes = new Hono<AppEnv>();
 
@@ -25,6 +25,10 @@ const sendDmSchema = z.object({
   attachments: z.array(z.string()).optional(),
   data: z.record(z.string(), z.unknown()).nullable().optional(),
   mode: z.enum(['wait', 'steer']).default('wait'),
+});
+
+const listDmConversationsQuerySchema = z.object({
+  limit: positiveIntQueryParam({ max: 100 }),
 });
 
 // POST /v1/dm - send a DM
@@ -152,7 +156,7 @@ dmRoutes.get(
   rateLimit,
   async (c) => {
     try {
-      const query = parseQueryParams(c, LimitQuerySchema, 'Invalid DM conversation query');
+      const query = parseQueryParams(c, listDmConversationsQuerySchema, 'Invalid DM conversation query');
       if (!query.ok) {
         return query.response;
       }

--- a/packages/mcp/src/__tests__/integration.test.ts
+++ b/packages/mcp/src/__tests__/integration.test.ts
@@ -460,6 +460,13 @@ describe('MCP → SDK → HTTP integration', () => {
     expect(req!.body).toMatchObject({ to: 'Alice', text: 'Hi' });
   });
 
+  it('message.dm.list → GET /v1/dm/conversations without limit', async () => {
+    await client.callTool({ name: 'message.dm.list', arguments: {} });
+    const req = findReq((r) => r.url.includes('/dm/conversations'));
+    expect(req).toBeDefined();
+    expect(new URL(req!.url).searchParams.has('limit')).toBe(false);
+  });
+
   it('message.dm.list → GET /v1/dm/conversations with limit', async () => {
     await client.callTool({ name: 'message.dm.list', arguments: { limit: 25 } });
     const req = findReq((r) => r.url.includes('/dm/conversations'));

--- a/packages/mcp/src/__tests__/integration.test.ts
+++ b/packages/mcp/src/__tests__/integration.test.ts
@@ -460,10 +460,11 @@ describe('MCP → SDK → HTTP integration', () => {
     expect(req!.body).toMatchObject({ to: 'Alice', text: 'Hi' });
   });
 
-  it('message.dm.list → GET /v1/dm/conversations', async () => {
-    await client.callTool({ name: 'message.dm.list', arguments: {} });
+  it('message.dm.list → GET /v1/dm/conversations with limit', async () => {
+    await client.callTool({ name: 'message.dm.list', arguments: { limit: 25 } });
     const req = findReq((r) => r.url.includes('/dm/conversations'));
     expect(req).toBeDefined();
+    expect(req!.url).toContain('limit=25');
   });
 
   it('message.dm.send_group → POST /v1/dm/group then POST /v1/dm/:id/messages', async () => {

--- a/packages/mcp/src/__tests__/messaging-tools.test.ts
+++ b/packages/mcp/src/__tests__/messaging-tools.test.ts
@@ -76,6 +76,12 @@ describe('messaging tools', () => {
     expect(mockAgentClient.dms.conversations).toHaveBeenCalled();
   });
 
+  it('get_dms forwards the requested conversation limit', async () => {
+    mockAgentClient.dms.conversations.mockResolvedValue([]);
+    await client.callTool({ name: 'message.dm.list', arguments: { limit: 25 } });
+    expect(mockAgentClient.dms.conversations).toHaveBeenCalledWith({ limit: 25 });
+  });
+
   it('send_group_dm calls dms.createGroup()', async () => {
     mockAgentClient.dms.createGroup.mockResolvedValue({ id: 'conv1' });
     mockAgentClient.dms.sendMessage.mockResolvedValue({ id: 'msg1' });

--- a/packages/mcp/src/__tests__/messaging-tools.test.ts
+++ b/packages/mcp/src/__tests__/messaging-tools.test.ts
@@ -82,6 +82,16 @@ describe('messaging tools', () => {
     expect(mockAgentClient.dms.conversations).toHaveBeenCalledWith({ limit: 25 });
   });
 
+  it('get_dms rejects conversation limits above the server maximum', async () => {
+    mockAgentClient.dms.conversations.mockResolvedValue([]);
+    const result = await client.callTool({
+      name: 'message.dm.list',
+      arguments: { limit: 101 },
+    });
+    expect(result.isError).toBe(true);
+    expect(mockAgentClient.dms.conversations).not.toHaveBeenCalled();
+  });
+
   it('send_group_dm calls dms.createGroup()', async () => {
     mockAgentClient.dms.createGroup.mockResolvedValue({ id: 'conv1' });
     mockAgentClient.dms.sendMessage.mockResolvedValue({ id: 'msg1' });

--- a/packages/mcp/src/tools/messaging.ts
+++ b/packages/mcp/src/tools/messaging.ts
@@ -124,7 +124,7 @@ export function registerMessagingTools(
     title: 'List DM Conversations',
     description: 'List all direct message conversations for the current agent. Returns a summary of each conversation including the other participant\'s name, the last message preview, and unread count. Use this to discover ongoing private conversations.',
     inputSchema: {
-      limit: z.number().optional().describe('Maximum number of conversations to return'),
+      limit: z.number().int().positive().optional().describe('Maximum number of conversations to return'),
       ...workspaceRoutingInputShape,
       ...identityOverrideInputShape,
     },
@@ -132,9 +132,9 @@ export function registerMessagingTools(
       conversations: z.array(z.object({}).passthrough()).describe('Array of DM conversation summaries'),
     },
     annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true, openWorldHint: true },
-  }, async ({ workspace_id, workspace_alias, as: asIdentity }) => {
+  }, async ({ limit, workspace_id, workspace_alias, as: asIdentity }) => {
     const client = getAgentClient(workspaceRefFromArgs({ workspace_id, workspace_alias }), asIdentity);
-    const convos = await client.dms.conversations();
+    const convos = await client.dms.conversations(limit === undefined ? undefined : { limit });
     return {
       content: [{ type: 'text' as const, text: JSON.stringify(convos, null, 2) }],
       structuredContent: { conversations: convos as unknown as Record<string, unknown>[] },

--- a/packages/mcp/src/tools/messaging.ts
+++ b/packages/mcp/src/tools/messaging.ts
@@ -124,7 +124,7 @@ export function registerMessagingTools(
     title: 'List DM Conversations',
     description: 'List all direct message conversations for the current agent. Returns a summary of each conversation including the other participant\'s name, the last message preview, and unread count. Use this to discover ongoing private conversations.',
     inputSchema: {
-      limit: z.number().int().positive().optional().describe('Maximum number of conversations to return'),
+      limit: z.number().int().positive().max(100).optional().describe('Maximum number of conversations to return'),
       ...workspaceRoutingInputShape,
       ...identityOverrideInputShape,
     },

--- a/packages/sdk-typescript/CHANGELOG.md
+++ b/packages/sdk-typescript/CHANGELOG.md
@@ -7,7 +7,11 @@ See the [root changelog](../../CHANGELOG.md) for cross-package release highlight
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [Unreleased - Patch]
+
+### Fixed
+
+- `AgentClient.dms.conversations({ limit })` forwards the optional server-side result limit used by MCP DM-list callers.
 
 ## [8.0.0] - 2026-08-10
 

--- a/packages/sdk-typescript/src/__tests__/agent-messaging.test.ts
+++ b/packages/sdk-typescript/src/__tests__/agent-messaging.test.ts
@@ -291,6 +291,16 @@ describe('AgentClient', () => {
       expect(init.method).toBe('GET');
     });
 
+    it('conversations() forwards a result limit', async () => {
+      mockFetch.mockImplementation(() => mockResponse([{ id: 'c_1' }]));
+
+      await me.dms.conversations({ limit: 25 });
+
+      const [url, init] = mockFetch.mock.calls[0]!;
+      expect(url).toBe('https://cast.agentrelay.com/v1/dm/conversations?limit=25');
+      expect(init.method).toBe('GET');
+    });
+
     it('messages() gets conversation messages', async () => {
       mockFetch.mockImplementation(() => mockResponse([{
         id: 'm_1',

--- a/packages/sdk-typescript/src/agent.ts
+++ b/packages/sdk-typescript/src/agent.ts
@@ -578,8 +578,11 @@ export class AgentClient {
   }
 
   dms = {
-    conversations: (): Promise<DmConversationSummary[]> =>
-      this.client.get('/v1/dm/conversations'),
+    conversations: (opts?: Pick<MessageListQuery, 'limit'>): Promise<DmConversationSummary[]> => {
+      const query: Record<string, string> = {};
+      if (opts?.limit != null) query.limit = String(opts.limit);
+      return this.client.get('/v1/dm/conversations', query);
+    },
 
     messages: (
       conversationId: string,


### PR DESCRIPTION
## Summary

- batch DM conversation and inbox enrichment lookups in D1-safe groups of 90 instead of emitting an unbounded `IN (...)` parameter list
- thread the existing `message.dm.list` limit through MCP, TypeScript SDK, and `GET /v1/dm/conversations`, applying it before enrichment
- add a 151-conversation regression harness that rejects statements above D1's real 100-bound-parameter ceiling

Fixes the Relaycast-side root cause documented in AgentWorkforce/relay#1471.

## Validation

- red regression before fix: list generated 151 bound parameters; inbox generated 152; both returned 500
- scale regression after fix: 2/2 passed with 151 conversations and a strict 100-parameter guard
- focused engine/SDK/MCP tests: 89/89 passed
- full engine suite (serial): 567/567 passed
- full TypeScript SDK suite (serial): 420/420 passed
- full MCP suite (serial): 221/221 passed
- monorepo build: 9/9 packages passed
- monorepo lint: 13/13 tasks passed
- engine typecheck and `git diff --check`: passed
- TruffleHog verified-secret scan: zero findings

## Gate notes

- An initial maximally parallel monorepo test run exposed existing cross-file SDK mock interference/timeouts; every affected file and the complete SDK suite passed serially.
- `npm audit --omit=dev` reports the existing Next.js/PostCSS backlog (2 high package findings); this PR changes no dependencies.
- Veto MCP tools are not exposed in this lane, so repository-native test, lint, build, type, diff, audit, and secret checks were used.

Draft only; do not merge without Khaliq's decision.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/AgentWorkforce/relaycast/pull/326?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

