### PR TITLE
fix(engine): tombstone on the DELETE /v1/agents/:name route too

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,23 @@ Packages without a separate changelog are covered by the cross-package notes bel
 
 ## [Unreleased]
 
+### Fixed
+
+- `DELETE /v1/agents/:name` now tombstones an agent instead of issuing a bare
+  `DELETE`. Four foreign keys reference `agents.id` with no `ON DELETE` action
+  (`messages.agent_id`, `channels.created_by`, `files.uploaded_by`,
+  `webhooks.created_by`), so removing an agent that had ever spoken failed and
+  surfaced the raw SQL to the caller. The name is freed, the credential is
+  rotated, and message attribution is preserved. Completes the set alongside
+  the local (#309) and node-completed (#330) release paths.
+- Releasing an agent now clears its `channel_members` and `dm_participants`
+  rows. Those cascade on `DELETE`, and the tombstone's `UPDATE` does not fire
+  the cascade, so a released agent could remain a delivery target.
+- A late `touchLastSeen` can no longer revive a released tombstone back to
+  `active`, and id-scoped `updateAgentById` writes no longer resolve to a
+  released row.
+
+
 ## [8.0.1] - 2026-08-14
 
 ### Changed

--- a/packages/engine/CHANGELOG.md
+++ b/packages/engine/CHANGELOG.md
@@ -9,6 +9,23 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+### Fixed
+
+- `DELETE /v1/agents/:name` now tombstones an agent instead of issuing a bare
+  `DELETE`. Four foreign keys reference `agents.id` with no `ON DELETE` action
+  (`messages.agent_id`, `channels.created_by`, `files.uploaded_by`,
+  `webhooks.created_by`), so removing an agent that had ever spoken failed and
+  surfaced the raw SQL to the caller. The name is freed, the credential is
+  rotated, and message attribution is preserved. Completes the set alongside
+  the local (#309) and node-completed (#330) release paths.
+- Releasing an agent now clears its `channel_members` and `dm_participants`
+  rows. Those cascade on `DELETE`, and the tombstone's `UPDATE` does not fire
+  the cascade, so a released agent could remain a delivery target.
+- A late `touchLastSeen` can no longer revive a released tombstone back to
+  `active`, and id-scoped `updateAgentById` writes no longer resolve to a
+  released row.
+
+
 ## [8.0.1] - 2026-08-14
 
 ### Fixed

--- a/packages/engine/src/__tests__/conformance/deleteAgentRoute.test.ts
+++ b/packages/engine/src/__tests__/conformance/deleteAgentRoute.test.ts
@@ -1,0 +1,103 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { and, eq } from 'drizzle-orm';
+import { createWorkspace, makeNodeStack, registerAgent, type TestStack } from './harness.js';
+import { agents, messages } from '../../db/schema.js';
+
+/**
+ * `DELETE /v1/agents/:name` -> `agentEngine.deleteAgent` was the last release
+ * path still doing a bare DELETE, after `relaycast#309` fixed the local release
+ * path and `relaycast#330` fixed the node-completed one.
+ *
+ * Four FKs reference `agents.id` with no ON DELETE action
+ * (`messages.agent_id`, `channels.created_by`, `files.uploaded_by`,
+ * `webhooks.created_by`), so the delete is refused for any agent that has ever
+ * spoken — and the refusal reaches the operator as raw SQL with the row id in
+ * it, observed in production as:
+ *
+ *   Failed query: delete from "agents" where "agents"."id" = ? params: 2144…
+ *
+ * This route is what older CLIs call, so it stays reachable after the other two
+ * fixes ship.
+ */
+describe('DELETE /v1/agents/:name preserves attributed history', () => {
+  let stack: TestStack;
+
+  beforeEach(() => {
+    stack = makeNodeStack();
+  });
+
+  afterEach(() => stack.close());
+
+  async function post(token: string, text: string) {
+    const res = await stack.app.request('/v1/channels/general/messages', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', authorization: `Bearer ${token}` },
+      body: JSON.stringify({ text }),
+    });
+    expect(res.status).toBe(201);
+  }
+
+  function removeAgent(workspaceKey: string, name: string) {
+    return stack.app.request(`/v1/agents/${name}`, {
+      method: 'DELETE',
+      headers: { authorization: `Bearer ${workspaceKey}` },
+    });
+  }
+
+  // MUST-FIRE: fails before the fix — the bare DELETE is refused by the FK.
+  it('removes an agent that has authored messages, keeping the attribution', async () => {
+    const ws = await createWorkspace(stack.app, 'route-delete-with-history');
+    const target = await registerAgent(stack.app, ws.workspaceKey, 'talkative');
+    await post(target.token, 'this message must keep its author');
+
+    const res = await removeAgent(ws.workspaceKey, target.name);
+    expect(res.status).toBeLessThan(300);
+
+    // The name is the scarce resource and must be free immediately.
+    expect(
+      await stack.runtime.deps.db
+        .select()
+        .from(agents)
+        .where(and(eq(agents.workspaceId, ws.workspaceId), eq(agents.name, target.name))),
+    ).toHaveLength(0);
+
+    // The row survives as a tombstone so history keeps its author.
+    const [tombstone] = await stack.runtime.deps.db
+      .select({ name: agents.name, status: agents.status })
+      .from(agents)
+      .where(eq(agents.id, target.agentId));
+    expect(tombstone).toMatchObject({
+      name: `${target.name}#released-${target.agentId}`,
+      status: 'released',
+    });
+
+    // Attribution intact; the old credential is dead; the name is reusable.
+    expect(
+      await stack.runtime.deps.db.select().from(messages).where(eq(messages.agentId, target.agentId)),
+    ).toHaveLength(1);
+    const reuse = await stack.app.request('/v1/channels/general/messages', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', authorization: `Bearer ${target.token}` },
+      body: JSON.stringify({ text: 'should be rejected' }),
+    });
+    expect(reuse.status).toBeGreaterThanOrEqual(400);
+    const successor = await registerAgent(stack.app, ws.workspaceKey, target.name);
+    expect(successor.agentId).not.toBe(target.agentId);
+  });
+
+  // MUST-NOT-FIRE: the silent case must behave identically, so the fix cannot
+  // pass by treating one class of agent specially.
+  it('removes an agent that never spoke through the same route', async () => {
+    const ws = await createWorkspace(stack.app, 'route-delete-no-history');
+    const target = await registerAgent(stack.app, ws.workspaceKey, 'silent');
+
+    const res = await removeAgent(ws.workspaceKey, target.name);
+    expect(res.status).toBeLessThan(300);
+    expect(
+      await stack.runtime.deps.db
+        .select()
+        .from(agents)
+        .where(and(eq(agents.workspaceId, ws.workspaceId), eq(agents.name, target.name))),
+    ).toHaveLength(0);
+  });
+});

--- a/packages/engine/src/__tests__/conformance/deleteAgentRoute.test.ts
+++ b/packages/engine/src/__tests__/conformance/deleteAgentRoute.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { and, eq } from 'drizzle-orm';
 import { createWorkspace, makeNodeStack, registerAgent, type TestStack } from './harness.js';
-import { agents, messages } from '../../db/schema.js';
+import { agents, channelMembers, messages } from '../../db/schema.js';
 
 /**
  * `DELETE /v1/agents/:name` -> `agentEngine.deleteAgent` was the last release
@@ -70,6 +70,16 @@ describe('DELETE /v1/agents/:name preserves attributed history', () => {
       name: `${target.name}#released-${target.agentId}`,
       status: 'released',
     });
+
+    // The tombstone must not stay subscribed: `channel_members` cascades on
+    // DELETE, and an UPDATE does not fire that cascade, so a released agent
+    // would otherwise remain a delivery target.
+    expect(
+      await stack.runtime.deps.db
+        .select()
+        .from(channelMembers)
+        .where(eq(channelMembers.agentId, target.agentId)),
+    ).toHaveLength(0);
 
     // Attribution intact; the old credential is dead; the name is reusable.
     expect(

--- a/packages/engine/src/engine/action.ts
+++ b/packages/engine/src/engine/action.ts
@@ -1,6 +1,6 @@
 import { and, asc, eq, inArray, isNotNull, isNull, lte, or, sql } from 'drizzle-orm';
 import type { getDb } from '../db/index.js';
-import { actions, actionInvocations, agents, agentNodeBindings, nodes } from '../db/schema.js';
+import { actions, actionInvocations, agents, agentNodeBindings, channelMembers, dmParticipants, nodes } from '../db/schema.js';
 import { generateId } from './snowflake.js';
 import { RELEASED_AGENT_STATUS, releasedAgentName } from './agent.js';
 import { randomHex, sha256Hex } from '../lib/crypto.js';
@@ -1383,6 +1383,11 @@ async function applyReleaseCompletionEffect(
         lastSeen: new Date(),
       })
       .where(and(eq(agents.workspaceId, workspaceId), eq(agents.id, agent.id)));
+    // `channel_members` and `dm_participants` reference `agents.id` ON DELETE
+    // CASCADE; an UPDATE does not fire that cascade, so drop the memberships
+    // explicitly or the released agent stays a delivery target.
+    await db.delete(channelMembers).where(eq(channelMembers.agentId, agent.id));
+    await db.delete(dmParticipants).where(eq(dmParticipants.agentId, agent.id));
     const implicitNodeId = `node_direct_${agent.id}`;
     await db.delete(nodes).where(and(eq(nodes.workspaceId, workspaceId), eq(nodes.id, implicitNodeId)));
   } else {

--- a/packages/engine/src/engine/agent.ts
+++ b/packages/engine/src/engine/agent.ts
@@ -1,6 +1,6 @@
 import { eq, and, gt, lt, ne, inArray, sql } from 'drizzle-orm';
 import type { getDb } from '../db/index.js';
-import { agents, agentNodeBindings, channels, channelMembers, actions, deliveries, nodes } from '../db/schema.js';
+import { agents, agentNodeBindings, channels, channelMembers, dmParticipants, actions, deliveries, nodes } from '../db/schema.js';
 import { randomHex, sha256Hex } from '../lib/crypto.js';
 import { generateId } from './snowflake.js';
 import { codedError } from '../lib/httpError.js';
@@ -559,6 +559,14 @@ export async function deleteAgent(db: Db, workspaceId: string, name: string) {
       lastSeen: new Date(),
     })
     .where(eq(agents.id, agent.id));
+  // `channel_members` and `dm_participants` reference `agents.id` ON DELETE
+  // CASCADE, so the bare DELETE used to clear them implicitly. An UPDATE does
+  // not fire that cascade, which would leave a released agent subscribed and
+  // therefore still selected as a delivery target (`delivery.ts` fans out over
+  // channel members). Drop the memberships explicitly to keep the tombstone
+  // equivalent to the delete it replaces.
+  await db.delete(channelMembers).where(eq(channelMembers.agentId, agent.id));
+  await db.delete(dmParticipants).where(eq(dmParticipants.agentId, agent.id));
   await db.delete(nodes).where(eq(nodes.id, directNodeIdForAgent(agent.id)));
   return true;
 }
@@ -567,7 +575,10 @@ export async function touchLastSeen(db: Db, agentId: string): Promise<void> {
   await db
     .update(agents)
     .set({ lastSeen: new Date(), status: 'active' })
-    .where(eq(agents.id, agentId));
+    // Auth schedules this without awaiting it, so a heartbeat racing a release
+    // can land after the tombstone and flip the row back to `active` — reviving
+    // a released agent as a live roster member. A tombstone is terminal.
+    .where(and(eq(agents.id, agentId), ne(agents.status, RELEASED_AGENT_STATUS)));
 }
 
 export async function sweepStaleAgents(db: Db, workspaceId?: string): Promise<number> {

--- a/packages/engine/src/engine/agent.ts
+++ b/packages/engine/src/engine/agent.ts
@@ -451,7 +451,15 @@ export async function updateAgentById(
   const [updated] = await db
     .update(agents)
     .set(setClause)
-    .where(and(eq(agents.workspaceId, workspaceId), eq(agents.id, agentId)))
+    // A released row is a tombstone kept only so history stays attributable —
+    // it is not a live agent and must not be updatable, matching the roster and
+    // presence reads that already exclude it. Without this, an id-scoped write
+    // against a released agent silently succeeds against the tombstone.
+    .where(and(
+      eq(agents.workspaceId, workspaceId),
+      eq(agents.id, agentId),
+      ne(agents.status, RELEASED_AGENT_STATUS),
+    ))
     .returning();
 
   if (!updated) return null;
@@ -527,7 +535,30 @@ export async function deleteAgent(db: Db, workspaceId: string, name: string) {
 
   if (!agent) return false;
 
-  await db.delete(agents).where(eq(agents.id, agent.id));
+  // Tombstone rather than DELETE, matching both release paths
+  // (`dispatchRelease` -> `completeLocally`, and `applyReleaseCompletionEffect`).
+  // Four FKs reference `agents.id` with no ON DELETE action —
+  // `messages.agent_id`, `channels.created_by`, `files.uploaded_by`,
+  // `webhooks.created_by` — so a bare DELETE is refused for any agent that has
+  // ever spoken, and the caller sees the raw SQL failure with the row id in it.
+  // Renaming frees the unique `(workspace_id, name)` immediately while every FK
+  // target stays valid and every message keeps its sender.
+  const releasedName = releasedAgentName(agent.name, agent.id);
+  // The row survives, so its credential must not. `token_hash` is NOT NULL
+  // UNIQUE and cannot be cleared, so rotate it to a value nobody holds.
+  const releasedTokenHash = await sha256Hex(`released:${agent.id}:${randomHex(16)}`);
+  await db
+    .update(agents)
+    .set({
+      name: releasedName,
+      handle: `@${releasedName}`,
+      status: RELEASED_AGENT_STATUS,
+      tokenHash: releasedTokenHash,
+      locationType: 'self_connected',
+      locationNodeId: null,
+      lastSeen: new Date(),
+    })
+    .where(eq(agents.id, agent.id));
   await db.delete(nodes).where(eq(nodes.id, directNodeIdForAgent(agent.id)));
   return true;
 }


### PR DESCRIPTION
Completes the set. `#309` fixed the local release path, `#330` fixed the node-completed one, and `agentEngine.deleteAgent` — behind `DELETE /v1/agents/:name` — was the last path still issuing a bare `DELETE`.

## Why it still matters after #330 shipped

Four FKs reference `agents.id` with no `ON DELETE` action (`messages.agent_id`, `channels.created_by`, `files.uploaded_by`, `webhooks.created_by`), so the delete is refused for any agent that has ever spoken, and the refusal reaches the operator as raw SQL carrying the row id:

```
Failed query: delete from "agents" where "agents"."id" = ? params: 2144…
```

Two reasons this is not redundant with `#330`:

1. **It is the route older CLI builds call**, so it stays reachable after the other fixes ship.
2. **It is the only SYNCHRONOUS removal path.** The release action is dispatched to a node and only tombstones when that node reports completion. A seat whose worker no longer exists — the common case after a node restart — cannot be reclaimed through it *at all*: the invocation simply stays `dispatched`. Three such seats are stuck on the production workspace right now, still `dispatched` after 8.0.2 deployed, precisely because no node will ever answer for them.

## A regression this surfaced, and why the fix is in the code rather than the test

With the row surviving as a tombstone, `updateAgentById` began finding released rows, so `legacyIdentityClaim > does not redirect an id-scoped cleanup update to a same-name replacement` failed on `expect(staleUpdate).toBeNull()`.

**The assertion was right and the semantics were wrong.** A released row is a tombstone kept only so history stays attributable; it is not a live agent and must not be updatable. `updateAgentById` now excludes it, matching the roster and presence reads that already filter released rows (`agent.ts:272`, `presence.ts:22`). The test is unchanged.

## Verification

`deleteAgentRoute.test.ts` — must-fire / must-not-fire through the HTTP route, both directions demonstrated rather than asserted:

- **without** this change: the has-history case fails with a **500**, the no-history case still passes
- **with** it: both pass

Full engine suite: **289 passed, 3 failed** — `a2aFederation`, `providerAttachRace`, `twoNodeWriteContention`. All three fail on a clean tree as well and the failing set varies between runs; pre-existing flakiness in the concurrency tests, not touched here. `legacyIdentityClaim` passes.

## Not merged

Khaliq owns the merge gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/AgentWorkforce/relaycast/pull/331?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

