### PR TITLE
fix(engine): preserve replay sequence after send failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,11 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 Packages without a separate changelog are covered by the cross-package notes below.
 
-## [Unreleased]
+## [Unreleased - Patch]
+
+### Fixed
+
+- Node delivery replay now stops an affected agent's sequence stream after a failed send, preventing a higher-sequence message from arriving first while other agents continue receiving.
 
 ## [8.0.4] - 2026-08-17
 

--- a/packages/engine/CHANGELOG.md
+++ b/packages/engine/CHANGELOG.md
@@ -7,7 +7,11 @@ See the [root changelog](../../CHANGELOG.md) for cross-package release highlight
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [Unreleased - Patch]
+
+### Fixed
+
+- `deliverPendingToNode` leaves an agent's remaining replay rows queued after its first failed send, preserving the durable per-agent sequence contract without blocking other agents on the node.
 
 ## [8.0.3] - 2026-08-15
 

--- a/packages/engine/src/__tests__/conformance/delivery.test.ts
+++ b/packages/engine/src/__tests__/conformance/delivery.test.ts
@@ -1806,6 +1806,72 @@ describe('durable delivery api', () => {
     ]);
   });
 
+  it('does not send a higher sequence after a replay send fails for the same agent', async () => {
+    // A partial provider failure must not put a gap on one agent's ordered
+    // stream, while another ready agent on the same node may keep receiving.
+    const ws = await createWorkspace(stack.app, 'mailbox-node-replay-partial-failure');
+    const alice = await registerAgent(stack.app, ws.workspaceKey, 'alice');
+    const node = await enrollAndAttachNode(ws);
+    const bob = await registerViaNode(node, 'bob');
+    const carol = await registerViaNode(node, 'carol');
+
+    for (const text of ['first', 'second']) {
+      const post = await stack.app.request('/v1/channels/general/messages', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json', authorization: `Bearer ${alice.token}` },
+        body: JSON.stringify({ text }),
+      });
+      expect(post.status).toBe(201);
+    }
+    await waitForAssertion(() => expect(node.sock.ofType('deliver')).toHaveLength(4));
+
+    const db = stack.runtime.deps.db;
+    await db
+      .update(deliveries)
+      .set({ status: 'queued', deliveredAt: null })
+      .where(and(
+        eq(deliveries.workspaceId, ws.workspaceId),
+        eq(deliveries.routeNodeId, node.id),
+      ));
+
+    const attempted: Array<{ agent: string; seq: number }> = [];
+    const registry: NodeConnectionRegistry = {
+      upgradeNode: async () => new Response(null, { status: 501 }),
+      sendToNode: async () => false,
+      sendToProvider: async (_workspaceId, _nodeId, _providerName, frame) => {
+        const delivery = frame as { agent: string; seq: number };
+        attempted.push({ agent: delivery.agent, seq: delivery.seq });
+        return !(delivery.agent === bob.name && delivery.seq === 1);
+      },
+      isNodeConnected: () => true,
+      isProviderConnected: () => true,
+      setProviderDeliveryReadiness: () => {},
+      markProviderAgentsDeliveryReady: () => {},
+      isProviderAgentDeliveryReady: () => true,
+      detachProvider: () => {},
+      disconnectNode: async () => {},
+      drainNode: async () => {},
+    };
+
+    expect(await deliverPendingToNode(db, registry, ws.workspaceId, node.id)).toBe(2);
+    expect(attempted).toEqual([
+      { agent: bob.name, seq: 1 },
+      { agent: carol.name, seq: 1 },
+      { agent: carol.name, seq: 2 },
+    ]);
+
+    const rows = await db
+      .select({ agentId: deliveries.agentId, seq: deliveries.seq, status: deliveries.status })
+      .from(deliveries)
+      .where(and(eq(deliveries.workspaceId, ws.workspaceId), eq(deliveries.routeNodeId, node.id)));
+    expect(rows).toEqual(expect.arrayContaining([
+      { agentId: bob.agentId, seq: 1, status: 'queued' },
+      { agentId: bob.agentId, seq: 2, status: 'queued' },
+      { agentId: carol.agentId, seq: 1, status: 'delivered' },
+      { agentId: carol.agentId, seq: 2, status: 'delivered' },
+    ]));
+  });
+
   it('redelivers a DM with the same deliver payload after broker death/reconnect', async () => {
     const ws = await createWorkspace(stack.app, 'mailbox-node-redeliver-dm');
     const alice = await registerAgent(stack.app, ws.workspaceKey, 'alice');

--- a/packages/engine/src/engine/delivery.ts
+++ b/packages/engine/src/engine/delivery.ts
@@ -893,7 +893,12 @@ export async function deliverPendingToNode(
   const attachmentsByMessageId = await fetchAttachmentsBatch(db, workspaceId, [...new Set(rows.map((row) => row.delivery.messageId))]);
 
   const deliveredIds: string[] = [];
+  // A broker admits durable frames only in ascending sequence order per agent.
+  // If a lower sequence frame did not reach a provider, leave the remainder of
+  // that agent's stream queued for the next replay instead of creating a gap.
+  const blockedAgentIds = new Set<string>();
   for (const row of rows) {
+    if (blockedAgentIds.has(row.delivery.agentId)) continue;
     if (!isProviderAgentDeliveryReady(
       registry,
       workspaceId,
@@ -915,7 +920,11 @@ export async function deliverPendingToNode(
       mode: wireMode(row.delivery.mode),
       payload: buildDeliverPayload(eventType, eventData),
     }));
-    if (sent) deliveredIds.push(row.delivery.id);
+    if (sent) {
+      deliveredIds.push(row.delivery.id);
+    } else {
+      blockedAgentIds.add(row.delivery.agentId);
+    }
   }
 
   await markDeliveriesDelivered(db, workspaceId, deliveredIds);


### PR DESCRIPTION
Prevents an agent's higher-sequence durable delivery from being sent after its lower-sequence replay fails. Other agents on the same node continue replaying normally.\n\nAdds conformance coverage for partial provider failure and records the patch-level behavior in the root and engine changelogs.\n\nValidated with the focused delivery suite (53 tests), engine build, and engine lint.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/AgentWorkforce/relaycast/pull/334?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

