### PR TITLE
fix(sdk-swift): decode action invocations by invocation_id

### DIFF
--- a/packages/sdk-swift/Sources/Relaycast/Models.swift
+++ b/packages/sdk-swift/Sources/Relaycast/Models.swift
@@ -1178,7 +1178,11 @@ public struct CompleteInvocationRequest: Codable, Equatable, Sendable {
 }
 
 public struct ActionInvocation: Codable, Equatable, Sendable {
-    public let id: String
+    /// The hosted API identifies an invocation as `invocation_id` on every
+    /// route that returns this record (invoke ack, status poll, completion),
+    /// matching ``InvokeActionResult``. A plain `id` is accepted as an alias so
+    /// a record echoed by another surface still decodes.
+    public let invocationId: String
     public let actionName: String?
     public let status: String
     public let input: [String: JSONValue]?
@@ -1186,6 +1190,44 @@ public struct ActionInvocation: Codable, Equatable, Sendable {
     public let error: String?
     public let createdAt: String?
     public let updatedAt: String?
+    public let completedAt: String?
+    public let durationMs: Int?
+
+    private enum CodingKeys: String, CodingKey {
+        case invocationId, id, actionName, status, input, output, error, createdAt, updatedAt, completedAt, durationMs
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        if let invocationId = try container.decodeIfPresent(String.self, forKey: .invocationId) {
+            self.invocationId = invocationId
+        } else {
+            self.invocationId = try container.decode(String.self, forKey: .id)
+        }
+        actionName = try container.decodeIfPresent(String.self, forKey: .actionName)
+        status = try container.decode(String.self, forKey: .status)
+        input = try container.decodeIfPresent([String: JSONValue].self, forKey: .input)
+        output = try container.decodeIfPresent([String: JSONValue].self, forKey: .output)
+        error = try container.decodeIfPresent(String.self, forKey: .error)
+        createdAt = try container.decodeIfPresent(String.self, forKey: .createdAt)
+        updatedAt = try container.decodeIfPresent(String.self, forKey: .updatedAt)
+        completedAt = try container.decodeIfPresent(String.self, forKey: .completedAt)
+        durationMs = try container.decodeIfPresent(Int.self, forKey: .durationMs)
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(invocationId, forKey: .invocationId)
+        try container.encodeIfPresent(actionName, forKey: .actionName)
+        try container.encode(status, forKey: .status)
+        try container.encodeIfPresent(input, forKey: .input)
+        try container.encodeIfPresent(output, forKey: .output)
+        try container.encodeIfPresent(error, forKey: .error)
+        try container.encodeIfPresent(createdAt, forKey: .createdAt)
+        try container.encodeIfPresent(updatedAt, forKey: .updatedAt)
+        try container.encodeIfPresent(completedAt, forKey: .completedAt)
+        try container.encodeIfPresent(durationMs, forKey: .durationMs)
+    }
 }
 
 // MARK: - Directory, routing, A2A, certification, console

--- a/packages/sdk-swift/Tests/RelaycastTests/RelaycastTests.swift
+++ b/packages/sdk-swift/Tests/RelaycastTests/RelaycastTests.swift
@@ -17,6 +17,44 @@ final class RelaycastTests: XCTestCase {
         }
     }
 
+    func testActionInvocationDecodesHostedInvocationIdentifier() throws {
+        // The hosted API identifies an invocation as `invocation_id` on the
+        // status-poll and completion routes; decoding it as `id` failed every
+        // action completion with "Invalid Relaycast API response".
+        let payload = Data("""
+        {
+          "invocation_id": "inv_215317590589313024",
+          "action_name": "add_rectangle",
+          "caller_id": "215317575185170432",
+          "caller_name": "board-driver",
+          "input": {"x": 120},
+          "output": {"text": "Added rectangle rect-1"},
+          "status": "completed",
+          "error": null,
+          "duration_ms": 42,
+          "created_at": "2026-08-18T03:55:13.000Z",
+          "completed_at": "2026-08-18T03:55:14.000Z"
+        }
+        """.utf8)
+
+        let decoded = try makeRelaycastDecoder().decode(ActionInvocation.self, from: payload)
+        XCTAssertEqual(decoded.invocationId, "inv_215317590589313024")
+        XCTAssertEqual(decoded.actionName, "add_rectangle")
+        XCTAssertEqual(decoded.status, "completed")
+        XCTAssertEqual(decoded.durationMs, 42)
+        XCTAssertEqual(decoded.completedAt, "2026-08-18T03:55:14.000Z")
+        XCTAssertEqual(decoded.output?["text"], .string("Added rectangle rect-1"))
+    }
+
+    func testActionInvocationAcceptsPlainIdAlias() throws {
+        let payload = Data("""
+        {"id": "inv_1", "status": "completed"}
+        """.utf8)
+
+        let decoded = try makeRelaycastDecoder().decode(ActionInvocation.self, from: payload)
+        XCTAssertEqual(decoded.invocationId, "inv_1")
+    }
+
     func testHttpClientEncodesSnakeCaseAndOriginHeaders() async throws {
         let session = makeMockSession()
         let client = try HttpClient(


### PR DESCRIPTION
`ActionInvocation` decodes the hosted invocation record by `invocation_id`, the key the API actually returns on the invoke ack, the status poll (`GET /v1/actions/{name}/invocations/{id}`), and the completion response (`POST .../complete`) — consistent with its sibling `InvokeActionResult`. `completed_at` and `duration_ms` are carried as well, and a plain `id` decodes as an alias.

## Why

The model required `id`, which no route sends, so every decode threw `RelayError.invalidResponse` → `"Invalid Relaycast API response"`.

The consequence lands on Swift agents that *provide* actions. `AgentClient.registerAction`'s dispatch loop completes an invocation and then decodes the response; the throw sent it down the error path, which reports the handler as failed:

```
status:  failed
error:   Invalid Relaycast API response
output:  null
```

The handler had in fact run and its output was stored — the SDK overwrote its own success with a failure it invented while parsing the reply.

Observed against `cast.agentrelay.com` with a macOS app registering canvas actions over the participant SDK; every one of its eight actions failed this way. With this fix the same invocation returns:

```
status:  completed
output:  {'value': 'Added rectangle c39b3855 at (120, 140).'}
```

## Tests

`testActionInvocationDecodesHostedInvocationIdentifier` decodes a captured hosted payload (verbatim from the status-poll route) and asserts the identifier, output, duration and completion timestamp. `testActionInvocationAcceptsPlainIdAlias` covers the alias. Suite: 30/30 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/AgentWorkforce/relaycast/pull/335?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

