### PR TITLE
feat: add workspace lifecycle controls

### DIFF
--- a/.agentworkforce/trajectories/completed/2026-08/traj_mm69pbtiruw8/summary.md
+++ b/.agentworkforce/trajectories/completed/2026-08/traj_mm69pbtiruw8/summary.md
@@ -1,0 +1,32 @@
+# Trajectory: Implement workspace lifecycle for issue 336
+
+> **Status:** ✅ Completed
+> **Confidence:** 92%
+> **Started:** August 18, 2026 at 11:33 AM
+> **Completed:** August 18, 2026 at 11:48 AM
+
+---
+
+## Summary
+
+Added authenticated id-scoped workspace deletion, explicit TTL creation and bounded reaping, SDK/types support, E2E TTL adoption, migration, documentation, and lifecycle/cascade tests.
+
+**Approach:** Standard approach
+
+---
+
+## Key Decisions
+
+### Implement both lifecycle halves: retain DELETE /workspace, add DELETE /workspaces/:id, and add explicit expires_at TTL reaping
+- **Chose:** Implement both lifecycle halves: retain DELETE /workspace, add DELETE /workspaces/:id, and add explicit expires_at TTL reaping
+- **Reasoning:** D1 enforces ON DELETE CASCADE; a nullable caller-supplied expiry is the only safe automatic deletion predicate, while names, age, message count, and agent count are ambiguous.
+
+---
+
+## Chapters
+
+### 1. Work
+*Agent: default*
+
+- Implement both lifecycle halves: retain DELETE /workspace, add DELETE /workspaces/:id, and add explicit expires_at TTL reaping: Implement both lifecycle halves: retain DELETE /workspace, add DELETE /workspaces/:id, and add explicit expires_at TTL reaping
+- Implemented authenticated id-scoped deletion, explicit workspace expiry, bounded automatic reaping, SDK support, E2E adoption, docs, and cascade safety tests; full test/build/lint gates are green.

--- a/.agentworkforce/trajectories/completed/2026-08/traj_mm69pbtiruw8/summary.md
+++ b/.agentworkforce/trajectories/completed/2026-08/traj_mm69pbtiruw8/summary.md
@@ -1,7 +1,7 @@
 # Trajectory: Implement workspace lifecycle for issue 336
 
 > **Status:** ✅ Completed
-> **Confidence:** 92%
+> **Confidence:** 75%
 > **Started:** August 18, 2026 at 11:33 AM
 > **Completed:** August 18, 2026 at 11:48 AM
 
@@ -10,6 +10,8 @@
 ## Summary
 
 Added authenticated id-scoped workspace deletion, explicit TTL creation and bounded reaping, SDK/types support, E2E TTL adoption, migration, documentation, and lifecycle/cascade tests.
+
+Implementation commit: `c1bb456b7de57b9dbe1c9c12759a93fa977a9edf`. The trajectory records the resulting change set but does not contain trace events proving test, build, or lint execution.
 
 **Approach:** Standard approach
 
@@ -29,4 +31,4 @@ Added authenticated id-scoped workspace deletion, explicit TTL creation and boun
 *Agent: default*
 
 - Implement both lifecycle halves: retain DELETE /workspace, add DELETE /workspaces/:id, and add explicit expires_at TTL reaping: Implement both lifecycle halves: retain DELETE /workspace, add DELETE /workspaces/:id, and add explicit expires_at TTL reaping
-- Implemented authenticated id-scoped deletion, explicit workspace expiry, bounded automatic reaping, SDK support, E2E adoption, docs, and cascade safety tests; full test/build/lint gates are green.
+- The resulting implementation scope includes authenticated id-scoped deletion, explicit workspace expiry, bounded automatic reaping, SDK support, E2E adoption, documentation, and lifecycle tests. This trajectory does not contain trace events proving test, build, or lint execution.

--- a/.agentworkforce/trajectories/completed/2026-08/traj_mm69pbtiruw8/trajectory.json
+++ b/.agentworkforce/trajectories/completed/2026-08/traj_mm69pbtiruw8/trajectory.json
@@ -37,7 +37,7 @@
         {
           "ts": 1787046464092,
           "type": "reflection",
-          "content": "Implemented authenticated id-scoped deletion, explicit workspace expiry, bounded automatic reaping, SDK support, E2E adoption, docs, and cascade safety tests; full test/build/lint gates are green.",
+          "content": "The resulting implementation scope includes authenticated id-scoped deletion, explicit workspace expiry, bounded automatic reaping, SDK support, E2E adoption, documentation, and lifecycle tests. This trajectory does not contain trace events proving test, build, or lint execution.",
           "raw": {
             "focalPoints": [
               "deletion-safety",
@@ -45,7 +45,7 @@
               "expiry-predicate",
               "verification"
             ],
-            "confidence": 0.9
+            "confidence": 0.75
           },
           "significance": "high",
           "tags": [
@@ -53,7 +53,7 @@
             "focal:D1-cascades",
             "focal:expiry-predicate",
             "focal:verification",
-            "confidence:0.9"
+            "confidence:0.75"
           ]
         }
       ]
@@ -62,14 +62,42 @@
   "retrospective": {
     "summary": "Added authenticated id-scoped workspace deletion, explicit TTL creation and bounded reaping, SDK/types support, E2E TTL adoption, migration, documentation, and lifecycle/cascade tests.",
     "approach": "Standard approach",
-    "confidence": 0.92
+    "confidence": 0.75
   },
-  "commits": [],
-  "filesChanged": [],
+  "commits": [
+    "c1bb456b7de57b9dbe1c9c12759a93fa977a9edf"
+  ],
+  "filesChanged": [
+    ".agentworkforce/trajectories/completed/2026-08/traj_mm69pbtiruw8/summary.md",
+    ".agentworkforce/trajectories/completed/2026-08/traj_mm69pbtiruw8/trajectory.json",
+    "CHANGELOG.md",
+    "README.md",
+    "openapi.yaml",
+    "packages/engine/CHANGELOG.md",
+    "packages/engine/src/__tests__/conformance/workspaceLifecycle.test.ts",
+    "packages/engine/src/adapters/node/index.ts",
+    "packages/engine/src/db/migrations/0036_workspace_expiry.sql",
+    "packages/engine/src/db/schema.ts",
+    "packages/engine/src/engine/workspace.ts",
+    "packages/engine/src/index.ts",
+    "packages/engine/src/routes/workspace.ts",
+    "packages/sdk-typescript/CHANGELOG.md",
+    "packages/sdk-typescript/src/__tests__/relay.test.ts",
+    "packages/sdk-typescript/src/__tests__/setup.test.ts",
+    "packages/sdk-typescript/src/relay.ts",
+    "packages/sdk-typescript/src/setup-types.ts",
+    "packages/sdk-typescript/src/setup.ts",
+    "packages/types/CHANGELOG.md",
+    "packages/types/src/__tests__/types.test.ts",
+    "packages/types/src/workspace.ts",
+    "scripts/e2e-actions.ts",
+    "scripts/e2e-sdk-setup-client.ts",
+    "scripts/e2e.ts"
+  ],
   "projectId": "AgentWorkforce/relaycast",
   "tags": [],
   "_trace": {
     "startRef": "3374966534c408d3656c0a8701dd98d82216576b",
-    "endRef": "3374966534c408d3656c0a8701dd98d82216576b"
+    "endRef": "c1bb456b7de57b9dbe1c9c12759a93fa977a9edf"
   }
 }

--- a/.agentworkforce/trajectories/completed/2026-08/traj_mm69pbtiruw8/trajectory.json
+++ b/.agentworkforce/trajectories/completed/2026-08/traj_mm69pbtiruw8/trajectory.json
@@ -1,0 +1,75 @@
+{
+  "id": "traj_mm69pbtiruw8",
+  "version": 1,
+  "task": {
+    "title": "Implement workspace lifecycle for issue 336"
+  },
+  "status": "completed",
+  "startedAt": "2026-08-18T09:33:52.274Z",
+  "completedAt": "2026-08-18T09:48:01.156Z",
+  "agents": [
+    {
+      "name": "default",
+      "role": "lead",
+      "joinedAt": "2026-08-18T09:36:44.789Z"
+    }
+  ],
+  "chapters": [
+    {
+      "id": "chap_c0uygc351ax8",
+      "title": "Work",
+      "agentName": "default",
+      "startedAt": "2026-08-18T09:36:44.789Z",
+      "endedAt": "2026-08-18T09:48:01.156Z",
+      "events": [
+        {
+          "ts": 1787045804790,
+          "type": "decision",
+          "content": "Implement both lifecycle halves: retain DELETE /workspace, add DELETE /workspaces/:id, and add explicit expires_at TTL reaping: Implement both lifecycle halves: retain DELETE /workspace, add DELETE /workspaces/:id, and add explicit expires_at TTL reaping",
+          "raw": {
+            "question": "Implement both lifecycle halves: retain DELETE /workspace, add DELETE /workspaces/:id, and add explicit expires_at TTL reaping",
+            "chosen": "Implement both lifecycle halves: retain DELETE /workspace, add DELETE /workspaces/:id, and add explicit expires_at TTL reaping",
+            "alternatives": [],
+            "reasoning": "D1 enforces ON DELETE CASCADE; a nullable caller-supplied expiry is the only safe automatic deletion predicate, while names, age, message count, and agent count are ambiguous."
+          },
+          "significance": "high"
+        },
+        {
+          "ts": 1787046464092,
+          "type": "reflection",
+          "content": "Implemented authenticated id-scoped deletion, explicit workspace expiry, bounded automatic reaping, SDK support, E2E adoption, docs, and cascade safety tests; full test/build/lint gates are green.",
+          "raw": {
+            "focalPoints": [
+              "deletion-safety",
+              "D1-cascades",
+              "expiry-predicate",
+              "verification"
+            ],
+            "confidence": 0.9
+          },
+          "significance": "high",
+          "tags": [
+            "focal:deletion-safety",
+            "focal:D1-cascades",
+            "focal:expiry-predicate",
+            "focal:verification",
+            "confidence:0.9"
+          ]
+        }
+      ]
+    }
+  ],
+  "retrospective": {
+    "summary": "Added authenticated id-scoped workspace deletion, explicit TTL creation and bounded reaping, SDK/types support, E2E TTL adoption, migration, documentation, and lifecycle/cascade tests.",
+    "approach": "Standard approach",
+    "confidence": 0.92
+  },
+  "commits": [],
+  "filesChanged": [],
+  "projectId": "AgentWorkforce/relaycast",
+  "tags": [],
+  "_trace": {
+    "startRef": "3374966534c408d3656c0a8701dd98d82216576b",
+    "endRef": "3374966534c408d3656c0a8701dd98d82216576b"
+  }
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,11 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 Packages without a separate changelog are covered by the cross-package notes below.
 
-## [Unreleased]
+## [Unreleased - Minor]
+
+### Added
+
+- Workspaces can opt into an explicit expiry at creation or be deleted immediately with their own key.
 
 ## [8.0.5] - 2026-08-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 Packages without a separate changelog are covered by the cross-package notes below.
 
-## [Unreleased - Major]
+## [Unreleased - Minor]
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,11 +16,11 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 Packages without a separate changelog are covered by the cross-package notes below.
 
-## [Unreleased - Minor]
+## [Unreleased - Major]
 
 ### Added
 
-- Workspaces can opt into an explicit expiry at creation or be deleted immediately with their own key.
+- Workspaces can opt into an explicit expiry at creation or be deleted immediately with their own key, including durable event rows and stored file bytes.
 
 ## [8.0.5] - 2026-08-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ Packages without a separate changelog are covered by the cross-package notes bel
 
 ### Added
 
-- Workspaces can opt into an explicit expiry at creation or be deleted immediately with their own key, including durable event rows and stored file bytes.
+- Workspaces can opt into an explicit expiry at creation or be deleted immediately with their own key, including durable event rows and retryable post-commit cleanup of stored file bytes.
 
 ## [8.0.5] - 2026-08-18
 

--- a/README.md
+++ b/README.md
@@ -121,6 +121,44 @@ if (ensured.existed) {
 }
 ```
 
+### Workspace lifecycle
+
+Persistent workspaces are the default. For CI, previews, and other throwaway
+uses, opt into a lifetime of 60 seconds to 30 days when creating the workspace:
+
+```ts
+const temporary = await RelayCast.createWorkspace('ci-run', {
+  expiresInSeconds: 60 * 60,
+});
+
+console.log(temporary.workspaceId, temporary.expiresAt);
+```
+
+The server stores the resulting `expires_at` deadline and reaps expired rows in
+bounded batches. That explicit, non-null deadline is the entire safety
+predicate: a workspace is never selected for automatic deletion because of its
+name, age, lack of agents, or lack of messages. Callers that set a TTL consent
+to deletion of the workspace and all of its data at that deadline.
+
+A creator can also delete its workspace immediately. The exact workspace key
+must authenticate the id in the path:
+
+```bash
+curl -X DELETE "https://cast.agentrelay.com/v1/workspaces/$WORKSPACE_ID" \
+  -H "Authorization: Bearer $RELAY_API_KEY"
+```
+
+Success returns `204`. A missing or invalid key returns `401`; a valid key for a
+different workspace id returns `404`. The legacy authenticated
+`DELETE /v1/workspace` form remains available.
+
+Relaycast relies on `ON DELETE CASCADE`. Cloudflare D1 enforces foreign keys by
+default, equivalently to SQLite `PRAGMA foreign_keys = ON`; the Node adapter
+also enables that pragma explicitly. Deleting rows reduces the row count and
+associated insert/index work. Cloudflare does not document `VACUUM` as a
+supported D1 operation, so deletion must not be presented as shrinking the D1
+file itself.
+
 ## Why Relaycast
 
 Most multi-agent stacks need a communication layer but don’t want to build one.
@@ -382,6 +420,11 @@ curl -X POST https://cast.agentrelay.com/v1/workspaces \
   -H "Content-Type: application/json" \
   -d '{"name": "my-project"}'
 
+# Create an explicitly ephemeral workspace that expires after one hour
+curl -X POST https://cast.agentrelay.com/v1/workspaces \
+  -H "Content-Type: application/json" \
+  -d '{"name": "ci-run", "expires_in_seconds": 3600}'
+
 # Register agent
 curl -X POST https://cast.agentrelay.com/v1/agents \
   -H "Authorization: Bearer rk_live_YOUR_KEY" \
@@ -411,6 +454,7 @@ Core endpoints:
 
 ```text
 POST   /workspaces
+DELETE /workspaces/:id             Delete the authenticated workspace (204; 401/404 on auth/id mismatch)
 GET    /agent                       Resolve the authenticated agent token
 POST   /agents
 POST   /channels

--- a/README.md
+++ b/README.md
@@ -607,6 +607,10 @@ remains exported as a deprecated alias for the old, http-push-only name.)
 They must also call `sweepExpiredDeliveries` to transition expired mailbox rows in
 bounded D1-safe batches and emit sender failure notices. Inbox and delivery reads do
 not run maintenance; they remain available if a scheduled cleanup attempt fails.
+Workspace-lifecycle hosts should schedule `reapExpiredWorkspaces`; every call also
+drains the durable post-commit file-cleanup outbox. Hosts that do not run workspace
+expiry can schedule the exported `drainFileCleanup` helper directly. The Node
+self-host adapter runs this maintenance on its local timer.
 Adapters that terminate `/v1/node/ws` outside the engine request handler should delegate
 node control frames to `handleNodeControlMessage` from `@relaycast/engine/node-control`:
 the handler only needs `{ db, registry, workspaceId, nodeId, socket, raw }`, where

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -92,6 +92,11 @@ components:
         created_at:
           type: string
           format: date-time
+        expires_at:
+          type: string
+          nullable: true
+          format: date-time
+          description: Explicit workspace expiry; null means the workspace is persistent
 
     CreateWorkspaceResponse:
       type: object
@@ -108,6 +113,11 @@ components:
         created_at:
           type: string
           format: date-time
+        expires_at:
+          type: string
+          nullable: true
+          format: date-time
+          description: Explicit workspace expiry; null means the workspace is persistent
 
     WorkspaceLookup:
       type: object
@@ -1221,6 +1231,14 @@ paths:
               properties:
                 name:
                   type: string
+                expires_in_seconds:
+                  type: integer
+                  minimum: 60
+                  maximum: 2592000
+                  description: >-
+                    Explicit lifetime for a throwaway workspace. Omit for a
+                    persistent workspace. Once stored, the resulting expiry is
+                    the sole automatic whole-workspace deletion predicate.
       responses:
         '200':
           description: Existing workspace returned (idempotent)
@@ -1256,6 +1274,38 @@ paths:
             exhausted and the committed workspace/channel pair could not be
             confirmed. The response does not expose database statements or
             bound parameters.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+  /workspaces/{id}:
+    delete:
+      summary: Delete workspace by id
+      description: >-
+        Delete the authenticated workspace and all associated data. The bearer
+        workspace key must belong to the exact id in the path.
+      tags:
+        - Workspaces
+      security:
+        - workspaceKey: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '204':
+          description: Workspace deleted
+        '401':
+          description: Missing or invalid workspace key
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '404':
+          description: The authenticated key does not belong to the requested workspace id
           content:
             application/json:
               schema:

--- a/packages/engine/CHANGELOG.md
+++ b/packages/engine/CHANGELOG.md
@@ -12,10 +12,11 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 ### Added
 
 - Migration `0036` adds indexed workspace expiry. The engine adds bounded automatic reaping and authenticated `DELETE /v1/workspaces/:id`, with complete database and blob-storage deletion.
+- Migration `0037` adds upload-capability expiry metadata and a durable file-cleanup outbox. Workspace deletion commits its cleanup tombstones atomically with the database cascade, retries storage failures after commit, and retains each tombstone long enough to remove a late presigned upload.
 
 ### Changed
 
-- `FileStorage` adapters must implement idempotent batch object deletion so whole-workspace deletion can fail closed before removing database rows.
+- `FileStorage` adapters must implement idempotent batch object deletion. Queue/cron-backed hosts can use the exported `drainFileCleanup` helper directly; `reapExpiredWorkspaces` and the Node adapter also drain it automatically.
 
 ## [8.0.5] - 2026-08-18
 

--- a/packages/engine/CHANGELOG.md
+++ b/packages/engine/CHANGELOG.md
@@ -7,7 +7,11 @@ See the [root changelog](../../CHANGELOG.md) for cross-package release highlight
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [Unreleased - Minor]
+
+### Added
+
+- Migration `0036` adds indexed workspace expiry, bounded automatic reaping, and authenticated `DELETE /v1/workspaces/:id` with cascade coverage.
 
 ## [8.0.5] - 2026-08-18
 

--- a/packages/engine/CHANGELOG.md
+++ b/packages/engine/CHANGELOG.md
@@ -7,7 +7,7 @@ See the [root changelog](../../CHANGELOG.md) for cross-package release highlight
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased - Major]
+## [Unreleased - Minor]
 
 ### Added
 
@@ -16,7 +16,7 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ### Changed
 
-- `FileStorage` adapters must implement idempotent batch object deletion. Queue/cron-backed hosts can use the exported `drainFileCleanup` helper directly; `reapExpiredWorkspaces` and the Node adapter also drain it automatically.
+- `FileStorage` has an optional idempotent batch object-deletion capability; lifecycle deletion returns 503 before database changes when an adapter does not provide it. Queue/cron-backed hosts can use the exported `drainFileCleanup` helper directly; `reapExpiredWorkspaces` and the Node adapter also drain it automatically.
 
 ## [8.0.5] - 2026-08-18
 

--- a/packages/engine/CHANGELOG.md
+++ b/packages/engine/CHANGELOG.md
@@ -7,11 +7,15 @@ See the [root changelog](../../CHANGELOG.md) for cross-package release highlight
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased - Minor]
+## [Unreleased - Major]
 
 ### Added
 
-- Migration `0036` adds indexed workspace expiry, bounded automatic reaping, and authenticated `DELETE /v1/workspaces/:id` with cascade coverage.
+- Migration `0036` adds indexed workspace expiry. The engine adds bounded automatic reaping and authenticated `DELETE /v1/workspaces/:id`, with complete database and blob-storage deletion.
+
+### Changed
+
+- `FileStorage` adapters must implement idempotent batch object deletion so whole-workspace deletion can fail closed before removing database rows.
 
 ## [8.0.5] - 2026-08-18
 

--- a/packages/engine/src/__tests__/conformance/workspaceLifecycle.test.ts
+++ b/packages/engine/src/__tests__/conformance/workspaceLifecycle.test.ts
@@ -169,6 +169,29 @@ describe('workspace lifecycle', () => {
     expect((await stack.runtime.fileHandler(new Request(blob.downloadUrl))).status).toBe(404);
   });
 
+  it('returns a stable 503 before database changes when storage cannot delete objects', async () => {
+    const workspace = await createWorkspace(stack.app, 'unsupported-file-cleanup');
+    Object.defineProperty(stack.runtime.deps.files, 'deleteObjects', {
+      configurable: true,
+      value: undefined,
+    });
+
+    const response = await stack.app.request(`/v1/workspaces/${workspace.workspaceId}`, {
+      method: 'DELETE',
+      headers: { authorization: `Bearer ${workspace.workspaceKey}` },
+    });
+
+    expect(response.status).toBe(503);
+    await expect(response.json()).resolves.toMatchObject({
+      ok: false,
+      error: {
+        code: 'file_storage_delete_unsupported',
+        message: 'The configured file storage cannot delete workspace objects',
+      },
+    });
+    expect(await stack.runtime.handle.db.select().from(workspaces)).toHaveLength(1);
+  });
+
   it('commits workspace deletion before blob removal and durably retries a storage failure', async () => {
     const workspace = await createWorkspace(stack.app, 'storage-failure');
     const agent = await registerAgent(stack.app, workspace.workspaceKey, 'uploader');

--- a/packages/engine/src/__tests__/conformance/workspaceLifecycle.test.ts
+++ b/packages/engine/src/__tests__/conformance/workspaceLifecycle.test.ts
@@ -3,12 +3,13 @@ import { eq } from 'drizzle-orm';
 import {
   agents,
   channels,
+  fileCleanupQueue,
   files,
   messages,
   workspaceEvents,
   workspaces,
 } from '../../db/schema.js';
-import { reapExpiredWorkspaces } from '../../engine/workspace.js';
+import { drainFileCleanup, reapExpiredWorkspaces } from '../../engine/workspace.js';
 import {
   createWorkspace,
   makeNodeStack,
@@ -168,7 +169,7 @@ describe('workspace lifecycle', () => {
     expect((await stack.runtime.fileHandler(new Request(blob.downloadUrl))).status).toBe(404);
   });
 
-  it('does not claim deletion when blob removal fails', async () => {
+  it('commits workspace deletion before blob removal and durably retries a storage failure', async () => {
     const workspace = await createWorkspace(stack.app, 'storage-failure');
     const agent = await registerAgent(stack.app, workspace.workspaceKey, 'uploader');
     await stack.runtime.handle.db.insert(files).values({
@@ -179,6 +180,7 @@ describe('workspace lifecycle', () => {
       contentType: 'text/plain',
       sizeBytes: 1,
       storageKey: `${workspace.workspaceId}/file_storage_failure/failure.txt`,
+      uploadExpiresAt: new Date(Date.now() - 1_000),
       status: 'complete',
     });
     vi.spyOn(stack.runtime.deps.files, 'deleteObjects')
@@ -189,13 +191,35 @@ describe('workspace lifecycle', () => {
       headers: { authorization: `Bearer ${workspace.workspaceKey}` },
     });
 
-    expect(response.status).toBe(500);
-    expect(await stack.runtime.handle.db.select().from(workspaces)).toHaveLength(1);
-    expect(await stack.runtime.handle.db.select().from(files)).toHaveLength(1);
+    expect(response.status).toBe(204);
+    expect(await stack.runtime.handle.db.select().from(workspaces)).toHaveLength(0);
+    expect(await stack.runtime.handle.db.select().from(files)).toHaveLength(0);
+    expect(await stack.runtime.handle.db.select().from(fileCleanupQueue)).toMatchObject([
+      { attempts: 1, lastError: 'storage unavailable' },
+    ]);
+
+    await expect(drainFileCleanup(
+      stack.runtime.handle.db,
+      stack.runtime.deps.files,
+      { now: new Date(Date.now() + 31_000) },
+    )).resolves.toBe(1);
+    expect(await stack.runtime.handle.db.select().from(fileCleanupQueue)).toHaveLength(0);
   });
 
-  it('atomically preserves durable events when workspace-row deletion fails', async () => {
+  it('rolls back events and cleanup tombstones without touching storage when database deletion fails', async () => {
     const workspace = await createWorkspace(stack.app, 'database-failure');
+    const agent = await registerAgent(stack.app, workspace.workspaceKey, 'database-failure-uploader');
+    await stack.runtime.handle.db.insert(files).values({
+      id: 'file_database_failure',
+      workspaceId: workspace.workspaceId,
+      uploadedBy: agent.agentId,
+      filename: 'retained.txt',
+      contentType: 'text/plain',
+      sizeBytes: 1,
+      storageKey: `${workspace.workspaceId}/file_database_failure/retained.txt`,
+      uploadExpiresAt: new Date(Date.now() - 1_000),
+      status: 'complete',
+    });
     await stack.runtime.handle.db.insert(workspaceEvents).values({
       workspaceId: workspace.workspaceId,
       seq: 1,
@@ -209,6 +233,7 @@ describe('workspace lifecycle', () => {
         SELECT RAISE(ABORT, 'workspace delete rejected');
       END;
     `);
+    const deleteObjects = vi.spyOn(stack.runtime.deps.files, 'deleteObjects');
 
     const response = await stack.app.request(`/v1/workspaces/${workspace.workspaceId}`, {
       method: 'DELETE',
@@ -217,7 +242,62 @@ describe('workspace lifecycle', () => {
 
     expect(response.status).toBe(500);
     expect(await stack.runtime.handle.db.select().from(workspaces)).toHaveLength(1);
+    expect(await stack.runtime.handle.db.select().from(files)).toHaveLength(1);
     expect(await stack.runtime.handle.db.select().from(workspaceEvents)).toHaveLength(1);
+    expect(await stack.runtime.handle.db.select().from(fileCleanupQueue)).toHaveLength(0);
+    expect(deleteObjects).not.toHaveBeenCalled();
+  });
+
+  it('keeps a cleanup tombstone until a late upload capability expires', async () => {
+    const workspace = await createWorkspace(stack.app, 'late-upload');
+    const agent = await registerAgent(stack.app, workspace.workspaceKey, 'late-uploader');
+    const uploadResponse = await stack.app.request('/v1/files/upload', {
+      method: 'POST',
+      headers: {
+        authorization: `Bearer ${agent.token}`,
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({
+        filename: 'late.txt',
+        content_type: 'text/plain',
+        size_bytes: 4,
+      }),
+    });
+    const upload = await uploadResponse.json() as {
+      data: { id: string; upload_url: string; expires_at: string };
+    };
+    const completeResponse = await stack.app.request(`/v1/files/${upload.data.id}/complete`, {
+      method: 'POST',
+      headers: { authorization: `Bearer ${agent.token}` },
+    });
+    const complete = await completeResponse.json() as { data: { download_url: string } };
+
+    const response = await stack.app.request(`/v1/workspaces/${workspace.workspaceId}`, {
+      method: 'DELETE',
+      headers: { authorization: `Bearer ${workspace.workspaceKey}` },
+    });
+
+    expect(response.status).toBe(204);
+    expect(await stack.runtime.handle.db.select().from(fileCleanupQueue)).toHaveLength(1);
+
+    // A presigned PUT already handed to the client can race after the database
+    // commit. The durable tombstone survives this first successful delete.
+    const latePut = await stack.runtime.fileHandler(new Request(upload.data.upload_url, {
+      method: 'PUT',
+      headers: { 'content-type': 'text/plain' },
+      body: 'late',
+    }));
+    expect(latePut.status).toBe(200);
+    expect((await stack.runtime.fileHandler(new Request(complete.data.download_url))).status).toBe(200);
+
+    const afterUploadExpiry = new Date(new Date(upload.data.expires_at).getTime() + 1);
+    await expect(drainFileCleanup(
+      stack.runtime.handle.db,
+      stack.runtime.deps.files,
+      { now: afterUploadExpiry },
+    )).resolves.toBe(1);
+    expect((await stack.runtime.fileHandler(new Request(complete.data.download_url))).status).toBe(404);
+    expect(await stack.runtime.handle.db.select().from(fileCleanupQueue)).toHaveLength(0);
   });
 
   it('does not let one workspace key delete another workspace id', async () => {

--- a/packages/engine/src/__tests__/conformance/workspaceLifecycle.test.ts
+++ b/packages/engine/src/__tests__/conformance/workspaceLifecycle.test.ts
@@ -1,0 +1,164 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { eq } from 'drizzle-orm';
+import { agents, channels, messages, workspaces } from '../../db/schema.js';
+import { reapExpiredWorkspaces } from '../../engine/workspace.js';
+import { createWorkspace, makeNodeStack, type TestStack } from './harness.js';
+
+describe('workspace lifecycle', () => {
+  let stack: TestStack;
+
+  beforeEach(() => {
+    stack = makeNodeStack();
+  });
+
+  afterEach(() => {
+    stack.close();
+  });
+
+  it('stores an explicit expiry only when the creator supplies a TTL', async () => {
+    const before = Date.now();
+    const ephemeralResponse = await stack.app.request('/v1/workspaces', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ name: 'short-lived', expires_in_seconds: 3_600 }),
+    });
+
+    expect(ephemeralResponse.status).toBe(201);
+    const ephemeralBody = await ephemeralResponse.json() as {
+      data: { workspace_id: string; expires_at: string | null };
+    };
+    const expiresAt = new Date(ephemeralBody.data.expires_at ?? '').getTime();
+    expect(expiresAt).toBeGreaterThanOrEqual(before + 3_599_000);
+    expect(expiresAt).toBeLessThanOrEqual(Date.now() + 3_601_000);
+
+    const persistent = await createWorkspace(stack.app, 'persistent');
+    const [ephemeralRow] = await stack.runtime.handle.db
+      .select({ expiresAt: workspaces.expiresAt })
+      .from(workspaces)
+      .where(eq(workspaces.id, ephemeralBody.data.workspace_id));
+    const [persistentRow] = await stack.runtime.handle.db
+      .select({ expiresAt: workspaces.expiresAt })
+      .from(workspaces)
+      .where(eq(workspaces.id, persistent.workspaceId));
+
+    expect(ephemeralRow.expiresAt?.getTime()).toBe(expiresAt);
+    expect(persistentRow.expiresAt).toBeNull();
+  });
+
+  it.each([0, 59, 2_592_001, 60.5])(
+    'rejects invalid expires_in_seconds value %s',
+    async (expiresInSeconds) => {
+      const response = await stack.app.request('/v1/workspaces', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ name: 'invalid-expiry', expires_in_seconds: expiresInSeconds }),
+      });
+
+      expect(response.status).toBe(400);
+      expect(await stack.runtime.handle.db.select().from(workspaces)).toHaveLength(0);
+    },
+  );
+
+  it('deletes the authenticated workspace by id and cascades all child rows', async () => {
+    const workspace = await createWorkspace(stack.app, 'delete-me');
+    const [general] = await stack.runtime.handle.db
+      .select({ id: channels.id })
+      .from(channels)
+      .where(eq(channels.workspaceId, workspace.workspaceId));
+    await stack.runtime.handle.db.insert(agents).values({
+      id: 'agent_delete_me',
+      workspaceId: workspace.workspaceId,
+      name: 'deleter',
+      tokenHash: 'agent_delete_me_hash',
+    });
+    await stack.runtime.handle.db.insert(messages).values({
+      id: 'message_delete_me',
+      workspaceId: workspace.workspaceId,
+      channelId: general.id,
+      agentId: 'agent_delete_me',
+      body: 'cascade me',
+    });
+
+    const response = await stack.app.request(`/v1/workspaces/${workspace.workspaceId}`, {
+      method: 'DELETE',
+      headers: { authorization: `Bearer ${workspace.workspaceKey}` },
+    });
+
+    expect(response.status).toBe(204);
+    expect(await stack.runtime.handle.db.select().from(workspaces)).toHaveLength(0);
+    expect(await stack.runtime.handle.db.select().from(channels)).toHaveLength(0);
+    expect(await stack.runtime.handle.db.select().from(agents)).toHaveLength(0);
+    expect(await stack.runtime.handle.db.select().from(messages)).toHaveLength(0);
+  });
+
+  it('does not let one workspace key delete another workspace id', async () => {
+    const first = await createWorkspace(stack.app, 'first');
+    const second = await createWorkspace(stack.app, 'second');
+
+    const response = await stack.app.request(`/v1/workspaces/${second.workspaceId}`, {
+      method: 'DELETE',
+      headers: { authorization: `Bearer ${first.workspaceKey}` },
+    });
+
+    expect(response.status).toBe(404);
+    expect((await response.json()) as object).toMatchObject({
+      ok: false,
+      error: { code: 'workspace_not_found' },
+    });
+    expect(await stack.runtime.handle.db.select().from(workspaces)).toHaveLength(2);
+  });
+
+  it('requires a workspace key for id-scoped deletion', async () => {
+    const workspace = await createWorkspace(stack.app, 'auth-required');
+
+    const response = await stack.app.request(`/v1/workspaces/${workspace.workspaceId}`, {
+      method: 'DELETE',
+    });
+
+    expect(response.status).toBe(401);
+    expect(await stack.runtime.handle.db.select().from(workspaces)).toHaveLength(1);
+  });
+
+  it('reaps only explicit expired deadlines, never inferred CI-like candidates', async () => {
+    const persistent = await createWorkspace(stack.app, 'relay-deadbeef');
+    const expired = await createWorkspace(stack.app, 'explicitly-expired');
+    const future = await createWorkspace(stack.app, 'future-expiry');
+    const now = new Date();
+
+    await stack.runtime.handle.db
+      .update(workspaces)
+      .set({ createdAt: new Date(now.getTime() - 10 * 24 * 60 * 60 * 1_000) })
+      .where(eq(workspaces.id, persistent.workspaceId));
+    await stack.runtime.handle.db
+      .update(workspaces)
+      .set({ expiresAt: new Date(now.getTime() - 1_000) })
+      .where(eq(workspaces.id, expired.workspaceId));
+    await stack.runtime.handle.db
+      .update(workspaces)
+      .set({ expiresAt: new Date(now.getTime() + 60_000) })
+      .where(eq(workspaces.id, future.workspaceId));
+
+    const deleted = await reapExpiredWorkspaces(stack.runtime.handle.db, { now });
+    const remaining = await stack.runtime.handle.db
+      .select({ id: workspaces.id })
+      .from(workspaces);
+
+    expect(deleted).toEqual([expired.workspaceId]);
+    expect(remaining.map((row) => row.id).sort()).toEqual(
+      [persistent.workspaceId, future.workspaceId].sort(),
+    );
+  });
+
+  it('keeps every direct workspace foreign key on delete cascade', () => {
+    const foreignKeys = stack.runtime.handle.sqlite.prepare(`
+      SELECT schema_table.name AS table_name, foreign_key.on_delete AS on_delete
+      FROM sqlite_schema AS schema_table,
+           pragma_foreign_key_list(schema_table.name) AS foreign_key
+      WHERE schema_table.type = 'table'
+        AND foreign_key."table" = 'workspaces'
+    `).all() as Array<{ table_name: string; on_delete: string }>;
+
+    expect(foreignKeys.length).toBeGreaterThan(0);
+    expect(foreignKeys.every((foreignKey) => foreignKey.on_delete === 'CASCADE')).toBe(true);
+  });
+});

--- a/packages/engine/src/__tests__/conformance/workspaceLifecycle.test.ts
+++ b/packages/engine/src/__tests__/conformance/workspaceLifecycle.test.ts
@@ -1,8 +1,59 @@
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { eq } from 'drizzle-orm';
-import { agents, channels, messages, workspaces } from '../../db/schema.js';
+import {
+  agents,
+  channels,
+  files,
+  messages,
+  workspaceEvents,
+  workspaces,
+} from '../../db/schema.js';
 import { reapExpiredWorkspaces } from '../../engine/workspace.js';
-import { createWorkspace, makeNodeStack, type TestStack } from './harness.js';
+import {
+  createWorkspace,
+  makeNodeStack,
+  registerAgent,
+  type TestStack,
+} from './harness.js';
+
+async function uploadBlob(stack: TestStack, agentToken: string) {
+  const uploadResponse = await stack.app.request('/v1/files/upload', {
+    method: 'POST',
+    headers: {
+      authorization: `Bearer ${agentToken}`,
+      'content-type': 'application/json',
+    },
+    body: JSON.stringify({
+      filename: 'delete-me.txt',
+      content_type: 'text/plain',
+      size_bytes: 9,
+    }),
+  });
+  expect(uploadResponse.status).toBe(201);
+  const uploadBody = await uploadResponse.json() as {
+    data: { id: string; upload_url: string };
+  };
+  const putResponse = await stack.runtime.fileHandler(new Request(uploadBody.data.upload_url, {
+    method: 'PUT',
+    headers: { 'content-type': 'text/plain' },
+    body: 'delete me',
+  }));
+  expect(putResponse.status).toBe(200);
+
+  const completeResponse = await stack.app.request(`/v1/files/${uploadBody.data.id}/complete`, {
+    method: 'POST',
+    headers: { authorization: `Bearer ${agentToken}` },
+  });
+  expect(completeResponse.status).toBe(200);
+  const completeBody = await completeResponse.json() as {
+    data: { download_url: string };
+  };
+
+  return {
+    fileId: uploadBody.data.id,
+    downloadUrl: completeBody.data.download_url,
+  };
+}
 
 describe('workspace lifecycle', () => {
   let stack: TestStack;
@@ -78,6 +129,12 @@ describe('workspace lifecycle', () => {
       agentId: 'agent_delete_me',
       body: 'cascade me',
     });
+    await stack.runtime.handle.db.insert(workspaceEvents).values({
+      workspaceId: workspace.workspaceId,
+      seq: 1,
+      type: 'message.created',
+      payload: JSON.stringify({ text: 'delete this event payload' }),
+    });
 
     const response = await stack.app.request(`/v1/workspaces/${workspace.workspaceId}`, {
       method: 'DELETE',
@@ -89,6 +146,78 @@ describe('workspace lifecycle', () => {
     expect(await stack.runtime.handle.db.select().from(channels)).toHaveLength(0);
     expect(await stack.runtime.handle.db.select().from(agents)).toHaveLength(0);
     expect(await stack.runtime.handle.db.select().from(messages)).toHaveLength(0);
+    expect(await stack.runtime.handle.db.select().from(workspaceEvents)).toHaveLength(0);
+  });
+
+  it('removes stored bytes so an issued download URL stops working', async () => {
+    const workspace = await createWorkspace(stack.app, 'delete-file-bytes');
+    const agent = await registerAgent(stack.app, workspace.workspaceKey, 'uploader');
+    const blob = await uploadBlob(stack, agent.token);
+
+    const beforeDelete = await stack.runtime.fileHandler(new Request(blob.downloadUrl));
+    expect(beforeDelete.status).toBe(200);
+    expect(await beforeDelete.text()).toBe('delete me');
+
+    const response = await stack.app.request(`/v1/workspaces/${workspace.workspaceId}`, {
+      method: 'DELETE',
+      headers: { authorization: `Bearer ${workspace.workspaceKey}` },
+    });
+
+    expect(response.status).toBe(204);
+    expect(await stack.runtime.handle.db.select().from(files)).toHaveLength(0);
+    expect((await stack.runtime.fileHandler(new Request(blob.downloadUrl))).status).toBe(404);
+  });
+
+  it('does not claim deletion when blob removal fails', async () => {
+    const workspace = await createWorkspace(stack.app, 'storage-failure');
+    const agent = await registerAgent(stack.app, workspace.workspaceKey, 'uploader');
+    await stack.runtime.handle.db.insert(files).values({
+      id: 'file_storage_failure',
+      workspaceId: workspace.workspaceId,
+      uploadedBy: agent.agentId,
+      filename: 'failure.txt',
+      contentType: 'text/plain',
+      sizeBytes: 1,
+      storageKey: `${workspace.workspaceId}/file_storage_failure/failure.txt`,
+      status: 'complete',
+    });
+    vi.spyOn(stack.runtime.deps.files, 'deleteObjects')
+      .mockRejectedValueOnce(new Error('storage unavailable'));
+
+    const response = await stack.app.request(`/v1/workspaces/${workspace.workspaceId}`, {
+      method: 'DELETE',
+      headers: { authorization: `Bearer ${workspace.workspaceKey}` },
+    });
+
+    expect(response.status).toBe(500);
+    expect(await stack.runtime.handle.db.select().from(workspaces)).toHaveLength(1);
+    expect(await stack.runtime.handle.db.select().from(files)).toHaveLength(1);
+  });
+
+  it('atomically preserves durable events when workspace-row deletion fails', async () => {
+    const workspace = await createWorkspace(stack.app, 'database-failure');
+    await stack.runtime.handle.db.insert(workspaceEvents).values({
+      workspaceId: workspace.workspaceId,
+      seq: 1,
+      type: 'workspace.test',
+      payload: JSON.stringify({ retain: true }),
+    });
+    stack.runtime.handle.sqlite.exec(`
+      CREATE TRIGGER reject_workspace_delete
+      BEFORE DELETE ON workspaces
+      BEGIN
+        SELECT RAISE(ABORT, 'workspace delete rejected');
+      END;
+    `);
+
+    const response = await stack.app.request(`/v1/workspaces/${workspace.workspaceId}`, {
+      method: 'DELETE',
+      headers: { authorization: `Bearer ${workspace.workspaceKey}` },
+    });
+
+    expect(response.status).toBe(500);
+    expect(await stack.runtime.handle.db.select().from(workspaces)).toHaveLength(1);
+    expect(await stack.runtime.handle.db.select().from(workspaceEvents)).toHaveLength(1);
   });
 
   it('does not let one workspace key delete another workspace id', async () => {
@@ -138,7 +267,11 @@ describe('workspace lifecycle', () => {
       .set({ expiresAt: new Date(now.getTime() + 60_000) })
       .where(eq(workspaces.id, future.workspaceId));
 
-    const deleted = await reapExpiredWorkspaces(stack.runtime.handle.db, { now });
+    const deleted = await reapExpiredWorkspaces(
+      stack.runtime.handle.db,
+      stack.runtime.deps.files,
+      { now },
+    );
     const remaining = await stack.runtime.handle.db
       .select({ id: workspaces.id })
       .from(workspaces);
@@ -149,16 +282,133 @@ describe('workspace lifecycle', () => {
     );
   });
 
-  it('keeps every direct workspace foreign key on delete cascade', () => {
-    const foreignKeys = stack.runtime.handle.sqlite.prepare(`
-      SELECT schema_table.name AS table_name, foreign_key.on_delete AS on_delete
-      FROM sqlite_schema AS schema_table,
-           pragma_foreign_key_list(schema_table.name) AS foreign_key
-      WHERE schema_table.type = 'table'
-        AND foreign_key."table" = 'workspaces'
-    `).all() as Array<{ table_name: string; on_delete: string }>;
+  it('reaping removes durable events and stored bytes', async () => {
+    const workspace = await createWorkspace(stack.app, 'reap-file-bytes');
+    const agent = await registerAgent(stack.app, workspace.workspaceKey, 'uploader');
+    const blob = await uploadBlob(stack, agent.token);
+    const now = new Date();
+    await stack.runtime.handle.db
+      .update(workspaces)
+      .set({ expiresAt: new Date(now.getTime() - 1_000) })
+      .where(eq(workspaces.id, workspace.workspaceId));
+    await stack.runtime.handle.db.insert(workspaceEvents).values({
+      workspaceId: workspace.workspaceId,
+      seq: 999,
+      type: 'file.uploaded',
+      payload: JSON.stringify({ file_id: blob.fileId }),
+    });
 
-    expect(foreignKeys.length).toBeGreaterThan(0);
-    expect(foreignKeys.every((foreignKey) => foreignKey.on_delete === 'CASCADE')).toBe(true);
+    const deleted = await reapExpiredWorkspaces(
+      stack.runtime.handle.db,
+      stack.runtime.deps.files,
+      { now },
+    );
+
+    expect(deleted).toEqual([workspace.workspaceId]);
+    expect(await stack.runtime.handle.db.select().from(workspaceEvents)).toHaveLength(0);
+    expect((await stack.runtime.fileHandler(new Request(blob.downloadUrl))).status).toBe(404);
+  });
+
+  it('normalizes non-finite and fractional reap limits before querying', async () => {
+    const first = await createWorkspace(stack.app, 'limit-first');
+    const second = await createWorkspace(stack.app, 'limit-second');
+    const now = new Date();
+    await stack.runtime.handle.db
+      .update(workspaces)
+      .set({ expiresAt: new Date(now.getTime() - 1_000) });
+
+    await expect(reapExpiredWorkspaces(
+      stack.runtime.handle.db,
+      stack.runtime.deps.files,
+      { now, limit: Number.NaN },
+    )).resolves.toEqual(expect.arrayContaining([first.workspaceId, second.workspaceId]));
+
+    const third = await createWorkspace(stack.app, 'limit-third');
+    const fourth = await createWorkspace(stack.app, 'limit-fourth');
+    await stack.runtime.handle.db
+      .update(workspaces)
+      .set({ expiresAt: new Date(now.getTime() - 1_000) });
+    const fractionallyLimited = await reapExpiredWorkspaces(
+      stack.runtime.handle.db,
+      stack.runtime.deps.files,
+      { now, limit: 1.8 },
+    );
+
+    expect(fractionallyLimited).toHaveLength(1);
+    expect([third.workspaceId, fourth.workspaceId]).toContain(fractionallyLimited[0]);
+  });
+
+  it('does not reuse an expired workspace during an authenticated retry', async () => {
+    const expired = await createWorkspace(stack.app, 'expired-retry');
+    await stack.runtime.handle.db
+      .update(workspaces)
+      .set({ expiresAt: new Date(Date.now() - 1_000) })
+      .where(eq(workspaces.id, expired.workspaceId));
+
+    const response = await stack.app.request('/v1/workspaces', {
+      method: 'POST',
+      headers: {
+        authorization: `Bearer ${expired.workspaceKey}`,
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({ name: 'expired-retry' }),
+    });
+    const body = await response.json() as { data: { workspace_id: string } };
+
+    expect(response.status).toBe(201);
+    expect(body.data.workspace_id).not.toBe(expired.workspaceId);
+    expect(await stack.runtime.handle.db
+      .select()
+      .from(workspaces)
+      .where(eq(workspaces.id, body.data.workspace_id))).toHaveLength(1);
+  });
+
+  it('does not schedule a reap for an idempotent create hit', async () => {
+    const persistent = await createWorkspace(stack.app, 'dedupe-hit');
+    const expired = await createWorkspace(stack.app, 'expired-bystander');
+    await stack.runtime.handle.db
+      .update(workspaces)
+      .set({ expiresAt: new Date(Date.now() - 1_000) })
+      .where(eq(workspaces.id, expired.workspaceId));
+
+    const response = await stack.app.request('/v1/workspaces', {
+      method: 'POST',
+      headers: {
+        authorization: `Bearer ${persistent.workspaceKey}`,
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({ name: 'dedupe-hit' }),
+    });
+
+    expect(response.status).toBe(200);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(await stack.runtime.handle.db
+      .select()
+      .from(workspaces)
+      .where(eq(workspaces.id, expired.workspaceId))).toHaveLength(1);
+  });
+
+  it('accounts for every workspace_id table and enables foreign-key enforcement', () => {
+    const coverage = stack.runtime.handle.sqlite.prepare(`
+      SELECT schema_table.name AS table_name,
+             (
+               SELECT foreign_key.on_delete
+               FROM pragma_foreign_key_list(schema_table.name) AS foreign_key
+               WHERE foreign_key."table" = 'workspaces'
+                 AND foreign_key."from" = 'workspace_id'
+             ) AS on_delete
+      FROM sqlite_schema AS schema_table
+      JOIN pragma_table_info(schema_table.name) AS column
+        ON column.name = 'workspace_id'
+      WHERE schema_table.type = 'table'
+      ORDER BY schema_table.name
+    `).all() as Array<{ table_name: string; on_delete: string | null }>;
+    const withoutDirectCascade = coverage.filter((table) => table.on_delete !== 'CASCADE');
+
+    expect(stack.runtime.handle.sqlite.pragma('foreign_keys', { simple: true })).toBe(1);
+    expect(coverage).toHaveLength(28);
+    expect(withoutDirectCascade).toEqual([
+      { table_name: 'workspace_events', on_delete: null },
+    ]);
   });
 });

--- a/packages/engine/src/adapters/node/files.ts
+++ b/packages/engine/src/adapters/node/files.ts
@@ -1,5 +1,5 @@
 import { createHmac, timingSafeEqual } from 'node:crypto';
-import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import { mkdir, readFile, rm, writeFile } from 'node:fs/promises';
 import { dirname, join, normalize, sep } from 'node:path';
 import { z } from 'zod';
 import type { FileStorage } from '../../ports/files.js';
@@ -50,6 +50,16 @@ export class LocalFileStorage implements FileStorage {
   async createDownloadUrl(args: { storageKey: string }): Promise<string> {
     const exp = Math.floor(Date.now() / 1000) + URL_TTL_SECONDS;
     return this.url({ key: args.storageKey, op: 'get', exp });
+  }
+
+  async deleteObjects(args: { storageKeys: string[] }): Promise<void> {
+    for (const storageKey of args.storageKeys) {
+      const path = this.resolvePath(storageKey);
+      await Promise.all([
+        rm(path, { force: true }),
+        rm(`${path}.ct`, { force: true }),
+      ]);
+    }
   }
 
   /** Resolve a storage key to an absolute path under `dir`, rejecting traversal. */

--- a/packages/engine/src/adapters/node/index.ts
+++ b/packages/engine/src/adapters/node/index.ts
@@ -169,7 +169,7 @@ export function createNodeRuntime(options: NodeRuntimeOptions): NodeRuntime {
     void sweepStaleAgents(db).catch(() => {});
     void sweepOfflineNodes(db, realtime, deps).catch(() => {});
     void sweepTimedOutInvocations(db, realtime, { completionDeps: deps }).catch(() => {});
-    void reapExpiredWorkspaces(db).catch(() => {});
+    void reapExpiredWorkspaces(db, fileStorage).catch(() => {});
     void runDeliveryMaintenance();
   }, 15_000);
   (sweepTimer as { unref?: () => void }).unref?.();

--- a/packages/engine/src/adapters/node/index.ts
+++ b/packages/engine/src/adapters/node/index.ts
@@ -18,6 +18,7 @@ import { sweepStaleAgents } from '../../engine/agent.js';
 import { sweepTimedOutInvocations } from '../../engine/action.js';
 import { sendNodePresenceContext } from '../../engine/nodeContext.js';
 import { createDeliveryMaintenanceRunner } from './delivery-maintenance.js';
+import { reapExpiredWorkspaces } from '../../engine/workspace.js';
 
 export {
   InProcessRealtime,
@@ -168,6 +169,7 @@ export function createNodeRuntime(options: NodeRuntimeOptions): NodeRuntime {
     void sweepStaleAgents(db).catch(() => {});
     void sweepOfflineNodes(db, realtime, deps).catch(() => {});
     void sweepTimedOutInvocations(db, realtime, { completionDeps: deps }).catch(() => {});
+    void reapExpiredWorkspaces(db).catch(() => {});
     void runDeliveryMaintenance();
   }, 15_000);
   (sweepTimer as { unref?: () => void }).unref?.();

--- a/packages/engine/src/db/migrations/0036_workspace_expiry.sql
+++ b/packages/engine/src/db/migrations/0036_workspace_expiry.sql
@@ -1,0 +1,3 @@
+ALTER TABLE `workspaces` ADD `expires_at` integer;
+--> statement-breakpoint
+CREATE INDEX `idx_workspaces_expires_at` ON `workspaces` (`expires_at`);

--- a/packages/engine/src/db/migrations/0037_file_cleanup_outbox.sql
+++ b/packages/engine/src/db/migrations/0037_file_cleanup_outbox.sql
@@ -1,0 +1,36 @@
+-- Record the exact expiry of each issued upload capability. Existing pending
+-- uploads are conservatively protected for one hour when their file row is
+-- removed, matching the documented FileStorage URL lifetime.
+ALTER TABLE `files` ADD `upload_expires_at` integer;
+--> statement-breakpoint
+
+-- This outbox intentionally has no workspace FK: cleanup must remain durable
+-- after the workspace and its file metadata have committed their deletion.
+CREATE TABLE `file_cleanup_queue` (
+  `storage_key` text PRIMARY KEY NOT NULL,
+  `delete_after` integer NOT NULL,
+  `process_after` integer DEFAULT (unixepoch()) NOT NULL,
+  `attempts` integer DEFAULT 0 NOT NULL,
+  `last_error` text,
+  `created_at` integer DEFAULT (unixepoch()) NOT NULL
+);
+--> statement-breakpoint
+CREATE INDEX `idx_file_cleanup_due`
+  ON `file_cleanup_queue` (`process_after`, `storage_key`);
+--> statement-breakpoint
+
+-- Queue the object in the same transaction that removes its metadata. This
+-- trigger also runs for workspace FK cascades, closing the upload/delete race:
+-- an upload row commits before the workspace delete and is queued, or it loses
+-- the race and its workspace FK insert fails.
+CREATE TRIGGER `files_enqueue_object_cleanup`
+AFTER DELETE ON `files`
+BEGIN
+  INSERT INTO `file_cleanup_queue` (`storage_key`, `delete_after`)
+  VALUES (
+    OLD.`storage_key`,
+    MAX(unixepoch(), COALESCE(OLD.`upload_expires_at`, unixepoch() + 3600))
+  )
+  ON CONFLICT (`storage_key`) DO UPDATE SET
+    `delete_after` = MAX(`file_cleanup_queue`.`delete_after`, excluded.`delete_after`);
+END;

--- a/packages/engine/src/db/schema.ts
+++ b/packages/engine/src/db/schema.ts
@@ -684,6 +684,10 @@ export const files = sqliteTable(
     contentType: text('content_type').notNull(),
     sizeBytes: integer('size_bytes').notNull(),
     storageKey: text('storage_key').notNull(),
+    // Persist the exact lifetime of the issued PUT capability. Workspace
+    // deletion keeps a cleanup tombstone through this deadline so a late PUT
+    // cannot permanently recreate an object after the first delete attempt.
+    uploadExpiresAt: integer('upload_expires_at', { mode: 'timestamp' }),
     status: text('status').notNull().default('pending'),
     createdAt: integer('created_at', { mode: 'timestamp' }).notNull().default(sql`(unixepoch())`),
   },
@@ -691,6 +695,28 @@ export const files = sqliteTable(
     index('idx_files_workspace').on(table.workspaceId, table.createdAt),
     index('idx_files_uploader').on(table.uploadedBy),
   ],
+);
+
+// ============================================
+// File Cleanup Outbox
+// ============================================
+/**
+ * Durable object-deletion tombstones created by a trigger whenever a file row
+ * is physically removed. There is deliberately no workspace foreign key: the
+ * row must survive the workspace cascade until external storage confirms the
+ * object is gone after every issued upload capability has expired.
+ */
+export const fileCleanupQueue = sqliteTable(
+  'file_cleanup_queue',
+  {
+    storageKey: text('storage_key').primaryKey(),
+    deleteAfter: integer('delete_after', { mode: 'timestamp' }).notNull(),
+    processAfter: integer('process_after', { mode: 'timestamp' }).notNull().default(sql`(unixepoch())`),
+    attempts: integer('attempts').notNull().default(0),
+    lastError: text('last_error'),
+    createdAt: integer('created_at', { mode: 'timestamp' }).notNull().default(sql`(unixepoch())`),
+  },
+  (table) => [index('idx_file_cleanup_due').on(table.processAfter, table.storageKey)],
 );
 
 // ============================================

--- a/packages/engine/src/db/schema.ts
+++ b/packages/engine/src/db/schema.ts
@@ -38,16 +38,23 @@ export interface ObserverTokenFilters {
   created_after?: string;
 }
 
-export const workspaces = sqliteTable('workspaces', {
-  id: text('id').primaryKey(),
-  name: text('name').notNull(),
-  apiKeyHash: text('api_key_hash').notNull().unique(),
-  systemPrompt: text('system_prompt'),
-  plan: text('plan').notNull().default('free'),
-  createdAt: integer('created_at', { mode: 'timestamp' }).notNull().default(sql`(unixepoch())`),
-  metadata: text('metadata', { mode: 'json' }).$type<Record<string, unknown>>().default({}),
-  retention: text('retention', { mode: 'json' }).$type<WorkspaceRetentionSettings>(),
-});
+export const workspaces = sqliteTable(
+  'workspaces',
+  {
+    id: text('id').primaryKey(),
+    name: text('name').notNull(),
+    apiKeyHash: text('api_key_hash').notNull().unique(),
+    systemPrompt: text('system_prompt'),
+    plan: text('plan').notNull().default('free'),
+    createdAt: integer('created_at', { mode: 'timestamp' }).notNull().default(sql`(unixepoch())`),
+    metadata: text('metadata', { mode: 'json' }).$type<Record<string, unknown>>().default({}),
+    retention: text('retention', { mode: 'json' }).$type<WorkspaceRetentionSettings>(),
+    // A non-null deadline is an explicit, immutable opt-in to whole-workspace
+    // deletion. Persistent workspaces always leave this null.
+    expiresAt: integer('expires_at', { mode: 'timestamp' }),
+  },
+  (table) => [index('idx_workspaces_expires_at').on(table.expiresAt)],
+);
 
 // ============================================
 // Agents

--- a/packages/engine/src/db/schema.ts
+++ b/packages/engine/src/db/schema.ts
@@ -1039,7 +1039,7 @@ export const pendingEvents = sqliteTable(
  * the exact `transformForClient(event)` JSON published to the stream (without
  * `seq` — the cursor lives in the column and is stamped onto the published
  * frame). No FK to `workspaces` by design: appends are best-effort and rows
- * are pruned by retention, not cascades.
+ * are pruned by retention or explicitly removed with their workspace.
  */
 export const workspaceEvents = sqliteTable(
   'workspace_events',

--- a/packages/engine/src/engine/__tests__/workspace.test.ts
+++ b/packages/engine/src/engine/__tests__/workspace.test.ts
@@ -10,9 +10,9 @@ import type {
   TransactionCapability,
 } from '../../ports/database.js';
 import * as snowflake from '../snowflake.js';
-import { createWorkspace } from '../workspace.js';
+import { createWorkspace, deleteWorkspace } from '../workspace.js';
 
-describe('workspace creation durability', () => {
+describe('workspace write durability', () => {
   let stack: TestStack;
   let db: EngineDb;
 
@@ -93,6 +93,14 @@ describe('workspace creation durability', () => {
       .mockReturnValueOnce(pair.workspaceId)
       .mockReturnValueOnce(pair.channelId);
     return pair;
+  }
+
+  async function seedDeletionWorkspace(id: string): Promise<void> {
+    await db.insert(workspaces).values({
+      id,
+      name: id,
+      apiKeyHash: `${id}-hash`,
+    });
   }
 
   it('retries a transient D1 failure and commits workspace plus channel atomically', async () => {
@@ -238,5 +246,66 @@ describe('workspace creation durability', () => {
 
     await expect(createWorkspace(db, 'invalid-write')).rejects.toThrow('D1_TYPE_ERROR');
     expect(calls).toBe(1);
+  });
+
+  it('retries a transient D1 workspace deletion and requires an atomic handle', async () => {
+    await seedDeletionWorkspace('delete-transient');
+    const batchCalls = attachD1Batch({ failBeforeFirst: true });
+
+    await deleteWorkspace(db, stack.runtime.deps.files, 'delete-transient');
+
+    expect(batchCalls()).toBe(2);
+    expect(await db.select().from(workspaces)).toHaveLength(0);
+
+    await seedDeletionWorkspace('delete-without-atomicity');
+    delete (db as Partial<BatchCapability>).batch;
+    await expect(deleteWorkspace(
+      db,
+      stack.runtime.deps.files,
+      'delete-without-atomicity',
+    )).rejects.toThrow('Atomic write capability required');
+    expect(await db.select().from(workspaces)).toHaveLength(1);
+  });
+
+  it('recognizes a committed deletion after transient retries exhaust', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    await seedDeletionWorkspace('delete-lost-response');
+    const batchCalls = attachD1Batch({
+      loseFirstResponse: true,
+      failAfterLostResponse: true,
+    });
+
+    const deletion = deleteWorkspace(
+      db,
+      stack.runtime.deps.files,
+      'delete-lost-response',
+    );
+    const outcome = deletion.then(
+      () => ({ ok: true as const }),
+      (error: unknown) => ({ ok: false as const, error }),
+    );
+    await vi.runAllTimersAsync();
+    const settled = await outcome;
+    if (!settled.ok) throw settled.error;
+
+    expect(batchCalls()).toBe(5);
+    expect(await db.select().from(workspaces)).toHaveLength(0);
+  });
+
+  it('does not retry a non-transient workspace deletion error', async () => {
+    await seedDeletionWorkspace('delete-type-error');
+    let calls = 0;
+    (db as EngineDb & Partial<BatchCapability>).batch = async () => {
+      calls += 1;
+      throw new Error('D1_TYPE_ERROR: Type mismatch');
+    };
+
+    await expect(deleteWorkspace(
+      db,
+      stack.runtime.deps.files,
+      'delete-type-error',
+    )).rejects.toThrow('D1_TYPE_ERROR');
+    expect(calls).toBe(1);
+    expect(await db.select().from(workspaces)).toHaveLength(1);
   });
 });

--- a/packages/engine/src/engine/file.ts
+++ b/packages/engine/src/engine/file.ts
@@ -23,6 +23,10 @@ export async function createUpload(
     contentType: data.content_type,
     sizeBytes: data.size_bytes,
   });
+  const uploadExpiresAt = new Date(expiresAt);
+  if (!Number.isFinite(uploadExpiresAt.getTime())) {
+    throw new Error('File storage returned an invalid upload expiry');
+  }
 
   await db.insert(files).values({
     id,
@@ -32,6 +36,7 @@ export async function createUpload(
     contentType: data.content_type,
     sizeBytes: data.size_bytes,
     storageKey,
+    uploadExpiresAt,
     status: 'pending',
   });
 

--- a/packages/engine/src/engine/workspace.ts
+++ b/packages/engine/src/engine/workspace.ts
@@ -1,4 +1,4 @@
-import { and, eq } from 'drizzle-orm';
+import { and, asc, eq, inArray, lte } from 'drizzle-orm';
 import type { getDb } from '../db/index.js';
 import { workspaces, channels } from '../db/schema.js';
 import { randomHex, sha256Hex } from '../lib/crypto.js';
@@ -24,7 +24,10 @@ type CreateWorkspaceOptions =
   | {
       ownerApiKey?: string;
       ownerApiKeyHash?: string;
+      expiresAt?: Date;
     };
+
+export const DEFAULT_WORKSPACE_REAP_LIMIT = 25;
 
 function hashApiKey(apiKey: string): Promise<string> {
   return sha256Hex(apiKey);
@@ -38,6 +41,7 @@ function buildWorkspaceResponse(
     workspace_id: workspace.id,
     ...(apiKey ? { api_key: apiKey } : {}),
     created_at: workspace.createdAt.toISOString(),
+    expires_at: workspace.expiresAt?.toISOString() ?? null,
   };
 }
 
@@ -136,6 +140,7 @@ export async function createWorkspace(
 ) {
   const providedOwnerApiKeyHash = typeof options === 'string' ? undefined : options?.ownerApiKeyHash;
   const providedOwnerApiKey = typeof options === 'string' ? options : options?.ownerApiKey;
+  const expiresAt = typeof options === 'string' ? undefined : options?.expiresAt;
   const derivedOwnerApiKeyHash = providedOwnerApiKey ? await hashApiKey(providedOwnerApiKey) : undefined;
 
   if (providedOwnerApiKeyHash && derivedOwnerApiKeyHash && providedOwnerApiKeyHash !== derivedOwnerApiKeyHash) {
@@ -175,7 +180,7 @@ export async function createWorkspace(
           (writeDb) => [
             writeDb
               .insert(workspaces)
-              .values({ id: workspaceId, name, apiKeyHash })
+              .values({ id: workspaceId, name, apiKeyHash, expiresAt })
               .returning(),
             writeDb
               .insert(channels)
@@ -279,6 +284,7 @@ export async function getWorkspace(db: Db, workspaceId: string) {
     system_prompt: workspace.systemPrompt,
     created_at: workspace.createdAt.toISOString(),
     metadata: workspace.metadata,
+    expires_at: workspace.expiresAt?.toISOString() ?? null,
   };
 }
 
@@ -311,9 +317,38 @@ export async function updateWorkspace(
     system_prompt: updated.systemPrompt,
     created_at: updated.createdAt.toISOString(),
     metadata: updated.metadata,
+    expires_at: updated.expiresAt?.toISOString() ?? null,
   };
 }
 
 export async function deleteWorkspace(db: Db, workspaceId: string) {
   await db.delete(workspaces).where(eq(workspaces.id, workspaceId));
+}
+
+/**
+ * Delete a bounded batch of workspaces whose callers explicitly opted into an
+ * expiry deadline at creation. No inferred signal (name, age, agents, or
+ * messages) participates in this predicate.
+ */
+export async function reapExpiredWorkspaces(
+  db: Db,
+  options: { now?: Date; limit?: number } = {},
+): Promise<string[]> {
+  const now = options.now ?? new Date();
+  const limit = Math.max(1, Math.min(options.limit ?? DEFAULT_WORKSPACE_REAP_LIMIT, 90));
+  const expired = await db
+    .select({ id: workspaces.id })
+    .from(workspaces)
+    .where(lte(workspaces.expiresAt, now))
+    .orderBy(asc(workspaces.expiresAt), asc(workspaces.id))
+    .limit(limit);
+
+  if (expired.length === 0) return [];
+
+  const ids = expired.map((workspace) => workspace.id);
+  const deleted = await db
+    .delete(workspaces)
+    .where(inArray(workspaces.id, ids))
+    .returning({ id: workspaces.id });
+  return deleted.map((workspace) => workspace.id);
 }

--- a/packages/engine/src/engine/workspace.ts
+++ b/packages/engine/src/engine/workspace.ts
@@ -1,11 +1,12 @@
-import { and, asc, eq, inArray, lte } from 'drizzle-orm';
+import { and, asc, eq, gt, inArray, isNull, lte, or } from 'drizzle-orm';
 import type { getDb } from '../db/index.js';
-import { workspaces, channels } from '../db/schema.js';
+import { workspaces, channels, files, workspaceEvents } from '../db/schema.js';
 import { randomHex, sha256Hex } from '../lib/crypto.js';
 import { generateId } from './snowflake.js';
 import { codedError } from '../lib/httpError.js';
 import { D1WriteRetryExhaustedError, retryD1Write } from '../lib/d1Retry.js';
 import { runAtomicWrites } from '../ports/database.js';
+import type { FileStorage } from '../ports/files.js';
 
 type Db = ReturnType<typeof getDb>;
 
@@ -154,7 +155,11 @@ export async function createWorkspace(
     const [existing] = await db
       .select()
       .from(workspaces)
-      .where(and(eq(workspaces.name, name), eq(workspaces.apiKeyHash, ownerApiKeyHash)));
+      .where(and(
+        eq(workspaces.name, name),
+        eq(workspaces.apiKeyHash, ownerApiKeyHash),
+        or(isNull(workspaces.expiresAt), gt(workspaces.expiresAt, new Date())),
+      ));
     if (existing) {
       const workspace = buildWorkspaceResponse(existing, providedOwnerApiKey);
       return {
@@ -321,8 +326,49 @@ export async function updateWorkspace(
   };
 }
 
-export async function deleteWorkspace(db: Db, workspaceId: string) {
-  await db.delete(workspaces).where(eq(workspaces.id, workspaceId));
+async function deleteWorkspaceBatch(
+  db: Db,
+  storage: FileStorage,
+  workspaceIds: string[],
+): Promise<string[]> {
+  if (workspaceIds.length === 0) return [];
+
+  const storedFiles = await db
+    .select({ storageKey: files.storageKey })
+    .from(files)
+    .where(inArray(files.workspaceId, workspaceIds));
+  const storageKeys = [...new Set(storedFiles.map((file) => file.storageKey))];
+
+  if (storageKeys.length > 0) {
+    if (typeof storage.deleteObjects !== 'function') {
+      throw codedError(
+        'The configured file storage cannot delete workspace objects',
+        'file_storage_delete_unsupported',
+        503,
+      );
+    }
+    await storage.deleteObjects({ storageKeys });
+  }
+
+  const results = await runAtomicWrites(db, (writeDb) => [
+    writeDb
+      .delete(workspaceEvents)
+      .where(inArray(workspaceEvents.workspaceId, workspaceIds)),
+    writeDb
+      .delete(workspaces)
+      .where(inArray(workspaces.id, workspaceIds))
+      .returning({ id: workspaces.id }),
+  ]);
+  const deleted = results[1] as Array<{ id: string }>;
+  return deleted.map((workspace) => workspace.id);
+}
+
+export async function deleteWorkspace(
+  db: Db,
+  storage: FileStorage,
+  workspaceId: string,
+) {
+  await deleteWorkspaceBatch(db, storage, [workspaceId]);
 }
 
 /**
@@ -332,10 +378,14 @@ export async function deleteWorkspace(db: Db, workspaceId: string) {
  */
 export async function reapExpiredWorkspaces(
   db: Db,
+  storage: FileStorage,
   options: { now?: Date; limit?: number } = {},
 ): Promise<string[]> {
   const now = options.now ?? new Date();
-  const limit = Math.max(1, Math.min(options.limit ?? DEFAULT_WORKSPACE_REAP_LIMIT, 90));
+  const requestedLimit = options.limit ?? DEFAULT_WORKSPACE_REAP_LIMIT;
+  const limit = Number.isFinite(requestedLimit)
+    ? Math.max(1, Math.min(Math.trunc(requestedLimit), 90))
+    : DEFAULT_WORKSPACE_REAP_LIMIT;
   const expired = await db
     .select({ id: workspaces.id })
     .from(workspaces)
@@ -346,9 +396,5 @@ export async function reapExpiredWorkspaces(
   if (expired.length === 0) return [];
 
   const ids = expired.map((workspace) => workspace.id);
-  const deleted = await db
-    .delete(workspaces)
-    .where(inArray(workspaces.id, ids))
-    .returning({ id: workspaces.id });
-  return deleted.map((workspace) => workspace.id);
+  return deleteWorkspaceBatch(db, storage, ids);
 }

--- a/packages/engine/src/engine/workspace.ts
+++ b/packages/engine/src/engine/workspace.ts
@@ -350,17 +350,48 @@ async function deleteWorkspaceBatch(
   // blobs were already removed. SQLite/D1 write serialization also means a
   // concurrent file insert either commits before this delete and is queued by
   // the cascade, or observes the deleted workspace and fails its FK check.
-  const results = await runAtomicWrites(db, (writeDb) => [
-    writeDb
-      .delete(workspaceEvents)
-      .where(inArray(workspaceEvents.workspaceId, workspaceIds)),
-    writeDb
-      .delete(workspaces)
-      .where(inArray(workspaces.id, workspaceIds))
-      .returning({ id: workspaces.id }),
-  ]);
-  const deleted = results[1] as Array<{ id: string }>;
-  const deletedIds = deleted.map((workspace) => workspace.id);
+  try {
+    await retryD1Write(() => runAtomicWrites(
+      db,
+      (writeDb) => [
+        writeDb
+          .delete(workspaceEvents)
+          .where(inArray(workspaceEvents.workspaceId, workspaceIds)),
+        writeDb
+          .delete(workspaces)
+          .where(inArray(workspaces.id, workspaceIds)),
+      ],
+      { requireAtomic: true },
+    ));
+  } catch (cause) {
+    if (!(cause instanceof D1WriteRetryExhaustedError)) throw cause;
+
+    let committed = false;
+    let storageError: string = cause.storageError;
+    try {
+      const remaining = await db
+        .select({ id: workspaces.id })
+        .from(workspaces)
+        .where(inArray(workspaces.id, workspaceIds));
+      committed = remaining.length === 0;
+    } catch {
+      storageError = 'readback_unavailable';
+    }
+    if (!committed) {
+      const error = codedError(
+        'Workspace storage temporarily unavailable',
+        'workspace_storage_unavailable',
+        503,
+      );
+      error.diagnostics = {
+        attempts: cause.attempts,
+        operation: 'workspace.delete',
+        storage_error: storageError,
+      };
+      throw error;
+    }
+  }
+  const deletedIds = workspaceIds;
 
   // Best-effort immediate revocation keeps old GET URLs from reading existing
   // bytes. The outbox row intentionally remains through the PUT URL's expiry,
@@ -415,6 +446,17 @@ async function deleteCleanupRows(
 ): Promise<{ settled: number; progressed: boolean }> {
   if (rows.length === 0) return { settled: 0, progressed: true };
   const storageKeys = rows.map((row) => row.storageKey);
+  if (typeof storage.deleteObjects !== 'function') {
+    const error = codedError(
+      'The configured file storage cannot delete workspace objects',
+      'file_storage_delete_unsupported',
+      503,
+    );
+    return {
+      settled: 0,
+      progressed: await markCleanupFailure(db, storageKeys, error, now),
+    };
+  }
   try {
     await storage.deleteObjects({ storageKeys });
   } catch (err) {

--- a/packages/engine/src/engine/workspace.ts
+++ b/packages/engine/src/engine/workspace.ts
@@ -1,6 +1,6 @@
-import { and, asc, eq, gt, inArray, isNull, lte, or } from 'drizzle-orm';
+import { and, asc, eq, gt, inArray, isNull, like, lte, or, sql } from 'drizzle-orm';
 import type { getDb } from '../db/index.js';
-import { workspaces, channels, files, workspaceEvents } from '../db/schema.js';
+import { workspaces, channels, fileCleanupQueue, workspaceEvents } from '../db/schema.js';
 import { randomHex, sha256Hex } from '../lib/crypto.js';
 import { generateId } from './snowflake.js';
 import { codedError } from '../lib/httpError.js';
@@ -29,6 +29,9 @@ type CreateWorkspaceOptions =
     };
 
 export const DEFAULT_WORKSPACE_REAP_LIMIT = 25;
+export const DEFAULT_FILE_CLEANUP_LIMIT = 90;
+const MAX_FILE_CLEANUP_LIMIT = 90;
+const FILE_CLEANUP_RETRY_MS = 30_000;
 
 function hashApiKey(apiKey: string): Promise<string> {
   return sha256Hex(apiKey);
@@ -333,23 +336,20 @@ async function deleteWorkspaceBatch(
 ): Promise<string[]> {
   if (workspaceIds.length === 0) return [];
 
-  const storedFiles = await db
-    .select({ storageKey: files.storageKey })
-    .from(files)
-    .where(inArray(files.workspaceId, workspaceIds));
-  const storageKeys = [...new Set(storedFiles.map((file) => file.storageKey))];
-
-  if (storageKeys.length > 0) {
-    if (typeof storage.deleteObjects !== 'function') {
-      throw codedError(
-        'The configured file storage cannot delete workspace objects',
-        'file_storage_delete_unsupported',
-        503,
-      );
-    }
-    await storage.deleteObjects({ storageKeys });
+  if (typeof storage.deleteObjects !== 'function') {
+    throw codedError(
+      'The configured file storage cannot delete workspace objects',
+      'file_storage_delete_unsupported',
+      503,
+    );
   }
 
+  // Deleting the workspace cascades its file rows. Migration 0037's file
+  // trigger writes each storage key to the durable cleanup outbox in this same
+  // transaction, so database rollback can never strand retained rows whose
+  // blobs were already removed. SQLite/D1 write serialization also means a
+  // concurrent file insert either commits before this delete and is queued by
+  // the cascade, or observes the deleted workspace and fails its FK check.
   const results = await runAtomicWrites(db, (writeDb) => [
     writeDb
       .delete(workspaceEvents)
@@ -360,7 +360,147 @@ async function deleteWorkspaceBatch(
       .returning({ id: workspaces.id }),
   ]);
   const deleted = results[1] as Array<{ id: string }>;
-  return deleted.map((workspace) => workspace.id);
+  const deletedIds = deleted.map((workspace) => workspace.id);
+
+  // Best-effort immediate revocation keeps old GET URLs from reading existing
+  // bytes. The outbox row intentionally remains through the PUT URL's expiry,
+  // then a scheduled drain deletes once more to catch a late presigned upload.
+  // A storage failure is not surfaced as a failed workspace delete: the DB
+  // commit is authoritative and the durable row is retried by later drains.
+  try {
+    await deleteQueuedWorkspaceObjects(db, storage, deletedIds);
+  } catch {
+    // The committed outbox is the source of truth after database deletion. A
+    // post-commit query/update failure must not turn a completed DELETE into a
+    // misleading error response; the maintenance drain will retry the row.
+  }
+  return deletedIds;
+}
+
+function cleanupErrorMessage(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
+async function markCleanupFailure(
+  db: Db,
+  storageKeys: string[],
+  err: unknown,
+  now: Date,
+): Promise<boolean> {
+  if (storageKeys.length === 0) return true;
+  try {
+    await db
+      .update(fileCleanupQueue)
+      .set({
+        attempts: sql`${fileCleanupQueue.attempts} + 1`,
+        lastError: cleanupErrorMessage(err).slice(0, 2_000),
+        processAfter: new Date(now.getTime() + FILE_CLEANUP_RETRY_MS),
+      })
+      .where(inArray(fileCleanupQueue.storageKey, storageKeys));
+    return true;
+  } catch {
+    // The cleanup rows were already committed with the workspace deletion.
+    // Preserve the original storage failure and let the next sweep retry even
+    // if recording diagnostics itself races a database outage. The caller
+    // stops its current loop so it cannot spin on the still-due rows.
+    return false;
+  }
+}
+
+async function deleteCleanupRows(
+  db: Db,
+  storage: FileStorage,
+  rows: Array<{ storageKey: string; deleteAfter: Date }>,
+  now: Date,
+): Promise<{ settled: number; progressed: boolean }> {
+  if (rows.length === 0) return { settled: 0, progressed: true };
+  const storageKeys = rows.map((row) => row.storageKey);
+  try {
+    await storage.deleteObjects({ storageKeys });
+  } catch (err) {
+    return {
+      settled: 0,
+      progressed: await markCleanupFailure(db, storageKeys, err, now),
+    };
+  }
+
+  const settledKeys = rows
+    .filter((row) => row.deleteAfter.getTime() <= now.getTime())
+    .map((row) => row.storageKey);
+  const deferredKeys = rows
+    .filter((row) => row.deleteAfter.getTime() > now.getTime())
+    .map((row) => row.storageKey);
+  if (settledKeys.length > 0) {
+    await db.delete(fileCleanupQueue).where(inArray(fileCleanupQueue.storageKey, settledKeys));
+  }
+  if (deferredKeys.length > 0) {
+    await db
+      .update(fileCleanupQueue)
+      .set({
+        attempts: sql`${fileCleanupQueue.attempts} + 1`,
+        lastError: null,
+        processAfter: fileCleanupQueue.deleteAfter,
+      })
+      .where(inArray(fileCleanupQueue.storageKey, deferredKeys));
+  }
+  return { settled: settledKeys.length, progressed: true };
+}
+
+async function deleteQueuedWorkspaceObjects(
+  db: Db,
+  storage: FileStorage,
+  workspaceIds: string[],
+): Promise<void> {
+  if (workspaceIds.length === 0) return;
+  const prefixConditions = workspaceIds.map((workspaceId) =>
+    like(fileCleanupQueue.storageKey, `${workspaceId}/%`));
+  const now = new Date();
+  for (;;) {
+    const rows = await db
+      .select({
+        storageKey: fileCleanupQueue.storageKey,
+        deleteAfter: fileCleanupQueue.deleteAfter,
+      })
+      .from(fileCleanupQueue)
+      .where(and(
+        or(...prefixConditions),
+        lte(fileCleanupQueue.processAfter, now),
+      ))
+      .orderBy(asc(fileCleanupQueue.processAfter), asc(fileCleanupQueue.storageKey))
+      .limit(MAX_FILE_CLEANUP_LIMIT);
+    if (rows.length === 0) return;
+    const result = await deleteCleanupRows(db, storage, rows, now);
+    if (!result.progressed) return;
+  }
+}
+
+/**
+ * Retry durable blob tombstones that are due for an immediate attempt, a
+ * storage-failure retry, or the final pass after the last upload capability
+ * expires. Hosts should run this from their maintenance schedule; the Node
+ * adapter does so every 15 seconds. Deletion is idempotent, making overlapping
+ * sweepers safe.
+ */
+export async function drainFileCleanup(
+  db: Db,
+  storage: FileStorage,
+  options: { now?: Date; limit?: number } = {},
+): Promise<number> {
+  const now = options.now ?? new Date();
+  const requestedLimit = options.limit ?? DEFAULT_FILE_CLEANUP_LIMIT;
+  const limit = Number.isFinite(requestedLimit)
+    ? Math.max(1, Math.min(Math.trunc(requestedLimit), MAX_FILE_CLEANUP_LIMIT))
+    : DEFAULT_FILE_CLEANUP_LIMIT;
+  const rows = await db
+    .select({
+      storageKey: fileCleanupQueue.storageKey,
+      deleteAfter: fileCleanupQueue.deleteAfter,
+    })
+    .from(fileCleanupQueue)
+    .where(lte(fileCleanupQueue.processAfter, now))
+    .orderBy(asc(fileCleanupQueue.processAfter), asc(fileCleanupQueue.storageKey))
+    .limit(limit);
+  return (await deleteCleanupRows(db, storage, rows, now)).settled;
 }
 
 export async function deleteWorkspace(
@@ -382,6 +522,10 @@ export async function reapExpiredWorkspaces(
   options: { now?: Date; limit?: number } = {},
 ): Promise<string[]> {
   const now = options.now ?? new Date();
+  // Always service prior durable cleanup work, even when no workspace reaches
+  // its expiry in this tick. Existing cron integrations therefore pick up the
+  // post-commit outbox without needing a second scheduler.
+  await drainFileCleanup(db, storage, { now });
   const requestedLimit = options.limit ?? DEFAULT_WORKSPACE_REAP_LIMIT;
   const limit = Number.isFinite(requestedLimit)
     ? Math.max(1, Math.min(Math.trunc(requestedLimit), 90))

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -93,6 +93,14 @@ export {
 export type { PruneOptions, PruneResult, RetentionDefaults } from './engine/retention.js';
 export type { WorkspaceRetentionSettings } from './db/schema.js';
 
+// Whole-workspace expiry is opt-in at creation and uses only the stored,
+// non-null deadline as its deletion predicate. Hosts may call this from cron;
+// the Node adapter also runs it on its local maintenance interval.
+export {
+  reapExpiredWorkspaces,
+  DEFAULT_WORKSPACE_REAP_LIMIT,
+} from './engine/workspace.js';
+
 // Durable workspace event log (observer plane): append + cursor reads over
 // `workspace_events`, and the shared append+stamp+publish helper used by every
 // workspace stream call site.

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -95,10 +95,13 @@ export type { WorkspaceRetentionSettings } from './db/schema.js';
 
 // Whole-workspace expiry is opt-in at creation and uses only the stored,
 // non-null deadline as its deletion predicate. Hosts may call this from cron;
-// the Node adapter also runs it on its local maintenance interval.
+// the Node adapter also runs it on its local maintenance interval. Blob cleanup
+// is a durable post-commit outbox: hosts must drain it from the same schedule.
 export {
   reapExpiredWorkspaces,
+  drainFileCleanup,
   DEFAULT_WORKSPACE_REAP_LIMIT,
+  DEFAULT_FILE_CLEANUP_LIMIT,
 } from './engine/workspace.js';
 
 // Durable workspace event log (observer plane): append + cursor reads over

--- a/packages/engine/src/ports/files.ts
+++ b/packages/engine/src/ports/files.ts
@@ -3,9 +3,9 @@
  *
  * The database rows (the `files` table: pending → complete → deleted lifecycle)
  * are portable domain logic and stay in the engine. Only the blob backend is the
- * port: Cloudflare signs R2 (S3-compatible) URLs; the Node adapter stores blobs
- * on local disk and serves them through an engine-mounted download route using a
- * short-lived signed token.
+ * port: Cloudflare signs R2 (S3-compatible) URLs and deletes R2 objects; the
+ * Node adapter stores blobs on local disk, serves them through an engine-mounted
+ * download route using a short-lived signed token, and removes them from disk.
  */
 export interface FileStorage {
   /**
@@ -20,4 +20,11 @@ export interface FileStorage {
 
   /** Return a URL the client can `GET` the file bytes from, valid ~1h. */
   createDownloadUrl(args: { storageKey: string }): Promise<string>;
+
+  /**
+   * Permanently remove the supplied objects. Implementations must be
+   * idempotent and resolve only after previously issued download URLs can no
+   * longer read the bytes.
+   */
+  deleteObjects(args: { storageKeys: string[] }): Promise<void>;
 }

--- a/packages/engine/src/ports/files.ts
+++ b/packages/engine/src/ports/files.ts
@@ -27,5 +27,5 @@ export interface FileStorage {
    * The engine retains a durable tombstone through every issued PUT URL's
    * expiry and calls this again afterward to remove any late upload.
    */
-  deleteObjects(args: { storageKeys: string[] }): Promise<void>;
+  deleteObjects?(args: { storageKeys: string[] }): Promise<void>;
 }

--- a/packages/engine/src/ports/files.ts
+++ b/packages/engine/src/ports/files.ts
@@ -23,8 +23,9 @@ export interface FileStorage {
 
   /**
    * Permanently remove the supplied objects. Implementations must be
-   * idempotent and resolve only after previously issued download URLs can no
-   * longer read the bytes.
+   * idempotent and resolve only after the currently stored bytes are gone.
+   * The engine retains a durable tombstone through every issued PUT URL's
+   * expiry and calls this again afterward to remove any late upload.
    */
   deleteObjects(args: { storageKeys: string[] }): Promise<void>;
 }

--- a/packages/engine/src/routes/workspace.ts
+++ b/packages/engine/src/routes/workspace.ts
@@ -83,7 +83,7 @@ async function deleteAuthenticatedWorkspace(c: Context<AppEnv>, expectedId?: str
     if (expectedId !== undefined && expectedId !== workspace.id) {
       return workspaceNotFound(c);
     }
-    await workspaceEngine.deleteWorkspace(db, workspace.id);
+    await workspaceEngine.deleteWorkspace(db, c.get('engine').files, workspace.id);
     emitServerEvent(c, workspace.id, 'relaycast_server_workspace_deleted', {
       deleted_via: 'api',
     });
@@ -194,11 +194,13 @@ workspaceRoutes.post('/workspaces', async (c) => {
         created_via: 'api',
       });
     }
-    runInBackground(
-      c,
-      workspaceEngine.reapExpiredWorkspaces(db),
-      'workspace expiry reap',
-    );
+    if (result.created) {
+      runInBackground(
+        c,
+        workspaceEngine.reapExpiredWorkspaces(db, c.get('engine').files),
+        'workspace expiry reap',
+      );
+    }
     return result.created ? jsonCreated(c, result.workspace) : jsonOk(c, result.workspace);
   } catch (err: unknown) {
     const error = asCodedError(err);

--- a/packages/engine/src/routes/workspace.ts
+++ b/packages/engine/src/routes/workspace.ts
@@ -38,11 +38,13 @@ import {
   parseQueryParams,
 } from '../lib/httpResponse.js';
 import { parsePaginationQuery, positiveIntQueryParam } from '../lib/httpQuery.js';
+import { runInBackground } from './background.js';
 
 export const workspaceRoutes = new Hono<AppEnv>();
 
 const createWorkspaceSchema = z.object({
   name: z.string().min(1),
+  expires_in_seconds: z.number().int().min(60).max(30 * 24 * 60 * 60).optional(),
 });
 
 const updateWorkspaceSchema = z.object({
@@ -72,6 +74,23 @@ const workspaceEventsQuerySchema = z.object({
 
 function workspaceNotFound(c: Context<AppEnv>) {
   return jsonNotFound(c, 'workspace_not_found', 'Workspace not found');
+}
+
+async function deleteAuthenticatedWorkspace(c: Context<AppEnv>, expectedId?: string) {
+  try {
+    const db = c.get('db');
+    const workspace = c.get('workspace');
+    if (expectedId !== undefined && expectedId !== workspace.id) {
+      return workspaceNotFound(c);
+    }
+    await workspaceEngine.deleteWorkspace(db, workspace.id);
+    emitServerEvent(c, workspace.id, 'relaycast_server_workspace_deleted', {
+      deleted_via: 'api',
+    });
+    return jsonNoContent(c);
+  } catch (err: unknown) {
+    return errorResponse(c, err);
+  }
 }
 
 const PUBLIC_WORKSPACE_LOOKUP_LIMIT = 30;
@@ -157,19 +176,29 @@ workspaceRoutes.post('/workspaces', async (c) => {
     if (!parsed.ok) {
       return parsed.response;
     }
-    const { name } = parsed.data;
+    const { name, expires_in_seconds: expiresInSeconds } = parsed.data;
     const db = c.get('db');
     const ownerApiKey = extractOwnerApiKey(c.req.header('Authorization'));
     const result = await workspaceEngine.createWorkspace(
       db,
       name,
-      ownerApiKey ? { ownerApiKey } : undefined,
+      {
+        ...(ownerApiKey ? { ownerApiKey } : {}),
+        ...(expiresInSeconds
+          ? { expiresAt: new Date(Date.now() + expiresInSeconds * 1_000) }
+          : {}),
+      },
     );
     if (result.created) {
       emitServerEvent(c, result.workspace.workspace_id, 'relaycast_server_workspace_created', {
         created_via: 'api',
       });
     }
+    runInBackground(
+      c,
+      workspaceEngine.reapExpiredWorkspaces(db),
+      'workspace expiry reap',
+    );
     return result.created ? jsonCreated(c, result.workspace) : jsonOk(c, result.workspace);
   } catch (err: unknown) {
     const error = asCodedError(err);
@@ -194,6 +223,11 @@ workspaceRoutes.post('/workspaces', async (c) => {
     }
     return errorResponse(c, err);
   }
+});
+
+// DELETE /workspaces/:id - delete the authenticated workspace by explicit id
+workspaceRoutes.delete('/workspaces/:id', requireWorkspaceKey, rateLimit, async (c) => {
+  return deleteAuthenticatedWorkspace(c, c.req.param('id'));
 });
 
 // GET /workspaces/by-name/:name - lookup public workspace metadata by name
@@ -349,17 +383,7 @@ workspaceRoutes.patch('/workspace', requireWorkspaceKey, rateLimit, async (c) =>
 
 // DELETE /workspace - delete workspace
 workspaceRoutes.delete('/workspace', requireWorkspaceKey, rateLimit, async (c) => {
-  try {
-    const db = c.get('db');
-    const workspace = c.get('workspace');
-    await workspaceEngine.deleteWorkspace(db, workspace.id);
-    emitServerEvent(c, workspace.id, 'relaycast_server_workspace_deleted', {
-      deleted_via: 'api',
-    });
-    return jsonNoContent(c);
-  } catch (err: unknown) {
-    return errorResponse(c, err);
-  }
+  return deleteAuthenticatedWorkspace(c);
 });
 
 // GET /activity — recent activity feed

--- a/packages/sdk-typescript/CHANGELOG.md
+++ b/packages/sdk-typescript/CHANGELOG.md
@@ -7,7 +7,12 @@ See the [root changelog](../../CHANGELOG.md) for cross-package release highlight
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [Unreleased - Minor]
+
+### Added
+
+- Workspace creation accepts `expiresInSeconds` and returns the resulting expiry timestamp.
+- `workspace.delete()` uses the id-scoped deletion endpoint and accepts an optional known workspace id.
 
 ## [8.0.1] - 2026-08-14
 

--- a/packages/sdk-typescript/CHANGELOG.md
+++ b/packages/sdk-typescript/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 ### Added
 
 - Workspace creation accepts `expiresInSeconds` and returns the resulting expiry timestamp.
-- `workspace.delete()` uses the id-scoped deletion endpoint and accepts an optional known workspace id.
+- `workspace.delete(id)` uses the id-scoped deletion endpoint, while the no-argument form keeps using the legacy endpoint for compatibility with older engines.
 
 ## [8.0.1] - 2026-08-14
 

--- a/packages/sdk-typescript/src/__tests__/relay.test.ts
+++ b/packages/sdk-typescript/src/__tests__/relay.test.ts
@@ -845,20 +845,19 @@ describe('RelayCast', () => {
   });
 
   describe('workspace.delete', () => {
-    it('delete() calls the id-scoped workspace endpoint', async () => {
+    it('delete() keeps using the legacy workspace endpoint', async () => {
       const { RelayCast } = await import('../relay.js');
       const relay = new RelayCast({ apiKey: 'rk_live_test123' });
 
-      mockFetch
-        .mockImplementationOnce(() => mockResponse({ id: 'ws_1' }))
-        .mockImplementationOnce(() =>
-          Promise.resolve({ ok: true, status: 204, json: () => Promise.resolve(undefined) }),
-        );
+      mockFetch.mockImplementationOnce(() =>
+        Promise.resolve({ ok: true, status: 204, json: () => Promise.resolve(undefined) }),
+      );
       await relay.workspace.delete();
 
-      const [url, init] = mockFetch.mock.calls[1]!;
-      expect(url).toBe('https://cast.agentrelay.com/v1/workspaces/ws_1');
+      const [url, init] = mockFetch.mock.calls[0]!;
+      expect(url).toBe('https://cast.agentrelay.com/v1/workspace');
       expect(init.method).toBe('DELETE');
+      expect(mockFetch).toHaveBeenCalledTimes(1);
     });
 
     it('delete(id) skips workspace lookup', async () => {

--- a/packages/sdk-typescript/src/__tests__/relay.test.ts
+++ b/packages/sdk-typescript/src/__tests__/relay.test.ts
@@ -845,18 +845,35 @@ describe('RelayCast', () => {
   });
 
   describe('workspace.delete', () => {
-    it('delete() calls DELETE /v1/workspace', async () => {
+    it('delete() calls the id-scoped workspace endpoint', async () => {
       const { RelayCast } = await import('../relay.js');
       const relay = new RelayCast({ apiKey: 'rk_live_test123' });
 
+      mockFetch
+        .mockImplementationOnce(() => mockResponse({ id: 'ws_1' }))
+        .mockImplementationOnce(() =>
+          Promise.resolve({ ok: true, status: 204, json: () => Promise.resolve(undefined) }),
+        );
+      await relay.workspace.delete();
+
+      const [url, init] = mockFetch.mock.calls[1]!;
+      expect(url).toBe('https://cast.agentrelay.com/v1/workspaces/ws_1');
+      expect(init.method).toBe('DELETE');
+    });
+
+    it('delete(id) skips workspace lookup', async () => {
+      const { RelayCast } = await import('../relay.js');
+      const relay = new RelayCast({ apiKey: 'rk_live_test123' });
       mockFetch.mockImplementation(() =>
         Promise.resolve({ ok: true, status: 204, json: () => Promise.resolve(undefined) }),
       );
-      await relay.workspace.delete();
+
+      await relay.workspace.delete('ws/explicit');
 
       const [url, init] = mockFetch.mock.calls[0]!;
-      expect(url).toBe('https://cast.agentrelay.com/v1/workspace');
+      expect(url).toBe('https://cast.agentrelay.com/v1/workspaces/ws%2Fexplicit');
       expect(init.method).toBe('DELETE');
+      expect(mockFetch).toHaveBeenCalledTimes(1);
     });
   });
 
@@ -986,6 +1003,36 @@ describe('RelayCast', () => {
 
       const [url] = mockFetch.mock.calls[0]!;
       expect(url).toBe('http://localhost:3000/v1/workspaces');
+    });
+
+    it('forwards an explicit expiry and returns the deadline', async () => {
+      const { RelayCast } = await import('../relay.js');
+      mockFetch.mockImplementation(() =>
+        Promise.resolve({
+          ok: true,
+          status: 201,
+          json: () => Promise.resolve({
+            ok: true,
+            data: {
+              workspace_id: 'ws_ephemeral',
+              api_key: 'rk_live_ephemeral',
+              created_at: '2024-01-01',
+              expires_at: '2024-01-01T01:00:00.000Z',
+            },
+          }),
+        }),
+      );
+
+      const result = await RelayCast.createWorkspace('CI Run', {
+        expiresInSeconds: 3_600,
+      });
+
+      const [, init] = mockFetch.mock.calls[0]!;
+      expect(init.body).toBe(JSON.stringify({
+        name: 'CI Run',
+        expires_in_seconds: 3_600,
+      }));
+      expect(result.expiresAt).toBe('2024-01-01T01:00:00.000Z');
     });
 
     it('sends Agent Relay distinct id when supplied', async () => {

--- a/packages/sdk-typescript/src/__tests__/setup.test.ts
+++ b/packages/sdk-typescript/src/__tests__/setup.test.ts
@@ -127,6 +127,33 @@ describe('RelaycastSetup', () => {
     expect(lookupInit.headers.Authorization).toBe('Bearer rk_live_setup_2');
   });
 
+  it('createWorkspace() forwards an explicit expiry and exposes the deadline', async () => {
+    const { RelaycastSetup } = await import('../setup.js');
+    mockFetch.mockImplementation(() =>
+      jsonResponse({
+        ok: true,
+        data: {
+          workspace_id: 'ws_ephemeral',
+          api_key: 'rk_live_ephemeral',
+          created_at: '2026-04-30T12:00:00.000Z',
+          expires_at: '2026-04-30T13:00:00.000Z',
+        },
+      }, 201),
+    );
+
+    const workspace = await new RelaycastSetup().createWorkspace({
+      name: 'CI Run',
+      expiresInSeconds: 3_600,
+    });
+
+    const [, init] = mockFetch.mock.calls[0]!;
+    expect(JSON.parse(init.body)).toEqual({
+      name: 'CI Run',
+      expires_in_seconds: 3_600,
+    });
+    expect(workspace.info.expiresAt).toBe('2026-04-30T13:00:00.000Z');
+  });
+
   it('createWorkspace() surfaces API errors with status and body', async () => {
     const { RelaycastSetup } = await import('../setup.js');
     const { RelaycastApiError } = await import('../setup-errors.js');

--- a/packages/sdk-typescript/src/relay.ts
+++ b/packages/sdk-typescript/src/relay.ts
@@ -622,10 +622,9 @@ export class RelayCast {
       this.reconnect(data, options),
     update: (data: UpdateWorkspaceRequest): Promise<Workspace> =>
       this.client.patch('/v1/workspace', data),
-    delete: async (workspaceId?: string): Promise<void> => {
-      const resolvedId = workspaceId ?? await this.resolveWorkspaceId();
-      return this.client.delete(`/v1/workspaces/${encodeURIComponent(resolvedId)}`);
-    },
+    delete: (workspaceId?: string): Promise<void> => workspaceId === undefined
+      ? this.client.delete('/v1/workspace')
+      : this.client.delete(`/v1/workspaces/${encodeURIComponent(workspaceId)}`),
   };
 
   observerTokens = {

--- a/packages/sdk-typescript/src/relay.ts
+++ b/packages/sdk-typescript/src/relay.ts
@@ -181,6 +181,8 @@ export interface WorkspaceIdentityOptions {
 export interface WorkspaceBootstrapOptions extends WorkspaceIdentityOptions {
   apiKey?: string;
   baseUrl?: string;
+  /** Explicit lifetime for a throwaway workspace; omit for persistence. */
+  expiresInSeconds?: number;
 }
 
 export interface WorkspaceLookupOptions extends WorkspaceIdentityOptions {
@@ -327,7 +329,12 @@ export class RelayCast {
         'X-Relaycast-Origin-Version': SDK_ORIGIN.version,
         ...agentRelayIdentityHeaders(identity),
       },
-      body: JSON.stringify({ name }),
+      body: JSON.stringify({
+        name,
+        ...(resolved.expiresInSeconds !== undefined
+          ? { expires_in_seconds: resolved.expiresInSeconds }
+          : {}),
+      }),
     });
 
     let parsed: unknown;
@@ -615,7 +622,10 @@ export class RelayCast {
       this.reconnect(data, options),
     update: (data: UpdateWorkspaceRequest): Promise<Workspace> =>
       this.client.patch('/v1/workspace', data),
-    delete: (): Promise<void> => this.client.delete('/v1/workspace'),
+    delete: async (workspaceId?: string): Promise<void> => {
+      const resolvedId = workspaceId ?? await this.resolveWorkspaceId();
+      return this.client.delete(`/v1/workspaces/${encodeURIComponent(resolvedId)}`);
+    },
   };
 
   observerTokens = {

--- a/packages/sdk-typescript/src/setup-types.ts
+++ b/packages/sdk-typescript/src/setup-types.ts
@@ -35,6 +35,11 @@ export interface CreateWorkspaceOptions {
    * Human-readable name for the workspace.
    */
   name: string;
+  /**
+   * Explicitly expire this throwaway workspace after 60 seconds to 30 days.
+   * Omit for a persistent workspace.
+   */
+  expiresInSeconds?: number;
 }
 
 export type JoinWorkspaceOptions = Record<string, never>;
@@ -45,6 +50,8 @@ export interface WorkspaceInfo {
   baseUrl: string;
   /** ISO 8601 creation timestamp */
   createdAt?: string;
+  /** ISO 8601 expiry timestamp for an explicitly ephemeral workspace. */
+  expiresAt?: string | null;
   name?: string;
 }
 

--- a/packages/sdk-typescript/src/setup.ts
+++ b/packages/sdk-typescript/src/setup.ts
@@ -58,6 +58,7 @@ interface CreateWorkspaceResult {
   workspaceId: string;
   apiKey: string;
   createdAt: string;
+  expiresAt?: string | null;
 }
 
 interface RequestConfig {
@@ -263,7 +264,12 @@ export class RelaycastSetup {
       method: 'POST',
       path: '/v1/workspaces',
       schema: CreateWorkspaceResponseSchema,
-      body: { name: options.name },
+      body: {
+        name: options.name,
+        ...(options.expiresInSeconds !== undefined
+          ? { expires_in_seconds: options.expiresInSeconds }
+          : {}),
+      },
       requireApiKey: true,
     });
 
@@ -277,6 +283,7 @@ export class RelaycastSetup {
         apiKey: workspace.apiKey,
         baseUrl: this.config.baseUrl,
         createdAt: workspace.createdAt,
+        ...(workspace.expiresAt !== undefined ? { expiresAt: workspace.expiresAt } : {}),
         name: options.name,
       },
       { retryPolicyInput: this.config.retryPolicyInput },

--- a/packages/types/CHANGELOG.md
+++ b/packages/types/CHANGELOG.md
@@ -7,7 +7,11 @@ See the [root changelog](../../CHANGELOG.md) for cross-package release highlight
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [Unreleased - Minor]
+
+### Added
+
+- Workspace creation and response schemas expose explicit expiry fields.
 
 ## [8.0.1] - 2026-08-14
 

--- a/packages/types/src/__tests__/types.test.ts
+++ b/packages/types/src/__tests__/types.test.ts
@@ -73,11 +73,13 @@ describe('Type definitions', () => {
 
   it('CreateWorkspaceRequest has name', () => {
     expectTypeOf<CreateWorkspaceRequest>().toHaveProperty('name');
+    expectTypeOf<CreateWorkspaceRequest>().toHaveProperty('expires_in_seconds');
   });
 
   it('CreateWorkspaceResponse has api_key', () => {
     expectTypeOf<CreateWorkspaceResponse>().toHaveProperty('api_key');
     expectTypeOf<CreateWorkspaceResponse>().toHaveProperty('workspace_id');
+    expectTypeOf<CreateWorkspaceResponse>().toHaveProperty('expires_at');
   });
 
   it('WorkspaceLookup exposes public lookup fields', () => {

--- a/packages/types/src/workspace.ts
+++ b/packages/types/src/workspace.ts
@@ -7,11 +7,13 @@ export const WorkspaceSchema = z.object({
   plan: z.enum(['free', 'pro', 'enterprise']),
   created_at: z.string(),
   metadata: z.record(z.string(), z.unknown()),
+  expires_at: z.string().nullable().optional(),
 });
 export type Workspace = z.infer<typeof WorkspaceSchema>;
 
 export const CreateWorkspaceRequestSchema = z.object({
   name: z.string(),
+  expires_in_seconds: z.number().int().min(60).max(30 * 24 * 60 * 60).optional(),
 });
 export type CreateWorkspaceRequest = z.infer<typeof CreateWorkspaceRequestSchema>;
 
@@ -19,6 +21,7 @@ export const CreateWorkspaceResponseSchema = z.object({
   workspace_id: z.string(),
   api_key: z.string().optional(),
   created_at: z.string(),
+  expires_at: z.string().nullable().optional(),
 });
 export type CreateWorkspaceResponse = z.infer<typeof CreateWorkspaceResponseSchema>;
 

--- a/scripts/e2e-actions.ts
+++ b/scripts/e2e-actions.ts
@@ -102,7 +102,9 @@ async function main(): Promise<void> {
 
   // ── Bootstrap: workspace + handler agent + caller agent ──
   const wsName = `actions-e2e-${Date.now()}`;
-  const wsRes = await req('POST', '/v1/workspaces', { body: { name: wsName } });
+  const wsRes = await req('POST', '/v1/workspaces', {
+    body: { name: wsName, expires_in_seconds: 24 * 60 * 60 },
+  });
   if (wsRes.status >= 300) throw new Error(`create workspace failed: ${wsRes.status}`);
   const workspaceKey: string = wsRes.json.data.api_key;
 

--- a/scripts/e2e-sdk-setup-client.ts
+++ b/scripts/e2e-sdk-setup-client.ts
@@ -150,7 +150,10 @@ async function main(): Promise<void> {
   const setup = new RelaycastSetup({ baseUrl });
   let workspace: WorkspaceHandle | null = null;
   await runStep('createWorkspace', async () => {
-    const created = await setup.createWorkspace({ name: workspaceName });
+    const created = await setup.createWorkspace({
+      name: workspaceName,
+      expiresInSeconds: 24 * 60 * 60,
+    });
     assert(created.workspaceId, 'createWorkspace', 'workspaceId was empty');
     assert(created.apiKey, 'createWorkspace', 'apiKey was empty');
     assert(created.info.name === workspaceName, 'createWorkspace', 'workspace name did not round-trip');

--- a/scripts/e2e.ts
+++ b/scripts/e2e.ts
@@ -361,7 +361,10 @@ ${B}${CYAN}╔══════════════════════
   step('Create workspace');
   await run('Create workspace', async () => {
     const wsName = `e2e-${Date.now()}`;
-    const res = await RelayCast.createWorkspace(wsName, BASE_URL);
+    const res = await RelayCast.createWorkspace(wsName, {
+      baseUrl: BASE_URL,
+      expiresInSeconds: 24 * 60 * 60,
+    });
     workspaceKey = res.apiKey;
     relay = new RelayCast({ apiKey: workspaceKey, baseUrl: BASE_URL });
     log('🔑', `Workspace ${B}${wsName}${R} — key: ${DIM}${workspaceKey.slice(0, 16)}…${R}`);


### PR DESCRIPTION
## Summary

- add `DELETE /v1/workspaces/{id}`, authenticated by the exact workspace's own key (`204` success, `401` missing/invalid key, `404` valid key for a different id); retain `DELETE /v1/workspace`
- add optional `expires_in_seconds` (60 seconds to 30 days) at creation, persist the resulting nullable `expires_at`, and reap expired workspaces in bounded D1-safe batches
- run expiry maintenance on the Node adapter's maintenance cadence and opportunistically after workspace creation; export the reaper for scheduled hosts
- expose expiry through shared types and both TypeScript workspace-creation surfaces; make repository E2E workspaces expire after 24 hours
- document the API, response codes, operational limits, and migration in README/OpenAPI/changelogs

## The safety predicate

**A workspace is eligible for automatic deletion only when its creator explicitly supplied `expires_in_seconds` and the persisted, non-null `expires_at` deadline has passed.**

Names, age, absence of agents, and absence of messages never participate in the predicate. Therefore a new or dormant real workspace cannot be mistaken for test debris. Setting a TTL is explicit consent to delete that workspace and all of its data at the deadline. Existing workspaces migrate with `expires_at = NULL` and are never selected automatically.

This PR does not delete production data and does not add any data-dropping migration. Reclaiming the existing production candidates remains a separate, reviewed operation owned by Khaliq.

## D1 findings

Cloudflare documents that D1 enforces foreign keys equivalently to SQLite `PRAGMA foreign_keys = ON`, including `ON DELETE CASCADE`: https://developers.cloudflare.com/d1/sql-api/foreign-keys/

The lifecycle test inspects every applied migration-level foreign key that directly references `workspaces` and requires `ON DELETE CASCADE`, then deletes a populated workspace through the API and verifies workspace, channel, agent, and message rows are gone.

Cloudflare's current D1 SQL statement documentation does not document `VACUUM` as a supported operation: https://developers.cloudflare.com/d1/sql-api/sql-statements/

Accordingly, this change promises lower row count and less insert/index work, not a smaller D1 file. Deleted pages may remain allocated.

## Verification

- `npx turbo test` — exit 0 (18/18 tasks; engine 594 tests, SDK 423 tests, types 163 tests)
- `npx turbo build` — exit 0 (9/9 tasks)
- `npx turbo lint` — exit 0 (13/13 tasks)
- OpenAPI YAML parse — exit 0
- `git diff --check` — exit 0

Closes #336


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/AgentWorkforce/relaycast/pull/338?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

