### PR TITLE
feat(fleet): persist safe repo keys as tags

### DIFF
--- a/.agentworkforce/trajectories/completed/2026-08/traj_uqiyc9zxdyh5/summary.md
+++ b/.agentworkforce/trajectories/completed/2026-08/traj_uqiyc9zxdyh5/summary.md
@@ -1,0 +1,32 @@
+# Trajectory: Persist safe Relaycast fleet repo keys
+
+> **Status:** ✅ Completed
+> **Task:** factory placement lane 2
+> **Confidence:** 92%
+> **Started:** August 19, 2026 at 09:21 AM
+> **Completed:** August 19, 2026 at 09:21 AM
+
+---
+
+## Summary
+
+Added validated repo_keys, canonical repo tags, reconnect/readback coverage, and release documentation in PR #343.
+
+**Approach:** Standard approach
+
+---
+
+## Key Decisions
+
+### Reused nodes.tags for placement keys
+- **Chose:** Reused nodes.tags for placement keys
+- **Reasoning:** Relay SDK already derives repo keys from repo:<owner>/<repo> tags, avoiding a schema migration while keeping absolute paths out of Relaycast.
+
+---
+
+## Chapters
+
+### 1. Work
+*Agent: default*
+
+- Reused nodes.tags for placement keys: Reused nodes.tags for placement keys

--- a/.agentworkforce/trajectories/completed/2026-08/traj_uqiyc9zxdyh5/trajectory.json
+++ b/.agentworkforce/trajectories/completed/2026-08/traj_uqiyc9zxdyh5/trajectory.json
@@ -1,0 +1,57 @@
+{
+  "id": "traj_uqiyc9zxdyh5",
+  "version": 1,
+  "task": {
+    "title": "Persist safe Relaycast fleet repo keys",
+    "source": {
+      "system": "plain",
+      "id": "factory placement lane 2"
+    }
+  },
+  "status": "completed",
+  "startedAt": "2026-08-19T07:21:46.641Z",
+  "completedAt": "2026-08-19T07:21:56.952Z",
+  "agents": [
+    {
+      "name": "default",
+      "role": "lead",
+      "joinedAt": "2026-08-19T07:21:51.585Z"
+    }
+  ],
+  "chapters": [
+    {
+      "id": "chap_byyz0cxxvexz",
+      "title": "Work",
+      "agentName": "default",
+      "startedAt": "2026-08-19T07:21:51.585Z",
+      "endedAt": "2026-08-19T07:21:56.952Z",
+      "events": [
+        {
+          "ts": 1787124111589,
+          "type": "decision",
+          "content": "Reused nodes.tags for placement keys: Reused nodes.tags for placement keys",
+          "raw": {
+            "question": "Reused nodes.tags for placement keys",
+            "chosen": "Reused nodes.tags for placement keys",
+            "alternatives": [],
+            "reasoning": "Relay SDK already derives repo keys from repo:<owner>/<repo> tags, avoiding a schema migration while keeping absolute paths out of Relaycast."
+          },
+          "significance": "high"
+        }
+      ]
+    }
+  ],
+  "retrospective": {
+    "summary": "Added validated repo_keys, canonical repo tags, reconnect/readback coverage, and release documentation in PR #343.",
+    "approach": "Standard approach",
+    "confidence": 0.92
+  },
+  "commits": [],
+  "filesChanged": [],
+  "projectId": "AgentWorkforce/relaycast",
+  "tags": [],
+  "_trace": {
+    "startRef": "bbad10466f8b994a843085228b3b7c230615cd50",
+    "endRef": "bbad10466f8b994a843085228b3b7c230615cd50"
+  }
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,12 @@ Packages without a separate changelog are covered by the cross-package notes bel
 
 ## [Unreleased]
 
+### Added
+
+- Fleet node registration accepts validated placement-safe `repo_keys` and
+  exposes them as canonical `repo:<owner>/<repo>` roster tags, without storing
+  node-local repository paths.
+
 ## [8.0.7] - 2026-08-19
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -559,6 +559,9 @@ ephemeral `node.online`, `node.heartbeat`, and `node.offline` events. Each
 carries a `node` payload matching the `GET /nodes` roster entry (capabilities,
 tags, `load`, `active_agents`/`max_agents`, `handlers_live`,
 `last_heartbeat_at`), so a single event fully refreshes a node's row.
+Node registration may include placement-safe `repo_keys` in `<owner>/<repo>`
+form; Relaycast exposes those as `repo:<owner>/<repo>` tags. Repository
+worktree paths remain node-local and are rejected from the control wire.
 `load` is normalized managed-agent capacity utilization and remains `null`
 unless a direct node, or every constituent provider of a broker node,
 explicitly reports a genuine measurement;

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -912,6 +912,7 @@ components:
                 type: object
         tags:
           type: array
+          description: Arbitrary node labels. Placement-safe repository identities are exposed as repo:<owner>/<repo>; node-local repository paths are never returned.
           items:
             type: string
         version:

--- a/packages/engine/CHANGELOG.md
+++ b/packages/engine/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+### Added
+
+- Fleet registration materializes validated `repo_keys` as `repo:<owner>/<repo>`
+  node tags for placement and roster readback. Absolute repository paths are
+  rejected and are never persisted.
+
 ## [8.0.7] - 2026-08-19
 
 ### Added

--- a/packages/engine/src/__tests__/conformance/node.test.ts
+++ b/packages/engine/src/__tests__/conformance/node.test.ts
@@ -504,6 +504,86 @@ describe('node adapter conformance', () => {
       return { sock, handle };
     }
 
+    it('persists placement-safe repo keys as tags across a reconnect and exposes the readback', async () => {
+      const ws = await createWorkspace(stack.app, 'fleet-repo-keys-ws');
+      const nodeId = 'node_repo_keys';
+      const name = 'repo-builder';
+      const enrolled = await stack.app.request('/v1/nodes', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json', authorization: `Bearer ${ws.workspaceKey}` },
+        body: JSON.stringify({ node_id: nodeId, name, max_agents: 4, tags: ['enrolled'], version: 'test-node' }),
+      });
+      expect(enrolled.status).toBe(201);
+
+      const legacySock = new FakeSocket();
+      const legacyHandle = stack.runtime.realtime.attachNodeSocket(ws.workspaceId, nodeId, legacySock);
+      await legacyHandle.handleMessage(JSON.stringify({
+        v: 1,
+        id: 'register-legacy-repo-tag',
+        type: 'node.register',
+        name,
+        node_id: nodeId,
+        capabilities: [capability('spawn:codex', 'spawn')],
+        max_agents: 4,
+        tags: ['region:eu', 'repo:AgentWorkforce/legacy'],
+        version: 'test-node',
+      }));
+      expect(legacySock.ofType('reply').at(-1)).toMatchObject({
+        data: { tags: ['region:eu', 'repo:AgentWorkforce/legacy'] },
+      });
+      await legacyHandle.handleClose();
+
+      const reconnectSock = new FakeSocket();
+      const reconnectHandle = stack.runtime.realtime.attachNodeSocket(ws.workspaceId, nodeId, reconnectSock);
+      await reconnectHandle.handleMessage(JSON.stringify({
+        v: 1,
+        id: 'register-repo-keys',
+        type: 'node.register',
+        name,
+        node_id: nodeId,
+        capabilities: [capability('spawn:codex', 'spawn')],
+        max_agents: 4,
+        // repo tags are ignored when repo_keys is present, so only the
+        // structured placement-safe input can update repository placement.
+        tags: ['region:us', 'repo:AgentWorkforce/forged'],
+        repo_keys: ['AgentWorkforce/factory'],
+        version: 'test-node',
+      }));
+      expect(reconnectSock.ofType('reply').at(-1)).toMatchObject({
+        data: { tags: ['region:us', 'repo:AgentWorkforce/factory'] },
+      });
+
+      const roster = await stack.app.request('/v1/nodes?name=repo-builder', {
+        headers: { authorization: `Bearer ${ws.workspaceKey}` },
+      });
+      expect(roster.status).toBe(200);
+      const rosterBody = await roster.json() as { data: Array<{ tags: string[] }> };
+      expect(rosterBody.data).toHaveLength(1);
+      expect(rosterBody.data[0].tags).toEqual(['region:us', 'repo:AgentWorkforce/factory']);
+
+      // Invalid paths fail schema validation before registerNode can update the
+      // persisted tags, so roster readback remains placement-safe.
+      await reconnectHandle.handleMessage(JSON.stringify({
+        v: 1,
+        id: 'register-absolute-repo-path',
+        type: 'node.register',
+        name,
+        node_id: nodeId,
+        capabilities: [capability('spawn:codex', 'spawn')],
+        max_agents: 4,
+        tags: ['region:unsafe'],
+        repo_keys: ['/Users/worker/factory'],
+        version: 'test-node',
+      }));
+      expect(reconnectSock.ofType('error').at(-1)).toMatchObject({ code: 'invalid_message' });
+
+      const afterInvalid = await stack.app.request('/v1/nodes?name=repo-builder', {
+        headers: { authorization: `Bearer ${ws.workspaceKey}` },
+      });
+      const afterInvalidBody = await afterInvalid.json() as { data: Array<{ tags: string[] }> };
+      expect(afterInvalidBody.data[0].tags).toEqual(['region:us', 'repo:AgentWorkforce/factory']);
+    });
+
     it('reports placeholder load as unavailable until a finite node explicitly marks it measured', async () => {
       const ws = await createWorkspace(stack.app, 'fleet-unreported-load-ws');
       const unbounded = await enrollAndAttachNode(ws, {

--- a/packages/engine/src/engine/node.ts
+++ b/packages/engine/src/engine/node.ts
@@ -100,6 +100,20 @@ function normalizeCapabilities(capabilities: CapabilityLike[]): FleetCapability[
   ));
 }
 
+/**
+ * Store repository placement metadata in the existing tag column. New
+ * `repo_keys` are authoritative when supplied; valid legacy repo tags remain
+ * supported only for registrations that have not adopted the field yet.
+ */
+function registrationTags(message: FleetNodeRegisterMessage): string[] {
+  const nonRepoTags = message.tags.filter((tag) => !tag.startsWith('repo:'));
+  const repoKeys = message.repo_keys
+    ?? message.tags
+      .filter((tag) => tag.startsWith('repo:'))
+      .map((tag) => tag.slice('repo:'.length));
+  return [...new Set([...nonRepoTags, ...repoKeys.map((repoKey) => `repo:${repoKey}`)])];
+}
+
 function supportsProviderDeliveryReadiness(registry: NodeConnectionRegistry): boolean {
   return typeof registry.setProviderDeliveryReadiness === 'function'
     && typeof registry.markProviderAgentsDeliveryReady === 'function'
@@ -383,7 +397,7 @@ export async function registerNode(
         deliveryConfig: existing.deliveryConfig,
         maxAgents: 1,
         activeAgents: 1,
-        tags: existing.tags,
+        tags: registrationTags(message),
         version: message.version,
         status: 'online',
         handlersLive: false,
@@ -397,6 +411,7 @@ export async function registerNode(
   }
 
   const capabilities = normalizeCapabilities(message.capabilities);
+  const tags = registrationTags(message);
   await runAtomic(db, async (tx) => {
     await upsertProvider(tx, workspaceId, authenticatedNodeId, {
       name: provider.name,
@@ -409,7 +424,7 @@ export async function registerNode(
     await materializeProviderActions(tx, workspaceId, authenticatedNodeId, provider.name, capabilities);
     await tx
       .update(nodes)
-      .set({ name: message.name, kind: 'ws', role: 'broker', deliveryAdapter: 'ws.node.v1', deliveryConfig: null, tags: message.tags })
+      .set({ name: message.name, kind: 'ws', role: 'broker', deliveryAdapter: 'ws.node.v1', deliveryConfig: null, tags })
       .where(and(eq(nodes.workspaceId, workspaceId), eq(nodes.id, authenticatedNodeId)));
     await recomputeNodeAggregate(tx, workspaceId, authenticatedNodeId, {
       version: message.version,

--- a/packages/types/CHANGELOG.md
+++ b/packages/types/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+### Added
+
+- `FleetNodeRegisterMessageSchema` accepts placement-safe `repo_keys` in
+  `<owner>/<repo>` form and rejects repository paths, including path-shaped
+  legacy `repo:` tags.
+
 ## [8.0.7] - 2026-08-19
 
 ### Added

--- a/packages/types/src/__tests__/fleet-wire-fixtures.test.ts
+++ b/packages/types/src/__tests__/fleet-wire-fixtures.test.ts
@@ -309,6 +309,39 @@ describe('fleet wire fixtures', () => {
     });
   });
 
+  it('accepts placement-safe repo keys but rejects repository paths', () => {
+    const register = {
+      v: 1,
+      type: 'node.register',
+      name: 'builder-1',
+      node_id: 'node_01J7FLEET000000000000001',
+      capabilities: [{ name: 'spawn:codex', kind: 'spawn' }],
+      max_agents: 8,
+      tags: ['darwin', 'region:eu'],
+      version: 'relay-broker/0.7.0',
+    };
+
+    expect(parseFleetBrokerToRelaycastMessage({
+      ...register,
+      repo_keys: ['AgentWorkforce/factory', 'AgentWorkforce/sandbox'],
+    })).toMatchObject({
+      repo_keys: ['AgentWorkforce/factory', 'AgentWorkforce/sandbox'],
+    });
+
+    for (const repoKey of ['/Users/worker/factory', '../factory', 'AgentWorkforce/factory/.git', 'C:\\work\\factory']) {
+      expect(() => parseFleetBrokerToRelaycastMessage({ ...register, repo_keys: [repoKey] })).toThrow();
+    }
+
+    expect(() => parseFleetBrokerToRelaycastMessage({
+      ...register,
+      tags: ['repo:/Users/worker/factory'],
+    })).toThrow();
+    expect(() => parseFleetBrokerToRelaycastMessage({
+      ...register,
+      repo_paths: { 'AgentWorkforce/factory': '/Users/worker/factory' },
+    })).toThrow();
+  });
+
   it('accepts broker requests with request ids', () => {
     expect(
       parseFleetBrokerToRelaycastMessage({

--- a/packages/types/src/fleet-wire.ts
+++ b/packages/types/src/fleet-wire.ts
@@ -96,6 +96,26 @@ export const FleetCapabilityAcceptanceSchema = z
   .strict();
 export type FleetCapabilityAcceptance = z.infer<typeof FleetCapabilityAcceptanceSchema>;
 
+/**
+ * A placement-safe repository identifier. Repository worktree paths are local
+ * node configuration and must never cross the fleet control wire.
+ */
+export const FleetRepoKeySchema = z
+  .string()
+  .max(201)
+  .regex(
+    /^[A-Za-z0-9][A-Za-z0-9._-]{0,99}\/[A-Za-z0-9][A-Za-z0-9._-]{0,99}$/,
+    'repo key must be an <owner>/<repo> identifier',
+  );
+export type FleetRepoKey = z.infer<typeof FleetRepoKeySchema>;
+
+// `repo:<key>` is the persisted roster representation. Validate the legacy
+// form too, so a path cannot bypass `repo_keys` through the generic tag list.
+const FleetNodeTagSchema = z.string().refine(
+  (tag) => !tag.startsWith('repo:') || FleetRepoKeySchema.safeParse(tag.slice('repo:'.length)).success,
+  'repo tags must use the placement-safe repo:<owner>/<repo> form',
+);
+
 function forbidOwnProperty(property: string) {
   return (message: object, ctx: z.RefinementCtx): void => {
     if (Object.prototype.hasOwnProperty.call(message, property)) {
@@ -121,7 +141,10 @@ export const FleetNodeRegisterMessageSchema = z
     capabilities: z.array(FleetCapabilitySchema),
     // Provider-level capacity; the node figure is the aggregate across providers.
     max_agents: z.number().int().nonnegative(),
-    tags: z.array(z.string()),
+    tags: z.array(FleetNodeTagSchema),
+    // Repository identities are placement metadata only. Local repository paths
+    // remain private to the registering node and are deliberately not accepted.
+    repo_keys: z.array(FleetRepoKeySchema).optional(),
     version: z.string(),
     machine_id: z.string().optional(),
     // Absent and null both mean a fresh node with no resume cursor.


### PR DESCRIPTION
## Summary
- accept only owner/repo repo_keys on fleet node registration
- materialize placement-safe repo tags in the existing nodes.tags column
- retain non-repo tags, reject path-shaped repository values, and document roster readback

## Verification
- npm --workspace @relaycast/types test -- --run src/__tests__/fleet-wire-fixtures.test.ts
- npm --workspace @relaycast/engine test -- --run src/__tests__/conformance/node.test.ts
- npm --workspace @relaycast/engine run typecheck
- npm --workspace @relaycast/types run lint
- npm --workspace @relaycast/engine run lint