### PR TITLE
fix(engine): drain expired deliveries sustainably

### DIFF
--- a/.agentworkforce/trajectories/completed/2026-08/traj_q8dnq4apid3v/summary.md
+++ b/.agentworkforce/trajectories/completed/2026-08/traj_q8dnq4apid3v/summary.md
@@ -1,0 +1,31 @@
+# Trajectory: Address delivery backlog PR review feedback
+
+> **Status:** ✅ Completed
+> **Confidence:** 95%
+> **Started:** August 19, 2026, at 19:48 UTC
+> **Completed:** August 19, 2026, at 19:56 UTC
+
+---
+
+## Summary
+
+Flushed delivery failure notices after every committed expiry batch, added bounded cross-workspace fanout, and verified the full engine suite
+
+**Approach:** Standard approach
+
+---
+
+## Key Decisions
+
+### Flush each committed expiry batch before attempting the next
+- **Chose:** Flush each committed expiry batch before attempting the next
+- **Reasoning:** PR review identified that a later D1 failure could otherwise discard in-memory notices for rows already dead-lettered. Cross-workspace event appends and node lookups are chunked globally so per-batch flushing remains bounded at about 350 D1 queries for a full 2,500-row run.
+
+---
+
+## Chapters
+
+### 1. Work
+*Agent: default*
+
+- Flush each committed expiry batch before attempting the next: Flush each committed expiry batch before attempting the next

--- a/.agentworkforce/trajectories/completed/2026-08/traj_q8dnq4apid3v/trajectory.json
+++ b/.agentworkforce/trajectories/completed/2026-08/traj_q8dnq4apid3v/trajectory.json
@@ -1,0 +1,53 @@
+{
+  "id": "traj_q8dnq4apid3v",
+  "version": 1,
+  "task": {
+    "title": "Address delivery backlog PR review feedback"
+  },
+  "status": "completed",
+  "startedAt": "2026-08-19T19:48:54.271Z",
+  "completedAt": "2026-08-19T19:56:41.094Z",
+  "agents": [
+    {
+      "name": "default",
+      "role": "lead",
+      "joinedAt": "2026-08-19T19:53:16.122Z"
+    }
+  ],
+  "chapters": [
+    {
+      "id": "chap_11802qab7wtp",
+      "title": "Work",
+      "agentName": "default",
+      "startedAt": "2026-08-19T19:53:16.122Z",
+      "endedAt": "2026-08-19T19:56:41.094Z",
+      "events": [
+        {
+          "ts": 1787169196122,
+          "type": "decision",
+          "content": "Flush each committed expiry batch before attempting the next: Flush each committed expiry batch before attempting the next",
+          "raw": {
+            "question": "Flush each committed expiry batch before attempting the next",
+            "chosen": "Flush each committed expiry batch before attempting the next",
+            "alternatives": [],
+            "reasoning": "PR review identified that a later D1 failure could otherwise discard in-memory notices for rows already dead-lettered. Cross-workspace event appends and node lookups are chunked globally so per-batch flushing remains bounded at about 350 D1 queries for a full 2,500-row run."
+          },
+          "significance": "high"
+        }
+      ]
+    }
+  ],
+  "retrospective": {
+    "summary": "Flushed delivery failure notices after every committed expiry batch, added bounded cross-workspace fanout, and verified the full engine suite",
+    "approach": "Standard approach",
+    "confidence": 0.95
+  },
+  "commits": [],
+  "filesChanged": [],
+  "projectId": "AgentWorkforce/relaycast",
+  "tags": [],
+  "_trace": {
+    "startRef": "33445def87505f9d69dc34b5823857509ef1c93e",
+    "endRef": "33445def87505f9d69dc34b5823857509ef1c93e"
+  }
+}

--- a/.agentworkforce/trajectories/completed/2026-08/traj_z5rw0bxmrzj3/summary.md
+++ b/.agentworkforce/trajectories/completed/2026-08/traj_z5rw0bxmrzj3/summary.md
@@ -2,8 +2,8 @@
 
 > **Status:** ✅ Completed
 > **Confidence:** 90%
-> **Started:** August 19, 2026 at 09:24 PM
-> **Completed:** August 19, 2026 at 09:39 PM
+> **Started:** August 19, 2026, at 19:24 UTC
+> **Completed:** August 19, 2026, at 19:39 UTC
 
 ---
 

--- a/.agentworkforce/trajectories/completed/2026-08/traj_z5rw0bxmrzj3/summary.md
+++ b/.agentworkforce/trajectories/completed/2026-08/traj_z5rw0bxmrzj3/summary.md
@@ -1,0 +1,37 @@
+# Trajectory: Fix expired delivery backlog drain and redrive indexing
+
+> **Status:** ✅ Completed
+> **Confidence:** 90%
+> **Started:** August 19, 2026 at 09:24 PM
+> **Completed:** August 19, 2026 at 09:39 PM
+
+---
+
+## Summary
+
+Raised expiry capacity to 2,500 deliveries per invocation with bounded 50-row D1 writes, batched failure fanout, and migration 0040's drain-first partial retry index; verified planner, full engine tests, build, and lint.
+
+**Approach:** Standard approach
+
+---
+
+## Key Decisions
+
+### Kept 50-row expiry SQL batches and bounded each sweep at 50 batches
+- **Chose:** Kept 50-row expiry SQL batches and bounded each sweep at 50 batches
+- **Reasoning:** A 50-row UPDATE leaves headroom under D1's 100 bound-parameter ceiling and keeps each write lock short; 2,500 rows per */5 invocation yields 720,000/day, exceeding the measured 519,000/day peak by 201,000/day.
+
+### Batch durable failure fanout and split NULL from due-retry redrive reads
+- **Chose:** Batch durable failure fanout and split NULL from due-retry redrive reads
+- **Reasoning:** Fifty expiry batches would otherwise multiply D1 reads per notice and exceed the 1,000-query invocation limit. Splitting the OR query lets a small non-NULL partial index serve due retries after the backlog drains.
+
+---
+
+## Chapters
+
+### 1. Work
+*Agent: default*
+
+- Kept 50-row expiry SQL batches and bounded each sweep at 50 batches: Kept 50-row expiry SQL batches and bounded each sweep at 50 batches
+- Batch durable failure fanout and split NULL from due-retry redrive reads: Batch durable failure fanout and split NULL from due-retry redrive reads
+- The drain, fanout batching, partial index, and query split are validated. Full engine suite passes (659 tests), build and lint pass, and EXPLAIN changes due retries from SCAN deliveries + temp B-tree to SEARCH USING idx_deliveries_retry_due.

--- a/.agentworkforce/trajectories/completed/2026-08/traj_z5rw0bxmrzj3/trajectory.json
+++ b/.agentworkforce/trajectories/completed/2026-08/traj_z5rw0bxmrzj3/trajectory.json
@@ -1,0 +1,88 @@
+{
+  "id": "traj_z5rw0bxmrzj3",
+  "version": 1,
+  "task": {
+    "title": "Fix expired delivery backlog drain and redrive indexing"
+  },
+  "status": "completed",
+  "startedAt": "2026-08-19T19:24:19.977Z",
+  "completedAt": "2026-08-19T19:39:06.973Z",
+  "agents": [
+    {
+      "name": "default",
+      "role": "lead",
+      "joinedAt": "2026-08-19T19:32:57.060Z"
+    }
+  ],
+  "chapters": [
+    {
+      "id": "chap_2awgjbvuku3t",
+      "title": "Work",
+      "agentName": "default",
+      "startedAt": "2026-08-19T19:32:57.060Z",
+      "endedAt": "2026-08-19T19:39:06.973Z",
+      "events": [
+        {
+          "ts": 1787167977062,
+          "type": "decision",
+          "content": "Kept 50-row expiry SQL batches and bounded each sweep at 50 batches: Kept 50-row expiry SQL batches and bounded each sweep at 50 batches",
+          "raw": {
+            "question": "Kept 50-row expiry SQL batches and bounded each sweep at 50 batches",
+            "chosen": "Kept 50-row expiry SQL batches and bounded each sweep at 50 batches",
+            "alternatives": [],
+            "reasoning": "A 50-row UPDATE leaves headroom under D1's 100 bound-parameter ceiling and keeps each write lock short; 2,500 rows per */5 invocation yields 720,000/day, exceeding the measured 519,000/day peak by 201,000/day."
+          },
+          "significance": "high"
+        },
+        {
+          "ts": 1787167977183,
+          "type": "decision",
+          "content": "Batch durable failure fanout and split NULL from due-retry redrive reads: Batch durable failure fanout and split NULL from due-retry redrive reads",
+          "raw": {
+            "question": "Batch durable failure fanout and split NULL from due-retry redrive reads",
+            "chosen": "Batch durable failure fanout and split NULL from due-retry redrive reads",
+            "alternatives": [],
+            "reasoning": "Fifty expiry batches would otherwise multiply D1 reads per notice and exceed the 1,000-query invocation limit. Splitting the OR query lets a small non-NULL partial index serve due retries after the backlog drains."
+          },
+          "significance": "high"
+        },
+        {
+          "ts": 1787168329937,
+          "type": "reflection",
+          "content": "The drain, fanout batching, partial index, and query split are validated. Full engine suite passes (659 tests), build and lint pass, and EXPLAIN changes due retries from SCAN deliveries + temp B-tree to SEARCH USING idx_deliveries_retry_due.",
+          "raw": {
+            "focalPoints": [
+              "D1 query budget",
+              "write contention",
+              "planner evidence",
+              "rollout order"
+            ],
+            "adjustments": "Keep migration 0040 drain-first; quote both the remaining NULL-branch scan and indexed due-retry branch in the PR so the tradeoff is explicit.",
+            "confidence": 0.9
+          },
+          "significance": "high",
+          "tags": [
+            "focal:D1 query budget",
+            "focal:write contention",
+            "focal:planner evidence",
+            "focal:rollout order",
+            "confidence:0.9"
+          ]
+        }
+      ]
+    }
+  ],
+  "retrospective": {
+    "summary": "Raised expiry capacity to 2,500 deliveries per invocation with bounded 50-row D1 writes, batched failure fanout, and migration 0040's drain-first partial retry index; verified planner, full engine tests, build, and lint.",
+    "approach": "Standard approach",
+    "confidence": 0.9
+  },
+  "commits": [],
+  "filesChanged": [],
+  "projectId": "AgentWorkforce/relaycast",
+  "tags": [],
+  "_trace": {
+    "startRef": "2bb9f32aa7817f5442e59ad97d76595b299a7cfb",
+    "endRef": "2bb9f32aa7817f5442e59ad97d76595b299a7cfb"
+  }
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,11 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 Packages without a separate changelog are covered by the cross-package notes below.
 
-## [Unreleased]
+## [Unreleased - Patch]
+
+### Fixed
+
+- Scheduled delivery expiry now drains up to 2,500 rows per invocation in bounded D1-safe batches, preventing expired mailbox rows from accumulating faster than the sweep can clear them.
 
 ## [8.1.0] - 2026-08-19
 

--- a/packages/engine/CHANGELOG.md
+++ b/packages/engine/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ### Fixed
 
-- The scheduled expiry sweep drains up to fifty 50-row batches per invocation and batches failure fanout; migration `0040` adds the global partial retry index and should be applied after the expired backlog has drained.
+- The scheduled expiry sweep drains up to fifty 50-row batches per invocation and batches failure fanout; migration `0040_delivery_retry_due_index.sql` adds the global partial retry index and should be applied after the expired backlog has drained.
 
 ## [8.1.0] - 2026-08-19
 

--- a/packages/engine/CHANGELOG.md
+++ b/packages/engine/CHANGELOG.md
@@ -7,7 +7,11 @@ See the [root changelog](../../CHANGELOG.md) for cross-package release highlight
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [Unreleased - Patch]
+
+### Fixed
+
+- The scheduled expiry sweep drains up to fifty 50-row batches per invocation and batches failure fanout; migration `0040` adds the global partial retry index and should be applied after the expired backlog has drained.
 
 ## [8.1.0] - 2026-08-19
 

--- a/packages/engine/src/__tests__/conformance/delivery.test.ts
+++ b/packages/engine/src/__tests__/conformance/delivery.test.ts
@@ -2121,7 +2121,12 @@ describe('durable delivery api', () => {
 
     await new Promise((r) => setTimeout(r, 1100));
     expect(await listDeliveries(bob.token)).toHaveLength(0);
-    expect(await sweepExpiredDeliveries(stack.runtime.deps, { workspaceId: ws.workspaceId })).toBe(1);
+    // Non-finite internal overrides must fall back to the production cap instead
+    // of turning the bounded loop into a silent no-op.
+    expect(await sweepExpiredDeliveries(stack.runtime.deps, {
+      workspaceId: ws.workspaceId,
+      maxBatches: Number.NaN,
+    })).toBe(1);
     expect(await listDeliveries(bob.token, '?status=dead_lettered')).toHaveLength(1);
     await new Promise((r) => setTimeout(r, 50));
     await waitForAssertion(() => {

--- a/packages/engine/src/__tests__/conformance/delivery.test.ts
+++ b/packages/engine/src/__tests__/conformance/delivery.test.ts
@@ -2176,6 +2176,19 @@ describe('durable delivery api', () => {
       .all(Math.floor(Date.now() / 1000)) as Array<{ detail: string }>;
     expect(expiryPlan.some((step) => step.detail.includes('idx_deliveries_active_expiry'))).toBe(true);
 
+    const retryPlan = stack.runtime.handle.sqlite
+      .prepare(`EXPLAIN QUERY PLAN
+        SELECT id FROM deliveries
+        WHERE status = 'queued'
+          AND route_node_kind IN ('http_push', 'ws', 'fleet_ws', 'direct_ws')
+          AND next_attempt_at IS NOT NULL
+          AND next_attempt_at <= ?
+          AND (expires_at IS NULL OR expires_at > ?)
+        ORDER BY next_attempt_at, created_at, id
+        LIMIT 50`)
+      .all(Math.floor(Date.now() / 1000), Math.floor(Date.now() / 1000)) as Array<{ detail: string }>;
+    expect(retryPlan.some((step) => step.detail.includes('idx_deliveries_retry_due'))).toBe(true);
+
     // Emulate D1's documented ceiling against the real SQL emitted by Drizzle.
     // The regression used to put all 121 delivery IDs in one UPDATE and trip this guard.
     const sqlite = stack.runtime.handle.sqlite;
@@ -2201,16 +2214,15 @@ describe('durable delivery api', () => {
     // Reads filter expired active rows but do not mutate them or depend on cleanup.
     expect(await deadLetteredCount()).toBe(0);
 
-    expect(await sweepExpiredDeliveries(stack.runtime.deps)).toBe(50);
-    expect(await deadLetteredCount()).toBe(50);
-
-    expect(await sweepExpiredDeliveries(stack.runtime.deps)).toBe(50);
+    // Must fire: one invocation advances through more than the 50-row SQL batch.
+    expect(await sweepExpiredDeliveries(stack.runtime.deps, { maxBatches: 2 })).toBe(100);
     // Charlie's remaining 10 rows and Bob's oldest 40 transitioned. Bob's 21
-    // still-unswept expired rows must not leak through the active list.
+    // still-unswept expired rows prove the invocation still honored its bound
+    // and must not leak through the active list.
     expect(await listDeliveries(bob.token)).toHaveLength(0);
     expect(await deadLetteredCount()).toBe(100);
 
-    expect(await sweepExpiredDeliveries(stack.runtime.deps)).toBe(21);
+    expect(await sweepExpiredDeliveries(stack.runtime.deps, { maxBatches: 1 })).toBe(21);
     expect(await deadLetteredCount()).toBe(121);
 
     await waitForAssertion(() => {

--- a/packages/engine/src/__tests__/conformance/delivery.test.ts
+++ b/packages/engine/src/__tests__/conformance/delivery.test.ts
@@ -2238,6 +2238,63 @@ describe('durable delivery api', () => {
       .filter((event) => event.data && (event.data as Record<string, unknown>).reason === 'ttl_expired')).toHaveLength(121);
   });
 
+  it("flushes a committed batch's failure notices before a later expiry batch fails", async () => {
+    const { ws, alice, bob, messageId } = await seed();
+    const { sock: aliceSock } = await attachDirectNodeSocket(stack, ws.workspaceId, alice);
+    const [seedMessage] = await stack.runtime.deps.db
+      .select({ channelId: messages.channelId })
+      .from(messages)
+      .where(eq(messages.id, messageId));
+    const expiredAt = new Date(Date.now() - 60_000);
+
+    await stack.runtime.deps.db.insert(messages).values(Array.from({ length: 50 }, (_, index) => ({
+      id: `expiry-failure-message-${index}`,
+      workspaceId: ws.workspaceId,
+      channelId: seedMessage.channelId,
+      agentId: alice.agentId,
+      body: `expired before later failure ${index}`,
+    })));
+    await stack.runtime.deps.db.insert(deliveries).values(Array.from({ length: 50 }, (_, index) => ({
+      id: `expiry-failure-delivery-${index}`,
+      workspaceId: ws.workspaceId,
+      messageId: `expiry-failure-message-${index}`,
+      agentId: bob.agentId,
+      status: 'queued',
+      seq: index + 2,
+      expiresAt: expiredAt,
+    })));
+    await stack.runtime.deps.db
+      .update(deliveries)
+      .set({ expiresAt: expiredAt })
+      .where(eq(deliveries.messageId, messageId));
+
+    const sqlite = stack.runtime.handle.sqlite;
+    const prepare = sqlite.prepare.bind(sqlite);
+    let expiryUpdates = 0;
+    sqlite.prepare = ((source: string) => {
+      if (source.startsWith('update "deliveries"') && source.includes('"dead_lettered_at"')) {
+        expiryUpdates++;
+        if (expiryUpdates === 2) throw new Error('simulated later expiry batch failure');
+      }
+      return prepare(source);
+    }) as typeof sqlite.prepare;
+
+    await expect(sweepExpiredDeliveries(stack.runtime.deps, { maxBatches: 2 }))
+      .rejects.toThrow('simulated later expiry batch failure');
+
+    const deadLettered = await stack.runtime.deps.db
+      .select({ id: deliveries.id })
+      .from(deliveries)
+      .where(eq(deliveries.status, 'dead_lettered'));
+    expect(deadLettered).toHaveLength(50);
+    await waitForAssertion(() => {
+      const notices = contextUpdatesOfType(aliceSock, 'delivery.failed')
+        .filter((event) => event.data && (event.data as Record<string, unknown>).reason === 'ttl_expired');
+      expect(notices).toHaveLength(50);
+      expect(new Set(notices.map((event) => (event.data as Record<string, unknown>).delivery_id)).size).toBe(50);
+    });
+  });
+
   it('keeps inbox and delivery reads available when scheduled expiry fails', async () => {
     const { ws, bob, messageId } = await seed();
     await stack.runtime.deps.db

--- a/packages/engine/src/db/migrations/0040_delivery_retry_due_index.sql
+++ b/packages/engine/src/db/migrations/0040_delivery_retry_due_index.sql
@@ -1,0 +1,10 @@
+-- Operational ordering: deploy the bounded expiry drain first and wait for the
+-- expired-delivery backlog to clear before applying this migration. At the
+-- projected ~150k-row steady state this scans ~150k table rows and, based on
+-- the measured production shape, writes only ~54.6k non-NULL retry entries.
+-- Wrangler D1 migrations are transactional and expose no per-file
+-- `transaction: false` mode; the reduced build is intentionally small enough
+-- to keep the transactional write lock short.
+CREATE INDEX IF NOT EXISTS idx_deliveries_retry_due
+  ON deliveries(status, next_attempt_at, created_at, id)
+  WHERE next_attempt_at IS NOT NULL;

--- a/packages/engine/src/db/schema.ts
+++ b/packages/engine/src/db/schema.ts
@@ -1056,6 +1056,9 @@ export const deliveries = sqliteTable(
     index('idx_deliveries_active_expiry')
       .on(table.expiresAt, table.id)
       .where(sql`${table.status} IN ('queued', 'delivered') AND ${table.expiresAt} IS NOT NULL`),
+    index('idx_deliveries_retry_due')
+      .on(table.status, table.nextAttemptAt, table.createdAt, table.id)
+      .where(sql`${table.nextAttemptAt} IS NOT NULL`),
     index('idx_deliveries_status').on(table.workspaceId, table.status, table.createdAt),
     index('idx_deliveries_http_push_due').on(table.workspaceId, table.routeNodeKind, table.status, table.nextAttemptAt),
   ],

--- a/packages/engine/src/engine/__tests__/workspaceEvents.test.ts
+++ b/packages/engine/src/engine/__tests__/workspaceEvents.test.ts
@@ -4,6 +4,7 @@ import { getSqliteDb, runMigrations, type SqliteDbHandle } from '../../adapters/
 import { workspaceEvents, workspaces } from '../../db/schema.js';
 import {
   appendAndPublishWorkspaceEvent,
+  appendWorkspaceEventBatch,
   appendWorkspaceEvents,
   appendWorkspaceEvent,
   listWorkspaceEvents,
@@ -83,6 +84,20 @@ describe('appendWorkspaceEvent', () => {
       .where(eq(workspaceEvents.workspaceId, 'ws_a'));
     expect(rows).toHaveLength(66);
     expect(new Set(rows.map((row) => row.seq)).size).toBe(66);
+  });
+
+  it('assigns independent sequences when one batch spans workspaces', async () => {
+    const { db } = track(openDb());
+    await appendWorkspaceEvent(db, 'ws_a', { type: 'seed', payload: { n: 0 } });
+
+    const seqs = await appendWorkspaceEventBatch(db, [
+      { workspaceId: 'ws_a', input: { type: 't', payload: { n: 1 } } },
+      { workspaceId: 'ws_b', input: { type: 't', payload: { n: 2 } } },
+      { workspaceId: 'ws_a', input: { type: 't', payload: { n: 3 } } },
+      { workspaceId: 'ws_b', input: { type: 't', payload: { n: 4 } } },
+    ]);
+
+    expect(seqs).toEqual([2, 1, 3, 2]);
   });
 });
 

--- a/packages/engine/src/engine/__tests__/workspaceEvents.test.ts
+++ b/packages/engine/src/engine/__tests__/workspaceEvents.test.ts
@@ -4,6 +4,7 @@ import { getSqliteDb, runMigrations, type SqliteDbHandle } from '../../adapters/
 import { workspaceEvents, workspaces } from '../../db/schema.js';
 import {
   appendAndPublishWorkspaceEvent,
+  appendWorkspaceEvents,
   appendWorkspaceEvent,
   listWorkspaceEvents,
 } from '../workspaceEvents.js';
@@ -60,6 +61,28 @@ describe('appendWorkspaceEvent', () => {
       appendWorkspaceEvent(handle.db, 'ws_a', { type: 'message.created', payload: { type: 'message.created' } }),
     ).resolves.toBeNull();
     expect(warn).toHaveBeenCalled();
+  });
+
+  it('appends large event sets in D1-safe chunks with contiguous sequence numbers', async () => {
+    const { db } = track(openDb());
+    await appendWorkspaceEvent(db, 'ws_a', { type: 'seed', payload: { n: 0 } });
+
+    const seqs = await appendWorkspaceEvents(
+      db,
+      'ws_a',
+      Array.from({ length: 65 }, (_, index) => ({
+        type: 'delivery.failed',
+        payload: { type: 'delivery.failed', n: index + 1 },
+      })),
+    );
+
+    expect(seqs).toEqual(Array.from({ length: 65 }, (_, index) => index + 2));
+    const rows = await db
+      .select()
+      .from(workspaceEvents)
+      .where(eq(workspaceEvents.workspaceId, 'ws_a'));
+    expect(rows).toHaveLength(66);
+    expect(new Set(rows.map((row) => row.seq)).size).toBe(66);
   });
 });
 

--- a/packages/engine/src/engine/delivery.ts
+++ b/packages/engine/src/engine/delivery.ts
@@ -1,4 +1,4 @@
-import { eq, and, or, not, asc, isNull, inArray, notInArray, lte, gt, sql } from 'drizzle-orm';
+import { eq, and, not, asc, isNull, inArray, notInArray, lte, gt, sql, type SQL } from 'drizzle-orm';
 import type { getDb } from '../db/index.js';
 import { deliveries, messages, agents, readReceipts, channelMembers, channels, dmConversations } from '../db/schema.js';
 import type { DeliveryStatus } from '@relaycast/types';
@@ -44,7 +44,7 @@ const TERMINAL_SUCCESS_STATUS = 'acked';
 // Keep expiry work bounded per request and leave ample room under D1's
 // 100-parameter ceiling for the UPDATE's SET and status/workspace predicates.
 // A larger backlog drains oldest-first across subsequent inbox/delivery reads.
-const DELIVERY_EXPIRY_BATCH_SIZE = 50;
+export const DELIVERY_EXPIRY_BATCH_SIZE = 50;
 
 function serializeDelivery(row: DeliveryRow & { channelId?: string }) {
   return {
@@ -451,11 +451,22 @@ export interface DeliveryFailureNotice {
   retryable: false;
 }
 
-export async function expireDueDeliveries(
+export interface ExpiredDeliveryBatch {
+  expiredCount: number;
+  notices: DeliveryFailureNotice[];
+}
+
+/**
+ * Transition one D1-safe batch of due deliveries and report both the number of
+ * rows changed and the sender notices that can be emitted for those rows.
+ * `expiredCount` deliberately stays separate from `notices.length`: system
+ * messages have no sender, but must not make a multi-batch sweep stop early.
+ */
+export async function expireDueDeliveryBatch(
   db: Db,
   workspaceId: string | undefined,
   now: Date = new Date(),
-): Promise<DeliveryFailureNotice[]> {
+): Promise<ExpiredDeliveryBatch> {
   const nowSeconds = Math.floor(now.getTime() / 1000);
   const due = await db
     .select({
@@ -477,7 +488,7 @@ export async function expireDueDeliveries(
     .orderBy(asc(deliveries.expiresAt), asc(deliveries.id))
     .limit(DELIVERY_EXPIRY_BATCH_SIZE);
 
-  if (due.length === 0) return [];
+  if (due.length === 0) return { expiredCount: 0, notices: [] };
 
   const ids = due.map((row) => row.delivery.id);
   const updated = await db
@@ -497,7 +508,7 @@ export async function expireDueDeliveries(
     .returning({ id: deliveries.id });
   const updatedIds = new Set(updated.map((row) => row.id));
 
-  return due
+  const notices = due
     .filter((row) => row.senderAgentId && updatedIds.has(row.delivery.id))
     .map((row) => ({
       workspace_id: row.delivery.workspaceId,
@@ -511,6 +522,15 @@ export async function expireDueDeliveries(
       error: 'delivery TTL expired',
       retryable: false as const,
     }));
+  return { expiredCount: updated.length, notices };
+}
+
+export async function expireDueDeliveries(
+  db: Db,
+  workspaceId: string | undefined,
+  now: Date = new Date(),
+): Promise<DeliveryFailureNotice[]> {
+  return (await expireDueDeliveryBatch(db, workspaceId, now)).notices;
 }
 
 function wireMode(mode: string): 'wait' | 'steer' {
@@ -661,22 +681,13 @@ export async function fetchDueNodeDeliveryEvents(
   const conditions = [
     eq(deliveries.status, 'queued'),
     inArray(deliveries.routeNodeKind, [...NODE_REDRIVE_KINDS]),
-    // Match deliveries that are EITHER never-attempted (nextAttemptAt IS NULL —
-    // e.g. the inline send-time dispatch never ran or its waitUntil was lost) OR
-    // due for retry (nextAttemptAt <= now). Without the NULL branch the cron
-    // could only ever *retry* deliveries that already had an inline attempt (the
-    // inline dispatch is what first stamps nextAttemptAt); a fresh delivery whose
-    // inline dispatch never fired would sit queued forever. For http_push the
-    // cron is the only guaranteed delivery path; for ws nodes it recovers a row
-    // whose single background dispatch was lost before the node re-announces.
-    or(isNull(deliveries.nextAttemptAt), lte(deliveries.nextAttemptAt, now)),
     sql`(${deliveries.expiresAt} IS NULL OR ${deliveries.expiresAt} > ${nowSeconds})`,
   ];
   if (opts.workspaceId) {
     conditions.push(eq(deliveries.workspaceId, opts.workspaceId));
   }
 
-  const rows = await db
+  const fetchRows = (attemptCondition: SQL, queryLimit: number, orderByRetryAt: boolean) => db
     .select({
       delivery: deliveries,
       recipientAgentName: agents.name,
@@ -700,9 +711,27 @@ export async function fetchDueNodeDeliveryEvents(
     .innerJoin(messages, eq(deliveries.messageId, messages.id))
     .innerJoin(channels, eq(messages.channelId, channels.id))
     .leftJoin(dmConversations, eq(dmConversations.channelId, messages.channelId))
-    .where(and(...conditions))
-    .orderBy(asc(deliveries.nextAttemptAt), asc(deliveries.createdAt), asc(deliveries.id))
-    .limit(limit);
+    .where(and(...conditions, attemptCondition))
+    .orderBy(
+      ...(orderByRetryAt ? [asc(deliveries.nextAttemptAt)] : []),
+      asc(deliveries.createdAt),
+      asc(deliveries.id),
+    )
+    .limit(queryLimit);
+
+  // SQLite orders NULL before timestamps, so preserve the former OR query's
+  // ordering by filling the page with never-attempted rows first. Splitting the
+  // branches lets the due-retry half use idx_deliveries_retry_due; a partial
+  // non-NULL index cannot serve an OR that also asks for NULL rows.
+  const neverAttempted = await fetchRows(isNull(deliveries.nextAttemptAt), limit, false);
+  const dueRetries = neverAttempted.length < limit
+    ? await fetchRows(
+      sql`${deliveries.nextAttemptAt} IS NOT NULL AND ${deliveries.nextAttemptAt} <= ${nowSeconds}`,
+      limit - neverAttempted.length,
+      true,
+    )
+    : [];
+  const rows = [...neverAttempted, ...dueRetries];
 
   if (!opts.workspaceId && rows.length > 0) {
     const workspaceAttachments = new Map<string, AttachmentRow[]>();

--- a/packages/engine/src/engine/nodeContext.ts
+++ b/packages/engine/src/engine/nodeContext.ts
@@ -31,6 +31,9 @@ type ScopedNodeRow = {
 // Node kinds eligible for context updates: WebSocket nodes receive a pushed
 // `context.update` frame; http_push nodes receive a best-effort POST.
 const CONTEXT_NODE_KINDS = ['ws', 'fleet_ws', 'direct_ws', 'http_push'] as const;
+// workspace/status/kind predicates add six bindings, so 80 agent ids leave
+// comfortable room below D1's 100-bound-parameter limit.
+const AGENT_CONTEXT_QUERY_CHUNK_SIZE = 80;
 
 function normalizeDeliveryAdapter(adapter: string | null | undefined, nodeKind: string | null | undefined): string | null {
   if (adapter === 'fleet.ws.v1' || adapter === 'direct.ws.v1') return 'ws.node.v1';
@@ -225,6 +228,44 @@ export async function sendNodePresenceContext(
   });
 }
 
+async function listNodeContextRowsForAgents(
+  deps: NodeContextDeps,
+  agentIds: readonly string[],
+): Promise<ScopedNodeRow[]> {
+  const rows: ScopedNodeRow[] = [];
+  for (let offset = 0; offset < agentIds.length; offset += AGENT_CONTEXT_QUERY_CHUNK_SIZE) {
+    const chunk = agentIds.slice(offset, offset + AGENT_CONTEXT_QUERY_CHUNK_SIZE);
+    rows.push(...await deps.db
+      .select({
+        nodeId: agentNodeBindings.nodeId,
+        agentId: agentNodeBindings.agentId,
+        nodeKind: nodes.kind,
+        nodeRole: nodes.role,
+        providerName: agents.providerName,
+        deliveryAdapter: nodes.deliveryAdapter,
+        deliveryConfig: nodes.deliveryConfig,
+      })
+      .from(agentNodeBindings)
+      .innerJoin(agents, and(
+        eq(agents.workspaceId, deps.workspaceId),
+        eq(agents.id, agentNodeBindings.agentId),
+        eq(agents.locationType, 'via_node'),
+        eq(agents.locationNodeId, agentNodeBindings.nodeId),
+      ))
+      .innerJoin(nodes, and(
+        eq(nodes.workspaceId, deps.workspaceId),
+        eq(nodes.id, agentNodeBindings.nodeId),
+      ))
+      .where(and(
+        eq(agentNodeBindings.workspaceId, deps.workspaceId),
+        eq(agentNodeBindings.status, 'active'),
+        inArray(agentNodeBindings.agentId, chunk),
+        inArray(nodes.kind, CONTEXT_NODE_KINDS),
+      )));
+  }
+  return rows;
+}
+
 export async function sendNodeContextToAgents(
   deps: NodeContextDeps,
   args: {
@@ -236,37 +277,45 @@ export async function sendNodeContextToAgents(
   const uniqueAgentIds = [...new Set(args.agentIds)].filter((id) => id.length > 0);
   if (uniqueAgentIds.length === 0) return;
 
-  const rows = await deps.db
-    .select({
-      nodeId: agentNodeBindings.nodeId,
-      agentId: agentNodeBindings.agentId,
-      nodeKind: nodes.kind,
-      nodeRole: nodes.role,
-      providerName: agents.providerName,
-      deliveryAdapter: nodes.deliveryAdapter,
-      deliveryConfig: nodes.deliveryConfig,
-    })
-    .from(agentNodeBindings)
-    .innerJoin(agents, and(
-      eq(agents.workspaceId, deps.workspaceId),
-      eq(agents.id, agentNodeBindings.agentId),
-      eq(agents.locationType, 'via_node'),
-      eq(agents.locationNodeId, agentNodeBindings.nodeId),
-    ))
-    .innerJoin(nodes, and(
-      eq(nodes.workspaceId, deps.workspaceId),
-      eq(nodes.id, agentNodeBindings.nodeId),
-    ))
-    .where(and(
-      eq(agentNodeBindings.workspaceId, deps.workspaceId),
-      eq(agentNodeBindings.status, 'active'),
-      inArray(agentNodeBindings.agentId, uniqueAgentIds),
-      inArray(nodes.kind, CONTEXT_NODE_KINDS),
-    ));
+  const rows = await listNodeContextRowsForAgents(deps, uniqueAgentIds);
 
   await sendContextToRows(deps, rows, {
     topic: 'agent',
     event: args.event,
     data: args.data,
   });
+}
+
+/**
+ * Send many agent-scoped context events after resolving all target bindings in
+ * bounded queries. External sends remain serialized per event, preserving the
+ * existing best-effort behavior without multiplying D1 reads by event count.
+ */
+export async function sendNodeContextEventsToAgents(
+  deps: NodeContextDeps,
+  events: ReadonlyArray<{
+    agentId: string;
+    event: string;
+    data: Record<string, unknown>;
+  }>,
+): Promise<void> {
+  const agentIds = [...new Set(events.map((event) => event.agentId))]
+    .filter((id) => id.length > 0);
+  if (agentIds.length === 0) return;
+
+  const rows = await listNodeContextRowsForAgents(deps, agentIds);
+  const rowsByAgent = new Map<string, ScopedNodeRow[]>();
+  for (const row of rows) {
+    const agentRows = rowsByAgent.get(row.agentId) ?? [];
+    agentRows.push(row);
+    rowsByAgent.set(row.agentId, agentRows);
+  }
+
+  for (const event of events) {
+    await sendContextToRows(deps, rowsByAgent.get(event.agentId) ?? [], {
+      topic: 'agent',
+      event: event.event,
+      data: event.data,
+    });
+  }
 }

--- a/packages/engine/src/engine/nodeContext.ts
+++ b/packages/engine/src/engine/nodeContext.ts
@@ -1,4 +1,4 @@
-import { and, eq, inArray } from 'drizzle-orm';
+import { and, eq, inArray, or } from 'drizzle-orm';
 import type { EngineDb } from '../ports/database.js';
 import type { NodeConnectionRegistry, RealtimeBus } from '../ports/realtime.js';
 import { agents, agentNodeBindings, channelMembers, nodes } from '../db/schema.js';
@@ -34,6 +34,9 @@ const CONTEXT_NODE_KINDS = ['ws', 'fleet_ws', 'direct_ws', 'http_push'] as const
 // workspace/status/kind predicates add six bindings, so 80 agent ids leave
 // comfortable room below D1's 100-bound-parameter limit.
 const AGENT_CONTEXT_QUERY_CHUNK_SIZE = 80;
+// A cross-workspace target can bind both workspace and agent id. Forty worst-
+// case one-agent workspaces plus the status/kind predicates use 85 bindings.
+const AGENT_CONTEXT_EVENT_QUERY_CHUNK_SIZE = 40;
 
 function normalizeDeliveryAdapter(adapter: string | null | undefined, nodeKind: string | null | undefined): string | null {
   if (adapter === 'fleet.ws.v1' || adapter === 'direct.ws.v1') return 'ws.node.v1';
@@ -292,27 +295,73 @@ export async function sendNodeContextToAgents(
  * existing best-effort behavior without multiplying D1 reads by event count.
  */
 export async function sendNodeContextEventsToAgents(
-  deps: NodeContextDeps,
+  deps: Omit<NodeContextDeps, 'workspaceId'>,
   events: ReadonlyArray<{
+    workspaceId: string;
     agentId: string;
     event: string;
     data: Record<string, unknown>;
   }>,
 ): Promise<void> {
-  const agentIds = [...new Set(events.map((event) => event.agentId))]
-    .filter((id) => id.length > 0);
-  if (agentIds.length === 0) return;
+  const targets = [...new Map(events
+    .filter((event) => event.workspaceId.length > 0 && event.agentId.length > 0)
+    .map((event) => [
+      JSON.stringify([event.workspaceId, event.agentId]),
+      { workspaceId: event.workspaceId, agentId: event.agentId },
+    ])).values()];
+  if (targets.length === 0) return;
 
-  const rows = await listNodeContextRowsForAgents(deps, agentIds);
-  const rowsByAgent = new Map<string, ScopedNodeRow[]>();
-  for (const row of rows) {
-    const agentRows = rowsByAgent.get(row.agentId) ?? [];
-    agentRows.push(row);
-    rowsByAgent.set(row.agentId, agentRows);
+  const rowsByTarget = new Map<string, ScopedNodeRow[]>();
+  for (let offset = 0; offset < targets.length; offset += AGENT_CONTEXT_EVENT_QUERY_CHUNK_SIZE) {
+    const chunk = targets.slice(offset, offset + AGENT_CONTEXT_EVENT_QUERY_CHUNK_SIZE);
+    const agentsByWorkspace = new Map<string, string[]>();
+    for (const target of chunk) {
+      const agentIds = agentsByWorkspace.get(target.workspaceId) ?? [];
+      agentIds.push(target.agentId);
+      agentsByWorkspace.set(target.workspaceId, agentIds);
+    }
+    const scopes = [...agentsByWorkspace].map(([workspaceId, agentIds]) => and(
+      eq(agentNodeBindings.workspaceId, workspaceId),
+      inArray(agentNodeBindings.agentId, agentIds),
+    ));
+    const rows = await deps.db
+      .select({
+        workspaceId: agentNodeBindings.workspaceId,
+        nodeId: agentNodeBindings.nodeId,
+        agentId: agentNodeBindings.agentId,
+        nodeKind: nodes.kind,
+        nodeRole: nodes.role,
+        providerName: agents.providerName,
+        deliveryAdapter: nodes.deliveryAdapter,
+        deliveryConfig: nodes.deliveryConfig,
+      })
+      .from(agentNodeBindings)
+      .innerJoin(agents, and(
+        eq(agents.workspaceId, agentNodeBindings.workspaceId),
+        eq(agents.id, agentNodeBindings.agentId),
+        eq(agents.locationType, 'via_node'),
+        eq(agents.locationNodeId, agentNodeBindings.nodeId),
+      ))
+      .innerJoin(nodes, and(
+        eq(nodes.workspaceId, agentNodeBindings.workspaceId),
+        eq(nodes.id, agentNodeBindings.nodeId),
+      ))
+      .where(and(
+        eq(agentNodeBindings.status, 'active'),
+        inArray(nodes.kind, CONTEXT_NODE_KINDS),
+        or(...scopes),
+      ));
+    for (const row of rows) {
+      const key = JSON.stringify([row.workspaceId, row.agentId]);
+      const targetRows = rowsByTarget.get(key) ?? [];
+      targetRows.push(row);
+      rowsByTarget.set(key, targetRows);
+    }
   }
 
   for (const event of events) {
-    await sendContextToRows(deps, rowsByAgent.get(event.agentId) ?? [], {
+    const key = JSON.stringify([event.workspaceId, event.agentId]);
+    await sendContextToRows({ ...deps, workspaceId: event.workspaceId }, rowsByTarget.get(key) ?? [], {
       topic: 'agent',
       event: event.event,
       data: event.data,

--- a/packages/engine/src/engine/workspaceEvents.ts
+++ b/packages/engine/src/engine/workspaceEvents.ts
@@ -22,6 +22,11 @@ export interface WorkspaceEventRecord {
   created_at: string;
 }
 
+// Each VALUES row binds type, channel_id, and payload. Thirty rows plus the
+// workspace id stay below D1's 100-bound-parameter ceiling (91 total), while
+// turning a large maintenance fanout into a small, predictable query count.
+const WORKSPACE_EVENT_APPEND_BATCH_SIZE = 30;
+
 function nextSeqSql(workspaceId: string) {
   return sql<number>`(
     SELECT COALESCE(MAX(we.seq), 0) + 1
@@ -66,6 +71,67 @@ export async function appendWorkspaceEvent(
     });
     return null;
   }
+}
+
+/**
+ * Append several events with one monotonic sequence allocation per SQL batch.
+ * The MAX(seq) read and all inserts live in the same statement, so concurrent
+ * appenders cannot reserve the same sequence range. Results align with inputs;
+ * a failed batch is represented by nulls and does not stop later batches.
+ */
+export async function appendWorkspaceEvents(
+  db: EngineDb,
+  workspaceId: string,
+  inputs: readonly WorkspaceEventInput[],
+): Promise<Array<number | null>> {
+  const assigned: Array<number | null> = [];
+
+  for (let offset = 0; offset < inputs.length; offset += WORKSPACE_EVENT_APPEND_BATCH_SIZE) {
+    const batch = inputs.slice(offset, offset + WORKSPACE_EVENT_APPEND_BATCH_SIZE);
+    const values = sql.join(batch.map((input, index) => sql`(
+      ${sql.raw(String(index))},
+      ${input.type},
+      ${input.channelId ?? null},
+      ${JSON.stringify(input.payload)}
+    )`), sql`, `);
+
+    try {
+      const rows = await db.all<{ seq: number }>(sql`
+        WITH
+          config(workspace_id) AS (VALUES (${workspaceId})),
+          input_events(ord, type, channel_id, payload) AS (VALUES ${values}),
+          base(seq) AS (
+            SELECT COALESCE(MAX(we.seq), 0)
+            FROM workspace_events we, config
+            WHERE we.workspace_id = config.workspace_id
+          )
+        INSERT INTO workspace_events (workspace_id, seq, type, channel_id, payload)
+        SELECT
+          config.workspace_id,
+          base.seq + input_events.ord + 1,
+          input_events.type,
+          input_events.channel_id,
+          input_events.payload
+        FROM input_events, base, config
+        ORDER BY input_events.ord
+        RETURNING seq
+      `);
+      const seqs = [...(rows ?? [])].map((row) => row.seq).sort((a, b) => a - b);
+      if (seqs.length !== batch.length) {
+        throw new Error(`expected ${batch.length} appended events, received ${seqs.length}`);
+      }
+      assigned.push(...seqs);
+    } catch (err) {
+      console.warn('[workspace.events] batch append failed', {
+        workspace_id: workspaceId,
+        event_count: batch.length,
+        error: err instanceof Error ? err.message : String(err),
+      });
+      assigned.push(...batch.map(() => null));
+    }
+  }
+
+  return assigned;
 }
 
 function parsePayload(raw: string): Record<string, unknown> {
@@ -144,5 +210,25 @@ export async function appendAndPublishWorkspaceEvent(
     await deps.realtime.publishToWorkspaceStream({ workspaceId, event });
   } catch (err) {
     onPublishError?.(err);
+  }
+}
+
+/** Batch form used by bounded maintenance jobs to stay under D1 query limits. */
+export async function appendAndPublishWorkspaceEvents(
+  deps: { db: EngineDb; realtime: WorkspaceStreamPublisher },
+  workspaceId: string,
+  inputs: readonly WorkspaceEventInput[],
+  onPublishError?: (err: unknown) => void,
+): Promise<void> {
+  const seqs = await appendWorkspaceEvents(deps.db, workspaceId, inputs);
+  for (let index = 0; index < inputs.length; index++) {
+    const input = inputs[index];
+    const seq = seqs[index];
+    const event = seq == null ? input.payload : { ...input.payload, seq };
+    try {
+      await deps.realtime.publishToWorkspaceStream({ workspaceId, event });
+    } catch (err) {
+      onPublishError?.(err);
+    }
   }
 }

--- a/packages/engine/src/engine/workspaceEvents.ts
+++ b/packages/engine/src/engine/workspaceEvents.ts
@@ -22,10 +22,15 @@ export interface WorkspaceEventRecord {
   created_at: string;
 }
 
-// Each VALUES row binds type, channel_id, and payload. Thirty rows plus the
-// workspace id stay below D1's 100-bound-parameter ceiling (91 total), while
-// turning a large maintenance fanout into a small, predictable query count.
-const WORKSPACE_EVENT_APPEND_BATCH_SIZE = 30;
+// Each VALUES row binds workspace_id, type, channel_id, and payload. Twenty-four
+// rows use 96 bindings, below D1's 100-bound-parameter ceiling, while allowing
+// one maintenance statement to append events for many workspaces.
+const WORKSPACE_EVENT_APPEND_BATCH_SIZE = 24;
+
+export interface ScopedWorkspaceEventInput {
+  workspaceId: string;
+  input: WorkspaceEventInput;
+}
 
 function nextSeqSql(workspaceId: string) {
   return sql<number>`(
@@ -79,51 +84,69 @@ export async function appendWorkspaceEvent(
  * appenders cannot reserve the same sequence range. Results align with inputs;
  * a failed batch is represented by nulls and does not stop later batches.
  */
-export async function appendWorkspaceEvents(
+export async function appendWorkspaceEventBatch(
   db: EngineDb,
-  workspaceId: string,
-  inputs: readonly WorkspaceEventInput[],
+  inputs: readonly ScopedWorkspaceEventInput[],
 ): Promise<Array<number | null>> {
   const assigned: Array<number | null> = [];
 
   for (let offset = 0; offset < inputs.length; offset += WORKSPACE_EVENT_APPEND_BATCH_SIZE) {
     const batch = inputs.slice(offset, offset + WORKSPACE_EVENT_APPEND_BATCH_SIZE);
-    const values = sql.join(batch.map((input, index) => sql`(
+    const values = sql.join(batch.map((event, index) => sql`(
       ${sql.raw(String(index))},
-      ${input.type},
-      ${input.channelId ?? null},
-      ${JSON.stringify(input.payload)}
+      ${event.workspaceId},
+      ${event.input.type},
+      ${event.input.channelId ?? null},
+      ${JSON.stringify(event.input.payload)}
     )`), sql`, `);
 
     try {
-      const rows = await db.all<{ seq: number }>(sql`
+      const rows = await db.all<{ workspace_id: string; seq: number }>(sql`
         WITH
-          config(workspace_id) AS (VALUES (${workspaceId})),
-          input_events(ord, type, channel_id, payload) AS (VALUES ${values}),
-          base(seq) AS (
-            SELECT COALESCE(MAX(we.seq), 0)
-            FROM workspace_events we, config
-            WHERE we.workspace_id = config.workspace_id
+          input_events(global_ord, workspace_id, type, channel_id, payload) AS (VALUES ${values}),
+          ranked AS (
+            SELECT
+              input_events.*,
+              ROW_NUMBER() OVER (
+                PARTITION BY input_events.workspace_id
+                ORDER BY input_events.global_ord
+              ) AS workspace_ord
+            FROM input_events
+          ),
+          bases AS (
+            SELECT
+              workspaces.workspace_id,
+              COALESCE(MAX(we.seq), 0) AS base_seq
+            FROM (SELECT DISTINCT workspace_id FROM input_events) workspaces
+            LEFT JOIN workspace_events we ON we.workspace_id = workspaces.workspace_id
+            GROUP BY workspaces.workspace_id
           )
         INSERT INTO workspace_events (workspace_id, seq, type, channel_id, payload)
         SELECT
-          config.workspace_id,
-          base.seq + input_events.ord + 1,
-          input_events.type,
-          input_events.channel_id,
-          input_events.payload
-        FROM input_events, base, config
-        ORDER BY input_events.ord
-        RETURNING seq
+          ranked.workspace_id,
+          bases.base_seq + ranked.workspace_ord,
+          ranked.type,
+          ranked.channel_id,
+          ranked.payload
+        FROM ranked
+        INNER JOIN bases ON bases.workspace_id = ranked.workspace_id
+        ORDER BY ranked.global_ord
+        RETURNING workspace_id, seq
       `);
-      const seqs = [...(rows ?? [])].map((row) => row.seq).sort((a, b) => a - b);
-      if (seqs.length !== batch.length) {
-        throw new Error(`expected ${batch.length} appended events, received ${seqs.length}`);
+      if ((rows ?? []).length !== batch.length) {
+        throw new Error(`expected ${batch.length} appended events, received ${(rows ?? []).length}`);
       }
-      assigned.push(...seqs);
+      const seqsByWorkspace = new Map<string, number[]>();
+      for (const row of rows ?? []) {
+        const seqs = seqsByWorkspace.get(row.workspace_id) ?? [];
+        seqs.push(row.seq);
+        seqsByWorkspace.set(row.workspace_id, seqs);
+      }
+      for (const seqs of seqsByWorkspace.values()) seqs.sort((a, b) => a - b);
+      assigned.push(...batch.map((event) => seqsByWorkspace.get(event.workspaceId)?.shift() ?? null));
     } catch (err) {
       console.warn('[workspace.events] batch append failed', {
-        workspace_id: workspaceId,
+        workspace_count: new Set(batch.map((event) => event.workspaceId)).size,
         event_count: batch.length,
         error: err instanceof Error ? err.message : String(err),
       });
@@ -132,6 +155,17 @@ export async function appendWorkspaceEvents(
   }
 
   return assigned;
+}
+
+export async function appendWorkspaceEvents(
+  db: EngineDb,
+  workspaceId: string,
+  inputs: readonly WorkspaceEventInput[],
+): Promise<Array<number | null>> {
+  return appendWorkspaceEventBatch(
+    db,
+    inputs.map((input) => ({ workspaceId, input })),
+  );
 }
 
 function parsePayload(raw: string): Record<string, unknown> {
@@ -220,9 +254,22 @@ export async function appendAndPublishWorkspaceEvents(
   inputs: readonly WorkspaceEventInput[],
   onPublishError?: (err: unknown) => void,
 ): Promise<void> {
-  const seqs = await appendWorkspaceEvents(deps.db, workspaceId, inputs);
-  for (let index = 0; index < inputs.length; index++) {
-    const input = inputs[index];
+  await appendAndPublishWorkspaceEventBatch(
+    deps,
+    inputs.map((input) => ({ workspaceId, input })),
+    onPublishError,
+  );
+}
+
+/** Batch form that can append and publish events across several workspaces. */
+export async function appendAndPublishWorkspaceEventBatch(
+  deps: { db: EngineDb; realtime: WorkspaceStreamPublisher },
+  events: readonly ScopedWorkspaceEventInput[],
+  onPublishError?: (err: unknown) => void,
+): Promise<void> {
+  const seqs = await appendWorkspaceEventBatch(deps.db, events);
+  for (let index = 0; index < events.length; index++) {
+    const { workspaceId, input } = events[index];
     const seq = seqs[index];
     const event = seq == null ? input.payload : { ...input.payload, seq };
     try {

--- a/packages/engine/src/routes/__tests__/deliveryExpirySweep.test.ts
+++ b/packages/engine/src/routes/__tests__/deliveryExpirySweep.test.ts
@@ -1,0 +1,33 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import * as deliveryEngine from '../../engine/delivery.js';
+import type { EngineDeps } from '../../ports/index.js';
+import {
+  DELIVERY_EXPIRY_MAX_BATCHES,
+  sweepExpiredDeliveries,
+} from '../deliveryRouting.js';
+
+const deps = {} as EngineDeps;
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('scheduled delivery expiry drain', () => {
+  it('must fire repeatedly so one invocation drains more than one SQL batch', async () => {
+    const expire = vi.spyOn(deliveryEngine, 'expireDueDeliveryBatch')
+      .mockResolvedValueOnce({ expiredCount: 50, notices: [] })
+      .mockResolvedValueOnce({ expiredCount: 17, notices: [] });
+
+    await expect(sweepExpiredDeliveries(deps)).resolves.toBe(67);
+    expect(expire).toHaveBeenCalledTimes(2);
+  });
+
+  it('must not fire past the fixed invocation bound while backlog remains', async () => {
+    const expire = vi.spyOn(deliveryEngine, 'expireDueDeliveryBatch')
+      .mockResolvedValue({ expiredCount: deliveryEngine.DELIVERY_EXPIRY_BATCH_SIZE, notices: [] });
+
+    await expect(sweepExpiredDeliveries(deps, { maxBatches: Number.MAX_SAFE_INTEGER }))
+      .resolves.toBe(DELIVERY_EXPIRY_MAX_BATCHES * deliveryEngine.DELIVERY_EXPIRY_BATCH_SIZE);
+    expect(expire).toHaveBeenCalledTimes(DELIVERY_EXPIRY_MAX_BATCHES);
+  });
+});

--- a/packages/engine/src/routes/deliveryRouting.ts
+++ b/packages/engine/src/routes/deliveryRouting.ts
@@ -13,8 +13,8 @@ import { isSafeExternalUrl } from '../lib/ssrf.js';
 import { transformForClient, type WsEvent } from '../engine/wsTransform.js';
 import { isProviderAgentDeliveryReady, type EngineDb, type EngineDeps } from '../ports/index.js';
 import { fanoutToAgents } from './fanout.js';
-import { sendNodeContextToAgents } from '../engine/nodeContext.js';
-import { appendAndPublishWorkspaceEvent } from '../engine/workspaceEvents.js';
+import { sendNodeContextEventsToAgents, sendNodeContextToAgents } from '../engine/nodeContext.js';
+import { appendAndPublishWorkspaceEvent, appendAndPublishWorkspaceEvents } from '../engine/workspaceEvents.js';
 type HonoContext = Context<AppEnv>;
 type RoutingEngine = EngineRuntime | EngineDeps;
 type RoutingContext = {
@@ -34,6 +34,10 @@ type DeliveryTarget = {
 };
 
 const DISPATCH_RETRY_DELAY_MS = 30_000;
+// Fifty 50-row statements expire at most 2,500 deliveries per invocation.
+// On a */5 schedule that is 720,000/day: above the measured 519,000/day peak
+// while each UPDATE remains well below D1's 100-bound-parameter ceiling.
+export const DELIVERY_EXPIRY_MAX_BATCHES = 50;
 
 function routingContextFromHono(c: HonoContext, workspaceIdOverride?: string): RoutingContext {
   const workspaceId = workspaceIdOverride ?? c.get('workspace')?.id;
@@ -627,8 +631,10 @@ async function notifyDeliveryFailuresForContext(
   ctx: RoutingContext,
   notices: deliveryEngine.DeliveryFailureNotice[],
 ): Promise<void> {
-  for (const notice of notices) {
-    await fanoutToAgentsForContext(ctx, [notice.sender_agent_id], 'delivery.failed', {
+  if (notices.length === 0) return;
+  const notifications = notices.map((notice) => ({
+    agentId: notice.sender_agent_id,
+    data: {
       delivery_id: notice.delivery_id,
       message_id: notice.message_id,
       target_agent_id: notice.target_agent_id,
@@ -637,21 +643,60 @@ async function notifyDeliveryFailuresForContext(
       reason: notice.reason,
       error: notice.error,
       retryable: notice.retryable,
-    });
-  }
+    },
+  }));
+  const inputs = notifications.map((notification) => {
+    const payload = transformForClient(buildEvent('delivery.failed', ctx.workspaceId, notification.data));
+    return { type: 'delivery.failed', payload };
+  });
+
+  await Promise.allSettled([
+    appendAndPublishWorkspaceEvents(
+      { db: ctx.db, realtime: ctx.engine.realtime },
+      ctx.workspaceId,
+      inputs,
+    ),
+    sendNodeContextEventsToAgents(
+      {
+        db: ctx.db,
+        nodeConnections: ctx.engine.nodeConnections,
+        realtime: ctx.engine.realtime,
+        workspaceId: ctx.workspaceId,
+        environment: ctx.engine.config?.environment,
+        httpPushProxy: ctx.engine.config?.httpPushProxy,
+      },
+      notifications.map((notification) => ({
+        agentId: notification.agentId,
+        event: 'delivery.failed',
+        data: notification.data,
+      })),
+    ),
+  ]);
 }
 
 /**
- * Scheduled TTL expiry maintenance. Each workspace advances by at most one
- * D1-safe delivery batch per invocation; adapters call this on a cadence rather
- * than coupling mailbox reads to cleanup work.
+ * Scheduled TTL expiry maintenance. One invocation advances through a bounded
+ * number of small D1-safe statements, then batches the best-effort failure
+ * fanout so increasing the drain rate does not multiply D1 reads per notice.
  */
 export async function sweepExpiredDeliveries(
   engine: EngineDeps,
-  opts: { workspaceId?: string; now?: Date } = {},
+  opts: { workspaceId?: string; now?: Date; maxBatches?: number } = {},
 ): Promise<number> {
   const now = opts.now ?? new Date();
-  const notices = await deliveryEngine.expireDueDeliveries(engine.db, opts.workspaceId, now);
+  const maxBatches = Math.min(
+    Math.max(Math.floor(opts.maxBatches ?? DELIVERY_EXPIRY_MAX_BATCHES), 1),
+    DELIVERY_EXPIRY_MAX_BATCHES,
+  );
+  let expiredCount = 0;
+  const notices: deliveryEngine.DeliveryFailureNotice[] = [];
+  for (let batchNumber = 0; batchNumber < maxBatches; batchNumber++) {
+    const batch = await deliveryEngine.expireDueDeliveryBatch(engine.db, opts.workspaceId, now);
+    expiredCount += batch.expiredCount;
+    notices.push(...batch.notices);
+    if (batch.expiredCount < deliveryEngine.DELIVERY_EXPIRY_BATCH_SIZE) break;
+  }
+
   const byWorkspace = new Map<string, deliveryEngine.DeliveryFailureNotice[]>();
   for (const notice of notices) {
     const workspaceNotices = byWorkspace.get(notice.workspace_id) ?? [];
@@ -664,7 +709,7 @@ export async function sweepExpiredDeliveries(
       workspaceNotices,
     );
   }
-  return notices.length;
+  return expiredCount;
 }
 
 export async function notifyDeliveryRejections(

--- a/packages/engine/src/routes/deliveryRouting.ts
+++ b/packages/engine/src/routes/deliveryRouting.ts
@@ -14,7 +14,7 @@ import { transformForClient, type WsEvent } from '../engine/wsTransform.js';
 import { isProviderAgentDeliveryReady, type EngineDb, type EngineDeps } from '../ports/index.js';
 import { fanoutToAgents } from './fanout.js';
 import { sendNodeContextEventsToAgents, sendNodeContextToAgents } from '../engine/nodeContext.js';
-import { appendAndPublishWorkspaceEvent, appendAndPublishWorkspaceEvents } from '../engine/workspaceEvents.js';
+import { appendAndPublishWorkspaceEvent, appendAndPublishWorkspaceEventBatch } from '../engine/workspaceEvents.js';
 type HonoContext = Context<AppEnv>;
 type RoutingEngine = EngineRuntime | EngineDeps;
 type RoutingContext = {
@@ -627,12 +627,13 @@ export async function sweepDueNodeDeliveries(
  */
 export const sweepDueHttpPushDeliveries = sweepDueNodeDeliveries;
 
-async function notifyDeliveryFailuresForContext(
-  ctx: RoutingContext,
+async function notifyDeliveryFailures(
+  engine: EngineDeps,
   notices: deliveryEngine.DeliveryFailureNotice[],
 ): Promise<void> {
   if (notices.length === 0) return;
   const notifications = notices.map((notice) => ({
+    workspaceId: notice.workspace_id,
     agentId: notice.sender_agent_id,
     data: {
       delivery_id: notice.delivery_id,
@@ -646,26 +647,28 @@ async function notifyDeliveryFailuresForContext(
     },
   }));
   const inputs = notifications.map((notification) => {
-    const payload = transformForClient(buildEvent('delivery.failed', ctx.workspaceId, notification.data));
-    return { type: 'delivery.failed', payload };
+    const payload = transformForClient(buildEvent('delivery.failed', notification.workspaceId, notification.data));
+    return {
+      workspaceId: notification.workspaceId,
+      input: { type: 'delivery.failed', payload },
+    };
   });
 
   await Promise.allSettled([
-    appendAndPublishWorkspaceEvents(
-      { db: ctx.db, realtime: ctx.engine.realtime },
-      ctx.workspaceId,
+    appendAndPublishWorkspaceEventBatch(
+      { db: engine.db, realtime: engine.realtime },
       inputs,
     ),
     sendNodeContextEventsToAgents(
       {
-        db: ctx.db,
-        nodeConnections: ctx.engine.nodeConnections,
-        realtime: ctx.engine.realtime,
-        workspaceId: ctx.workspaceId,
-        environment: ctx.engine.config?.environment,
-        httpPushProxy: ctx.engine.config?.httpPushProxy,
+        db: engine.db,
+        nodeConnections: engine.nodeConnections,
+        realtime: engine.realtime,
+        environment: engine.config?.environment,
+        httpPushProxy: engine.config?.httpPushProxy,
       },
       notifications.map((notification) => ({
+        workspaceId: notification.workspaceId,
         agentId: notification.agentId,
         event: 'delivery.failed',
         data: notification.data,
@@ -689,25 +692,14 @@ export async function sweepExpiredDeliveries(
     DELIVERY_EXPIRY_MAX_BATCHES,
   );
   let expiredCount = 0;
-  const notices: deliveryEngine.DeliveryFailureNotice[] = [];
   for (let batchNumber = 0; batchNumber < maxBatches; batchNumber++) {
     const batch = await deliveryEngine.expireDueDeliveryBatch(engine.db, opts.workspaceId, now);
     expiredCount += batch.expiredCount;
-    notices.push(...batch.notices);
+    // Flush every committed batch before another state transition can fail.
+    // Otherwise a later D1 error would strand already-dead-lettered rows with
+    // notices held only in this invocation's memory.
+    await notifyDeliveryFailures(engine, batch.notices);
     if (batch.expiredCount < deliveryEngine.DELIVERY_EXPIRY_BATCH_SIZE) break;
-  }
-
-  const byWorkspace = new Map<string, deliveryEngine.DeliveryFailureNotice[]>();
-  for (const notice of notices) {
-    const workspaceNotices = byWorkspace.get(notice.workspace_id) ?? [];
-    workspaceNotices.push(notice);
-    byWorkspace.set(notice.workspace_id, workspaceNotices);
-  }
-  for (const [workspaceId, workspaceNotices] of byWorkspace) {
-    await notifyDeliveryFailuresForContext(
-      { db: engine.db, workspaceId, engine },
-      workspaceNotices,
-    );
   }
   return expiredCount;
 }

--- a/packages/engine/src/routes/deliveryRouting.ts
+++ b/packages/engine/src/routes/deliveryRouting.ts
@@ -687,10 +687,10 @@ export async function sweepExpiredDeliveries(
   opts: { workspaceId?: string; now?: Date; maxBatches?: number } = {},
 ): Promise<number> {
   const now = opts.now ?? new Date();
-  const maxBatches = Math.min(
-    Math.max(Math.floor(opts.maxBatches ?? DELIVERY_EXPIRY_MAX_BATCHES), 1),
-    DELIVERY_EXPIRY_MAX_BATCHES,
-  );
+  const requestedMaxBatches = opts.maxBatches ?? DELIVERY_EXPIRY_MAX_BATCHES;
+  const maxBatches = Number.isFinite(requestedMaxBatches)
+    ? Math.min(Math.max(Math.floor(requestedMaxBatches), 1), DELIVERY_EXPIRY_MAX_BATCHES)
+    : DELIVERY_EXPIRY_MAX_BATCHES;
   let expiredCount = 0;
   for (let batchNumber = 0; batchNumber < maxBatches; batchNumber++) {
     const batch = await deliveryEngine.expireDueDeliveryBatch(engine.db, opts.workspaceId, now);


### PR DESCRIPTION
## Summary

- Keep each expiry SQL statement at 50 rows, but run at most 50 batches per scheduled invocation: 2,500 expirations/run instead of 50.
- Flush `delivery.failed` notices after every committed expiry batch, with cross-workspace durable event appends (24 events/statement) and sender node lookups (40 targets/query). A later batch failure therefore cannot strand notices for rows already dead-lettered.
- Split the redrive sweep's `next_attempt_at IS NULL OR next_attempt_at <= now` read into its NULL-first and due-retry branches so a non-NULL partial index can serve retries without changing ordering.
- Add drain-first migration `0040_delivery_retry_due_index.sql`; `0038` is current on `main` and `0039` remains reserved for #339.

## Capacity and steady state

The hosted cron runs 288 times/day (`*/5`).

- Old capacity: `50 * 288 = 14,400/day`
- New capacity: `2,500 * 288 = 720,000/day`
- Measured peak creation/expiry pressure: `519,000/day`
- Peak headroom: `201,000/day` (38.7%)
- Existing 1,596,656-row backlog: about 2.22 days with no new expirations, or about 7.94 days while the measured peak continues

The drain rate now exceeds the measured peak, so the backlog converges instead of growing.

## D1 bounds and contention

Cloudflare currently limits a query to 100 bound parameters and a paid Worker invocation to 1,000 D1 queries. The 50-row state-transition batch stays comfortably below the parameter ceiling and limits each write lock to 50 delivery rows. Every committed batch flushes its notices before starting the next batch. In the worst case of 50 unique cross-workspace targets per batch, a full 2,500-row invocation uses at most 350 D1 queries: 100 expiry queries, 150 durable event append queries, and 100 node lookup queries.

Migration `0040` is intentionally applied only after the drain. At the projected steady-state table size it scans about 150,000 table rows and writes about 54,642 partial-index entries, versus scanning the current 1.75M-row table. A local SQLite build at that shape took 0.02s; that is only a contention sanity check, not a D1 wall-time guarantee. `CREATE INDEX` still holds a write lock for its build.

This repository uses `wrangler d1 migrations apply`; Wrangler rolls an errored migration back and exposes no per-file `transaction: false` mode. The Node migration runner likewise wraps every migration file in a transaction. At the reduced build size, a special non-transactional path is neither supported nor needed.

Hosted rollout order:

1. Deploy the bounded drain while deferring migration `0040`.
2. Monitor expired queued deliveries until the backlog has cleared and the table is near steady state (~150k rows).
3. Apply `0040`, then verify the production plan and rows-read metadata.

The migration never deletes delivery rows.

## Query plans

Before (the original global OR query):

```text
|--SCAN deliveries
`--USE TEMP B-TREE FOR ORDER BY
```

After, never-attempted branch (intentionally still a scan, but over the post-drain table):

```text
|--SCAN deliveries
`--USE TEMP B-TREE FOR ORDER BY
```

After, due-retry branch:

```text
`--SEARCH deliveries USING INDEX idx_deliveries_retry_due (status=? AND next_attempt_at>? AND next_attempt_at<?)
```

## Verification

- Must-fire integration: one invocation with a two-batch test bound expires 100 rows, not 50.
- Must-not-fire unit: a permanently full mocked backlog stops exactly at 50 batches / 2,500 rows even when the caller requests an unbounded count.
- Durability regression: if the second expiry batch fails, all 50 notices from the first committed batch have already been emitted.
- Multi-workspace event append regression: one batch assigns independent contiguous workspace sequences.
- D1 100-parameter guards cover the real emitted expiry and batched fanout SQL.
- Partial-index plan assertion covers the due-retry query.
- `@relaycast/engine`: 661 tests passed across 64 files.
- `@relaycast/engine`: build passed.
- `@relaycast/engine`: lint passed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/AgentWorkforce/relaycast/pull/345?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->
