### PR TITLE
fix(engine): keep activity feed on workspace index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,11 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 Packages without a separate changelog are covered by the cross-package notes below.
 
-## [Unreleased]
+## [Unreleased - Patch]
+
+### Fixed
+
+- The activity feed now uses the indexed monotonic message order instead of scanning and sorting an entire workspace history.
 
 ## [8.1.1] - 2026-08-19
 

--- a/packages/engine/CHANGELOG.md
+++ b/packages/engine/CHANGELOG.md
@@ -7,7 +7,11 @@ See the [root changelog](../../CHANGELOG.md) for cross-package release highlight
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [Unreleased - Patch]
+
+### Fixed
+
+- Activity-feed reads use `idx_messages_workspace` for newest-first results instead of sorting every message in the workspace.
 
 ## [8.1.1] - 2026-08-19
 

--- a/packages/engine/src/__tests__/conformance/activity.test.ts
+++ b/packages/engine/src/__tests__/conformance/activity.test.ts
@@ -1,0 +1,69 @@
+import { eq } from 'drizzle-orm';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { channels, messages } from '../../db/schema.js';
+import { createWorkspace, makeNodeStack, registerAgent, type TestStack } from './harness.js';
+
+describe('activity feed', () => {
+  let stack: TestStack;
+
+  beforeEach(() => {
+    stack = makeNodeStack();
+  });
+
+  afterEach(() => stack.close());
+
+  it('orders by monotonic message id through the workspace index', async () => {
+    const workspace = await createWorkspace(stack.app, 'indexed-activity');
+    const agent = await registerAgent(stack.app, workspace.workspaceKey, 'activity-author');
+    const [general] = await stack.runtime.deps.db
+      .select({ id: channels.id })
+      .from(channels)
+      .where(eq(channels.workspaceId, workspace.workspaceId));
+
+    const lowerId = '100000000000000001';
+    const higherId = '100000000000000002';
+    await stack.runtime.deps.db.insert(messages).values([
+      {
+        id: lowerId,
+        workspaceId: workspace.workspaceId,
+        channelId: general.id,
+        agentId: agent.agentId,
+        body: 'lower snowflake',
+        // Deliberately later: created_at-first ordering would return this row
+        // first and make the regression test fail.
+        createdAt: new Date('2030-01-02T00:00:00.000Z'),
+      },
+      {
+        id: higherId,
+        workspaceId: workspace.workspaceId,
+        channelId: general.id,
+        agentId: agent.agentId,
+        body: 'higher snowflake',
+        createdAt: new Date('2030-01-01T00:00:00.000Z'),
+      },
+    ]);
+
+    const response = await stack.app.request('/v1/activity?limit=2', {
+      headers: { authorization: `Bearer ${workspace.workspaceKey}` },
+    });
+    const body = await response.json() as { data: Array<{ id: string }> };
+
+    expect(response.status).toBe(200);
+    expect(body.data.map((item) => item.id)).toEqual([higherId, lowerId]);
+
+    const plan = stack.runtime.handle.sqlite.prepare(`
+      EXPLAIN QUERY PLAN
+      SELECT messages.id
+      FROM messages
+      INNER JOIN channels ON messages.channel_id = channels.id
+      INNER JOIN agents ON messages.agent_id = agents.id
+      LEFT JOIN dm_conversations ON dm_conversations.channel_id = channels.id
+      WHERE messages.workspace_id = ?
+      ORDER BY messages.id DESC
+      LIMIT 20
+    `).all(workspace.workspaceId) as Array<{ detail: string }>;
+    const details = plan.map((step) => step.detail).join('\n');
+    expect(details).toContain('idx_messages_workspace');
+    expect(details).not.toContain('USE TEMP B-TREE');
+  });
+});

--- a/packages/engine/src/engine/activity.ts
+++ b/packages/engine/src/engine/activity.ts
@@ -28,9 +28,11 @@ export async function getActivityFeed(
     .innerJoin(agents, eq(messages.agentId, agents.id))
     .leftJoin(dmConversations, eq(dmConversations.channelId, channels.id))
     .where(eq(messages.workspaceId, workspaceId))
-    // id is a monotonic snowflake — use it as a stable tiebreaker so same-second
-    // messages don't shuffle between calls.
-    .orderBy(desc(messages.createdAt), desc(messages.id))
+    // Message ids are fixed-width monotonic snowflakes. Ordering directly by
+    // id preserves newest-first activity while letting SQLite satisfy both the
+    // workspace filter and ordering from idx_messages_workspace. Ordering by
+    // created_at first forces D1 to scan and sort the entire workspace history.
+    .orderBy(desc(messages.id))
     .limit(effectiveLimit);
 
   return rows.map((r) => {


### PR DESCRIPTION
## Summary
- order activity messages by fixed-width monotonic message id
- use the existing workspace/message index instead of sorting the full workspace history
- add a conformance regression that checks ordering and the SQLite query plan

## Production evidence
Wrangler D1 Insights showed this activity query averaging about 63 million rows read and 5 seconds per call. The old created-at-first ordering forced a temporary B-tree; the new plan uses idx_messages_workspace with no temporary sort.

## Validation
- full monorepo Turbo test/lint/build: 26/26 tasks
- engine: 65 files, 662 tests
- MCP regression: 10 tests
- regression test proven must-fire against old ordering
- git diff whitespace and changed-file secret-pattern scans clean

Veto MCP was requested by repository instructions but is not exposed in this session, so the equivalent local gates and manual diff/security review were performed.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/AgentWorkforce/relaycast/pull/346?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

