### PR TITLE
fix(engine): remove D1 hot-path amplification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,11 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 Packages without a separate changelog are covered by the cross-package notes below.
 
-## [Unreleased]
+## [Unreleased - Patch]
+
+### Fixed
+
+- Fleet heartbeats and agent reads no longer amplify into workspace-wide D1 maintenance scans; pending delivery views also exclude expired rows before cleanup runs.
 
 ## [8.2.0] - 2026-08-21
 

--- a/packages/engine/CHANGELOG.md
+++ b/packages/engine/CHANGELOG.md
@@ -7,7 +7,12 @@ See the [root changelog](../../CHANGELOG.md) for cross-package release highlight
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [Unreleased - Patch]
+
+### Fixed
+
+- Steady node heartbeats no longer re-scan pending workspace invocations; drains now run when reconnect, handler-liveness, or capacity transitions make queued work dispatchable.
+- Agent reads derive presence without issuing cleanup writes, and migration `0042_d1_read_path_indexes.sql` indexes scheduled presence cleanup plus active, unexpired delivery reads.
 
 ## [8.2.0] - 2026-08-21
 

--- a/packages/engine/src/__tests__/conformance/agentLifecycle.test.ts
+++ b/packages/engine/src/__tests__/conformance/agentLifecycle.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { and, eq } from 'drizzle-orm';
 import { actionInvocations, agentNodeBindings, agents, nodes, workspaceEvents } from '../../db/schema.js';
-import { AGENT_LIVENESS_TTL_MS } from '../../engine/agent.js';
+import { AGENT_LIVENESS_TTL_MS, sweepStaleAgents } from '../../engine/agent.js';
 import {
   attachDirectNodeSocket,
   createWorkspace,
@@ -16,7 +16,7 @@ describe('agent presence and release lifecycle', () => {
   beforeEach(() => { stack = makeNodeStack(); });
   afterEach(() => stack.close());
 
-  it('derives presence from last_seen and persists stale active agents offline', async () => {
+  it('derives stale presence without writing during a roster read', async () => {
     const ws = await createWorkspace(stack.app, 'agent-presence-expiry');
     const stale = await registerAgent(stack.app, ws.workspaceKey, 'stale-agent');
     await stack.runtime.deps.db
@@ -38,10 +38,17 @@ describe('agent presence and release lifecycle', () => {
       .select({ status: agents.status })
       .from(agents)
       .where(eq(agents.id, stale.agentId));
-    expect(persisted.status).toBe('offline');
+    expect(persisted.status).toBe('active');
+
+    expect(await sweepStaleAgents(stack.runtime.deps.db, ws.workspaceId)).toBe(1);
+    const [swept] = await stack.runtime.deps.db
+      .select({ status: agents.status })
+      .from(agents)
+      .where(eq(agents.id, stale.agentId));
+    expect(swept.status).toBe('offline');
   });
 
-  it('persists stale presence before returning agent detail', async () => {
+  it('derives stale presence without writing during an agent detail read', async () => {
     const ws = await createWorkspace(stack.app, 'agent-detail-presence-expiry');
     const stale = await registerAgent(stack.app, ws.workspaceKey, 'stale-detail-agent');
     await stack.runtime.deps.db
@@ -62,10 +69,10 @@ describe('agent presence and release lifecycle', () => {
       .select({ status: agents.status })
       .from(agents)
       .where(eq(agents.id, stale.agentId));
-    expect(persisted.status).toBe('offline');
+    expect(persisted.status).toBe('active');
   });
 
-  it('clamps a future last_seen before applying the liveness window', async () => {
+  it('leaves future last_seen untouched on reads and lets maintenance clamp it', async () => {
     const ws = await createWorkspace(stack.app, 'agent-future-presence');
     const target = await registerAgent(stack.app, ws.workspaceKey, 'future-agent');
     const beforeRead = Date.now();
@@ -83,14 +90,21 @@ describe('agent presence and release lifecycle', () => {
     expect(response.status).toBe(200);
     expect((await response.json() as { data: { status: string } }).data.status).toBe('active');
 
-    const afterRead = Date.now();
     const [persisted] = await stack.runtime.deps.db
       .select({ lastSeen: agents.lastSeen })
       .from(agents)
       .where(eq(agents.id, target.agentId));
+    expect(persisted.lastSeen.getTime()).toBeGreaterThan(beforeRead);
+
+    expect(await sweepStaleAgents(stack.runtime.deps.db, ws.workspaceId)).toBe(1);
+    const afterSweep = Date.now();
+    const [normalized] = await stack.runtime.deps.db
+      .select({ lastSeen: agents.lastSeen })
+      .from(agents)
+      .where(eq(agents.id, target.agentId));
     // SQLite timestamp mode stores whole seconds.
-    expect(persisted.lastSeen.getTime()).toBeGreaterThanOrEqual(beforeRead - 1_000);
-    expect(persisted.lastSeen.getTime()).toBeLessThanOrEqual(afterRead);
+    expect(normalized.lastSeen.getTime()).toBeGreaterThanOrEqual(beforeRead - 1_000);
+    expect(normalized.lastSeen.getTime()).toBeLessThanOrEqual(afterSweep);
   });
 
   it('atomically registers human rows with an implicit direct binding', async () => {

--- a/packages/engine/src/__tests__/conformance/delivery.test.ts
+++ b/packages/engine/src/__tests__/conformance/delivery.test.ts
@@ -338,6 +338,42 @@ describe('durable delivery api', () => {
     expect(queued!.status).toBe('queued');
   });
 
+  it('does not expose an expired unswept delivery as pending agent detail', async () => {
+    const { ws, bob } = await seed();
+    const [item] = await listDeliveries(bob.token);
+    await stack.runtime.deps.db
+      .update(deliveries)
+      .set({ expiresAt: new Date(Date.now() - 1_000) })
+      .where(eq(deliveries.id, item.id as string));
+
+    const res = await stack.app.request('/v1/agents/bob', {
+      headers: { authorization: `Bearer ${ws.workspaceKey}` },
+    });
+    expect(res.status).toBe(200);
+    const pending = ((await res.json()) as {
+      data: { pending_deliveries: Array<{ id: string }> };
+    }).data.pending_deliveries;
+    expect(pending.map((delivery) => delivery.id)).not.toContain(item.id);
+
+    const [stored] = await stack.runtime.deps.db
+      .select({ status: deliveries.status })
+      .from(deliveries)
+      .where(eq(deliveries.id, item.id as string));
+    expect(stored.status).toBe('queued');
+
+    const plan = stack.runtime.handle.sqlite
+      .prepare(`EXPLAIN QUERY PLAN
+        SELECT id FROM deliveries
+        WHERE workspace_id = ?
+          AND agent_id = ?
+          AND status IN ('queued', 'delivered')
+          AND (expires_at IS NULL OR expires_at > unixepoch())
+        ORDER BY created_at, id
+        LIMIT 50`)
+      .all(ws.workspaceId, bob.agentId) as Array<{ detail: string }>;
+    expect(plan.some((step) => step.detail.includes('idx_deliveries_agent_active_created'))).toBe(true);
+  });
+
   it('rejects a malformed JSON fail body with 400 (no state change)', async () => {
     const { bob } = await seed();
     const [item] = await listDeliveries(bob.token);

--- a/packages/engine/src/__tests__/conformance/node.test.ts
+++ b/packages/engine/src/__tests__/conformance/node.test.ts
@@ -1604,7 +1604,7 @@ describe('node adapter conformance', () => {
       expect(updated.attemptedNodeIds).toEqual(['node_alpha']);
     });
 
-    it('exported drain helper preserves spawn-prefixed actions and skips retry-delayed invocations', async () => {
+    it('exported drain helper preserves spawn-prefixed actions and only includes retry-delayed invocations when forced', async () => {
       const ws = await createWorkspace(stack.app, 'fleet-spawn-prefix-drain-helper-ws');
       const caller = await registerAgent(stack.app, ws.workspaceKey, 'caller');
       const alpha = await enrollAndAttachNode(ws, {
@@ -1674,6 +1674,19 @@ describe('node adapter conformance', () => {
       expect(delayed.spawnReservedAt).toBeNull();
       expect(delayed.retryAfterAt).toBeInstanceOf(Date);
       expect(delayed.retryAfterAt!.getTime()).toBeGreaterThan(Date.now());
+
+      alpha.sock.received.length = 0;
+      const forced = await drainNodeInvocations(
+        db,
+        stack.runtime.realtime,
+        ws.workspaceId,
+        'node_alpha',
+        { includeDeferred: true },
+      );
+      expect(forced).toBe(1);
+      expect(alpha.sock.ofType('action.invoke')).toEqual([
+        expect.objectContaining({ invocation_id: 'inv_spawn_future_retry' }),
+      ]);
     });
 
     it('exported drain helper releases spawn capacity when redispatch is rejected', async () => {
@@ -2025,7 +2038,11 @@ describe('node adapter conformance', () => {
         handlers_live: true,
       }));
       expect(drain).toHaveBeenCalledOnce();
-      expect(drain).toHaveBeenCalledWith(ws.workspaceId, 'node_alpha');
+      expect(drain).toHaveBeenCalledWith(
+        ws.workspaceId,
+        'node_alpha',
+        { includeDeferred: true },
+      );
     });
 
     it('publishes action.invoked to the workspace observer stream', async () => {

--- a/packages/engine/src/__tests__/conformance/node.test.ts
+++ b/packages/engine/src/__tests__/conformance/node.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { and, eq } from 'drizzle-orm';
 import { drainNodeInvocations, sweepTimedOutInvocations } from '../../index.js';
 import {
@@ -1987,6 +1987,45 @@ describe('node adapter conformance', () => {
       expect(stillNode.maxAgents).toBe(8);
       expect(stillNode.version).toBe('test-node-v2');
       expect(stillNode.capabilities.map((cap) => cap.name).sort()).toEqual(['echo', 'spawn:claude']);
+    });
+
+    it('does not scan pending invocations on steady heartbeats but drains when capacity becomes available', async () => {
+      const ws = await createWorkspace(stack.app, 'fleet-heartbeat-drain-transition-ws');
+      const alpha = await enrollAndAttachNode(ws, {
+        id: 'node_alpha',
+        name: 'alpha',
+        capabilities: [capability('spawn:claude', 'spawn', { agent: 'claude' })],
+        maxAgents: 1,
+      });
+      const drain = vi.spyOn(stack.runtime.realtime, 'drainNode');
+
+      await alpha.handle.handleMessage(JSON.stringify({
+        v: 1,
+        type: 'node.heartbeat',
+        load: 0,
+        active_agents: 0,
+        handlers_live: true,
+      }));
+      expect(drain).not.toHaveBeenCalled();
+
+      await alpha.handle.handleMessage(JSON.stringify({
+        v: 1,
+        type: 'node.heartbeat',
+        load: 1,
+        active_agents: 1,
+        handlers_live: true,
+      }));
+      expect(drain).not.toHaveBeenCalled();
+
+      await alpha.handle.handleMessage(JSON.stringify({
+        v: 1,
+        type: 'node.heartbeat',
+        load: 0,
+        active_agents: 0,
+        handlers_live: true,
+      }));
+      expect(drain).toHaveBeenCalledOnce();
+      expect(drain).toHaveBeenCalledWith(ws.workspaceId, 'node_alpha');
     });
 
     it('publishes action.invoked to the workspace observer stream', async () => {

--- a/packages/engine/src/adapters/node/realtime.ts
+++ b/packages/engine/src/adapters/node/realtime.ts
@@ -2,6 +2,7 @@ import type {
   RealtimeBus,
   ConnectionRegistry,
   NodeConnectionRegistry,
+  NodeDrainOptions,
   EngineEvent,
   UpgradeArgs,
   NodeUpgradeArgs,
@@ -587,10 +588,14 @@ export class InProcessRealtime implements RealtimeBus, ConnectionRegistry, NodeC
    * chained so two drains never run at once (which could double-reserve spawn
    * capacity); each caller's promise resolves after its own drain pass runs.
    */
-  drainNode(workspaceId: string, nodeId: string): Promise<void> {
+  drainNode(
+    workspaceId: string,
+    nodeId: string,
+    options?: NodeDrainOptions,
+  ): Promise<void> {
     const key = this.nodeKey(workspaceId, nodeId);
     const prior = this.nodeDrainChains.get(key) ?? Promise.resolve();
-    const next = prior.catch(() => {}).then(() => this.drainNodeQueue(workspaceId, nodeId));
+    const next = prior.catch(() => {}).then(() => this.drainNodeQueue(workspaceId, nodeId, options));
     this.nodeDrainChains.set(key, next);
     void next.finally(() => {
       if (this.nodeDrainChains.get(key) === next) this.nodeDrainChains.delete(key);
@@ -598,9 +603,13 @@ export class InProcessRealtime implements RealtimeBus, ConnectionRegistry, NodeC
     return next;
   }
 
-  private async drainNodeQueue(workspaceId: string, nodeId: string): Promise<void> {
+  private async drainNodeQueue(
+    workspaceId: string,
+    nodeId: string,
+    options?: NodeDrainOptions,
+  ): Promise<void> {
     if (!this.isNodeConnected(workspaceId, nodeId)) return;
-    await drainNodeInvocations(this.db, this, workspaceId, nodeId);
+    await drainNodeInvocations(this.db, this, workspaceId, nodeId, options);
     // The authoritative re-dispatch is DB-driven; clear the per-provider
     // in-memory buffers now that their frames have been re-sent.
     const nodeKey = this.nodeKey(workspaceId, nodeId);

--- a/packages/engine/src/adapters/node/realtime.ts
+++ b/packages/engine/src/adapters/node/realtime.ts
@@ -533,8 +533,8 @@ export class InProcessRealtime implements RealtimeBus, ConnectionRegistry, NodeC
       handleClose: async () => this.onNodeConnectionClose(connectionId),
     };
     // Best-effort early flush (covers non-spawn frames that need no capacity);
-    // the authoritative drain fires post node.register/heartbeat once the node
-    // is marked online, so queued spawns can reserve capacity. See drainNode.
+    // the authoritative drain fires after node.register and after heartbeat
+    // liveness/capacity transitions once the node is dispatchable. See drainNode.
     void this.drainNode(workspaceId, nodeId);
     return handle;
   }

--- a/packages/engine/src/db/migrations/0042_d1_read_path_indexes.sql
+++ b/packages/engine/src/db/migrations/0042_d1_read_path_indexes.sql
@@ -1,0 +1,13 @@
+-- Presence cleanup runs from host maintenance rather than roster reads. Keep
+-- both its future-clock normalization and stale-offline updates on the small
+-- active presence set, ordered by the timestamp range each update applies.
+CREATE INDEX IF NOT EXISTS idx_agents_active_last_seen
+  ON agents(last_seen)
+  WHERE status IN ('active', 'online');
+
+-- Agent detail and mailbox replay only need non-terminal delivery rows. Match
+-- the request scope and FIFO order while excluding retained terminal history;
+-- the read predicate still filters any expired row awaiting the scheduled sweep.
+CREATE INDEX IF NOT EXISTS idx_deliveries_agent_active_created
+  ON deliveries(workspace_id, agent_id, created_at, id)
+  WHERE status IN ('queued', 'delivered');

--- a/packages/engine/src/db/schema.ts
+++ b/packages/engine/src/db/schema.ts
@@ -119,6 +119,9 @@ export const agents = sqliteTable(
     index('idx_agents_workspace').on(table.workspaceId),
     index('idx_agents_token').on(table.tokenHash),
     index('idx_agents_previous_token').on(table.previousTokenHash),
+    index('idx_agents_active_last_seen')
+      .on(table.lastSeen)
+      .where(sql`${table.status} IN ('active', 'online')`),
   ],
 );
 
@@ -1139,6 +1142,9 @@ export const deliveries = sqliteTable(
     uniqueIndex('deliveries_agent_seq_unique').on(table.workspaceId, table.agentId, table.seq),
     index('idx_deliveries_agent').on(table.agentId, table.createdAt),
     index('idx_deliveries_agent_status_seq').on(table.workspaceId, table.agentId, table.status, table.seq),
+    index('idx_deliveries_agent_active_created')
+      .on(table.workspaceId, table.agentId, table.createdAt, table.id)
+      .where(sql`${table.status} IN ('queued', 'delivered')`),
     index('idx_deliveries_expires').on(table.workspaceId, table.status, table.expiresAt),
     index('idx_deliveries_active_expiry')
       .on(table.expiresAt, table.id)

--- a/packages/engine/src/engine/action.ts
+++ b/packages/engine/src/engine/action.ts
@@ -12,7 +12,7 @@ import {
   fleetInvocationId,
   type InvocationCompletionDeps,
 } from './invocationCompletion.js';
-import type { NodeConnectionRegistry } from '../ports/realtime.js';
+import type { NodeConnectionRegistry, NodeDrainOptions } from '../ports/realtime.js';
 import { runAtomic, runAtomicWrites, type AtomicWrite } from '../ports/database.js';
 import { claimSpawnNode, chooseNodeForAction, isNodeLive, releaseNodeCapacity, reserveNodeCapacity } from './placement.js';
 import { DEFAULT_PROVIDER_NAME, capacityProviderName, getProvider, isProviderLive } from './nodeProvider.js';
@@ -1619,6 +1619,7 @@ export async function drainNodeInvocations(
   registry: NodeConnectionRegistry,
   workspaceId: string,
   nodeId: string,
+  options: NodeDrainOptions = {},
 ): Promise<number> {
   const now = new Date();
   const rows = await db
@@ -1643,7 +1644,9 @@ export async function drainNodeInvocations(
     .where(and(
       eq(actionInvocations.workspaceId, workspaceId),
       eq(actionInvocations.status, 'pending'),
-      or(isNull(actionInvocations.retryAfterAt), lte(actionInvocations.retryAfterAt, now)),
+      options.includeDeferred
+        ? undefined
+        : or(isNull(actionInvocations.retryAfterAt), lte(actionInvocations.retryAfterAt, now)),
       or(
         eq(actionInvocations.dispatchedNodeId, nodeId),
         eq(actions.handlerNodeId, nodeId),

--- a/packages/engine/src/engine/agent.ts
+++ b/packages/engine/src/engine/agent.ts
@@ -1,4 +1,4 @@
-import { eq, and, gt, lt, ne, inArray, sql } from 'drizzle-orm';
+import { eq, and, gt, lt, ne, sql } from 'drizzle-orm';
 import type { getDb } from '../db/index.js';
 import { agents, agentNodeBindings, agentRecoveryCredentials, channels, channelMembers, dmParticipants, actions, deliveries, nodes } from '../db/schema.js';
 import { randomHex, sha256Hex } from '../lib/crypto.js';
@@ -313,9 +313,6 @@ export async function registerAgent(
 }
 
 export async function listAgents(db: Db, workspaceId: string, status?: string) {
-  // Keep the durable state aligned as a cleanup side effect, while still
-  // deriving below so correctness never depends on a cron/sweep having run.
-  await sweepStaleAgents(db, workspaceId);
   const rows = await db
     .select()
     .from(agents)
@@ -339,9 +336,6 @@ export async function listAgents(db: Db, workspaceId: string, status?: string) {
 }
 
 export async function getAgentByName(db: Db, workspaceId: string, name: string) {
-  // Match roster reads: detail consumers should observe both derived and
-  // durable presence consistently within this workspace.
-  await sweepStaleAgents(db, workspaceId);
   const [agent] = await db
     .select()
     .from(agents)
@@ -383,10 +377,17 @@ export async function getAgentByName(db: Db, workspaceId: string, name: string) 
         createdAt: deliveries.createdAt,
       })
       .from(deliveries)
-      // Mirror the GET /v1/deliveries replay queue: queued + delivered are the
-      // non-terminal, still-pending states.
-      .where(and(eq(deliveries.agentId, agent.id), inArray(deliveries.status, ['queued', 'delivered'])))
-      .orderBy(deliveries.createdAt)
+      // Keep this detail projection aligned with GET /v1/deliveries: an
+      // expired row is no longer pending even if scheduled maintenance has not
+      // transitioned its durable status yet. Keep the active predicate literal
+      // so SQLite can use idx_deliveries_agent_active_created.
+      .where(and(
+        eq(deliveries.workspaceId, workspaceId),
+        eq(deliveries.agentId, agent.id),
+        sql`${deliveries.status} IN ('queued', 'delivered')`,
+        sql`(${deliveries.expiresAt} IS NULL OR ${deliveries.expiresAt} > unixepoch())`,
+      ))
+      .orderBy(deliveries.createdAt, deliveries.id)
       .limit(50),
   ]);
 
@@ -659,7 +660,9 @@ export async function sweepStaleAgents(db: Db, workspaceId?: string): Promise<nu
   const now = new Date();
   const cutoff = new Date(now.getTime() - AGENT_LIVENESS_TTL_MS);
   const future = and(
-    inArray(agents.status, ['active', 'online']),
+    // Keep this literal aligned with idx_agents_active_last_seen. SQLite cannot
+    // prove a parameterized IN predicate implies a partial-index predicate.
+    sql`${agents.status} IN ('active', 'online')`,
     gt(agents.lastSeen, now),
     ...(workspaceId ? [eq(agents.workspaceId, workspaceId)] : []),
   );
@@ -669,7 +672,7 @@ export async function sweepStaleAgents(db: Db, workspaceId?: string): Promise<nu
     .where(future)
     .returning({ id: agents.id });
   const stale = and(
-    inArray(agents.status, ['active', 'online']),
+    sql`${agents.status} IN ('active', 'online')`,
     lt(agents.lastSeen, cutoff),
     ...(workspaceId ? [eq(agents.workspaceId, workspaceId)] : []),
   );

--- a/packages/engine/src/engine/delivery.ts
+++ b/packages/engine/src/engine/delivery.ts
@@ -95,7 +95,10 @@ export async function listDeliveries(
   const limit = Math.min(Math.max(opts.limit ?? 100, 1), 200);
   const statusFilter = opts.status
     ? eq(deliveries.status, opts.status)
-    : inArray(deliveries.status, [...ACTIVE_DELIVERY_STATUSES]);
+    // Keep the default active predicate literal so SQLite can use the partial
+    // idx_deliveries_agent_active_created index. Explicit status queries
+    // intentionally continue to reflect durable stored state.
+    : sql`${deliveries.status} IN ('queued', 'delivered')`;
   // A bounded workspace sweep may spend its batch on another agent's older
   // backlog. Never expose this agent's still-unswept expired rows through the
   // default active queue; explicit status queries continue to reflect stored state.

--- a/packages/engine/src/engine/node.ts
+++ b/packages/engine/src/engine/node.ts
@@ -25,11 +25,12 @@ import { isProviderAgentDeliveryReady, type NodeConnectionRegistry } from '../po
 import { generateId } from './snowflake.js';
 import { assertRegistrableAgentName } from './agent.js';
 import { rotateAgentIdentity } from './agentIdentity.js';
-import { isNodeLive, nodeHasCapability } from './placement.js';
+import { isNodeLive, nodeHasCapacity, nodeHasCapability } from './placement.js';
 import {
   DEFAULT_PROVIDER_NAME,
   capabilityKind,
   heartbeatProvider,
+  isProviderLive,
   markProviderOffline,
   materializeProviderActions,
   recomputeNodeAggregate,
@@ -1691,6 +1692,68 @@ async function readNodeStatus(db: Db, workspaceId: string, nodeId: string): Prom
   return row?.status;
 }
 
+async function readHeartbeatDrainState(
+  db: Db,
+  workspaceId: string,
+  nodeId: string,
+  providerName: string,
+) {
+  const [nodeRows, providerRows] = await Promise.all([
+    db
+      .select({
+        status: nodes.status,
+        handlersLive: nodes.handlersLive,
+        maxAgents: nodes.maxAgents,
+        activeAgents: nodes.activeAgents,
+        reservedAgents: nodes.reservedAgents,
+        lastHeartbeatAt: nodes.lastHeartbeatAt,
+      })
+      .from(nodes)
+      .where(and(eq(nodes.workspaceId, workspaceId), eq(nodes.id, nodeId))),
+    db
+      .select({
+        status: nodeProviders.status,
+        handlersLive: nodeProviders.handlersLive,
+        lastHeartbeatAt: nodeProviders.lastHeartbeatAt,
+      })
+      .from(nodeProviders)
+      .where(and(
+        eq(nodeProviders.workspaceId, workspaceId),
+        eq(nodeProviders.nodeId, nodeId),
+        eq(nodeProviders.name, providerName),
+      )),
+  ]);
+  return { node: nodeRows[0], provider: providerRows[0] };
+}
+
+/**
+ * A steady heartbeat only refreshes liveness metadata; draining every such
+ * frame turns node cadence into a workspace-wide pending-invocation scan. A
+ * drain is needed only when the heartbeat makes queued work dispatchable.
+ */
+function shouldDrainAfterHeartbeat(
+  prior: Awaited<ReturnType<typeof readHeartbeatDrainState>>,
+  current: ReturnType<typeof publicNode> | null,
+  message: FleetNodeHeartbeatMessage,
+): boolean {
+  if (!current?.live) return false;
+  if (!prior.node || !isNodeLive(prior.node)) return true;
+  if (!prior.node.handlersLive && current.handlers_live) return true;
+
+  // A provider can become dispatchable while another provider kept the node's
+  // aggregate handlers_live flag true, so preserve the provider transition too.
+  if (
+    message.handlers_live
+    && (!prior.provider || !isProviderLive(prior.provider) || !prior.provider.handlersLive)
+  ) {
+    return true;
+  }
+
+  const currentHasCapacity = current.max_agents === 0
+    || current.active_agents + prior.node.reservedAgents < current.max_agents;
+  return !nodeHasCapacity(prior.node) && currentHasCapacity;
+}
+
 /**
  * Emit a durable `node.status.online` only on a real offline -> online
  * transition: the node was not `online` before the register/heartbeat and the
@@ -1842,16 +1905,21 @@ export async function handleNodeControlMessage(args: HandleNodeControlMessageArg
         return;
       }
       case 'node.heartbeat': {
-        const priorStatus = await readNodeStatus(args.db, args.workspaceId, args.nodeId);
+        const prior = await readHeartbeatDrainState(
+          args.db,
+          args.workspaceId,
+          args.nodeId,
+          frameProviderName,
+        );
         const beat = await heartbeatNode(args.db, args.workspaceId, args.nodeId, frameProviderName, message);
         // The node row is already persisted, so emit the durable online
         // transition before draining: a drainNode rejection must not skip the
         // node.status.online event. Isolated so its own failure can't either.
-        await emitNodeOnlineTransition(args.completionDeps, args.workspaceId, priorStatus, beat)
+        await emitNodeOnlineTransition(args.completionDeps, args.workspaceId, prior.node?.status, beat)
           .catch((err) => console.error('[node.status] online event emission failed', err));
-        // Heartbeat refreshes online/capacity state; re-drain as a backstop in
-        // case a queued spawn could not reserve capacity at register time.
-        await args.registry.drainNode(args.workspaceId, args.nodeId);
+        if (shouldDrainAfterHeartbeat(prior, beat, message)) {
+          await args.registry.drainNode(args.workspaceId, args.nodeId);
+        }
         return;
       }
       case 'node.deregister':

--- a/packages/engine/src/engine/node.ts
+++ b/packages/engine/src/engine/node.ts
@@ -1885,7 +1885,9 @@ export async function handleNodeControlMessage(args: HandleNodeControlMessageArg
           .catch((err) => console.error('[node.status] online event emission failed', err));
         // Node is now marked online: flush any queued action.invoke frames so
         // spawns queued while it was offline can reserve capacity and dispatch.
-        await args.registry.drainNode(args.workspaceId, args.nodeId);
+        // Reconnect makes deferred work dispatchable too; bypass a retry delay
+        // that may have been armed only because the prior socket was unavailable.
+        await args.registry.drainNode(args.workspaceId, args.nodeId, { includeDeferred: true });
         // The success reply was already sent above; keep the pending flush
         // best-effort so a delivery error cannot trigger a second error reply
         // for the same request id from the outer catch.
@@ -1918,7 +1920,10 @@ export async function handleNodeControlMessage(args: HandleNodeControlMessageArg
         await emitNodeOnlineTransition(args.completionDeps, args.workspaceId, prior.node?.status, beat)
           .catch((err) => console.error('[node.status] online event emission failed', err));
         if (shouldDrainAfterHeartbeat(prior, beat, message)) {
-          await args.registry.drainNode(args.workspaceId, args.nodeId);
+          // A readiness transition invalidates the old backoff condition. Include
+          // retry-delayed rows in this one bounded pass so a transition just
+          // before retryAfterAt cannot strand work until another reconnect.
+          await args.registry.drainNode(args.workspaceId, args.nodeId, { includeDeferred: true });
         }
         return;
       }

--- a/packages/engine/src/ports/realtime.ts
+++ b/packages/engine/src/ports/realtime.ts
@@ -62,6 +62,11 @@ export interface NodeUpgradeArgs {
   originActor?: string;
 }
 
+export interface NodeDrainOptions {
+  /** Include pending rows whose prior retry deadline has not elapsed yet. */
+  includeDeferred?: boolean;
+}
+
 export interface NodeConnectionRegistry {
   /**
    * Upgrade an incoming node-control request. Cloudflare adapters own the 101
@@ -189,7 +194,11 @@ export interface NodeConnectionRegistry {
    * when heartbeat liveness/capacity transitions make queued work dispatchable.
    * Implementations serialize concurrent drains per node.
    */
-  drainNode(workspaceId: string, nodeId: string): Promise<void>;
+  drainNode(
+    workspaceId: string,
+    nodeId: string,
+    options?: NodeDrainOptions,
+  ): Promise<void>;
 }
 
 /** Registries without cursor-readiness support retain legacy immediate delivery. */

--- a/packages/engine/src/ports/realtime.ts
+++ b/packages/engine/src/ports/realtime.ts
@@ -185,8 +185,8 @@ export interface NodeConnectionRegistry {
 
   /**
    * Flush any queued `action.invoke` frames to the node's live connection.
-   * Must be invoked once the node is marked online (post node.register /
-   * node.heartbeat) so capacity reservation for queued spawns can succeed.
+   * Must be invoked once the node is marked online (post node.register) and
+   * when heartbeat liveness/capacity transitions make queued work dispatchable.
    * Implementations serialize concurrent drains per node.
    */
   drainNode(workspaceId: string, nodeId: string): Promise<void>;

--- a/packages/sdk-rust/src/ws.rs
+++ b/packages/sdk-rust/src/ws.rs
@@ -611,7 +611,7 @@ fn node_heartbeat(registration: &NodeRegistration) -> serde_json::Value {
 async fn send_node_register<S>(
     write: &mut S,
     registration: &NodeRegistration,
-) -> std::result::Result<(), Box<tokio_tungstenite::tungstenite::Error>>
+) -> std::result::Result<(), tokio_tungstenite::tungstenite::Error>
 where
     S: Sink<Message, Error = tokio_tungstenite::tungstenite::Error> + Unpin,
 {
@@ -627,10 +627,7 @@ where
         "version": SDK_VERSION,
         "resume_cursor": null,
     });
-    write
-        .send(Message::Text(msg.to_string()))
-        .await
-        .map_err(Box::new)
+    write.send(Message::Text(msg.to_string())).await
 }
 
 fn node_delivery_ack(value: &serde_json::Value) -> Option<serde_json::Value> {

--- a/packages/sdk-rust/src/ws.rs
+++ b/packages/sdk-rust/src/ws.rs
@@ -604,7 +604,7 @@ fn node_heartbeat(registration: &NodeRegistration) -> serde_json::Value {
 async fn send_node_register<S>(
     write: &mut S,
     registration: &NodeRegistration,
-) -> std::result::Result<(), tokio_tungstenite::tungstenite::Error>
+) -> std::result::Result<(), Box<tokio_tungstenite::tungstenite::Error>>
 where
     S: Sink<Message, Error = tokio_tungstenite::tungstenite::Error> + Unpin,
 {
@@ -620,7 +620,10 @@ where
         "version": SDK_VERSION,
         "resume_cursor": null,
     });
-    write.send(Message::Text(msg.to_string())).await
+    write
+        .send(Message::Text(msg.to_string()))
+        .await
+        .map_err(Box::new)
 }
 
 fn node_delivery_ack(value: &serde_json::Value) -> Option<serde_json::Value> {


### PR DESCRIPTION
## Summary

- stop steady fleet heartbeats from draining and scanning all pending workspace invocations
- remove stale-presence UPDATE sweeps from roster and agent-detail reads
- exclude expired pending deliveries at read time and add partial indexes for active presence and delivery paths
- preserve drains on reconnect, handler-liveness, provider-liveness, and capacity-available transitions

## Root cause

The prior query-plan fix made the pending-invocation scan cheaper, but the scan was still triggered by every node heartbeat. Agent reads also performed two presence UPDATE sweeps, and agent detail could walk retained delivery history. These request-amplification paths kept D1 work high even with the query-plan regression fixed.

## Validation

- `mise exec node@22 -- npx turbo build`
- `mise exec node@22 -- npx turbo test` (67 engine files / 680 engine tests; all workspace tasks green)
- `mise exec node@22 -- npx turbo lint`
- focused engine conformance tests: 100 passed
- `git diff --check`

## Deployment

Includes migration `0042_d1_read_path_indexes.sql`. A companion relaycast-cloud change provisions the missing Cloudflare Cron Trigger and moves durable presence cleanup onto scheduled maintenance.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/AgentWorkforce/relaycast/pull/350?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

