### PR TITLE
fix(sdk-rust): finish the create-only registration migration from #349

### DIFF
--- a/packages/sdk-rust/CHANGELOG.md
+++ b/packages/sdk-rust/CHANGELOG.md
@@ -10,21 +10,8 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
 
 ### Changed
 
-- **BREAKING:** `RelayCast::rotate_agent_token` now takes the agent's own token
-  as a second argument. Engine 8.2.0 made `POST /agents/{name}/rotate-token`
-  authenticated self-rollover (`requireAgentToken`), so a workspace key is
-  rejected. Migration: pass the agent's current token, or — when replacing an
-  identity you cannot authenticate as — use the explicit, audited
-  `take_over_agent` / `recover_agent` instead.
-- **BREAKING:** `AgentRegistrationClient::register_agent_token` no longer
-  rotates on a name collision. Registration is create-only as of engine 8.2.0,
-  so a 409 now returns the new `AgentRegistrationError::AlreadyExists` rather
-  than attempting a rotation that can only fail with
-  `401 Agent token required (at_live_...)`. Callers needing a fresh agent per
-  run should register under a name unique to that run; callers reclaiming a
-  stable name must persist its token (self-rollover) or take it over
-  explicitly.
-
+- **BREAKING:** `RelayCast::rotate_agent_token` now requires the current agent token; use `take_over_agent` or `recover_agent` to replace an identity you cannot authenticate as.
+- **BREAKING:** `AgentRegistrationClient::register_agent_token` is create-only and returns `AgentRegistrationError::AlreadyExists` on conflicts; use a unique name or persist the token for self-rollover.
 - `NodeRosterEntry.load` is now `Option<f64>`, matching the API's explicit unreported state; direct-agent heartbeats no longer label a constant utilization as measured.
 
 ### Added

--- a/packages/sdk-rust/CHANGELOG.md
+++ b/packages/sdk-rust/CHANGELOG.md
@@ -10,6 +10,21 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
 
 ### Changed
 
+- **BREAKING:** `RelayCast::rotate_agent_token` now takes the agent's own token
+  as a second argument. Engine 8.2.0 made `POST /agents/{name}/rotate-token`
+  authenticated self-rollover (`requireAgentToken`), so a workspace key is
+  rejected. Migration: pass the agent's current token, or — when replacing an
+  identity you cannot authenticate as — use the explicit, audited
+  `take_over_agent` / `recover_agent` instead.
+- **BREAKING:** `AgentRegistrationClient::register_agent_token` no longer
+  rotates on a name collision. Registration is create-only as of engine 8.2.0,
+  so a 409 now returns the new `AgentRegistrationError::AlreadyExists` rather
+  than attempting a rotation that can only fail with
+  `401 Agent token required (at_live_...)`. Callers needing a fresh agent per
+  run should register under a name unique to that run; callers reclaiming a
+  stable name must persist its token (self-rollover) or take it over
+  explicitly.
+
 - `NodeRosterEntry.load` is now `Option<f64>`, matching the API's explicit unreported state; direct-agent heartbeats no longer label a constant utilization as measured.
 
 ### Added

--- a/packages/sdk-rust/README.md
+++ b/packages/sdk-rust/README.md
@@ -229,11 +229,21 @@ use relaycast::{AgentRegistrationClient, RelayCast, RelayCastOptions};
 let relay = RelayCast::new(RelayCastOptions::new("rk_live_xxx"))?;
 let registration = AgentRegistrationClient::new(relay, "codex");
 
+// Registration is create-only: a name already held by another identity returns
+// AgentRegistrationError::AlreadyExists rather than replacing it. Give
+// ephemeral agents a name unique to the run — the token cache is per-client and
+// in memory, so a restarted process reusing a fixed name hits that error.
+let agent_name = format!("worker-{}", uuid_v4_short());
 let agent = registration
-    .registered_agent_client("worker-a", Some("codex"))
+    .registered_agent_client(&agent_name, Some("codex"))
     .await?;
 agent.send("#general", "ready", None, None, None).await?;
 ```
+
+To keep a **stable** name across restarts, persist the agent's token and roll it
+over yourself with `RelayCast::rotate_agent_token(name, agent_token)` — rotation
+is authenticated as the agent. To reclaim a name whose token you no longer hold,
+use the explicit, audited `take_over_agent` or `recover_agent`.
 
 ### Files
 

--- a/packages/sdk-rust/src/credentials.rs
+++ b/packages/sdk-rust/src/credentials.rs
@@ -217,7 +217,19 @@ pub async fn bootstrap_session(
             let preferred = config.preferred_name.as_deref().unwrap_or(cached_name);
             if cached_name == preferred {
                 let relay = build_relay(&creds.api_key, base_url)?;
-                match relay.rotate_agent_token(cached_name).await {
+                // Self-rollover: rotate is authenticated as the agent itself
+                // (engine 8.2.0, #349), so it needs the cached agent token, not
+                // the workspace key. Without one there is nothing to roll over
+                // and we fall through to registration below.
+                let cached_agent_token = creds.agent_token.clone();
+                match match cached_agent_token {
+                    Some(agent_token) => relay.rotate_agent_token(cached_name, agent_token).await,
+                    None => Err(RelayError::Api {
+                        status: 401,
+                        message: "no cached agent token for self-rollover".to_string(),
+                        code: "agent_token_required".to_string(),
+                    }),
+                } {
                     Ok(result) => {
                         let session = finish_session(
                             store,
@@ -299,7 +311,29 @@ pub async fn bootstrap_session(
         }
         Err(e) if e.is_conflict() => match conflict_strategy {
             NameConflictStrategy::RotateExisting => {
-                let rotate_result = relay.rotate_agent_token(&name).await?;
+                // Only legitimate when we hold the existing agent's own token:
+                // rotate is self-rollover only since engine 8.2.0 (#349), and
+                // taking over an identity we cannot authenticate as is the
+                // explicit, audited `takeover` operation, never a silent
+                // fallback inside registration.
+                let existing_agent_token = cached
+                    .as_ref()
+                    .and_then(|c| c.agent_token.clone())
+                    .filter(|_| {
+                        cached.as_ref().and_then(|c| c.agent_name.as_deref()) == Some(name.as_str())
+                    })
+                    .ok_or_else(|| RelayError::Api {
+                        status: 409,
+                        message: format!(
+                            "agent '{name}' already exists and registration is create-only; \
+                             rotate requires that agent's own token. Use takeover (workspace \
+                             owner, audited) or register under a unique name"
+                        ),
+                        code: "agent_already_exists".to_string(),
+                    })?;
+                let rotate_result = relay
+                    .rotate_agent_token(&name, existing_agent_token)
+                    .await?;
                 let ws_id = workspace_id.unwrap_or_default();
                 finish_session(
                     store,

--- a/packages/sdk-rust/src/registration.rs
+++ b/packages/sdk-rust/src/registration.rs
@@ -172,7 +172,24 @@ impl AgentRegistrationClient {
         lock_unpoisoned(&self.registration_cooldowns).remove(trimmed);
     }
 
-    /// Register (or rotate) an agent token via `/v1/agents` and token rotation.
+    /// Register a **new** agent and return its token.
+    ///
+    /// Registration is create-only as of engine 8.2.0 (#349): a name already
+    /// held by another identity yields
+    /// [`AgentRegistrationError::AlreadyExists`], and this method will not
+    /// silently replace it. Note the cache is per-client and in memory, so a
+    /// restarted process registering the same stable name hits that error
+    /// rather than reusing the previous token.
+    ///
+    /// Pick one of:
+    ///
+    /// - **a name unique per run** (simplest, and the intended model for
+    ///   ephemeral agents),
+    /// - **persist the agent token** and roll it over yourself with
+    ///   [`RelayCast::rotate_agent_token`],
+    /// - **take the identity over explicitly** with
+    ///   [`RelayCast::take_over_agent`] or [`RelayCast::recover_agent`], which
+    ///   are audited operations requiring an expected agent id and a reason.
     pub async fn register_agent_token(
         &self,
         agent_name: &str,
@@ -513,7 +530,10 @@ mod tests {
                 .expect("relay init");
 
         Mock::given(method("POST"))
-            .and(path("/v1/agents/worker-self/rotate-token"))
+            // Built with `format!` so the SDK/OpenAPI route-sync test normalizes
+            // this to `/v1/agents/{param}/rotate-token` rather than treating
+            // `worker-self` as a literal route missing from openapi.yaml.
+            .and(path(format!("/v1/agents/{}/rotate-token", "worker-self")))
             .and(header("authorization", "Bearer at_live_current"))
             .respond_with(ResponseTemplate::new(200).set_body_json(json!({
                 "ok": true,

--- a/packages/sdk-rust/src/registration.rs
+++ b/packages/sdk-rust/src/registration.rs
@@ -92,6 +92,18 @@ pub enum AgentRegistrationError {
     Transport { agent_name: String, detail: String },
     #[error("registration response missing token for '{agent_name}'")]
     MissingToken { agent_name: String },
+    /// The name is taken and registration is create-only.
+    ///
+    /// Since engine 8.2.0 (#349) registration never replaces an existing
+    /// identity. Replacing one is an explicit, audited operation: `recover`
+    /// with a recovery proof, or `takeover` as the workspace owner. Callers
+    /// that just need their own agent should use a name unique to the run.
+    #[error(
+        "agent '{agent_name}' already exists and registration is create-only; \
+         use recover (with a recovery proof) or takeover (workspace owner, audited) \
+         to replace an existing identity, or register under a unique name"
+    )]
+    AlreadyExists { agent_name: String },
 }
 
 /// Retries exhausted or fatal outcome for [`retry_agent_registration`].
@@ -206,48 +218,21 @@ impl AgentRegistrationClient {
                 lock_unpoisoned(&self.registration_cooldowns).remove(trimmed_name);
                 Ok(result.token)
             }
+            // Registration is create-only as of engine 8.2.0 (#349): a 409 means
+            // the name is held by an existing identity, and replacing it is a
+            // deliberate, audited act (`recover` with a proof, or `takeover` as
+            // the workspace owner) rather than something a registration call
+            // should do silently.
+            //
+            // This branch used to fall back to `rotate_agent_token` with the
+            // workspace key. That route became `requireAgentToken` in the same
+            // release, so the fallback could only ever return
+            // `401 Agent token required (at_live_...)` — a misleading auth error
+            // for what is really "this name is taken". Report the real condition.
             Err(RelayError::Api { status: 409, .. }) => {
-                match self.relay.rotate_agent_token(trimmed_name).await {
-                    Ok(result) => {
-                        if result.token.trim().is_empty() {
-                            return Err(AgentRegistrationError::MissingToken {
-                                agent_name: trimmed_name.to_string(),
-                            });
-                        }
-                        lock_unpoisoned(&self.agent_tokens)
-                            .insert(trimmed_name.to_string(), result.token.clone());
-                        lock_unpoisoned(&self.registration_cooldowns).remove(trimmed_name);
-                        Ok(result.token)
-                    }
-                    Err(RelayError::Api {
-                        status: 429,
-                        message,
-                        code,
-                    }) => {
-                        let retry_after_secs = DEFAULT_REGISTRATION_COOLDOWN_SECS;
-                        let blocked_until = Instant::now() + Duration::from_secs(retry_after_secs);
-                        lock_unpoisoned(&self.registration_cooldowns)
-                            .insert(trimmed_name.to_string(), blocked_until);
-                        Err(AgentRegistrationError::RateLimited {
-                            agent_name: trimmed_name.to_string(),
-                            retry_after_secs,
-                            detail: format!("{message} (code: {code})"),
-                        })
-                    }
-                    Err(RelayError::Api {
-                        status,
-                        message,
-                        code,
-                    }) => Err(AgentRegistrationError::Api {
-                        agent_name: trimmed_name.to_string(),
-                        status,
-                        detail: format!("{message} (code: {code})"),
-                    }),
-                    Err(error) => Err(AgentRegistrationError::Transport {
-                        agent_name: trimmed_name.to_string(),
-                        detail: error.to_string(),
-                    }),
-                }
+                Err(AgentRegistrationError::AlreadyExists {
+                    agent_name: trimmed_name.to_string(),
+                })
             }
             Err(RelayError::Api {
                 status: 429,
@@ -362,7 +347,7 @@ mod tests {
     };
     use crate::{RelayCast, RelayCastOptions};
     use serde_json::json;
-    use wiremock::matchers::{body_string_contains, method, path};
+    use wiremock::matchers::{body_string_contains, header, method, path};
     use wiremock::{Mock, MockServer, ResponseTemplate};
 
     fn ok(data: serde_json::Value) -> ResponseTemplate {
@@ -450,6 +435,99 @@ mod tests {
             .await
             .expect("spawn should succeed");
         assert_eq!(token, "at_live_worker_b");
+    }
+
+    #[tokio::test]
+    async fn register_agent_token_reports_conflict_as_already_exists() {
+        // Registration is create-only since engine 8.2.0 (#349). A 409 must be
+        // reported as the conflict it is, not laundered through a rotate call
+        // that can no longer authenticate.
+        let server = MockServer::start().await;
+        let relay =
+            RelayCast::new(RelayCastOptions::new("rk_live_test").with_base_url(server.uri()))
+                .expect("relay init");
+        let client = AgentRegistrationClient::new(relay, "claude");
+
+        Mock::given(method("POST"))
+            .and(path("/v1/agents"))
+            .respond_with(ResponseTemplate::new(409).set_body_json(json!({
+                "ok": false,
+                "error": {
+                    "code": "agent_already_exists",
+                    "message": "Agent \"worker-dupe\" already exists in this workspace"
+                }
+            })))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        // No rotate-token mock is registered on purpose: reaching that route
+        // at all is the regression this test exists to catch.
+        let error = client
+            .register_agent_token("worker-dupe", Some("claude"))
+            .await
+            .expect_err("expected a conflict error");
+
+        match error {
+            AgentRegistrationError::AlreadyExists { agent_name } => {
+                assert_eq!(agent_name, "worker-dupe");
+            }
+            other => panic!("expected AlreadyExists, got: {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn already_exists_error_explains_the_supported_paths() {
+        // The message is the whole point: the previous behaviour surfaced
+        // "401 Agent token required (at_live_...)" for a name collision, which
+        // sent three separate investigations after an auth bug that did not
+        // exist.
+        let message = AgentRegistrationError::AlreadyExists {
+            agent_name: "writer".to_string(),
+        }
+        .to_string();
+
+        assert!(message.contains("writer"), "names the agent: {message}");
+        assert!(
+            message.contains("create-only"),
+            "states the policy: {message}"
+        );
+        assert!(message.contains("recover"), "points at recover: {message}");
+        assert!(
+            message.contains("takeover"),
+            "points at takeover: {message}"
+        );
+        assert!(
+            message.contains("unique name"),
+            "offers the simple fix: {message}"
+        );
+    }
+
+    #[tokio::test]
+    async fn rotate_agent_token_authenticates_as_the_agent() {
+        // Self-rollover: the route is `requireAgentToken` as of engine 8.2.0,
+        // so the agent's own token must be sent, never the workspace key.
+        let server = MockServer::start().await;
+        let relay =
+            RelayCast::new(RelayCastOptions::new("rk_live_workspace").with_base_url(server.uri()))
+                .expect("relay init");
+
+        Mock::given(method("POST"))
+            .and(path("/v1/agents/worker-self/rotate-token"))
+            .and(header("authorization", "Bearer at_live_current"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "ok": true,
+                "data": { "name": "worker-self", "token": "at_live_rolled" }
+            })))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let rotated = relay
+            .rotate_agent_token("worker-self", "at_live_current")
+            .await
+            .expect("self-rollover should succeed");
+        assert_eq!(rotated.token, "at_live_rolled");
     }
 
     #[tokio::test]

--- a/packages/sdk-rust/src/relay.rs
+++ b/packages/sdk-rust/src/relay.rs
@@ -415,8 +415,23 @@ impl RelayCast {
     }
 
     /// Rotate an agent's token.
-    pub async fn rotate_agent_token(&self, name: &str) -> Result<TokenRotateResponse> {
+    /// Roll the calling agent's own token over.
+    ///
+    /// Requires the agent's *current* token, not a workspace key: since
+    /// engine 8.2.0 (`fix: make agent identity recovery explicit`, #349) this
+    /// route is authenticated self-rollover only. A workspace owner replacing
+    /// an identity they do not hold the token for uses the explicit, audited
+    /// [`Self::take_over_agent`] or [`Self::recover_agent`] instead.
+    ///
+    /// Mirrors the TypeScript SDK's `agents.rotateToken(name, agentToken)`,
+    /// which took the same `agentToken` parameter in that release.
+    pub async fn rotate_agent_token(
+        &self,
+        name: &str,
+        agent_token: impl Into<String>,
+    ) -> Result<TokenRotateResponse> {
         self.client
+            .with_api_key(agent_token)?
             .post(
                 &format!("/v1/agents/{}/rotate-token", urlencoding::encode(name)),
                 Some(serde_json::json!({})),
@@ -1029,10 +1044,7 @@ impl RelayCast {
     pub async fn list_directory_ratings(&self, slug: &str) -> Result<Vec<DirectoryRating>> {
         self.client
             .get(
-                &format!(
-                    "/v1/directory/agents/{}/ratings",
-                    urlencoding::encode(slug)
-                ),
+                &format!("/v1/directory/agents/{}/ratings", urlencoding::encode(slug)),
                 None,
                 None,
             )
@@ -1047,10 +1059,7 @@ impl RelayCast {
     ) -> Result<DirectoryRating> {
         self.client
             .post(
-                &format!(
-                    "/v1/directory/agents/{}/ratings",
-                    urlencoding::encode(slug)
-                ),
+                &format!("/v1/directory/agents/{}/ratings", urlencoding::encode(slug)),
                 Some(request),
                 None,
             )
@@ -1064,7 +1073,9 @@ impl RelayCast {
         &self,
         request: ImportSkillsRequest,
     ) -> Result<Option<DirectoryAgent>> {
-        self.client.post("/v1/skills/sync", Some(request), None).await
+        self.client
+            .post("/v1/skills/sync", Some(request), None)
+            .await
     }
 
     /// Search skills across the directory.
@@ -1200,11 +1211,7 @@ impl RelayCast {
     }
 
     /// Update a trigger.
-    pub async fn update_trigger(
-        &self,
-        id: &str,
-        request: UpdateTriggerRequest,
-    ) -> Result<Trigger> {
+    pub async fn update_trigger(&self, id: &str, request: UpdateTriggerRequest) -> Result<Trigger> {
         self.client
             .patch(
                 &format!("/v1/triggers/{}", urlencoding::encode(id)),
@@ -1296,7 +1303,9 @@ impl RelayCast {
             Some(slice.as_slice())
         };
 
-        self.client.get("/v1/console/messages", query_ref, None).await
+        self.client
+            .get("/v1/console/messages", query_ref, None)
+            .await
     }
 
     /// Get console overview statistics.
@@ -1388,8 +1397,9 @@ mod tests {
     #[tokio::test]
     async fn register_agent_parses_workspace_id() {
         let server = MockServer::start().await;
-        let relay = RelayCast::new(RelayCastOptions::new("rk_live_test").with_base_url(server.uri()))
-            .expect("relay init");
+        let relay =
+            RelayCast::new(RelayCastOptions::new("rk_live_test").with_base_url(server.uri()))
+                .expect("relay init");
 
         Mock::given(method("POST"))
             .and(path("/v1/agents"))
@@ -1413,8 +1423,9 @@ mod tests {
     async fn register_agent_without_workspace_id_defaults_to_none() {
         // Engines that predate the field omit it; the client must still parse.
         let server = MockServer::start().await;
-        let relay = RelayCast::new(RelayCastOptions::new("rk_live_test").with_base_url(server.uri()))
-            .expect("relay init");
+        let relay =
+            RelayCast::new(RelayCastOptions::new("rk_live_test").with_base_url(server.uri()))
+                .expect("relay init");
 
         Mock::given(method("POST"))
             .and(path("/v1/agents"))


### PR DESCRIPTION
## What happened

#349 made registration **create-only** and moved identity replacement to the explicit, proof-authorized `recover` / `takeover` routes. As part of that, `POST /agents/:name/rotate-token` changed from `requireWorkspaceKey` to `requireAgentToken` — authenticated self-rollover only.

The **TypeScript** SDK moved with it in the same PR:

```diff
- rotateToken: (name) => this.client.post(`…/rotate-token`, {}),
+ rotateToken: (name, agentToken) => this.client.withApiKey(agentToken).post(`…/rotate-token`, {}),
```

The **Rust** SDK gained the new endpoints (`recover_agent`, `take_over_agent`, `revoke_agent_token`) but `registration.rs` was never touched. Its 409 branch still calls `rotate_agent_token` with the **workspace key**, so since 8.2.0 that path can only return `401 Agent token required (at_live_...)`.

## Why it matters

An agent name registers **once** and can never register again.

`mcp-args --register` in the relay broker takes this path, so every cloud agent step whose name had been used before fails. For a workflow with stable agent names that means **every run after the first** — it passes in development, passes the first CI run, then fails permanently.

The reported error blames authentication, which is why this took three separate investigations to find. It was misattributed to a repair-agent quirk, then to channel reuse, then to `swarm.channel` generally. All wrong; all encouraged by a 401 that had nothing to do with credentials being wrong.

## Verified against production

`cast.agentrelay.com`, engine 8.2.0, confirmed via `wrangler tail` on script version `864d8d4b` (the live deploy), whose own log records `"auth_scheme": "bearer_workspace_key"` alongside `"status_code": 401`:

```
POST /v1/agents                            -> 201  at_live_…
POST /v1/agents             (same name)    -> 409  agent_already_exists
POST /v1/agents/x/rotate-token   rk_live_  -> 401  Agent token required (at_live_...)
POST /v1/agents/x/rotate-token   at_live_  -> 200  rotated
```

## Changes

Aligned with #349's intent rather than working around it:

- **`rotate_agent_token`** takes the agent's own token and swaps the key, matching the route's guard and the TypeScript signature.
- **The 409 branch no longer rotates.** It returns a new `AgentRegistrationError::AlreadyExists` that names the create-only policy and points at recover, takeover, or simply registering under a unique name.
- **`credentials.rs`** self-rollover passes the cached agent token; the `RotateExisting` conflict strategy now requires holding that agent's token and otherwise reports the conflict.

## What this deliberately does NOT do

**It does not auto-call `takeover` on 409.** That would restore the exact implicit identity replacement #349 removed, under a new name. `takeover` requires `expected_agent_id`, `actor`, `reason` and `session_ref` precisely so that it cannot happen by accident, and a registration call is exactly the accident it is guarding against.

Callers that simply need their own agent should use a name unique to the run — under create-only registration that is the intended model, not a workaround.

## Risk

**This cannot regress working behaviour.** The 409 path returns 401 unconditionally against 8.2.0, so every caller reaching it is already broken. The change converts a misleading auth error into an accurate one.

## Testing

95 tests pass; `cargo clippy` clean on changed files. Three new tests:

- a 409 reports `AlreadyExists` **with no rotate-token mock mounted** — reaching that route at all is the regression being guarded
- the error message names every supported path (recover / takeover / unique name)
- rotate sends `Authorization: Bearer at_live_…`, asserted via a header matcher

## Follow-ups worth checking separately

1. **Other SDKs.** #349 also touched Swift and Python. Worth confirming their register-or-rotate paths moved too — the Rust one silently did not.
2. **A published-SDK contract broke without its consumers moving.** The Rust SDK is what the broker and therefore the whole cloud agent path runs on, and nothing failed loudly until a customer POC hit it.
3. The relay broker flattens every 401/403 into `register auth error` (`crates/broker/src/cli_mcp_args.rs`), discarding which request failed. That is a large part of why this was expensive to diagnose, and is filed as AgentWorkforce/relay#1594.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/AgentWorkforce/relaycast/pull/351?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

