### PR TITLE
fix(sdk-rust): unbreak clippy on Rust 1.98

### DIFF
--- a/packages/sdk-rust/src/ws.rs
+++ b/packages/sdk-rust/src/ws.rs
@@ -601,6 +601,13 @@ fn node_heartbeat(registration: &NodeRegistration) -> serde_json::Value {
     })
 }
 
+// The error type is `tungstenite::Error`, fixed by the `Sink` bound this
+// function is generic over, and Rust 1.98's tightened `result_large_err`
+// threshold now flags it. Boxing would mean allocating on a path that only ever
+// forwards `write.send()`, and would change the signature of an external
+// crate's error for every caller — so the size is acknowledged rather than
+// worked around.
+#[allow(clippy::result_large_err)]
 async fn send_node_register<S>(
     write: &mut S,
     registration: &NodeRegistration,


### PR DESCRIPTION
## What
Rust **1.98.0** (2026-08-18) tightened `clippy::result_large_err`, which now fires on `send_node_register`:

```
error: the `Err`-variant returned from this function is very large
   --> src/ws.rs:607:6
607 | ) -> std::result::Result<(), tokio_tungstenite::tungstenite::Error>
```

CI runs `cargo clippy … -- -D warnings`, so **`main` has been red on the Rust SDK job since that release** and every Rust PR inherits the failure. Confirmed against a pristine `origin/main` worktree:

```
$ cargo +stable clippy --manifest-path packages/sdk-rust/Cargo.toml -- -D warnings
error: the `Err`-variant returned from this function is very large
   --> src/ws.rs:607:6
exit=101
```

## Why an `#[allow]` rather than boxing

The error type is `tungstenite::Error`, fixed by the `Sink` bound the function is generic over. Boxing would allocate on a path that only forwards `write.send()`, and would change an external crate error type for every caller. The size is acknowledged with a scoped allow and a comment, not reshaped to satisfy the lint. Scoped to the one function — no module-wide allow.

## Testing
Clippy clean and 92 tests pass on `stable` (rustc 1.98.0).

## Note
CI appears not to have run on `main` since February, which is why a three-day-old toolchain break went unnoticed until a PR happened to trip it. Unblocks #351.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/AgentWorkforce/relaycast/pull/352?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

