### PR TITLE
fix(engine): classify unkeyed provider send misses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@ Packages without a separate changelog are covered by the cross-package notes bel
 
 - `POST /v1/nodes` accepts `machine_id` and uses it as the enrollment key of last resort, after `node_id` and `name`. A fleet host that persists no `node_id` renames itself on every boot, and each boot used to leave another roster row behind; it now rotates the machine's existing `broker` node instead. `direct` node-of-one delivery hosts are never matched this way, and reuse requires the matched broker to have proved it was alive — by an actual heartbeat frame, tracked in a new `proven_live_at` column, since `last_heartbeat_at` is also written by registration and disconnect cleanup. That proof is cleared whenever enrollment re-issues a row's token, so a row cannot be taken twice before its new holder proves itself. Rows that never heartbeated, rows still live, and rows with a future proof are all left alone, so hosts cold-booting from a shared baked `machine_id` keep separate identities and credentials. An explicit `node_id` still pins identity. Hosts that enroll or register but never heartbeat are not deduped; those rows are reclaimed by the roster reaper. Node roster entries now return `machine_id`.
 
+### Fixed
+
+- Unkeyed agent-action invocations now report `handler_unavailable` and fail their durable row when the owner-side provider send misses, instead of returning an unrelated idempotency error and leaving the invocation pending.
+
 ## [8.3.0] - 2026-09-02
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ Packages without a separate changelog are covered by the cross-package notes bel
 
 ### Fixed
 
-- Unkeyed agent-action invocations now report `handler_unavailable` and fail their durable row when the owner-side provider send misses, instead of returning an unrelated idempotency error and leaving the invocation pending.
+- Unkeyed agent-action invocations now report `handler_unavailable` and fail their durable row when the owner-side provider send misses, while still acknowledging work that completes between provider acceptance and dispatch bookkeeping.
 
 ## [8.3.0] - 2026-09-02
 
@@ -377,7 +377,7 @@ Packages without a separate changelog are covered by the cross-package notes bel
 
 Earlier releases are available on the [GitHub releases page](https://github.com/AgentWorkforce/relaycast/releases).
 
-[Unreleased - Minor]: https://github.com/AgentWorkforce/relaycast/compare/v6.0.3...HEAD
+[Unreleased - Minor]: https://github.com/AgentWorkforce/relaycast/compare/v8.3.0...HEAD
 [6.0.3]: https://github.com/AgentWorkforce/relaycast/compare/v6.0.2...v6.0.3
 [6.0.2]: https://github.com/AgentWorkforce/relaycast/compare/v6.0.1...v6.0.2
 [6.0.1]: https://github.com/AgentWorkforce/relaycast/compare/v6.0.0...v6.0.1

--- a/packages/engine/CHANGELOG.md
+++ b/packages/engine/CHANGELOG.md
@@ -16,6 +16,12 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ### Fixed
 
+- Unkeyed agent-action invocations now report `handler_unavailable` and fail their durable row when the owner-side provider send misses, instead of returning an unrelated idempotency error and leaving the invocation pending.
+
+## [8.2.2] - 2026-09-02
+
+### Fixed
+
 - `sweepTimedOutInvocations` now fails `pending` invocations that never dispatched (`dispatch_attempts = 0`) and are older than `PENDING_INVOCATION_MAX_AGE_MS` (default 72h) with the distinguishing error `never_dispatched_expired`. The existing `handler_unavailable` TTL guard, which requires a dispatched handler connection to observe unreachable, still runs first; the age bound covers the never-dispatched shape it cannot see.
 - `POST /v1/actions/:name/invoke` atomically claims caller-scoped idempotency keys before provider dispatch, waits for a durable dispatch outcome, and replays the original invocation with its immutable handler and node identity, including locally completed releases.
 

--- a/packages/engine/CHANGELOG.md
+++ b/packages/engine/CHANGELOG.md
@@ -16,7 +16,7 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ### Fixed
 
-- Unkeyed agent-action invocations now report `handler_unavailable` and fail their durable row when the owner-side provider send misses, instead of returning an unrelated idempotency error and leaving the invocation pending.
+- Unkeyed agent-action invocations now report `handler_unavailable` and fail their durable row when the owner-side provider send misses, while still acknowledging work that completes between provider acceptance and dispatch bookkeeping.
 
 ## [8.2.2] - 2026-09-02
 

--- a/packages/engine/src/__tests__/conformance/sdk-contract.test.ts
+++ b/packages/engine/src/__tests__/conformance/sdk-contract.test.ts
@@ -412,6 +412,72 @@ describe('SDK v8 service contract', () => {
     expect(stored).toEqual({ status: 'failed', error: 'handler_unavailable' });
   });
 
+  it('acknowledges an unkeyed invocation when completion wins after provider send', async () => {
+    const ws = await createWorkspace(stack.app, 'sdk-action-unkeyed-completion-race-ws');
+    const caller = await registerAgent(stack.app, ws.workspaceKey, 'caller');
+    const handler = await registerAgent(stack.app, ws.workspaceKey, 'handler');
+
+    const register = await stack.app.request('/v1/actions', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', authorization: `Bearer ${handler.token}` },
+      body: JSON.stringify({
+        name: 'unkeyed-completion-race',
+        description: 'Acknowledge provider work that completes before dispatch recording',
+        handler_agent: 'handler',
+        available_to: ['caller'],
+      }),
+    });
+    expect(register.status).toBe(201);
+    const handlerNode = await attachDirectNodeSocket(stack, ws.workspaceId, handler);
+    const nodeConnections = stack.runtime.deps.nodeConnections!;
+    const originalSend = nodeConnections.sendAuthorizedActionToProvider!.bind(nodeConnections);
+    vi.spyOn(nodeConnections, 'sendAuthorizedActionToProvider').mockImplementation(async (...args) => {
+      const sent = await originalSend(...args);
+      if (args[3].type !== 'action.invoke' || args[3].action !== 'unkeyed-completion-race') {
+        return sent;
+      }
+      await stack.runtime.handle.db
+        .update(actionInvocations)
+        .set({
+          status: 'completed',
+          output: { result: 'done' },
+          completedAt: new Date(),
+        })
+        .where(and(
+          eq(actionInvocations.workspaceId, ws.workspaceId),
+          eq(actionInvocations.id, args[3].invocation_id),
+        ));
+      return sent;
+    });
+
+    const response = await stack.app.request('/v1/actions/unkeyed-completion-race/invoke', {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        authorization: `Bearer ${caller.token}`,
+      },
+      body: JSON.stringify({ input: { text: 'hello' } }),
+    });
+
+    expect(response.status).toBe(201);
+    await expect(response.json()).resolves.toMatchObject({
+      data: {
+        handler_agent_id: handler.agentId,
+        handler_node_id: handlerNode.nodeId,
+        status: 'completed',
+      },
+    });
+    expect(handlerNode.sock.ofType('action.invoke')).toHaveLength(1);
+    const [stored] = await stack.runtime.handle.db
+      .select({ status: actionInvocations.status, output: actionInvocations.output })
+      .from(actionInvocations)
+      .where(and(
+        eq(actionInvocations.workspaceId, ws.workspaceId),
+        eq(actionInvocations.actionName, 'unkeyed-completion-race'),
+      ));
+    expect(stored).toEqual({ status: 'completed', output: { result: 'done' } });
+  });
+
   it('does not acknowledge an agent-hosted claim that takeover fails before provider dispatch starts', async () => {
     const ws = await createWorkspace(stack.app, 'sdk-action-pre-send-takeover-ws');
     const caller = await registerAgent(stack.app, ws.workspaceKey, 'caller');

--- a/packages/engine/src/__tests__/conformance/sdk-contract.test.ts
+++ b/packages/engine/src/__tests__/conformance/sdk-contract.test.ts
@@ -368,6 +368,50 @@ describe('SDK v8 service contract', () => {
     expect(stored).toEqual({ status: 'failed', error: 'node_dispatch_unavailable' });
   });
 
+  it('classifies an unkeyed owner-side send miss as handler unavailable', async () => {
+    const ws = await createWorkspace(stack.app, 'sdk-action-unkeyed-send-miss-ws');
+    const caller = await registerAgent(stack.app, ws.workspaceKey, 'caller');
+    const handler = await registerAgent(stack.app, ws.workspaceKey, 'handler');
+
+    const register = await stack.app.request('/v1/actions', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', authorization: `Bearer ${handler.token}` },
+      body: JSON.stringify({
+        name: 'unkeyed-send-miss',
+        description: 'Reject an unkeyed invocation when the owner-side send misses',
+        handler_agent: 'handler',
+        available_to: ['caller'],
+      }),
+    });
+    expect(register.status).toBe(201);
+    const handlerNode = await attachDirectNodeSocket(stack, ws.workspaceId, handler);
+    const nodeConnections = stack.runtime.deps.nodeConnections!;
+    vi.spyOn(nodeConnections, 'sendAuthorizedActionToProvider').mockResolvedValue(false);
+
+    const response = await stack.app.request('/v1/actions/unkeyed-send-miss/invoke', {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        authorization: `Bearer ${caller.token}`,
+      },
+      body: JSON.stringify({ input: { text: 'hello' } }),
+    });
+
+    expect(response.status).toBe(503);
+    await expect(response.json()).resolves.toMatchObject({
+      error: { code: 'handler_unavailable' },
+    });
+    expect(handlerNode.sock.ofType('action.invoke')).toHaveLength(0);
+    const [stored] = await stack.runtime.handle.db
+      .select({ status: actionInvocations.status, error: actionInvocations.error })
+      .from(actionInvocations)
+      .where(and(
+        eq(actionInvocations.workspaceId, ws.workspaceId),
+        eq(actionInvocations.actionName, 'unkeyed-send-miss'),
+      ));
+    expect(stored).toEqual({ status: 'failed', error: 'handler_unavailable' });
+  });
+
   it('does not acknowledge an agent-hosted claim that takeover fails before provider dispatch starts', async () => {
     const ws = await createWorkspace(stack.app, 'sdk-action-pre-send-takeover-ws');
     const caller = await registerAgent(stack.app, ws.workspaceKey, 'caller');

--- a/packages/engine/src/engine/action.ts
+++ b/packages/engine/src/engine/action.ts
@@ -1586,7 +1586,28 @@ export async function invokeAction(
     actionId: action.id,
   });
 
-  if (!dispatched.accepted) {
+  if (dispatched.sent && !dispatched.accepted) {
+    // The provider owns the frame once the send returns true. A fast completion
+    // can make the following open-row dispatch UPDATE lose legitimately; in
+    // that case acknowledge the durable terminal state instead of reporting a
+    // retryable send failure for work the handler already executed.
+    const [settled] = await db
+      .select()
+      .from(actionInvocations)
+      .where(and(
+        eq(actionInvocations.workspaceId, workspaceId),
+        eq(actionInvocations.id, invocation.id),
+      ));
+    if (settled) {
+      return invocationAck(settled, {
+        actionName,
+        handlerAgentId: action.handlerAgentId,
+        handlerNodeId: handlerAgent.locationNodeId,
+      });
+    }
+  }
+
+  if (!dispatched.sent) {
     if (invocationId !== undefined) {
       // A keyed claim must remain durable across a transient disconnect. Re-read
       // it so the original request and its replay agree on the same pre-send
@@ -1881,7 +1902,7 @@ async function dispatchNodeInvocation(args: {
   retryAfterAt?: Date | null;
   reservationHeld?: boolean;
   skipIncrementAttempts?: boolean;
-}): Promise<{ accepted: boolean; pending: boolean }> {
+}): Promise<{ accepted: boolean; pending: boolean; sent: boolean }> {
   const frame = {
     v: 1 as const,
     type: 'action.invoke' as const,
@@ -1901,7 +1922,7 @@ async function dispatchNodeInvocation(args: {
         args.invocationId,
         args.nodeId,
       );
-  if (!snapshotted) return { accepted: false, pending: false };
+  if (!snapshotted) return { accepted: false, pending: false, sent: false };
   const connectedBefore = args.registry.isProviderConnected(args.workspaceId, args.nodeId, args.providerName);
   const sent = args.agent && args.actionId
     ? await (args.registry.sendAuthorizedActionToProvider?.(
@@ -1924,7 +1945,7 @@ async function dispatchNodeInvocation(args: {
         frame,
       );
 
-  if (!sent) return { accepted: false, pending: false };
+  if (!sent) return { accepted: false, pending: false, sent: false };
 
   const pending = !!args.pending || !connectedBefore;
   const accepted = await dispatchNodeAttempt(
@@ -1941,7 +1962,7 @@ async function dispatchNodeInvocation(args: {
       actionId: args.actionId,
     },
   );
-  return { accepted, pending };
+  return { accepted, pending, sent: true };
 }
 
 function attemptedNodeSet(invocation: Pick<InvocationRow, 'attemptedNodeIds' | 'dispatchedNodeId'>): string[] {

--- a/packages/engine/src/engine/action.ts
+++ b/packages/engine/src/engine/action.ts
@@ -1587,15 +1587,28 @@ export async function invokeAction(
   });
 
   if (!dispatched.accepted) {
-    // A takeover can invalidate the last-moment adapter gate. Re-read the
-    // durable claim so the original request and its replay agree on the same
-    // pre-send failure instead of returning a pending 201.
-    await waitForInvocationReplayOutcome(
-      db,
-      workspaceId,
-      invocation,
-      { acceptDispatchStarted: true },
-    );
+    if (invocationId !== undefined) {
+      // A keyed claim must remain durable across a transient disconnect. Re-read
+      // it so the original request and its replay agree on the same pre-send
+      // outcome without releasing the key for a second execution.
+      await waitForInvocationReplayOutcome(
+        db,
+        workspaceId,
+        invocation,
+        { acceptDispatchStarted: true },
+      );
+    } else {
+      // An unkeyed invocation has no replay contract to preserve. Leaving its
+      // pre-send row pending reports an idempotency failure to a caller that did
+      // not request idempotency and strands work no retry can address. Fail the
+      // row and classify the actual condition instead.
+      await failOpenInvocationRows(db, workspaceId, [invocation.id], 'handler_unavailable');
+      throw codedError(
+        `Action "${actionName}" handler "${handlerAgent.name}" has no live connection`,
+        'handler_unavailable',
+        503,
+      );
+    }
   }
 
   return {


### PR DESCRIPTION
## Summary
- fail an unkeyed agent-action invocation when the authoritative owner-side provider send misses
- return `handler_unavailable` instead of the keyed-idempotency timeout/error
- preserve the existing durable claim/replay behavior for requests carrying an Idempotency-Key

## Release-train finding
The relaycast-cloud integration suite against published engine 8.2.2 reproduced this hosted path: the Worker preflight reports the provider live, the NodeDO authoritative send returns false, and an unkeyed request receives `idempotency_unavailable` while its row remains pending. This patch makes that path fail closed with the actual condition.

## Verification
- `npm run -w @relaycast/engine typecheck`
- `npm run -w @relaycast/engine lint`
- `npm run -w @relaycast/engine test` (68 files, 698 tests)
- focused SDK contract suite (12/12), including the existing keyed replay race control

This is the corrective patch required before promoting the engine bump to relaycast-cloud. It must be released as a follow-up patch; #363 remains excluded from this release train.