### PR TITLE
fix(deps): pin @vitejs/devtools-vitest's vitest peer so fresh installs survive vitest 5

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -87,7 +87,7 @@ jobs:
       # lockfile-less reinstall after the version bump resolves with the same
       # npm that publishes, instead of Node 22's bundled npm 10.
       - name: Setup npm
-        run: npm install -g npm@11
+        run: npm install -g npm@11.19.1
 
       - name: Install dependencies
         run: npm ci
@@ -215,7 +215,7 @@ jobs:
           registry-url: "https://registry.npmjs.org"
 
       - name: Setup npm for trusted publishing
-        run: npm install -g npm@11
+        run: npm install -g npm@11.19.1
 
       - name: Download build artifacts
         uses: actions/download-artifact@v4
@@ -254,7 +254,7 @@ jobs:
           registry-url: "https://registry.npmjs.org"
 
       - name: Setup npm for trusted publishing
-        run: npm install -g npm@11
+        run: npm install -g npm@11.19.1
 
       - name: Download build artifacts
         uses: actions/download-artifact@v4

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -83,6 +83,12 @@ jobs:
           cache-dependency-path: package-lock.json
           registry-url: "https://registry.npmjs.org"
 
+      # The publish job below already runs on npm 11. Use it here too so the
+      # lockfile-less reinstall after the version bump resolves with the same
+      # npm that publishes, instead of Node 22's bundled npm 10.
+      - name: Setup npm
+        run: npm install -g npm@11
+
       - name: Install dependencies
         run: npm ci
 

--- a/package.json
+++ b/package.json
@@ -32,5 +32,10 @@
     "typescript-eslint": "^8.54.0",
     "vite-node": "^3.2.4",
     "vitest": "^4.0.18"
+  },
+  "overrides": {
+    "@vitejs/devtools-vitest": {
+      "vitest": "^4.0.18"
+    }
   }
 }


### PR DESCRIPTION
## Summary

The 8.3.2 publish ([run 33766053231](https://github.com/AgentWorkforce/relaycast/actions/runs/33766053231)) failed in the build job's "Clean reinstall after version bump" step, which deletes the lockfile and runs `npm install` on Node 22's bundled npm 10.9:

```
npm error Cannot read properties of null (reading 'edgesOut')
    at #loadPeerSet (@npmcli/arborist/lib/arborist/build-ideal-tree.js:1289)
```

Root cause, verified locally against `main`'s manifests with `npx npm@10.9.2 install --package-lock-only`:

- vitest 5.0.0 and the `@vitest/*` 5.0.0 family were published 2026-09-03 12:24 UTC. Fencing the registry with `--before=2026-09-03T12:00:00Z` resolves cleanly (vitest 4.1.11); `--before=2026-09-03T12:30:00Z` crashes.
- vite 8 has an optional peer on `@vitejs/devtools`, whose `@vitejs/devtools-vitest` plugin declares `peerDependencies: { vitest: "*" }`. That wildcard now lands on vitest 5 even though every workspace range is `^4.0.18` (openclaw and react still ask for `^3`), and npm 10.9's arborist crashes building the peer set. npm 11 handles it.

Nothing was published or committed by the failed run; it stopped before the commit/publish steps.

## Change

- `package.json`: a nested override, `"@vitejs/devtools-vitest": { "vitest": "^4.0.18" }`, rewrites only that wildcard peer edge to the root's own vitest range. A fresh npm 10.9.2 install on `main` then resolves to vitest 4.1.11, matching the lockfile, which is unchanged by this PR. A root-level `vitest` override was rejected because it would force the `^3` consumers onto 4. The `$vitest` reference form was rejected because npm 10.9 fails to resolve it on peer edges (`Unable to resolve reference $vitest`).
- `.github/workflows/publish-npm.yml`: the build job now runs `npm install -g npm@11` after setup-node, the same step the publish job already has, so the lockfile-less reinstall resolves with the npm that publishes instead of Node 22's bundled npm 10.

The override only needs revisiting when the repo itself moves to vitest 5 (bump the range alongside the root devDependency). No runtime code changes, so no changelog entry.

## Test plan

- `npx npm@10.9.2 install --package-lock-only` against `main`'s manifests: crashes (reproduces the publish failure).
- Same with this PR's root `package.json`: succeeds, vitest resolves to 4.1.11.
- `npm install --package-lock-only` in the checkout with the override: lockfile unchanged.
- Workflow change is untestable locally; it mirrors the existing publish-job step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MB3K5bK7Jc5HM92fsZRUyS

---
_Generated by [Claude Code](https://claude.ai/code/session_01MB3K5bK7Jc5HM92fsZRUyS)_

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/AgentWorkforce/relaycast/pull/370?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

