### PR TITLE
fix(engine): make delegated workspace creates crash-idempotent

### DIFF
--- a/.agentworkforce/trajectories/completed/2026-09/traj_eotsycu13u5c/summary.md
+++ b/.agentworkforce/trajectories/completed/2026-09/traj_eotsycu13u5c/summary.md
@@ -1,0 +1,37 @@
+# Trajectory: Implement crash-idempotent delegated workspace creation for relaycast #371
+
+> **Status:** ✅ Completed
+> **Confidence:** 90%
+> **Started:** September 5, 2026 at 10:04 PM
+> **Completed:** September 5, 2026 at 10:04 PM
+
+---
+
+## Summary
+
+Added owner-scoped crash-idempotent delegated workspace creation with request-digest conflicts, concurrent replay recovery, HMAC-derived child credentials, atomic terminalization on delete/expiry, OpenAPI/SDK/docs, and tests. Commit 9c1c971e, PR #372.
+
+**Approach:** Standard approach
+
+---
+
+## Key Decisions
+
+### Use a durable owner-hash plus idempotency-key binding and request digest
+- **Chose:** Use a durable owner-hash plus idempotency-key binding and request digest
+- **Reasoning:** Atomic binding prevents duplicate child workspaces under concurrent requests and stable 409 conflicts protect key reuse.
+
+### Derive child API keys with HMAC instead of persisting plaintext
+- **Chose:** Derive child API keys with HMAC instead of persisting plaintext
+- **Reasoning:** Replay remains usable after response loss while database compromise does not expose child bearer secrets.
+
+---
+
+## Chapters
+
+### 1. Work
+*Agent: default*
+
+- Use a durable owner-hash plus idempotency-key binding and request digest: Use a durable owner-hash plus idempotency-key binding and request digest
+- Derive child API keys with HMAC instead of persisting plaintext: Derive child API keys with HMAC instead of persisting plaintext
+- Engine and SDK implementation passed focused and full local gates; independent diff review found no plaintext credential persistence or cross-owner binding path.

--- a/.agentworkforce/trajectories/completed/2026-09/traj_eotsycu13u5c/summary.md
+++ b/.agentworkforce/trajectories/completed/2026-09/traj_eotsycu13u5c/summary.md
@@ -9,7 +9,7 @@
 
 ## Summary
 
-Added owner-scoped crash-idempotent delegated workspace creation with request-digest conflicts, concurrent replay recovery, HMAC-derived child credentials, atomic terminalization on delete/expiry, OpenAPI/SDK/docs, and tests. Commit 9c1c971e, PR #372.
+Recorded the decision context for the owner-scoped crash-idempotent workspace implementation in product commit `9c1c971e`. The implementation and its engine/SDK gates were PR verification completed before this trajectory began; this trajectory record was committed separately as `129ecc6` in PR #372.
 
 **Approach:** Standard approach
 
@@ -34,4 +34,4 @@ Added owner-scoped crash-idempotent delegated workspace creation with request-di
 
 - Use a durable owner-hash plus idempotency-key binding and request digest: Use a durable owner-hash plus idempotency-key binding and request digest
 - Derive child API keys with HMAC instead of persisting plaintext: Derive child API keys with HMAC instead of persisting plaintext
-- Engine and SDK implementation passed focused and full local gates; independent diff review found no plaintext credential persistence or cross-owner binding path.
+- PR verification recorded before this trajectory reported that commit `9c1c971e` passed the engine and SDK gates and an independent diff review; this trajectory itself recorded the implementation decisions after that product commit.

--- a/.agentworkforce/trajectories/completed/2026-09/traj_eotsycu13u5c/trajectory.json
+++ b/.agentworkforce/trajectories/completed/2026-09/traj_eotsycu13u5c/trajectory.json
@@ -49,7 +49,7 @@
         {
           "ts": 1788638678749,
           "type": "reflection",
-          "content": "Engine and SDK implementation passed focused and full local gates; independent diff review found no plaintext credential persistence or cross-owner binding path.",
+          "content": "PR verification recorded before this trajectory reported that commit 9c1c971e passed the engine and SDK gates and an independent diff review; this trajectory itself recorded the implementation decisions after that product commit.",
           "raw": {
             "focalPoints": [
               "atomicity",
@@ -70,12 +70,32 @@
     }
   ],
   "retrospective": {
-    "summary": "Added owner-scoped crash-idempotent delegated workspace creation with request-digest conflicts, concurrent replay recovery, HMAC-derived child credentials, atomic terminalization on delete/expiry, OpenAPI/SDK/docs, and tests. Commit 9c1c971e, PR #372.",
+    "summary": "Recorded the decision context for the owner-scoped crash-idempotent workspace implementation in product commit 9c1c971e. The trajectory record was committed separately as 129ecc6 in PR #372.",
     "approach": "Standard approach",
     "confidence": 0.9
   },
-  "commits": [],
-  "filesChanged": [],
+  "commits": [
+    "9c1c971e"
+  ],
+  "filesChanged": [
+    "CHANGELOG.md",
+    "README.md",
+    "docs/sdk-setup-client.md",
+    "openapi.yaml",
+    "packages/engine/CHANGELOG.md",
+    "packages/engine/src/__tests__/conformance/workspaceLifecycle.test.ts",
+    "packages/engine/src/db/migrations/0045_workspace_create_idempotency.sql",
+    "packages/engine/src/db/schema.ts",
+    "packages/engine/src/engine/__tests__/workspace.test.ts",
+    "packages/engine/src/engine/workspace.ts",
+    "packages/engine/src/routes/workspace.ts",
+    "packages/sdk-typescript/CHANGELOG.md",
+    "packages/sdk-typescript/src/__tests__/relay.test.ts",
+    "packages/sdk-typescript/src/__tests__/setup.test.ts",
+    "packages/sdk-typescript/src/relay.ts",
+    "packages/sdk-typescript/src/setup-types.ts",
+    "packages/sdk-typescript/src/setup.ts"
+  ],
   "projectId": "AgentWorkforce/relaycast",
   "tags": [],
   "_trace": {

--- a/.agentworkforce/trajectories/completed/2026-09/traj_eotsycu13u5c/trajectory.json
+++ b/.agentworkforce/trajectories/completed/2026-09/traj_eotsycu13u5c/trajectory.json
@@ -1,0 +1,85 @@
+{
+  "id": "traj_eotsycu13u5c",
+  "version": 1,
+  "task": {
+    "title": "Implement crash-idempotent delegated workspace creation for relaycast #371"
+  },
+  "status": "completed",
+  "startedAt": "2026-09-05T20:04:29.437Z",
+  "completedAt": "2026-09-05T20:04:39.253Z",
+  "agents": [
+    {
+      "name": "default",
+      "role": "lead",
+      "joinedAt": "2026-09-05T20:04:37.739Z"
+    }
+  ],
+  "chapters": [
+    {
+      "id": "chap_63m8u38vlw1r",
+      "title": "Work",
+      "agentName": "default",
+      "startedAt": "2026-09-05T20:04:37.739Z",
+      "endedAt": "2026-09-05T20:04:39.253Z",
+      "events": [
+        {
+          "ts": 1788638677739,
+          "type": "decision",
+          "content": "Use a durable owner-hash plus idempotency-key binding and request digest: Use a durable owner-hash plus idempotency-key binding and request digest",
+          "raw": {
+            "question": "Use a durable owner-hash plus idempotency-key binding and request digest",
+            "chosen": "Use a durable owner-hash plus idempotency-key binding and request digest",
+            "alternatives": [],
+            "reasoning": "Atomic binding prevents duplicate child workspaces under concurrent requests and stable 409 conflicts protect key reuse."
+          },
+          "significance": "high"
+        },
+        {
+          "ts": 1788638678238,
+          "type": "decision",
+          "content": "Derive child API keys with HMAC instead of persisting plaintext: Derive child API keys with HMAC instead of persisting plaintext",
+          "raw": {
+            "question": "Derive child API keys with HMAC instead of persisting plaintext",
+            "chosen": "Derive child API keys with HMAC instead of persisting plaintext",
+            "alternatives": [],
+            "reasoning": "Replay remains usable after response loss while database compromise does not expose child bearer secrets."
+          },
+          "significance": "high"
+        },
+        {
+          "ts": 1788638678749,
+          "type": "reflection",
+          "content": "Engine and SDK implementation passed focused and full local gates; independent diff review found no plaintext credential persistence or cross-owner binding path.",
+          "raw": {
+            "focalPoints": [
+              "atomicity",
+              "credential-security",
+              "owner-isolation"
+            ],
+            "confidence": 0.9
+          },
+          "significance": "high",
+          "tags": [
+            "focal:atomicity",
+            "focal:credential-security",
+            "focal:owner-isolation",
+            "confidence:0.9"
+          ]
+        }
+      ]
+    }
+  ],
+  "retrospective": {
+    "summary": "Added owner-scoped crash-idempotent delegated workspace creation with request-digest conflicts, concurrent replay recovery, HMAC-derived child credentials, atomic terminalization on delete/expiry, OpenAPI/SDK/docs, and tests. Commit 9c1c971e, PR #372.",
+    "approach": "Standard approach",
+    "confidence": 0.9
+  },
+  "commits": [],
+  "filesChanged": [],
+  "projectId": "AgentWorkforce/relaycast",
+  "tags": [],
+  "_trace": {
+    "startRef": "9c1c971e0b04c5b923515322701d1d22a31e0770",
+    "endRef": "9c1c971e0b04c5b923515322701d1d22a31e0770"
+  }
+}

--- a/.agentworkforce/trajectories/completed/2026-09/traj_mioo8t6tdut5/summary.md
+++ b/.agentworkforce/trajectories/completed/2026-09/traj_mioo8t6tdut5/summary.md
@@ -1,0 +1,33 @@
+# Trajectory: Address PR 372 review feedback and prepare verified release
+
+> **Status:** ✅ Completed
+> **Task:** relaycast#372
+> **Confidence:** 95%
+> **Started:** September 5, 2026 at 10:20 PM
+> **Completed:** September 5, 2026 at 10:29 PM
+
+---
+
+## Summary
+
+Hardened Relaycast workspace-create idempotency across SDK transport, documentation, OpenAPI, SemVer metadata, and audit records; full Node 20 build, lint, and tests pass.
+
+**Approach:** Standard approach
+
+---
+
+## Key Decisions
+
+### Preserve explicit empty idempotency keys at the SDK transport boundary
+- **Chose:** Preserve explicit empty idempotency keys at the SDK transport boundary
+- **Reasoning:** The server owns validation; dropping an empty key silently converts an intended crash-safe request into an unkeyed create.
+
+---
+
+## Chapters
+
+### 1. Work
+*Agent: default*
+
+- Preserve explicit empty idempotency keys at the SDK transport boundary: Preserve explicit empty idempotency keys at the SDK transport boundary
+- Addressed every actionable PR review item: SDK transport semantics, authenticated-owner documentation, OpenAPI response requirements, SemVer classification, and trajectory attribution. Full Node 20 build, lint, and test gates are green.

--- a/.agentworkforce/trajectories/completed/2026-09/traj_mioo8t6tdut5/summary.md
+++ b/.agentworkforce/trajectories/completed/2026-09/traj_mioo8t6tdut5/summary.md
@@ -10,7 +10,7 @@
 
 ## Summary
 
-Hardened Relaycast workspace-create idempotency across SDK transport, documentation, OpenAPI, SemVer metadata, and audit records; full Node 20 build, lint, and tests pass.
+Hardened the first-round Relaycast workspace-create idempotency review patch across SDK transport, documentation, OpenAPI, SemVer metadata, and audit records; full Node 20 build, lint, and tests passed for commit `52dbe22e`.
 
 **Approach:** Standard approach
 
@@ -30,4 +30,4 @@ Hardened Relaycast workspace-create idempotency across SDK transport, documentat
 *Agent: default*
 
 - Preserve explicit empty idempotency keys at the SDK transport boundary: Preserve explicit empty idempotency keys at the SDK transport boundary
-- Addressed every actionable PR review item: SDK transport semantics, authenticated-owner documentation, OpenAPI response requirements, SemVer classification, and trajectory attribution. Full Node 20 build, lint, and test gates are green.
+- Addressed every actionable first-round PR review item: SDK transport semantics, authenticated-owner documentation, OpenAPI response requirements, SemVer classification, and trajectory attribution. Full Node 20 build, lint, and test gates for commit `52dbe22e` are green.

--- a/.agentworkforce/trajectories/completed/2026-09/traj_mioo8t6tdut5/trajectory.json
+++ b/.agentworkforce/trajectories/completed/2026-09/traj_mioo8t6tdut5/trajectory.json
@@ -41,7 +41,7 @@
         {
           "ts": 1788640182912,
           "type": "reflection",
-          "content": "Addressed every actionable PR review item: SDK transport semantics, authenticated-owner documentation, OpenAPI response requirements, SemVer classification, and trajectory attribution. Full Node 20 build, lint, and test gates are green.",
+      "content": "Addressed every actionable first-round PR review item: SDK transport semantics, authenticated-owner documentation, OpenAPI response requirements, SemVer classification, and trajectory attribution. Full Node 20 build, lint, and test gates for commit 52dbe22e are green.",
           "raw": {
             "focalPoints": [
               "review-closure",
@@ -62,16 +62,32 @@
     }
   ],
   "retrospective": {
-    "summary": "Hardened Relaycast workspace-create idempotency across SDK transport, documentation, OpenAPI, SemVer metadata, and audit records; full Node 20 build, lint, and tests pass.",
+    "summary": "Hardened the first-round Relaycast workspace-create idempotency review patch across SDK transport, documentation, OpenAPI, SemVer metadata, and audit records; full Node 20 build, lint, and tests passed for commit 52dbe22e.",
     "approach": "Standard approach",
     "confidence": 0.95
   },
-  "commits": [],
-  "filesChanged": [],
+  "commits": [
+    "52dbe22e78c79cd069f6c5cbe2779c2eb7b568ff"
+  ],
+  "filesChanged": [
+    ".agentworkforce/trajectories/completed/2026-09/traj_eotsycu13u5c/summary.md",
+    ".agentworkforce/trajectories/completed/2026-09/traj_eotsycu13u5c/trajectory.json",
+    ".agentworkforce/trajectories/completed/2026-09/traj_mioo8t6tdut5/summary.md",
+    ".agentworkforce/trajectories/completed/2026-09/traj_mioo8t6tdut5/trajectory.json",
+    "CHANGELOG.md",
+    "docs/sdk-setup-client.md",
+    "openapi.yaml",
+    "packages/engine/CHANGELOG.md",
+    "packages/sdk-typescript/CHANGELOG.md",
+    "packages/sdk-typescript/src/__tests__/relay.test.ts",
+    "packages/sdk-typescript/src/__tests__/setup.test.ts",
+    "packages/sdk-typescript/src/relay.ts",
+    "packages/sdk-typescript/src/setup.ts"
+  ],
   "projectId": "AgentWorkforce/relaycast",
   "tags": [],
   "_trace": {
     "startRef": "129ecc6e025f1b08afcdfc8dfe125838689789be",
-    "endRef": "129ecc6e025f1b08afcdfc8dfe125838689789be"
+    "endRef": "52dbe22e78c79cd069f6c5cbe2779c2eb7b568ff"
   }
 }

--- a/.agentworkforce/trajectories/completed/2026-09/traj_mioo8t6tdut5/trajectory.json
+++ b/.agentworkforce/trajectories/completed/2026-09/traj_mioo8t6tdut5/trajectory.json
@@ -41,7 +41,7 @@
         {
           "ts": 1788640182912,
           "type": "reflection",
-      "content": "Addressed every actionable first-round PR review item: SDK transport semantics, authenticated-owner documentation, OpenAPI response requirements, SemVer classification, and trajectory attribution. Full Node 20 build, lint, and test gates for commit 52dbe22e are green.",
+      "content": "Addressed every actionable first-round PR review item: SDK transport semantics, authenticated-owner documentation, OpenAPI response requirements, SemVer classification, and trajectory attribution. Full Node 20 build, lint, and test gates for commit 52dbe22e are green. Release metadata was aligned in commit 4cabc3e.",
           "raw": {
             "focalPoints": [
               "review-closure",
@@ -62,18 +62,15 @@
     }
   ],
   "retrospective": {
-    "summary": "Hardened the first-round Relaycast workspace-create idempotency review patch across SDK transport, documentation, OpenAPI, SemVer metadata, and audit records; full Node 20 build, lint, and tests passed for commit 52dbe22e.",
+    "summary": "Hardened the first-round Relaycast workspace-create idempotency review patch across SDK transport, documentation, OpenAPI, SemVer metadata, and audit records; full Node 20 build, lint, and tests passed for commit 52dbe22e. Release metadata was aligned in commit 4cabc3e.",
     "approach": "Standard approach",
     "confidence": 0.95
   },
   "commits": [
-    "52dbe22e78c79cd069f6c5cbe2779c2eb7b568ff"
+    "52dbe22e78c79cd069f6c5cbe2779c2eb7b568ff",
+    "4cabc3e31458ca8d26740087656d101f4490d08f"
   ],
   "filesChanged": [
-    ".agentworkforce/trajectories/completed/2026-09/traj_eotsycu13u5c/summary.md",
-    ".agentworkforce/trajectories/completed/2026-09/traj_eotsycu13u5c/trajectory.json",
-    ".agentworkforce/trajectories/completed/2026-09/traj_mioo8t6tdut5/summary.md",
-    ".agentworkforce/trajectories/completed/2026-09/traj_mioo8t6tdut5/trajectory.json",
     "CHANGELOG.md",
     "docs/sdk-setup-client.md",
     "openapi.yaml",
@@ -88,6 +85,6 @@
   "tags": [],
   "_trace": {
     "startRef": "129ecc6e025f1b08afcdfc8dfe125838689789be",
-    "endRef": "52dbe22e78c79cd069f6c5cbe2779c2eb7b568ff"
+    "endRef": "4cabc3e31458ca8d26740087656d101f4490d08f"
   }
 }

--- a/.agentworkforce/trajectories/completed/2026-09/traj_mioo8t6tdut5/trajectory.json
+++ b/.agentworkforce/trajectories/completed/2026-09/traj_mioo8t6tdut5/trajectory.json
@@ -1,0 +1,77 @@
+{
+  "id": "traj_mioo8t6tdut5",
+  "version": 1,
+  "task": {
+    "title": "Address PR 372 review feedback and prepare verified release",
+    "source": {
+      "system": "plain",
+      "id": "relaycast#372"
+    }
+  },
+  "status": "completed",
+  "startedAt": "2026-09-05T20:20:04.174Z",
+  "completedAt": "2026-09-05T20:29:43.352Z",
+  "agents": [
+    {
+      "name": "default",
+      "role": "lead",
+      "joinedAt": "2026-09-05T20:29:42.482Z"
+    }
+  ],
+  "chapters": [
+    {
+      "id": "chap_07bigxr4x01b",
+      "title": "Work",
+      "agentName": "default",
+      "startedAt": "2026-09-05T20:29:42.482Z",
+      "endedAt": "2026-09-05T20:29:43.352Z",
+      "events": [
+        {
+          "ts": 1788640182483,
+          "type": "decision",
+          "content": "Preserve explicit empty idempotency keys at the SDK transport boundary: Preserve explicit empty idempotency keys at the SDK transport boundary",
+          "raw": {
+            "question": "Preserve explicit empty idempotency keys at the SDK transport boundary",
+            "chosen": "Preserve explicit empty idempotency keys at the SDK transport boundary",
+            "alternatives": [],
+            "reasoning": "The server owns validation; dropping an empty key silently converts an intended crash-safe request into an unkeyed create."
+          },
+          "significance": "high"
+        },
+        {
+          "ts": 1788640182912,
+          "type": "reflection",
+          "content": "Addressed every actionable PR review item: SDK transport semantics, authenticated-owner documentation, OpenAPI response requirements, SemVer classification, and trajectory attribution. Full Node 20 build, lint, and test gates are green.",
+          "raw": {
+            "focalPoints": [
+              "review-closure",
+              "api-contract",
+              "release-readiness"
+            ],
+            "confidence": 0.95
+          },
+          "significance": "high",
+          "tags": [
+            "focal:review-closure",
+            "focal:api-contract",
+            "focal:release-readiness",
+            "confidence:0.95"
+          ]
+        }
+      ]
+    }
+  ],
+  "retrospective": {
+    "summary": "Hardened Relaycast workspace-create idempotency across SDK transport, documentation, OpenAPI, SemVer metadata, and audit records; full Node 20 build, lint, and tests pass.",
+    "approach": "Standard approach",
+    "confidence": 0.95
+  },
+  "commits": [],
+  "filesChanged": [],
+  "projectId": "AgentWorkforce/relaycast",
+  "tags": [],
+  "_trace": {
+    "startRef": "129ecc6e025f1b08afcdfc8dfe125838689789be",
+    "endRef": "129ecc6e025f1b08afcdfc8dfe125838689789be"
+  }
+}

--- a/.agentworkforce/trajectories/completed/2026-09/traj_qwxx66458n6g/summary.md
+++ b/.agentworkforce/trajectories/completed/2026-09/traj_qwxx66458n6g/summary.md
@@ -1,0 +1,15 @@
+# Trajectory: Audit Relaycast PR #372 release gate
+
+> **Status:** ✅ Completed
+> **Task:** relaycast-372-gate
+> **Confidence:** 97%
+> **Started:** September 5, 2026 at 10:51 PM
+> **Completed:** September 5, 2026 at 10:54 PM
+
+---
+
+## Summary
+
+Audited Relaycast PR #372 at 4cabc3e: local full test passed, CI arm64 still pending, two Codex P2 threads and two Cubic metadata threads remain unresolved; PR is not merge-ready.
+
+**Approach:** Standard approach

--- a/.agentworkforce/trajectories/completed/2026-09/traj_qwxx66458n6g/summary.md
+++ b/.agentworkforce/trajectories/completed/2026-09/traj_qwxx66458n6g/summary.md
@@ -10,6 +10,6 @@
 
 ## Summary
 
-Audited Relaycast PR #372 at 4cabc3e: local full test passed, CI arm64 still pending, two Codex P2 threads and two Cubic metadata threads remain unresolved; PR is not merge-ready.
+Audited Relaycast PR #372 at 4cabc3e: identified two Codex P2 threads and two Cubic metadata threads; PR was not merge-ready. This trajectory recorded gate findings only and did not author product changes or validation claims.
 
 **Approach:** Standard approach

--- a/.agentworkforce/trajectories/completed/2026-09/traj_qwxx66458n6g/trajectory.json
+++ b/.agentworkforce/trajectories/completed/2026-09/traj_qwxx66458n6g/trajectory.json
@@ -1,0 +1,29 @@
+{
+  "id": "traj_qwxx66458n6g",
+  "version": 1,
+  "task": {
+    "title": "Audit Relaycast PR #372 release gate",
+    "source": {
+      "system": "plain",
+      "id": "relaycast-372-gate"
+    }
+  },
+  "status": "completed",
+  "startedAt": "2026-09-05T20:51:59.492Z",
+  "completedAt": "2026-09-05T20:54:06.359Z",
+  "agents": [],
+  "chapters": [],
+  "retrospective": {
+    "summary": "Audited Relaycast PR #372 at 4cabc3e: local full test passed, CI arm64 still pending, two Codex P2 threads and two Cubic metadata threads remain unresolved; PR is not merge-ready.",
+    "approach": "Standard approach",
+    "confidence": 0.97
+  },
+  "commits": [],
+  "filesChanged": [],
+  "projectId": "AgentWorkforce/relaycast",
+  "tags": [],
+  "_trace": {
+    "startRef": "4cabc3e31458ca8d26740087656d101f4490d08f",
+    "endRef": "4cabc3e31458ca8d26740087656d101f4490d08f"
+  }
+}

--- a/.agentworkforce/trajectories/completed/2026-09/traj_qwxx66458n6g/trajectory.json
+++ b/.agentworkforce/trajectories/completed/2026-09/traj_qwxx66458n6g/trajectory.json
@@ -14,7 +14,7 @@
   "agents": [],
   "chapters": [],
   "retrospective": {
-    "summary": "Audited Relaycast PR #372 at 4cabc3e: local full test passed, CI arm64 still pending, two Codex P2 threads and two Cubic metadata threads remain unresolved; PR is not merge-ready.",
+    "summary": "Audited Relaycast PR #372 at 4cabc3e: identified two Codex P2 threads and two Cubic metadata threads; PR was not merge-ready. This trajectory recorded gate findings only and did not author product changes or validation claims.",
     "approach": "Standard approach",
     "confidence": 0.97
   },

--- a/.agentworkforce/trajectories/completed/2026-09/traj_uxoudwx7qv7k/summary.md
+++ b/.agentworkforce/trajectories/completed/2026-09/traj_uxoudwx7qv7k/summary.md
@@ -1,0 +1,37 @@
+# Trajectory: Close second-round Relaycast workspace idempotency review findings
+
+> **Status:** ✅ Completed
+> **Task:** relaycast#372
+> **Confidence:** 95%
+> **Started:** September 5, 2026 at 10:31 PM
+> **Completed:** September 5, 2026 at 10:31 PM
+
+---
+
+## Summary
+
+Canonicalized workspace-create request hashing, removed a redundant index, aligned release notes, corrected auth documentation, and added regression coverage.
+
+**Approach:** Standard approach
+
+---
+
+## Key Decisions
+
+### Hash declared provenance in a fixed schema order
+- **Chose:** Hash declared provenance in a fixed schema order
+- **Reasoning:** JSON object insertion order is not semantic; idempotency digests must treat equivalent request bodies as the same request.
+
+### Remove the duplicate workspace binding index
+- **Chose:** Remove the duplicate workspace binding index
+- **Reasoning:** The unique workspace_id index already supports equality lookup and avoids duplicate write amplification.
+
+---
+
+## Chapters
+
+### 1. Work
+*Agent: default*
+
+- Hash declared provenance in a fixed schema order: Hash declared provenance in a fixed schema order
+- Remove the duplicate workspace binding index: Remove the duplicate workspace binding index

--- a/.agentworkforce/trajectories/completed/2026-09/traj_uxoudwx7qv7k/trajectory.json
+++ b/.agentworkforce/trajectories/completed/2026-09/traj_uxoudwx7qv7k/trajectory.json
@@ -58,12 +58,24 @@
     "approach": "Standard approach",
     "confidence": 0.95
   },
-  "commits": [],
-  "filesChanged": [],
+  "commits": [
+    "3b060d02ef654177df3c2bee6eed3ac1931b78be"
+  ],
+  "filesChanged": [
+    ".agentworkforce/trajectories/completed/2026-09/traj_uxoudwx7qv7k/summary.md",
+    ".agentworkforce/trajectories/completed/2026-09/traj_uxoudwx7qv7k/trajectory.json",
+    "CHANGELOG.md",
+    "docs/sdk-setup-client.md",
+    "packages/engine/CHANGELOG.md",
+    "packages/engine/src/db/migrations/0045_workspace_create_idempotency.sql",
+    "packages/engine/src/db/schema.ts",
+    "packages/engine/src/engine/__tests__/workspace.test.ts",
+    "packages/engine/src/engine/workspace.ts"
+  ],
   "projectId": "AgentWorkforce/relaycast",
   "tags": [],
   "_trace": {
     "startRef": "52dbe22e78c79cd069f6c5cbe2779c2eb7b568ff",
-    "endRef": "52dbe22e78c79cd069f6c5cbe2779c2eb7b568ff"
+    "endRef": "3b060d02ef654177df3c2bee6eed3ac1931b78be"
   }
 }

--- a/.agentworkforce/trajectories/completed/2026-09/traj_uxoudwx7qv7k/trajectory.json
+++ b/.agentworkforce/trajectories/completed/2026-09/traj_uxoudwx7qv7k/trajectory.json
@@ -1,0 +1,69 @@
+{
+  "id": "traj_uxoudwx7qv7k",
+  "version": 1,
+  "task": {
+    "title": "Close second-round Relaycast workspace idempotency review findings",
+    "source": {
+      "system": "plain",
+      "id": "relaycast#372"
+    }
+  },
+  "status": "completed",
+  "startedAt": "2026-09-05T20:31:43.781Z",
+  "completedAt": "2026-09-05T20:31:44.930Z",
+  "agents": [
+    {
+      "name": "default",
+      "role": "lead",
+      "joinedAt": "2026-09-05T20:31:44.203Z"
+    }
+  ],
+  "chapters": [
+    {
+      "id": "chap_o33aeu9r0wg4",
+      "title": "Work",
+      "agentName": "default",
+      "startedAt": "2026-09-05T20:31:44.203Z",
+      "endedAt": "2026-09-05T20:31:44.930Z",
+      "events": [
+        {
+          "ts": 1788640304204,
+          "type": "decision",
+          "content": "Hash declared provenance in a fixed schema order: Hash declared provenance in a fixed schema order",
+          "raw": {
+            "question": "Hash declared provenance in a fixed schema order",
+            "chosen": "Hash declared provenance in a fixed schema order",
+            "alternatives": [],
+            "reasoning": "JSON object insertion order is not semantic; idempotency digests must treat equivalent request bodies as the same request."
+          },
+          "significance": "high"
+        },
+        {
+          "ts": 1788640304570,
+          "type": "decision",
+          "content": "Remove the duplicate workspace binding index: Remove the duplicate workspace binding index",
+          "raw": {
+            "question": "Remove the duplicate workspace binding index",
+            "chosen": "Remove the duplicate workspace binding index",
+            "alternatives": [],
+            "reasoning": "The unique workspace_id index already supports equality lookup and avoids duplicate write amplification."
+          },
+          "significance": "high"
+        }
+      ]
+    }
+  ],
+  "retrospective": {
+    "summary": "Canonicalized workspace-create request hashing, removed a redundant index, aligned release notes, corrected auth documentation, and added regression coverage.",
+    "approach": "Standard approach",
+    "confidence": 0.95
+  },
+  "commits": [],
+  "filesChanged": [],
+  "projectId": "AgentWorkforce/relaycast",
+  "tags": [],
+  "_trace": {
+    "startRef": "52dbe22e78c79cd069f6c5cbe2779c2eb7b568ff",
+    "endRef": "52dbe22e78c79cd069f6c5cbe2779c2eb7b568ff"
+  }
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Packages without a separate changelog are covered by the cross-package notes bel
 
 ### Fixed
 
+- Delegated `POST /v1/workspaces` creates now accept an owner-scoped `Idempotency-Key`, recover the same child key after response loss, reject request-digest conflicts, and terminalize bindings on deletion or expiry.
 - Keyed (idempotent) agent-action invocations whose host cannot deliver to the handler now fail with 503 `handler_unavailable` instead of 503 `idempotency_unavailable`.
 - An agent-action invocation is no longer reported as `handler_unavailable` when its handler reconnected and received it mid-request; the caller sees the live dispatch instead.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,9 +18,12 @@ Packages without a separate changelog are covered by the cross-package notes bel
 
 ## [Unreleased - Minor]
 
-### Fixed
+### Added
 
 - Delegated `POST /v1/workspaces` creates now accept an owner-scoped `Idempotency-Key`, recover the same child key after response loss, reject request-digest conflicts, and terminalize bindings on deletion or expiry.
+
+### Fixed
+
 - Keyed (idempotent) agent-action invocations whose host cannot deliver to the handler now fail with 503 `handler_unavailable` instead of 503 `idempotency_unavailable`.
 - An agent-action invocation is no longer reported as `handler_unavailable` when its handler reconnected and received it mid-request; the caller sees the live dispatch instead.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -388,7 +388,7 @@ Packages without a separate changelog are covered by the cross-package notes bel
 
 Earlier releases are available on the [GitHub releases page](https://github.com/AgentWorkforce/relaycast/releases).
 
-[Unreleased - Patch]: https://github.com/AgentWorkforce/relaycast/compare/v8.3.1...HEAD
+[Unreleased - Minor]: https://github.com/AgentWorkforce/relaycast/compare/v8.3.1...HEAD
 [6.0.3]: https://github.com/AgentWorkforce/relaycast/compare/v6.0.2...v6.0.3
 [6.0.2]: https://github.com/AgentWorkforce/relaycast/compare/v6.0.1...v6.0.2
 [6.0.1]: https://github.com/AgentWorkforce/relaycast/compare/v6.0.0...v6.0.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 Packages without a separate changelog are covered by the cross-package notes below.
 
-## [Unreleased - Patch]
+## [Unreleased - Minor]
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -95,7 +95,20 @@ valid lowercase SHA-256 verifier, but malformed registration values and claims
 return 400; already-claimed, non-offline, or concurrently changed records return
 409.
 
-Workspace names are not globally unique. Workspace creation is idempotent for the same workspace name and API key: repeating that combination returns the existing workspace instead of creating another one.
+Workspace names are not globally unique. Workspace creation is idempotent for the same workspace name and API key: repeating that combination returns the existing workspace instead of creating another one. For delegated or crash-retryable creates, send an owner-authenticated `Idempotency-Key`; the same key and request digest recover the exact child workspace and usable child key, while a changed request is rejected with `409`.
+
+```ts
+const child = await RelayCast.createWorkspace('job-child', {
+  apiKey: parentWorkspaceKey,
+  expiresInSeconds: 60 * 60,
+  idempotencyKey: `job:${jobId}`,
+});
+```
+
+The child key is derived from the owner key and idempotency binding rather than
+stored in plaintext. Deleting or expiring the child terminalizes its binding;
+replaying the key cannot accidentally create a replacement. Unauthenticated
+by-name lookup never returns workspace credentials.
 
 If workspace storage remains unavailable after its transient retries and the
 server cannot confirm the committed workspace/channel pair, creation returns

--- a/docs/sdk-setup-client.md
+++ b/docs/sdk-setup-client.md
@@ -176,6 +176,8 @@ export interface CreateWorkspaceOptions {
    * Required by POST /v1/workspaces.
    */
   name: string
+  /** Owner-scoped key for crash-safe delegated workspace-create retries. */
+  idempotencyKey?: string
 }
 ```
 
@@ -352,7 +354,8 @@ export class MissingApiKeyError extends RelaycastSetupError {
 
 Sequence:
 
-1. `POST {baseUrl}/v1/workspaces` with body `{ name }`
+1. `POST {baseUrl}/v1/workspaces` with body `{ name }` (and an optional
+   `Idempotency-Key` header from `idempotencyKey`)
    — Auth header: `Authorization: Bearer {apiKey}` if provided, else anonymous
    — Returns: `{ ok: true, data: { workspace_id, api_key, created_at } }`
 

--- a/docs/sdk-setup-client.md
+++ b/docs/sdk-setup-client.md
@@ -360,7 +360,8 @@ Sequence:
 
 1. `POST {baseUrl}/v1/workspaces` with body `{ name }` (and an optional
    `Idempotency-Key` header from `idempotencyKey`)
-   — Auth header: `Authorization: Bearer {apiKey}` if provided, else anonymous
+   — Auth header: `Authorization: Bearer {apiKey}` is required when
+   `idempotencyKey` is set and optional otherwise
    — Returns: `{ ok: true, data: { workspace_id, api_key, created_at } }`
 
 2. Construct and return a `WorkspaceHandle` with:

--- a/docs/sdk-setup-client.md
+++ b/docs/sdk-setup-client.md
@@ -176,7 +176,11 @@ export interface CreateWorkspaceOptions {
    * Required by POST /v1/workspaces.
    */
   name: string
-  /** Owner-scoped key for crash-safe delegated workspace-create retries. */
+  /**
+   * Owner-scoped key for crash-safe delegated workspace-create retries.
+   * Requires this setup client to have an authenticated owner `apiKey`;
+   * keyed anonymous creation is rejected.
+   */
   idempotencyKey?: string
 }
 ```

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -180,7 +180,7 @@ components:
           description: Snowflake ID of the workspace
         api_key:
           type: string
-          description: Workspace API key (only returned on first creation)
+          description: Workspace API key (returned on first creation and on an authenticated idempotent replay)
         created_at:
           type: string
           format: date-time
@@ -1472,12 +1472,12 @@ paths:
       summary: Create workspace
       description: >
         Create a workspace and get an API key when a new workspace is created. This operation is
-        idempotent by workspace name for the same bearer workspace key: if you repeat the call with
-        the same name and the same `Authorization: Bearer rk_*` key, the existing workspace is
-        returned with a `200` response; otherwise a new workspace is created and returned with a
-        `201` response. If transient storage attempts are exhausted and the server cannot confirm
-        the committed workspace/channel pair, it returns `503 workspace_storage_unavailable`.
-        That outcome is indeterminate; callers must not assume no workspace committed.
+        idempotent by workspace name for the same bearer workspace key. For delegated creates,
+        provide an `Idempotency-Key`: the authenticated owner, key, and exact request digest are
+        durably bound to one child. Replaying the same request returns the same child key with a
+        `200` response, while changing the request returns `409`. If transient storage attempts are
+        exhausted and the server cannot confirm the committed workspace/channel pair, it returns
+        `503 workspace_storage_unavailable`; that outcome is indeterminate.
       tags:
         - Workspaces
       security:
@@ -1504,6 +1504,17 @@ paths:
                     the sole automatic whole-workspace deletion predicate.
                 provenance:
                   $ref: '#/components/schemas/WorkspaceProvenanceInput'
+      parameters:
+        - name: Idempotency-Key
+          in: header
+          required: false
+          schema:
+            type: string
+            maxLength: 255
+          description: >-
+            Owner-scoped key for crash-safe delegated creation. Requires an
+            authenticated `Authorization: Bearer rk_*` owner. Reusing it with
+            the same request replays the child; a different request is a 409.
       responses:
         '200':
           description: Existing workspace returned (idempotent)
@@ -1529,6 +1540,12 @@ paths:
                     $ref: '#/components/schemas/CreateWorkspaceResponse'
         '400':
           description: Invalid request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '409':
+          description: Idempotency key conflict or terminalized child binding
           content:
             application/json:
               schema:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1545,6 +1545,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          description: Missing or invalid owner workspace key for keyed creation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
         '409':
           description: Idempotency key conflict or terminalized child binding
           content:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1511,7 +1511,9 @@ paths:
           required: false
           schema:
             type: string
+            minLength: 1
             maxLength: 255
+            pattern: '^[\x21-\x7E]+$'
           description: >-
             Owner-scoped key for crash-safe delegated creation. Requires an
             authenticated `Authorization: Bearer rk_*` owner. Reusing it with

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -173,6 +173,7 @@ components:
       type: object
       required:
         - workspace_id
+        - api_key
         - created_at
       properties:
         workspace_id:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1523,9 +1523,13 @@ paths:
             application/json:
               schema:
                 type: object
+                required:
+                  - ok
+                  - data
                 properties:
                   ok:
                     type: boolean
+                    enum: [true]
                   data:
                     $ref: '#/components/schemas/CreateWorkspaceResponse'
         '201':
@@ -1534,9 +1538,13 @@ paths:
             application/json:
               schema:
                 type: object
+                required:
+                  - ok
+                  - data
                 properties:
                   ok:
                     type: boolean
+                    enum: [true]
                   data:
                     $ref: '#/components/schemas/CreateWorkspaceResponse'
         '400':

--- a/packages/engine/CHANGELOG.md
+++ b/packages/engine/CHANGELOG.md
@@ -9,9 +9,12 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased - Minor]
 
-### Fixed
+### Added
 
 - Delegated workspace creates now recover the same child credential after response loss with an owner-scoped `Idempotency-Key`; conflicting replays fail closed and deletion/expiry terminalizes the binding.
+
+### Fixed
+
 - Keyed (idempotent) agent-action invocations whose host cannot deliver to the handler now fail with 503 `handler_unavailable` instead of 503 `idempotency_unavailable`.
 - An agent-action invocation is no longer reported as `handler_unavailable` when its handler reconnected and received it mid-request; the caller sees the live dispatch instead.
 

--- a/packages/engine/CHANGELOG.md
+++ b/packages/engine/CHANGELOG.md
@@ -7,7 +7,7 @@ See the [root changelog](../../CHANGELOG.md) for cross-package release highlight
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased - Patch]
+## [Unreleased - Minor]
 
 ### Fixed
 

--- a/packages/engine/CHANGELOG.md
+++ b/packages/engine/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ### Fixed
 
+- Delegated workspace creates now recover the same child credential after response loss with an owner-scoped `Idempotency-Key`; conflicting replays fail closed and deletion/expiry terminalizes the binding.
 - Keyed (idempotent) agent-action invocations whose host cannot deliver to the handler now fail with 503 `handler_unavailable` instead of 503 `idempotency_unavailable`.
 - An agent-action invocation is no longer reported as `handler_unavailable` when its handler reconnected and received it mid-request; the caller sees the live dispatch instead.
 

--- a/packages/engine/src/__tests__/conformance/workspaceLifecycle.test.ts
+++ b/packages/engine/src/__tests__/conformance/workspaceLifecycle.test.ts
@@ -97,6 +97,47 @@ describe('workspace lifecycle', () => {
     expect(persistentRow.expiresAt).toBeNull();
   });
 
+  it('replays delegated workspace creation by owner and request digest', async () => {
+    const parent = await createWorkspace(stack.app, 'delegating-parent');
+    const unauthenticated = await stack.app.request('/v1/workspaces', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', 'Idempotency-Key': 'cloud-job-unauthenticated' },
+      body: JSON.stringify({ name: 'must-not-create' }),
+    });
+    expect(unauthenticated.status).toBe(401);
+    expect((await unauthenticated.json() as { error: { code: string } }).error.code)
+      .toBe('workspace_create_idempotency_owner_required');
+
+    const headers = {
+      'content-type': 'application/json',
+      authorization: `Bearer ${parent.workspaceKey}`,
+      'Idempotency-Key': 'cloud-job-371',
+    };
+    const body = JSON.stringify({ name: 'delegated-child', expires_in_seconds: 3_600 });
+    const first = await stack.app.request('/v1/workspaces', { method: 'POST', headers, body });
+    expect(first.status).toBe(201);
+    const firstData = (await first.json() as { data: { workspace_id: string; api_key: string } }).data;
+    const replay = await stack.app.request('/v1/workspaces', { method: 'POST', headers, body });
+    expect(replay.status).toBe(200);
+    const replayData = (await replay.json() as { data: { workspace_id: string; api_key: string } }).data;
+    expect(replayData).toEqual(firstData);
+
+    const changed = await stack.app.request('/v1/workspaces', {
+      method: 'POST', headers,
+      body: JSON.stringify({ name: 'different-child', expires_in_seconds: 3_600 }),
+    });
+    expect(changed.status).toBe(409);
+    expect((await changed.json() as { error: { code: string } }).error.code).toBe('workspace_create_idempotency_conflict');
+
+    const deleted = await stack.app.request(`/v1/workspaces/${firstData.workspace_id}`, {
+      method: 'DELETE', headers: { authorization: `Bearer ${firstData.api_key}` },
+    });
+    expect(deleted.status).toBe(204);
+    const afterDelete = await stack.app.request('/v1/workspaces', { method: 'POST', headers, body });
+    expect(afterDelete.status).toBe(409);
+    expect((await afterDelete.json() as { error: { code: string } }).error.code).toBe('workspace_create_idempotency_terminalized');
+  });
+
   it.each([0, 59, 2_592_001, 60.5])(
     'rejects invalid expires_in_seconds value %s',
     async (expiresInSeconds) => {
@@ -509,8 +550,9 @@ describe('workspace lifecycle', () => {
     const withoutDirectCascade = coverage.filter((table) => table.on_delete !== 'CASCADE');
 
     expect(stack.runtime.handle.sqlite.pragma('foreign_keys', { simple: true })).toBe(1);
-    expect(coverage).toHaveLength(31);
+    expect(coverage).toHaveLength(32);
     expect(withoutDirectCascade).toEqual([
+      { table_name: 'workspace_create_idempotency', on_delete: null },
       { table_name: 'workspace_events', on_delete: null },
     ]);
   });

--- a/packages/engine/src/db/migrations/0045_workspace_create_idempotency.sql
+++ b/packages/engine/src/db/migrations/0045_workspace_create_idempotency.sql
@@ -1,0 +1,18 @@
+-- relaycast#371: bind delegated workspace creation to an owner-scoped,
+-- request-digested idempotency key. The child bearer key is derived at replay
+-- time and is never persisted in plaintext.
+CREATE TABLE workspace_create_idempotency (
+  owner_scope_hash TEXT NOT NULL,
+  idempotency_key_hash TEXT NOT NULL,
+  request_digest TEXT NOT NULL,
+  workspace_id TEXT NOT NULL,
+  status TEXT NOT NULL DEFAULT 'active',
+  created_at INTEGER NOT NULL DEFAULT (unixepoch()),
+  terminalized_at INTEGER,
+  PRIMARY KEY (owner_scope_hash, idempotency_key_hash)
+);
+
+CREATE UNIQUE INDEX workspace_create_idempotency_workspace_unique
+  ON workspace_create_idempotency(workspace_id);
+CREATE INDEX idx_workspace_create_idempotency_workspace
+  ON workspace_create_idempotency(workspace_id);

--- a/packages/engine/src/db/migrations/0045_workspace_create_idempotency.sql
+++ b/packages/engine/src/db/migrations/0045_workspace_create_idempotency.sql
@@ -14,5 +14,3 @@ CREATE TABLE workspace_create_idempotency (
 
 CREATE UNIQUE INDEX workspace_create_idempotency_workspace_unique
   ON workspace_create_idempotency(workspace_id);
-CREATE INDEX idx_workspace_create_idempotency_workspace
-  ON workspace_create_idempotency(workspace_id);

--- a/packages/engine/src/db/schema.ts
+++ b/packages/engine/src/db/schema.ts
@@ -94,7 +94,6 @@ export const workspaceCreateIdempotency = sqliteTable(
   (table) => [
     primaryKey({ columns: [table.ownerScopeHash, table.idempotencyKeyHash] }),
     uniqueIndex('workspace_create_idempotency_workspace_unique').on(table.workspaceId),
-    index('idx_workspace_create_idempotency_workspace').on(table.workspaceId),
   ],
 );
 

--- a/packages/engine/src/db/schema.ts
+++ b/packages/engine/src/db/schema.ts
@@ -75,6 +75,29 @@ export const workspaces = sqliteTable(
   ],
 );
 
+/**
+ * Durable owner-scoped idempotency bindings for delegated workspace creates.
+ * The child API key is derived at replay time and is never persisted in
+ * plaintext.
+ */
+export const workspaceCreateIdempotency = sqliteTable(
+  'workspace_create_idempotency',
+  {
+    ownerScopeHash: text('owner_scope_hash').notNull(),
+    idempotencyKeyHash: text('idempotency_key_hash').notNull(),
+    requestDigest: text('request_digest').notNull(),
+    workspaceId: text('workspace_id').notNull(),
+    status: text('status').notNull().default('active'),
+    createdAt: integer('created_at', { mode: 'timestamp' }).notNull().default(sql`(unixepoch())`),
+    terminalizedAt: integer('terminalized_at', { mode: 'timestamp' }),
+  },
+  (table) => [
+    primaryKey({ columns: [table.ownerScopeHash, table.idempotencyKeyHash] }),
+    uniqueIndex('workspace_create_idempotency_workspace_unique').on(table.workspaceId),
+    index('idx_workspace_create_idempotency_workspace').on(table.workspaceId),
+  ],
+);
+
 // ============================================
 // Agents
 // ============================================

--- a/packages/engine/src/engine/__tests__/workspace.test.ts
+++ b/packages/engine/src/engine/__tests__/workspace.test.ts
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { makeNodeStack, type TestStack } from '../../__tests__/conformance/harness.js';
 import { channels, workspaceCreateIdempotency, workspaces } from '../../db/schema.js';
+import { hmacSha256Hex, sha256Hex } from '../../lib/crypto.js';
 import type {
   AtomicWrite,
   BatchCapability,
@@ -33,6 +34,7 @@ describe('workspace write durability', () => {
     failAfterLostResponse?: boolean;
     failBeforeFirst?: boolean;
     loseFirstResponse?: boolean;
+    beforeFirstBatch?: () => void | Promise<void>;
   }): () => number {
     let calls = 0;
     const sqlite = stack.runtime.handle.sqlite;
@@ -44,6 +46,9 @@ describe('workspace write durability', () => {
       }
       if (calls > 1 && options.failAfterLostResponse) {
         throw new Error('D1_ERROR: D1 DB is overloaded. Too many requests queued.');
+      }
+      if (calls === 1 && options.beforeFirstBatch) {
+        await options.beforeFirstBatch();
       }
 
       sqlite.exec('BEGIN IMMEDIATE');
@@ -212,6 +217,49 @@ describe('workspace write durability', () => {
     expect(replay.created).toBe(false);
     expect(replay.workspace_id).toBe(created.workspace_id);
     expect(replay.api_key).toBe(created.api_key);
+  });
+
+  it('does not treat an unrelated workspace-id collision as own recovery', async () => {
+    const ownerApiKey = 'rk_live_collision_owner';
+    const idempotencyKey = 'collision-job';
+    const requestDigest = await workspaceCreateRequestDigest({ name: 'collision-child' });
+    const deterministicApiKey = `rk_live_${(await hmacSha256Hex(
+      `relaycast:workspace-create:v1:${idempotencyKey}:${requestDigest}`,
+      ownerApiKey,
+    )).slice(0, 32)}`;
+    const pair = useGeneratedPair();
+
+    attachD1Batch({
+      beforeFirstBatch: async () => {
+        await db.insert(workspaces).values({
+          id: pair.workspaceId,
+          name: 'collision-child',
+          apiKeyHash: await sha256Hex(deterministicApiKey),
+        });
+        await db.insert(channels).values({
+          id: 'bound-channel',
+          workspaceId: pair.workspaceId,
+          name: 'general',
+          topic: 'General discussion',
+        });
+        await db.insert(workspaceCreateIdempotency).values({
+          ownerScopeHash: await sha256Hex(ownerApiKey),
+          idempotencyKeyHash: await sha256Hex(idempotencyKey),
+          requestDigest,
+          workspaceId: pair.workspaceId,
+        });
+      },
+    });
+
+    const result = await createWorkspace(db, 'collision-child', {
+      ownerApiKey,
+      idempotencyKey,
+      requestDigest,
+    });
+
+    expect(result.created).toBe(false);
+    expect(result.workspace_id).toBe(pair.workspaceId);
+    expect(result.api_key).toBe(deterministicApiKey);
   });
 
   it('canonicalizes provenance field order in workspace-create request digests', async () => {

--- a/packages/engine/src/engine/__tests__/workspace.test.ts
+++ b/packages/engine/src/engine/__tests__/workspace.test.ts
@@ -3,7 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { makeNodeStack, type TestStack } from '../../__tests__/conformance/harness.js';
 import { channels, workspaceCreateIdempotency, workspaces } from '../../db/schema.js';
-import { hmacSha256Hex, sha256Hex } from '../../lib/crypto.js';
+import { sha256Hex } from '../../lib/crypto.js';
 import type {
   AtomicWrite,
   BatchCapability,
@@ -11,7 +11,12 @@ import type {
   TransactionCapability,
 } from '../../ports/database.js';
 import * as snowflake from '../snowflake.js';
-import { createWorkspace, deleteWorkspace, workspaceCreateRequestDigest } from '../workspace.js';
+import {
+  createWorkspace,
+  deleteWorkspace,
+  deriveIdempotentWorkspaceApiKey,
+  workspaceCreateRequestDigest,
+} from '../workspace.js';
 
 describe('workspace write durability', () => {
   let stack: TestStack;
@@ -223,10 +228,7 @@ describe('workspace write durability', () => {
     const ownerApiKey = 'rk_live_collision_owner';
     const idempotencyKey = 'collision-job';
     const requestDigest = await workspaceCreateRequestDigest({ name: 'collision-child' });
-    const deterministicApiKey = `rk_live_${(await hmacSha256Hex(
-      `relaycast:workspace-create:v1:${idempotencyKey}:${requestDigest}`,
-      ownerApiKey,
-    )).slice(0, 32)}`;
+    const deterministicApiKey = await deriveIdempotentWorkspaceApiKey(ownerApiKey, idempotencyKey, requestDigest);
     const pair = useGeneratedPair();
 
     attachD1Batch({
@@ -260,6 +262,66 @@ describe('workspace write durability', () => {
     expect(result.created).toBe(false);
     expect(result.workspace_id).toBe(pair.workspaceId);
     expect(result.api_key).toBe(deterministicApiKey);
+  });
+
+  it('fails closed when binding recovery cannot verify the committed pair', async () => {
+    const ownerApiKey = 'rk_live_readback_owner';
+    const idempotencyKey = 'readback-job';
+    const requestDigest = await workspaceCreateRequestDigest({ name: 'readback-child' });
+    const deterministicApiKey = await deriveIdempotentWorkspaceApiKey(ownerApiKey, idempotencyKey, requestDigest);
+    const pair = useGeneratedPair();
+
+    attachD1Batch({
+      beforeFirstBatch: async () => {
+        await db.insert(workspaces).values({
+          id: pair.workspaceId,
+          name: 'readback-child',
+          apiKeyHash: await sha256Hex(deterministicApiKey),
+        });
+        await db.insert(channels).values({
+          id: 'readback-channel',
+          workspaceId: pair.workspaceId,
+          name: 'general',
+          topic: 'General discussion',
+        });
+        await db.insert(workspaceCreateIdempotency).values({
+          ownerScopeHash: await sha256Hex(ownerApiKey),
+          idempotencyKeyHash: await sha256Hex(idempotencyKey),
+          requestDigest,
+          workspaceId: pair.workspaceId,
+        });
+      },
+    });
+
+    let selectCalls = 0;
+    const failingReadbackDb = new Proxy(db, {
+      get(target, property) {
+        if (property === 'select') {
+          return (...args: Parameters<EngineDb['select']>) => {
+            selectCalls += 1;
+            if (selectCalls >= 4) {
+              throw new Error('readback query unavailable');
+            }
+            return target.select(...args);
+          };
+        }
+        const value = Reflect.get(target, property, target) as unknown;
+        return typeof value === 'function' ? value.bind(target) : value;
+      },
+    });
+
+    await expect(createWorkspace(failingReadbackDb, 'readback-child', {
+      ownerApiKey,
+      idempotencyKey,
+      requestDigest,
+    })).rejects.toMatchObject({
+      code: 'workspace_storage_unavailable',
+      status: 503,
+      diagnostics: {
+        operation: 'workspace.create',
+        storage_error: 'readback_unavailable',
+      },
+    });
   });
 
   it('canonicalizes provenance field order in workspace-create request digests', async () => {

--- a/packages/engine/src/engine/__tests__/workspace.test.ts
+++ b/packages/engine/src/engine/__tests__/workspace.test.ts
@@ -293,16 +293,25 @@ describe('workspace write durability', () => {
       },
     });
 
-    let selectCalls = 0;
     const failingReadbackDb = new Proxy(db, {
       get(target, property) {
         if (property === 'select') {
           return (...args: Parameters<EngineDb['select']>) => {
-            selectCalls += 1;
-            if (selectCalls >= 4) {
-              throw new Error('readback query unavailable');
-            }
-            return target.select(...args);
+            const query = target.select(...args) as unknown as {
+              from(table: unknown): unknown;
+            };
+            const originalFrom = query.from.bind(query);
+            return new Proxy(query, {
+              get(queryTarget, queryProperty, receiver) {
+                if (queryProperty === 'from') {
+                  return (table: unknown) => {
+                    if (table === channels) throw new Error('readback query unavailable');
+                    return originalFrom(table);
+                  };
+                }
+                return Reflect.get(queryTarget, queryProperty, receiver);
+              },
+            });
           };
         }
         const value = Reflect.get(target, property, target) as unknown;

--- a/packages/engine/src/engine/__tests__/workspace.test.ts
+++ b/packages/engine/src/engine/__tests__/workspace.test.ts
@@ -198,7 +198,9 @@ describe('workspace write durability', () => {
     });
 
     expect(batchCalls()).toBe(2);
-    expect(created.created).toBe(false);
+    // The first write committed before its response was lost, so this is a
+    // recovery of this invocation's own create and must retain 201 semantics.
+    expect(created.created).toBe(true);
     expect(created.api_key).toMatch(/^rk_live_[0-9a-f]{32}$/);
     expect(await db.select().from(workspaces)).toHaveLength(1);
     expect(await db.select().from(workspaceCreateIdempotency)).toHaveLength(1);

--- a/packages/engine/src/engine/__tests__/workspace.test.ts
+++ b/packages/engine/src/engine/__tests__/workspace.test.ts
@@ -212,6 +212,19 @@ describe('workspace write durability', () => {
     expect(replay.api_key).toBe(created.api_key);
   });
 
+  it('canonicalizes provenance field order in workspace-create request digests', async () => {
+    const first = await workspaceCreateRequestDigest({
+      name: 'canonical-child',
+      provenance: { source: 'ci', origin_id: 'run-371', classification: 'internal' },
+    });
+    const reordered = await workspaceCreateRequestDigest({
+      name: 'canonical-child',
+      provenance: { classification: 'internal', origin_id: 'run-371', source: 'ci' },
+    });
+
+    expect(reordered).toBe(first);
+  });
+
   it('serializes concurrent delegated duplicates and scopes bindings to the owner', async () => {
     attachD1Batch({});
     const requestDigest = await workspaceCreateRequestDigest({ name: 'concurrent-child' });

--- a/packages/engine/src/engine/__tests__/workspace.test.ts
+++ b/packages/engine/src/engine/__tests__/workspace.test.ts
@@ -268,30 +268,9 @@ describe('workspace write durability', () => {
     const ownerApiKey = 'rk_live_readback_owner';
     const idempotencyKey = 'readback-job';
     const requestDigest = await workspaceCreateRequestDigest({ name: 'readback-child' });
-    const deterministicApiKey = await deriveIdempotentWorkspaceApiKey(ownerApiKey, idempotencyKey, requestDigest);
-    const pair = useGeneratedPair();
-
-    attachD1Batch({
-      beforeFirstBatch: async () => {
-        await db.insert(workspaces).values({
-          id: pair.workspaceId,
-          name: 'readback-child',
-          apiKeyHash: await sha256Hex(deterministicApiKey),
-        });
-        await db.insert(channels).values({
-          id: 'readback-channel',
-          workspaceId: pair.workspaceId,
-          name: 'general',
-          topic: 'General discussion',
-        });
-        await db.insert(workspaceCreateIdempotency).values({
-          ownerScopeHash: await sha256Hex(ownerApiKey),
-          idempotencyKeyHash: await sha256Hex(idempotencyKey),
-          requestDigest,
-          workspaceId: pair.workspaceId,
-        });
-      },
-    });
+    // The first atomic write commits, but its response is lost. The retry then
+    // reaches generated-pair readback before it can classify the replay.
+    attachD1Batch({ loseFirstResponse: true });
 
     const failingReadbackDb = new Proxy(db, {
       get(target, property) {

--- a/packages/engine/src/engine/__tests__/workspace.test.ts
+++ b/packages/engine/src/engine/__tests__/workspace.test.ts
@@ -2,7 +2,7 @@ import { eq } from 'drizzle-orm';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { makeNodeStack, type TestStack } from '../../__tests__/conformance/harness.js';
-import { channels, workspaces } from '../../db/schema.js';
+import { channels, workspaceCreateIdempotency, workspaces } from '../../db/schema.js';
 import type {
   AtomicWrite,
   BatchCapability,
@@ -10,7 +10,7 @@ import type {
   TransactionCapability,
 } from '../../ports/database.js';
 import * as snowflake from '../snowflake.js';
-import { createWorkspace, deleteWorkspace } from '../workspace.js';
+import { createWorkspace, deleteWorkspace, workspaceCreateRequestDigest } from '../workspace.js';
 
 describe('workspace write durability', () => {
   let stack: TestStack;
@@ -186,6 +186,69 @@ describe('workspace write durability', () => {
 
     expect(batchCalls()).toBe(2);
     await expectOneCompleteWorkspace(created.workspace_id);
+  });
+
+  it('recovers a delegated child key after commit/response loss', async () => {
+    const batchCalls = attachD1Batch({ loseFirstResponse: true });
+    const ownerApiKey = 'rk_live_parent_for_recovery';
+    const requestDigest = await workspaceCreateRequestDigest({ name: 'delegated-child', expiresInSeconds: 3_600 });
+    const created = await createWorkspace(db, 'delegated-child', {
+      ownerApiKey, idempotencyKey: 'cloud-job-123', requestDigest,
+      expiresAt: new Date(Date.now() + 3_600_000),
+    });
+
+    expect(batchCalls()).toBe(2);
+    expect(created.created).toBe(false);
+    expect(created.api_key).toMatch(/^rk_live_[0-9a-f]{32}$/);
+    expect(await db.select().from(workspaces)).toHaveLength(1);
+    expect(await db.select().from(workspaceCreateIdempotency)).toHaveLength(1);
+
+    const replay = await createWorkspace(db, 'delegated-child', {
+      ownerApiKey, idempotencyKey: 'cloud-job-123', requestDigest,
+      expiresAt: new Date(Date.now() + 3_600_000),
+    });
+    expect(replay.created).toBe(false);
+    expect(replay.workspace_id).toBe(created.workspace_id);
+    expect(replay.api_key).toBe(created.api_key);
+  });
+
+  it('serializes concurrent delegated duplicates and scopes bindings to the owner', async () => {
+    attachD1Batch({});
+    const requestDigest = await workspaceCreateRequestDigest({ name: 'concurrent-child' });
+    const firstOwner = 'rk_live_owner_a';
+    const secondOwner = 'rk_live_owner_b';
+    const [a, b] = await Promise.all([
+      createWorkspace(db, 'concurrent-child', { ownerApiKey: firstOwner, idempotencyKey: 'same-job', requestDigest }),
+      createWorkspace(db, 'concurrent-child', { ownerApiKey: firstOwner, idempotencyKey: 'same-job', requestDigest }),
+    ]);
+    expect(a.workspace_id).toBe(b.workspace_id);
+    expect(a.api_key).toBe(b.api_key);
+    expect(await db.select().from(workspaces)).toHaveLength(1);
+
+    const otherOwner = await createWorkspace(db, 'concurrent-child', {
+      ownerApiKey: secondOwner, idempotencyKey: 'same-job', requestDigest,
+    });
+    expect(otherOwner.workspace_id).not.toBe(a.workspace_id);
+    expect(await db.select().from(workspaces)).toHaveLength(2);
+  });
+
+  it('rejects digest conflicts and prevents recreation after child deletion', async () => {
+    attachD1Batch({});
+    const ownerApiKey = 'rk_live_owner_conflict';
+    const key = 'cloud-job-conflict';
+    const originalDigest = await workspaceCreateRequestDigest({ name: 'original' });
+    const created = await createWorkspace(db, 'original', { ownerApiKey, idempotencyKey: key, requestDigest: originalDigest });
+    const changedDigest = await workspaceCreateRequestDigest({ name: 'changed' });
+    await expect(createWorkspace(db, 'changed', { ownerApiKey, idempotencyKey: key, requestDigest: changedDigest }))
+      .rejects.toMatchObject({ code: 'workspace_create_idempotency_conflict', status: 409 });
+
+    await deleteWorkspace(db, stack.runtime.deps.files, created.workspace_id);
+    await expect(createWorkspace(db, 'original', { ownerApiKey, idempotencyKey: key, requestDigest: originalDigest }))
+      .rejects.toMatchObject({ code: 'workspace_create_idempotency_terminalized', status: 409 });
+    expect(await db.select().from(workspaces)).toHaveLength(0);
+    expect(await db.select().from(workspaceCreateIdempotency)).toMatchObject([
+      { status: 'terminalized', workspaceId: created.workspace_id },
+    ]);
   });
 
   it('returns storage unavailable when committed-pair readback fails', async () => {

--- a/packages/engine/src/engine/workspace.ts
+++ b/packages/engine/src/engine/workspace.ts
@@ -69,7 +69,11 @@ export function workspaceCreateRequestDigest(input: {
   }));
 }
 
-async function deriveIdempotentWorkspaceApiKey(ownerApiKey: string, idempotencyKey: string, requestDigest: string): Promise<string> {
+export async function deriveIdempotentWorkspaceApiKey(
+  ownerApiKey: string,
+  idempotencyKey: string,
+  requestDigest: string,
+): Promise<string> {
   const material = `relaycast:workspace-create:v1:${idempotencyKey}:${requestDigest}`;
   return `rk_live_${(await hmacSha256Hex(material, ownerApiKey)).slice(0, 32)}`;
 }
@@ -346,6 +350,18 @@ export async function createWorkspace(
             // semantics; matching only workspaceId would misclassify an
             // unrelated workspace-id collision as our own recovery.
             const committed = await readCommittedWorkspacePair(db, expected);
+            if (committed.status === 'unavailable') {
+              const error = codedError(
+                'Workspace storage temporarily unavailable',
+                'workspace_storage_unavailable',
+                503,
+              );
+              error.diagnostics = {
+                operation: 'workspace.create',
+                storage_error: 'readback_unavailable',
+              };
+              throw error;
+            }
             recoveredOwnWorkspace = committed.status === 'match';
             return [[existing], await db.select().from(channels).where(eq(channels.workspaceId, existing.id))] as WorkspaceWriteResult;
           }

--- a/packages/engine/src/engine/workspace.ts
+++ b/packages/engine/src/engine/workspace.ts
@@ -1,7 +1,7 @@
 import { and, asc, eq, gt, inArray, isNull, like, lte, or, sql } from 'drizzle-orm';
 import type { getDb } from '../db/index.js';
-import { workspaces, channels, fileCleanupQueue, workspaceEvents } from '../db/schema.js';
-import { randomHex, sha256Hex } from '../lib/crypto.js';
+import { workspaces, channels, fileCleanupQueue, workspaceEvents, workspaceCreateIdempotency } from '../db/schema.js';
+import { hmacSha256Hex, randomHex, sha256Hex } from '../lib/crypto.js';
 import { generateId } from './snowflake.js';
 import { codedError } from '../lib/httpError.js';
 import { D1WriteRetryExhaustedError, retryD1Write } from '../lib/d1Retry.js';
@@ -27,6 +27,8 @@ type CreateWorkspaceOptions =
   | {
       ownerApiKey?: string;
       ownerApiKeyHash?: string;
+      idempotencyKey?: string;
+      requestDigest?: string;
       expiresAt?: Date;
       provenance?: WorkspaceProvenanceRecord;
       usageClassification?: 'internal' | 'external' | 'unknown';
@@ -42,6 +44,28 @@ const FILE_CLEANUP_RETRY_MS = 30_000;
 
 function hashApiKey(apiKey: string): Promise<string> {
   return sha256Hex(apiKey);
+}
+
+/** Canonical digest for the public workspace-create request contract. */
+export function workspaceCreateRequestDigest(input: {
+  name: string;
+  expiresInSeconds?: number;
+  provenance?: Pick<WorkspaceProvenanceRecord, 'source' | 'origin_id' | 'classification'>;
+}): Promise<string> {
+  return sha256Hex(JSON.stringify({
+    name: input.name,
+    ...(input.expiresInSeconds === undefined ? {} : { expires_in_seconds: input.expiresInSeconds }),
+    ...(input.provenance === undefined ? {} : { provenance: input.provenance }),
+  }));
+}
+
+async function deriveIdempotentWorkspaceApiKey(ownerApiKey: string, idempotencyKey: string, requestDigest: string): Promise<string> {
+  const material = `relaycast:workspace-create:v1:${idempotencyKey}:${requestDigest}`;
+  return `rk_live_${(await hmacSha256Hex(material, ownerApiKey)).slice(0, 32)}`;
+}
+
+function idempotencyConflict(message: string, code = 'workspace_create_idempotency_conflict') {
+  return codedError(message, code, 409);
 }
 
 function buildWorkspaceResponse(
@@ -160,9 +184,61 @@ export async function createWorkspace(
 
   const ownerApiKeyHash = providedOwnerApiKeyHash ?? derivedOwnerApiKeyHash;
   const createOptions = typeof options === 'string' ? undefined : options;
+  const idempotencyKey = createOptions?.idempotencyKey;
+  const requestDigest = createOptions?.requestDigest;
+
+  if (idempotencyKey && !providedOwnerApiKey) {
+    throw codedError(
+      'An authenticated owner API key is required when Idempotency-Key is supplied',
+      'workspace_create_idempotency_owner_required',
+      401,
+    );
+  }
+  if (idempotencyKey && !requestDigest) {
+    throw codedError(
+      'A request digest is required for workspace create idempotency',
+      'workspace_create_idempotency_digest_required',
+      400,
+    );
+  }
+
+  const idempotencyKeyHash = idempotencyKey ? await hashApiKey(idempotencyKey) : undefined;
+  const deterministicApiKey = idempotencyKey && requestDigest
+    ? await deriveIdempotentWorkspaceApiKey(providedOwnerApiKey!, idempotencyKey, requestDigest)
+    : undefined;
+
+  if (ownerApiKeyHash && idempotencyKeyHash && requestDigest) {
+    const [binding] = await db
+      .select()
+      .from(workspaceCreateIdempotency)
+      .where(and(
+        eq(workspaceCreateIdempotency.ownerScopeHash, ownerApiKeyHash),
+        eq(workspaceCreateIdempotency.idempotencyKeyHash, idempotencyKeyHash),
+      ));
+    if (binding) {
+      if (binding.requestDigest !== requestDigest) {
+        throw idempotencyConflict('Idempotency-Key was reused with a different request payload');
+      }
+      if (binding.status !== 'active') {
+        throw idempotencyConflict(
+          'The workspace create idempotency binding has been terminalized and cannot be replayed',
+          'workspace_create_idempotency_terminalized',
+        );
+      }
+      const [existing] = await db.select().from(workspaces).where(eq(workspaces.id, binding.workspaceId));
+      if (!existing || existing.apiKeyHash !== await hashApiKey(deterministicApiKey!)) {
+        throw idempotencyConflict(
+          'The workspace create idempotency binding cannot recover its child workspace',
+          'workspace_create_idempotency_unusable',
+        );
+      }
+      const workspace = buildWorkspaceResponse(existing, deterministicApiKey);
+      return { workspace, created: false, ...workspace };
+    }
+  }
 
   // Repeated creates from the same owner/key should reuse the existing workspace.
-  if (ownerApiKeyHash) {
+  if (ownerApiKeyHash && !idempotencyKey) {
     const [existing] = await db
       .select()
       .from(workspaces)
@@ -182,11 +258,12 @@ export async function createWorkspace(
   }
 
   const workspaceId = generateId();
-  const apiKey = `rk_live_${randomHex(16)}`;
+  const apiKey = deterministicApiKey ?? `rk_live_${randomHex(16)}`;
   const apiKeyHash = await hashApiKey(apiKey);
 
   const channelId = generateId();
   const expected = { workspaceId, name, apiKeyHash, channelId };
+  let replayedWorkspace: typeof workspaces.$inferSelect | undefined;
   let writeResult: WorkspaceWriteResult;
   try {
     writeResult = await retryD1Write(async () => {
@@ -217,10 +294,44 @@ export async function createWorkspace(
                 topic: 'General discussion',
               })
               .returning(),
+            ...(ownerApiKeyHash && idempotencyKeyHash && requestDigest
+              ? [writeDb.insert(workspaceCreateIdempotency).values({
+                ownerScopeHash: ownerApiKeyHash,
+                idempotencyKeyHash,
+                requestDigest,
+                workspaceId,
+              }).returning()]
+              : []),
           ],
           { requireAtomic: true },
         ) as WorkspaceWriteResult;
       } catch (cause) {
+        if (isUniqueConstraintError(cause) && ownerApiKeyHash && idempotencyKeyHash && requestDigest) {
+          const [binding] = await db.select().from(workspaceCreateIdempotency).where(and(
+            eq(workspaceCreateIdempotency.ownerScopeHash, ownerApiKeyHash),
+            eq(workspaceCreateIdempotency.idempotencyKeyHash, idempotencyKeyHash),
+          ));
+          if (binding) {
+            if (binding.requestDigest !== requestDigest) {
+              throw idempotencyConflict('Idempotency-Key was reused with a different request payload');
+            }
+            if (binding.status !== 'active') {
+              throw idempotencyConflict(
+                'The workspace create idempotency binding has been terminalized and cannot be replayed',
+                'workspace_create_idempotency_terminalized',
+              );
+            }
+            const [existing] = await db.select().from(workspaces).where(eq(workspaces.id, binding.workspaceId));
+            if (!existing || existing.apiKeyHash !== apiKeyHash) {
+              throw idempotencyConflict(
+                'The workspace create idempotency binding cannot recover its child workspace',
+                'workspace_create_idempotency_unusable',
+              );
+            }
+            replayedWorkspace = existing;
+            return [[existing], await db.select().from(channels).where(eq(channels.workspaceId, existing.id))] as WorkspaceWriteResult;
+          }
+        }
         if (!isUniqueConstraintError(cause)) throw cause;
 
         // A prior attempt may have committed before its response was lost.
@@ -264,6 +375,11 @@ export async function createWorkspace(
 
   const [workspaceRows] = writeResult;
   const createdWorkspace = workspaceRows[0];
+
+  if (replayedWorkspace) {
+    const workspace = buildWorkspaceResponse(replayedWorkspace, apiKey);
+    return { workspace, created: false, ...workspace };
+  }
 
   // A conflict can only be an idempotent replay of this exact generated pair.
   if (!isExpectedWorkspacePair(writeResult, expected) || !createdWorkspace) {
@@ -392,6 +508,10 @@ async function deleteWorkspaceBatch(
         writeDb
           .delete(workspaceEvents)
           .where(inArray(workspaceEvents.workspaceId, workspaceIds)),
+        writeDb
+          .update(workspaceCreateIdempotency)
+          .set({ status: 'terminalized', terminalizedAt: new Date() })
+          .where(inArray(workspaceCreateIdempotency.workspaceId, workspaceIds)),
         writeDb
           .delete(workspaces)
           .where(inArray(workspaces.id, workspaceIds)),

--- a/packages/engine/src/engine/workspace.ts
+++ b/packages/engine/src/engine/workspace.ts
@@ -52,10 +52,20 @@ export function workspaceCreateRequestDigest(input: {
   expiresInSeconds?: number;
   provenance?: Pick<WorkspaceProvenanceRecord, 'source' | 'origin_id' | 'classification'>;
 }): Promise<string> {
+  const provenance = input.provenance === undefined
+    ? undefined
+    : {
+        source: input.provenance.source,
+        ...(input.provenance.origin_id === undefined ? {} : { origin_id: input.provenance.origin_id }),
+        ...(input.provenance.classification === undefined
+          ? {}
+          : { classification: input.provenance.classification }),
+      };
+
   return sha256Hex(JSON.stringify({
     name: input.name,
     ...(input.expiresInSeconds === undefined ? {} : { expires_in_seconds: input.expiresInSeconds }),
-    ...(input.provenance === undefined ? {} : { provenance: input.provenance }),
+    ...(provenance === undefined ? {} : { provenance }),
   }));
 }
 

--- a/packages/engine/src/engine/workspace.ts
+++ b/packages/engine/src/engine/workspace.ts
@@ -342,9 +342,11 @@ export async function createWorkspace(
             replayedWorkspace = existing;
             // The binding can point at this invocation's generated workspace
             // when the first atomic write committed but its response was lost.
-            // Preserve the original create semantics in that case; a binding
-            // owned by another invocation is a replay and must remain 200/false.
-            recoveredOwnWorkspace = existing.id === workspaceId;
+            // Verify the complete generated pair before preserving create
+            // semantics; matching only workspaceId would misclassify an
+            // unrelated workspace-id collision as our own recovery.
+            const committed = await readCommittedWorkspacePair(db, expected);
+            recoveredOwnWorkspace = committed.status === 'match';
             return [[existing], await db.select().from(channels).where(eq(channels.workspaceId, existing.id))] as WorkspaceWriteResult;
           }
         }

--- a/packages/engine/src/engine/workspace.ts
+++ b/packages/engine/src/engine/workspace.ts
@@ -274,6 +274,7 @@ export async function createWorkspace(
   const channelId = generateId();
   const expected = { workspaceId, name, apiKeyHash, channelId };
   let replayedWorkspace: typeof workspaces.$inferSelect | undefined;
+  let recoveredOwnWorkspace = false;
   let writeResult: WorkspaceWriteResult;
   try {
     writeResult = await retryD1Write(async () => {
@@ -339,6 +340,11 @@ export async function createWorkspace(
               );
             }
             replayedWorkspace = existing;
+            // The binding can point at this invocation's generated workspace
+            // when the first atomic write committed but its response was lost.
+            // Preserve the original create semantics in that case; a binding
+            // owned by another invocation is a replay and must remain 200/false.
+            recoveredOwnWorkspace = existing.id === workspaceId;
             return [[existing], await db.select().from(channels).where(eq(channels.workspaceId, existing.id))] as WorkspaceWriteResult;
           }
         }
@@ -388,7 +394,7 @@ export async function createWorkspace(
 
   if (replayedWorkspace) {
     const workspace = buildWorkspaceResponse(replayedWorkspace, apiKey);
-    return { workspace, created: false, ...workspace };
+    return { workspace, created: recoveredOwnWorkspace, ...workspace };
   }
 
   // A conflict can only be an idempotent replay of this exact generated pair.

--- a/packages/engine/src/routes/workspace.ts
+++ b/packages/engine/src/routes/workspace.ts
@@ -1,10 +1,12 @@
 import { Hono } from 'hono';
 import type { Context } from 'hono';
+import type { ContentfulStatusCode } from 'hono/utils/http-status';
 import { createMiddleware } from 'hono/factory';
 import { z } from 'zod';
 import { WorkspaceProvenanceInputSchema } from '@relaycast/types';
 import type { AppEnv } from '../env.js';
 import { requireAgentToken, requireWorkspaceKey, requireWorkspaceRead } from '../middleware/auth.js';
+import { parseIdempotencyKey } from '../middleware/idempotency.js';
 import { rateLimit } from '../middleware/rateLimit.js';
 import * as workspaceEngine from '../engine/workspace.js';
 import * as activityEngine from '../engine/activity.js';
@@ -196,14 +198,36 @@ workspaceRoutes.post('/workspaces', async (c) => {
       expires_in_seconds: expiresInSeconds,
       provenance: declaredProvenance,
     } = parsed.data;
+    const { key: idempotencyKey, error: idempotencyError } = parseIdempotencyKey(c.req.header('Idempotency-Key'));
+    if (idempotencyError) {
+      return jsonError(c, 'invalid_idempotency_key', idempotencyError, 400);
+    }
     const db = c.get('db');
     const ownerApiKey = extractOwnerApiKey(c.req.header('Authorization'));
+    if (idempotencyKey) {
+      if (!ownerApiKey) {
+        return jsonError(c, 'workspace_create_idempotency_owner_required', 'An authenticated workspace owner is required when Idempotency-Key is supplied', 401);
+      }
+      const ownerAuth = await c.get('engine').auth.authenticate({ token: ownerApiKey, require: 'workspace', db });
+      if (!ownerAuth.ok) {
+        return jsonError(c, ownerAuth.code, ownerAuth.message, ownerAuth.status as ContentfulStatusCode);
+      }
+    }
+    const requestDigest = idempotencyKey
+      ? await workspaceEngine.workspaceCreateRequestDigest({
+        name,
+        ...(expiresInSeconds === undefined ? {} : { expiresInSeconds }),
+        ...(declaredProvenance === undefined ? {} : { provenance: declaredProvenance }),
+      })
+      : undefined;
     const attribution = buildWorkspaceProvenance(c.req.raw, declaredProvenance);
     const result = await workspaceEngine.createWorkspace(
       db,
       name,
       {
         ...(ownerApiKey ? { ownerApiKey } : {}),
+        ...(idempotencyKey ? { idempotencyKey } : {}),
+        ...(requestDigest ? { requestDigest } : {}),
         ...(expiresInSeconds
           ? { expiresAt: new Date(Date.now() + expiresInSeconds * 1_000) }
           : {}),

--- a/packages/sdk-typescript/CHANGELOG.md
+++ b/packages/sdk-typescript/CHANGELOG.md
@@ -7,7 +7,11 @@ See the [root changelog](../../CHANGELOG.md) for cross-package release highlight
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [Unreleased - Patch]
+
+### Added
+
+- `RelayCast.createWorkspace()` and `RelaycastSetup.createWorkspace()` accept `idempotencyKey` for crash-safe delegated workspace creation retries.
 
 ## [8.2.2] - 2026-09-02
 

--- a/packages/sdk-typescript/CHANGELOG.md
+++ b/packages/sdk-typescript/CHANGELOG.md
@@ -7,7 +7,7 @@ See the [root changelog](../../CHANGELOG.md) for cross-package release highlight
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased - Patch]
+## [Unreleased - Minor]
 
 ### Added
 

--- a/packages/sdk-typescript/src/__tests__/relay.test.ts
+++ b/packages/sdk-typescript/src/__tests__/relay.test.ts
@@ -1153,6 +1153,29 @@ describe('RelayCast', () => {
       expect(init.headers['Idempotency-Key']).toBe('cloud-job-371');
     });
 
+    it('does not silently downgrade an explicitly empty idempotency key', async () => {
+      const { RelayCast } = await import('../relay.js');
+      mockFetch.mockImplementation(() =>
+        Promise.resolve({
+          ok: false,
+          status: 400,
+          json: () => Promise.resolve({
+            ok: false,
+            error: { code: 'invalid_idempotency_key', message: 'Idempotency-Key must not be empty' },
+          }),
+        }),
+      );
+
+      await expect(RelayCast.createWorkspace('child', {
+        apiKey: 'rk_live_parent',
+        idempotencyKey: '',
+        baseUrl: 'http://localhost:3000',
+      })).rejects.toMatchObject({ statusCode: 400 });
+
+      const [, init] = mockFetch.mock.calls[0]!;
+      expect(init.headers['Idempotency-Key']).toBe('');
+    });
+
     it('forwards explicit creation provenance', async () => {
       const { RelayCast } = await import('../relay.js');
       mockFetch.mockImplementation(() =>

--- a/packages/sdk-typescript/src/__tests__/relay.test.ts
+++ b/packages/sdk-typescript/src/__tests__/relay.test.ts
@@ -1129,6 +1129,30 @@ describe('RelayCast', () => {
       expect(result.expiresAt).toBe('2024-01-01T01:00:00.000Z');
     });
 
+    it('forwards the owner-scoped idempotency key for delegated creates', async () => {
+      const { RelayCast } = await import('../relay.js');
+      mockFetch.mockImplementation(() =>
+        Promise.resolve({
+          ok: true,
+          status: 201,
+          json: () => Promise.resolve({
+            ok: true,
+            data: { workspace_id: 'ws_child', api_key: 'rk_live_child', created_at: '2024-01-01' },
+          }),
+        }),
+      );
+
+      await RelayCast.createWorkspace('child', {
+        apiKey: 'rk_live_parent',
+        idempotencyKey: 'cloud-job-371',
+        baseUrl: 'http://localhost:3000',
+      });
+
+      const [, init] = mockFetch.mock.calls[0]!;
+      expect(init.headers.Authorization).toBe('Bearer rk_live_parent');
+      expect(init.headers['Idempotency-Key']).toBe('cloud-job-371');
+    });
+
     it('forwards explicit creation provenance', async () => {
       const { RelayCast } = await import('../relay.js');
       mockFetch.mockImplementation(() =>

--- a/packages/sdk-typescript/src/__tests__/relay.test.ts
+++ b/packages/sdk-typescript/src/__tests__/relay.test.ts
@@ -1289,7 +1289,7 @@ describe('RelayCast', () => {
           json: () =>
             Promise.resolve({
               ok: true,
-              data: { workspace_id: 'ws_existing', created_at: '2024-01-02' },
+              data: { workspace_id: 'ws_existing', api_key: 'rk_live_existing', created_at: '2024-01-02' },
             }),
         }),
       );
@@ -1298,6 +1298,7 @@ describe('RelayCast', () => {
         RelayCast.createWorkspace('Dup', { apiKey: 'rk_live_existing', baseUrl: 'http://localhost:3000' }),
       ).resolves.toEqual({
         workspaceId: 'ws_existing',
+        apiKey: 'rk_live_existing',
         createdAt: '2024-01-02',
       });
 
@@ -1413,7 +1414,7 @@ describe('RelayCast', () => {
           json: () =>
             Promise.resolve({
               ok: true,
-              data: { workspace_id: 'ws_existing', created_at: '2024-01-02' },
+              data: { workspace_id: 'ws_existing', api_key: 'rk_live_existing', created_at: '2024-01-02' },
             }),
         }),
       );
@@ -1426,6 +1427,7 @@ describe('RelayCast', () => {
         existed: true,
         name: 'Taken Workspace',
         workspaceId: 'ws_existing',
+        apiKey: 'rk_live_existing',
         createdAt: '2024-01-02',
       });
       expect(mockFetch).toHaveBeenCalledTimes(1);

--- a/packages/sdk-typescript/src/__tests__/setup.test.ts
+++ b/packages/sdk-typescript/src/__tests__/setup.test.ts
@@ -116,6 +116,23 @@ describe('RelaycastSetup', () => {
     expect(init.headers['Idempotency-Key']).toBe('cloud-job-371');
   });
 
+  it('does not silently downgrade an explicitly empty idempotency key', async () => {
+    const { RelaycastSetup } = await import('../setup.js');
+    mockFetch.mockImplementation(() =>
+      jsonResponse({
+        ok: false,
+        error: { code: 'invalid_idempotency_key', message: 'Idempotency-Key must not be empty' },
+      }, 400),
+    );
+
+    const setup = new RelaycastSetup({ apiKey: 'rk_live_parent' });
+    await expect(setup.createWorkspace({ name: 'child', idempotencyKey: '' }))
+      .rejects.toMatchObject({ httpStatus: 400 });
+
+    const [, init] = mockFetch.mock.calls[0]!;
+    expect(init.headers['Idempotency-Key']).toBe('');
+  });
+
   it('createWorkspace() uses a custom baseUrl and resolves apiKey functions per request', async () => {
     const { RelaycastSetup } = await import('../setup.js');
 

--- a/packages/sdk-typescript/src/__tests__/setup.test.ts
+++ b/packages/sdk-typescript/src/__tests__/setup.test.ts
@@ -99,6 +99,23 @@ describe('RelaycastSetup', () => {
     });
   });
 
+  it('createWorkspace() forwards the delegated idempotency key header', async () => {
+    const { RelaycastSetup } = await import('../setup.js');
+    mockFetch.mockImplementation(() =>
+      jsonResponse({
+        ok: true,
+        data: { workspace_id: 'ws_child', api_key: 'rk_live_child', created_at: '2026-04-30T12:00:00.000Z' },
+      }, 201),
+    );
+
+    const setup = new RelaycastSetup({ apiKey: 'rk_live_parent' });
+    await setup.createWorkspace({ name: 'child', idempotencyKey: 'cloud-job-371' });
+
+    const [, init] = mockFetch.mock.calls[0]!;
+    expect(init.headers.Authorization).toBe('Bearer rk_live_parent');
+    expect(init.headers['Idempotency-Key']).toBe('cloud-job-371');
+  });
+
   it('createWorkspace() uses a custom baseUrl and resolves apiKey functions per request', async () => {
     const { RelaycastSetup } = await import('../setup.js');
 

--- a/packages/sdk-typescript/src/relay.ts
+++ b/packages/sdk-typescript/src/relay.ts
@@ -343,7 +343,9 @@ export class RelayCast {
       headers: {
         'Content-Type': 'application/json',
         ...(apiKey ? { Authorization: `Bearer ${apiKey}` } : {}),
-        ...(resolved.idempotencyKey ? { 'Idempotency-Key': resolved.idempotencyKey } : {}),
+        ...(resolved.idempotencyKey !== undefined
+          ? { 'Idempotency-Key': resolved.idempotencyKey }
+          : {}),
         'X-SDK-Version': SDK_VERSION,
         'X-Relaycast-Origin-Client': SDK_ORIGIN.client,
         'X-Relaycast-Origin-Version': SDK_ORIGIN.version,

--- a/packages/sdk-typescript/src/relay.ts
+++ b/packages/sdk-typescript/src/relay.ts
@@ -200,6 +200,8 @@ export interface WorkspaceBootstrapOptions extends WorkspaceIdentityOptions {
   expiresInSeconds?: number;
   /** Creation context recorded once for hosted usage attribution. */
   provenance?: WorkspaceProvenanceOptions;
+  /** Owner-scoped key for crash-safe delegated workspace-create retries. */
+  idempotencyKey?: string;
 }
 
 export interface WorkspaceLookupOptions extends WorkspaceIdentityOptions {
@@ -341,6 +343,7 @@ export class RelayCast {
       headers: {
         'Content-Type': 'application/json',
         ...(apiKey ? { Authorization: `Bearer ${apiKey}` } : {}),
+        ...(resolved.idempotencyKey ? { 'Idempotency-Key': resolved.idempotencyKey } : {}),
         'X-SDK-Version': SDK_VERSION,
         'X-Relaycast-Origin-Client': SDK_ORIGIN.client,
         'X-Relaycast-Origin-Version': SDK_ORIGIN.version,

--- a/packages/sdk-typescript/src/setup-types.ts
+++ b/packages/sdk-typescript/src/setup-types.ts
@@ -43,6 +43,8 @@ export interface CreateWorkspaceOptions {
   expiresInSeconds?: number;
   /** Creation context recorded once for hosted usage attribution. */
   provenance?: WorkspaceProvenanceOptions;
+  /** Owner-scoped key for crash-safe delegated workspace-create retries. */
+  idempotencyKey?: string;
 }
 
 export type JoinWorkspaceOptions = Record<string, never>;

--- a/packages/sdk-typescript/src/setup.ts
+++ b/packages/sdk-typescript/src/setup.ts
@@ -273,7 +273,9 @@ export class RelaycastSetup {
           : {}),
         provenance: toWorkspaceProvenanceInput(options.provenance),
       },
-      headers: options.idempotencyKey ? { 'Idempotency-Key': options.idempotencyKey } : undefined,
+      headers: options.idempotencyKey !== undefined
+        ? { 'Idempotency-Key': options.idempotencyKey }
+        : undefined,
       requireApiKey: true,
     });
 

--- a/packages/sdk-typescript/src/setup.ts
+++ b/packages/sdk-typescript/src/setup.ts
@@ -69,6 +69,7 @@ interface RequestConfig {
   body?: Record<string, unknown>;
   allowNotFound?: boolean;
   requireApiKey?: boolean;
+  headers?: Record<string, string>;
 }
 
 function sleep(ms: number): Promise<void> {
@@ -272,6 +273,7 @@ export class RelaycastSetup {
           : {}),
         provenance: toWorkspaceProvenanceInput(options.provenance),
       },
+      headers: options.idempotencyKey ? { 'Idempotency-Key': options.idempotencyKey } : undefined,
       requireApiKey: true,
     });
 
@@ -333,6 +335,7 @@ export class RelaycastSetup {
     method: 'GET' | 'POST',
     path: string,
     body?: Record<string, unknown>,
+    extraHeaders?: Record<string, string>,
   ): Promise<Response> {
     const url = new URL(path, this.config.baseUrl);
     const apiKey = await this.resolveApiKey();
@@ -350,6 +353,7 @@ export class RelaycastSetup {
     if (method === 'POST') {
       headers['Content-Type'] = 'application/json';
     }
+    Object.assign(headers, extraHeaders ?? {});
 
     let attempt = 0;
 
@@ -388,10 +392,11 @@ export class RelaycastSetup {
     path,
     schema,
     body,
+    headers: extraHeaders,
     allowNotFound = false,
     requireApiKey = false,
   }: RequestConfig): Promise<TOutput | null> {
-    const response = await this.fetchWithRetry(method, path, body);
+    const response = await this.fetchWithRetry(method, path, body, extraHeaders);
 
     if (allowNotFound && response.status === 404) {
       return null;

--- a/packages/types/CHANGELOG.md
+++ b/packages/types/CHANGELOG.md
@@ -7,7 +7,11 @@ See the [root changelog](../../CHANGELOG.md) for cross-package release highlight
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [Unreleased - Minor]
+
+### Changed
+
+- `CreateWorkspaceResponse` now requires the `api_key` returned by workspace creation and authenticated idempotent replays.
 
 ## [8.3.0] - 2026-09-02
 

--- a/packages/types/src/__tests__/types.test.ts
+++ b/packages/types/src/__tests__/types.test.ts
@@ -5,6 +5,7 @@ import {
   ServerEventSchema,
   SessionMessagesResultSchema,
   WorkspaceSchema,
+  CreateWorkspaceResponseSchema,
 } from '../index.js';
 import type {
   Workspace,
@@ -105,6 +106,13 @@ describe('Type definitions', () => {
     expectTypeOf<CreateWorkspaceResponse>().toHaveProperty('api_key');
     expectTypeOf<CreateWorkspaceResponse>().toHaveProperty('workspace_id');
     expectTypeOf<CreateWorkspaceResponse>().toHaveProperty('expires_at');
+  });
+
+  it('CreateWorkspaceResponse requires the returned api_key', () => {
+    expect(() => CreateWorkspaceResponseSchema.parse({
+      workspace_id: 'ws_missing_key',
+      created_at: '2026-09-05T00:00:00.000Z',
+    })).toThrow();
   });
 
   it('WorkspaceLookup exposes public lookup fields', () => {

--- a/packages/types/src/workspace.ts
+++ b/packages/types/src/workspace.ts
@@ -71,7 +71,7 @@ export type CreateWorkspaceRequest = z.infer<typeof CreateWorkspaceRequestSchema
 
 export const CreateWorkspaceResponseSchema = z.object({
   workspace_id: z.string(),
-  api_key: z.string().optional(),
+  api_key: z.string(),
   created_at: z.string(),
   expires_at: z.string().nullable().optional(),
 });


### PR DESCRIPTION
## Summary

Closes #371.

- Add durable owner-scoped (owner API key hash, Idempotency-Key) bindings with request digests.
- Atomically create the child workspace, general channel, and binding; concurrent/retried writes recover the same child.
- Derive the child bearer key with HMAC at replay time; no plaintext child key is persisted.
- Return stable 409 conflicts for changed requests, unusable bindings, and terminalized bindings.
- Terminalize bindings atomically on explicit deletion and expiry reaping.
- Expose the contract through OpenAPI, TypeScript SDKs, setup docs, README, and changelogs.

## Verification

- build: types, a2a, engine, sdk
- lint: engine, sdk
- Engine: 70 files / 746 tests passed
- SDK: 22 files / 438 tests passed
- Focused workspace crash/concurrency/security: 2 files / 35 tests passed

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/AgentWorkforce/relaycast/pull/372?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

