### PR TITLE
fix(release): preserve lockfile during version bump

### DIFF
--- a/.agentworkforce/trajectories/active/traj_tklpxq0u1yhz/trajectory.json
+++ b/.agentworkforce/trajectories/active/traj_tklpxq0u1yhz/trajectory.json
@@ -1,0 +1,50 @@
+{
+  "id": "traj_tklpxq0u1yhz",
+  "version": 1,
+  "task": {
+    "title": "Fix Relaycast publish workflow npm edgesOut failure and release 8.4.0",
+    "source": {
+      "system": "plain",
+      "id": "relaycast-release-8.4.0"
+    }
+  },
+  "status": "active",
+  "startedAt": "2026-09-05T21:56:12.811Z",
+  "agents": [
+    {
+      "name": "default",
+      "role": "lead",
+      "joinedAt": "2026-09-05T21:57:35.346Z"
+    }
+  ],
+  "chapters": [
+    {
+      "id": "chap_5is6cx70hyhj",
+      "title": "Work",
+      "agentName": "default",
+      "startedAt": "2026-09-05T21:57:35.346Z",
+      "events": [
+        {
+          "ts": 1788645455347,
+          "type": "decision",
+          "content": "Preserve and refresh the existing lockfile before npm ci: Preserve and refresh the existing lockfile before npm ci",
+          "raw": {
+            "question": "Preserve and refresh the existing lockfile before npm ci",
+            "chosen": "Preserve and refresh the existing lockfile before npm ci",
+            "alternatives": [],
+            "reasoning": "The release failed in npm/arborist while resolving all workspaces from a deleted lockfile. On the exact Node 22 toolchain and 8.4.0 manifest transformation, npm install --package-lock-only --ignore-scripts followed by npm ci completed cleanly and retained the reviewed dependency graph."
+          },
+          "significance": "high"
+        }
+      ]
+    }
+  ],
+  "commits": [],
+  "filesChanged": [],
+  "projectId": "AgentWorkforce/relaycast",
+  "tags": [],
+  "_trace": {
+    "startRef": "9f1dcb401ee0a33091862098b8fb7702a3385cbd",
+    "endRef": "9f1dcb401ee0a33091862098b8fb7702a3385cbd"
+  }
+}

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -154,10 +154,14 @@ jobs:
             }
           NODE
 
+      - name: Refresh lockfile after version bump
+        # Preserve the resolved dependency graph and update only the workspace
+        # metadata. Re-resolving from an empty lockfile can trip npm/arborist's
+        # `edgesOut` failure after every workspace version changes at once.
+        run: npm install --package-lock-only --ignore-scripts
+
       - name: Clean reinstall after version bump
-        run: |
-          rm -rf node_modules packages/*/node_modules package-lock.json
-          npm install
+        run: npm ci
 
       - name: Build all packages
         run: npx turbo build


### PR DESCRIPTION
## Failure reproduced

Release run [33993997783](https://github.com/AgentWorkforce/relaycast/actions/runs/33993997783) failed before publishing in the `Clean reinstall after version bump` step after deleting both `package-lock.json` and installed dependencies:

```
npm error Cannot read properties of null (reading 'edgesOut')
```

No npm package, tag, release, or release commit was created.

## Fix

Refresh the reviewed lockfile for the all-workspace version change with `npm install --package-lock-only --ignore-scripts`, then perform the clean install with `npm ci`. This avoids making npm/arborist reconstruct the entire workspace graph from no lockfile.

## Exact validation

On Node 22.22.2/npm 10.9.7 from merge commit `9f1dcb401ee0a33091862098b8fb7702a3385cbd`:

1. `npm ci`
2. applied the workflow's exact 8.3.1 → 8.4.0 all-package manifest/dependency transformation
3. `npm install --package-lock-only --ignore-scripts` — passed
4. `npm ci` — passed
5. Prettier and YAML lint — passed
6. `git diff --check` — passed

`actionlint` reports only pre-existing findings at lines 96, 366, and 408; this patch adds none.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/AgentWorkforce/relaycast/pull/373?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

