### PR TITLE
fix(sdk-rust): preserve final 5xx diagnostic and bound Retry-After

### DIFF
--- a/packages/sdk-rust/CHANGELOG.md
+++ b/packages/sdk-rust/CHANGELOG.md
@@ -10,11 +10,12 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
 
 ### Fixed
 
-- `HttpClient::request` no longer sleeps after its final retry attempt, and no longer discards a repeatedly-retried 5xx response into a generic `InvalidResponse("Max retries exceeded")`. The last response's real HTTP status, structured API error code/message (or a raw-body summary if the final response wasn't JSON), correlation/request id, and attempt count are now returned to the caller as a `RelayError::Api`, still reporting as retryable. (#374)
-- A retried 5xx response's `Retry-After` header (delay-seconds form) is now honored for the wait before the next attempt, bounded to 5 seconds so a misconfigured or hostile server can't stall a caller far past the client's own backoff.
+- Retryable HTTP failures retain the final status, API error, request metadata, and attempt count after retries are exhausted.
+- Retried 5xx responses honor a bounded `Retry-After` delay.
 
 ### Changed
 
+- Automatic 5xx retries require an idempotent request or an idempotency key.
 - **BREAKING:** `RelayCast::rotate_agent_token` now requires the current agent token; use `take_over_agent` or `recover_agent` to replace an identity you cannot authenticate as.
 - **BREAKING:** `AgentRegistrationClient::register_agent_token` is create-only and returns `AgentRegistrationError::AlreadyExists` on conflicts; use a unique name or persist the token for self-rollover.
 - **BREAKING:** `RelayError::Api` gained `request_id: Option<String>` and `attempts: u32` fields (also exposed via new `RelayError::request_id()`/`RelayError::attempts()` accessors); match arms that destructure it exhaustively need a trailing `..`.

--- a/packages/sdk-rust/CHANGELOG.md
+++ b/packages/sdk-rust/CHANGELOG.md
@@ -8,10 +8,16 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
 
 ## [Unreleased - Major]
 
+### Fixed
+
+- `HttpClient::request` no longer sleeps after its final retry attempt, and no longer discards a repeatedly-retried 5xx response into a generic `InvalidResponse("Max retries exceeded")`. The last response's real HTTP status, structured API error code/message (or a raw-body summary if the final response wasn't JSON), correlation/request id, and attempt count are now returned to the caller as a `RelayError::Api`, still reporting as retryable. (#374)
+- A retried 5xx response's `Retry-After` header (delay-seconds form) is now honored for the wait before the next attempt, bounded to 5 seconds so a misconfigured or hostile server can't stall a caller far past the client's own backoff.
+
 ### Changed
 
 - **BREAKING:** `RelayCast::rotate_agent_token` now requires the current agent token; use `take_over_agent` or `recover_agent` to replace an identity you cannot authenticate as.
 - **BREAKING:** `AgentRegistrationClient::register_agent_token` is create-only and returns `AgentRegistrationError::AlreadyExists` on conflicts; use a unique name or persist the token for self-rollover.
+- **BREAKING:** `RelayError::Api` gained `request_id: Option<String>` and `attempts: u32` fields (also exposed via new `RelayError::request_id()`/`RelayError::attempts()` accessors); match arms that destructure it exhaustively need a trailing `..`.
 - `NodeRosterEntry.load` is now `Option<f64>`, matching the API's explicit unreported state; direct-agent heartbeats no longer label a constant utilization as measured.
 
 ### Added

--- a/packages/sdk-rust/src/client.rs
+++ b/packages/sdk-rust/src/client.rs
@@ -15,7 +15,37 @@ use crate::DEFAULT_BASE_URL;
 
 const SDK_VERSION: &str = env!("CARGO_PKG_VERSION");
 const DEFAULT_ORIGIN_CLIENT: &str = "@relaycast/sdk-rust";
+// One entry per attempt. The delay for the final attempt is never used —
+// there is nothing left to wait for once retries are exhausted.
 const RETRY_BACKOFFS_MS: [u64; 3] = [200, 400, 800];
+// Upper bound on a server-provided `Retry-After` delay so a misconfigured or
+// hostile response can't stall a caller far past the client's own backoff.
+const MAX_RETRY_AFTER_MS: u64 = 5_000;
+const REQUEST_ID_HEADER_CANDIDATES: [&str; 2] = ["x-request-id", "x-correlation-id"];
+
+/// Parse a bounded retry delay (in milliseconds) from a response's
+/// `Retry-After` header. Only the delay-seconds form is supported; malformed
+/// or missing headers fall back to the caller's default backoff.
+fn parse_retry_after_ms(response: &reqwest::Response) -> Option<u64> {
+    let value = response
+        .headers()
+        .get(reqwest::header::RETRY_AFTER)?
+        .to_str()
+        .ok()?;
+    let seconds: u64 = value.trim().parse().ok()?;
+    Some(seconds.saturating_mul(1000).min(MAX_RETRY_AFTER_MS))
+}
+
+/// Extract a correlation/request id from a response, if the server sent one.
+fn extract_request_id(response: &reqwest::Response) -> Option<String> {
+    REQUEST_ID_HEADER_CANDIDATES.iter().find_map(|name| {
+        response
+            .headers()
+            .get(*name)
+            .and_then(|value| value.to_str().ok())
+            .map(|value| value.to_string())
+    })
+}
 
 /// Options for creating an HTTP client.
 #[derive(Debug, Clone)]
@@ -190,6 +220,7 @@ impl HttpClient {
     ) -> Result<T> {
         let url = format!("{}{}", self.base_url, path);
         let options = options.unwrap_or_default();
+        let last_attempt = RETRY_BACKOFFS_MS.len() - 1;
 
         for (attempt, backoff) in RETRY_BACKOFFS_MS.iter().enumerate() {
             let mut request = self.build_request(method.clone(), &url, &options);
@@ -204,12 +235,18 @@ impl HttpClient {
 
             let response = request.send().await?;
             let status = response.status().as_u16();
+            let attempts = (attempt + 1) as u32;
 
-            // Retry on 5xx errors
-            if (500..=599).contains(&status) && attempt < RETRY_BACKOFFS_MS.len() {
-                tokio::time::sleep(Duration::from_millis(*backoff)).await;
+            // Retry on 5xx errors, but never after the final attempt: there is
+            // nothing left to wait for, and the caller needs this response's
+            // real diagnostic instead of a swallowed "max retries exceeded".
+            if (500..=599).contains(&status) && attempt < last_attempt {
+                let delay_ms = parse_retry_after_ms(&response).unwrap_or(*backoff);
+                tokio::time::sleep(Duration::from_millis(delay_ms)).await;
                 continue;
             }
+
+            let request_id = extract_request_id(&response);
 
             // Handle 204 No Content
             if status == 204 {
@@ -218,14 +255,38 @@ impl HttpClient {
                 return Ok(empty_json);
             }
 
-            let json: ApiResponse<T> = response.json().await?;
+            let bytes = response.bytes().await?;
+            let json: ApiResponse<T> = match serde_json::from_slice(&bytes) {
+                Ok(json) => json,
+                Err(err) => {
+                    // A non-JSON body from an error status (e.g. a gateway's
+                    // plain-text 502/503/504) still carries a real status; do
+                    // not let a body-parse failure erase it.
+                    if (400..=599).contains(&status) {
+                        return Err(RelayError::Api {
+                            code: "invalid_response_body".to_string(),
+                            message: format!("Server returned a non-JSON {status} response: {err}"),
+                            status,
+                            request_id,
+                            attempts,
+                        });
+                    }
+                    return Err(err.into());
+                }
+            };
 
             if !json.ok {
                 let error = json.error.unwrap_or_else(|| crate::types::ApiErrorInfo {
                     code: "unknown_error".to_string(),
                     message: "Unknown error".to_string(),
                 });
-                return Err(RelayError::api(error.code, error.message, status));
+                return Err(RelayError::Api {
+                    code: error.code,
+                    message: error.message,
+                    status,
+                    request_id,
+                    attempts,
+                });
             }
 
             return json.data.ok_or_else(|| {
@@ -233,10 +294,7 @@ impl HttpClient {
             });
         }
 
-        // This shouldn't be reached, but just in case
-        Err(RelayError::InvalidResponse(
-            "Max retries exceeded".to_string(),
-        ))
+        unreachable!("the retry loop always returns on its final attempt")
     }
 
     fn build_request(&self, method: Method, url: &str, options: &RequestOptions) -> RequestBuilder {

--- a/packages/sdk-rust/src/client.rs
+++ b/packages/sdk-rust/src/client.rs
@@ -1,6 +1,6 @@
 //! HTTP client for the RelayCast API.
 
-use reqwest::{Client, Method, RequestBuilder};
+use reqwest::{header::HeaderMap, Client, Method, RequestBuilder};
 use serde::{de::DeserializeOwned, Serialize};
 use std::time::Duration;
 
@@ -21,30 +21,86 @@ const RETRY_BACKOFFS_MS: [u64; 3] = [200, 400, 800];
 // Upper bound on a server-provided `Retry-After` delay so a misconfigured or
 // hostile response can't stall a caller far past the client's own backoff.
 const MAX_RETRY_AFTER_MS: u64 = 5_000;
+const MAX_ERROR_BODY_SUMMARY_CHARS: usize = 512;
+const MAX_REQUEST_ID_CHARS: usize = 256;
 const REQUEST_ID_HEADER_CANDIDATES: [&str; 2] = ["x-request-id", "x-correlation-id"];
 
 /// Parse a bounded retry delay (in milliseconds) from a response's
 /// `Retry-After` header. Only the delay-seconds form is supported; malformed
 /// or missing headers fall back to the caller's default backoff.
-fn parse_retry_after_ms(response: &reqwest::Response) -> Option<u64> {
-    let value = response
-        .headers()
-        .get(reqwest::header::RETRY_AFTER)?
-        .to_str()
-        .ok()?;
+fn parse_retry_after_ms(headers: &HeaderMap) -> Option<u64> {
+    let value = headers.get(reqwest::header::RETRY_AFTER)?.to_str().ok()?;
     let seconds: u64 = value.trim().parse().ok()?;
     Some(seconds.saturating_mul(1000).min(MAX_RETRY_AFTER_MS))
 }
 
+fn retry_delay_ms(headers: &HeaderMap, fallback_ms: u64) -> u64 {
+    parse_retry_after_ms(headers).unwrap_or(fallback_ms)
+}
+
+fn request_is_retryable(method: &Method, options: &RequestOptions) -> bool {
+    matches!(
+        *method,
+        Method::GET | Method::HEAD | Method::OPTIONS | Method::TRACE | Method::PUT | Method::DELETE
+    ) || options.idempotency_key.is_some()
+}
+
+fn should_retry_server_error(
+    method: &Method,
+    options: &RequestOptions,
+    status: u16,
+    attempt: usize,
+    last_attempt: usize,
+) -> bool {
+    request_is_retryable(method, options) && (500..=599).contains(&status) && attempt < last_attempt
+}
+
 /// Extract a correlation/request id from a response, if the server sent one.
-fn extract_request_id(response: &reqwest::Response) -> Option<String> {
+fn extract_request_id(headers: &HeaderMap) -> Option<String> {
     REQUEST_ID_HEADER_CANDIDATES.iter().find_map(|name| {
-        response
-            .headers()
+        headers
             .get(*name)
             .and_then(|value| value.to_str().ok())
-            .map(|value| value.to_string())
+            .and_then(|value| {
+                let value = value.trim();
+                let value: String = value
+                    .chars()
+                    .filter(|character| !character.is_control())
+                    .take(MAX_REQUEST_ID_CHARS)
+                    .collect();
+                (!value.is_empty()).then_some(value)
+            })
     })
+}
+
+/// Return a bounded, single-line, lossy summary suitable for an error message.
+///
+/// Gateway errors are often HTML or plain text. Keeping a small diagnostic
+/// excerpt is materially more useful than a serde parse error, but response
+/// bodies must not be allowed to create multi-line logs or unbounded errors.
+fn error_body_summary(bytes: &[u8]) -> String {
+    let decoded = String::from_utf8_lossy(bytes);
+    let mut characters = decoded.chars().map(|character| {
+        if character.is_control() || matches!(character, '\u{2028}' | '\u{2029}') {
+            ' '
+        } else {
+            character
+        }
+    });
+    let summary: String = characters
+        .by_ref()
+        .take(MAX_ERROR_BODY_SUMMARY_CHARS)
+        .collect();
+    let truncated = characters.next().is_some();
+    let summary = summary.trim();
+
+    if summary.is_empty() {
+        "<empty>".to_string()
+    } else if truncated {
+        format!("{summary}…")
+    } else {
+        summary.to_string()
+    }
 }
 
 /// Options for creating an HTTP client.
@@ -240,13 +296,13 @@ impl HttpClient {
             // Retry on 5xx errors, but never after the final attempt: there is
             // nothing left to wait for, and the caller needs this response's
             // real diagnostic instead of a swallowed "max retries exceeded".
-            if (500..=599).contains(&status) && attempt < last_attempt {
-                let delay_ms = parse_retry_after_ms(&response).unwrap_or(*backoff);
+            if should_retry_server_error(&method, &options, status, attempt, last_attempt) {
+                let delay_ms = retry_delay_ms(response.headers(), *backoff);
                 tokio::time::sleep(Duration::from_millis(delay_ms)).await;
                 continue;
             }
 
-            let request_id = extract_request_id(&response);
+            let request_id = extract_request_id(response.headers());
 
             // Handle 204 No Content
             if status == 204 {
@@ -265,7 +321,10 @@ impl HttpClient {
                     if (400..=599).contains(&status) {
                         return Err(RelayError::Api {
                             code: "invalid_response_body".to_string(),
-                            message: format!("Server returned a non-JSON {status} response: {err}"),
+                            message: format!(
+                                "Server returned a non-JSON {status} response: {err}; body: {}",
+                                error_body_summary(&bytes)
+                            ),
                             status,
                             request_id,
                             attempts,
@@ -371,5 +430,73 @@ impl HttpClient {
     pub async fn delete(&self, path: &str, options: Option<RequestOptions>) -> Result<()> {
         self.request::<()>(Method::DELETE, path, None::<()>, None, options)
             .await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        error_body_summary, extract_request_id, parse_retry_after_ms, retry_delay_ms,
+        should_retry_server_error, RequestOptions, MAX_RETRY_AFTER_MS,
+    };
+    use reqwest::header::{HeaderMap, HeaderValue};
+    use reqwest::Method;
+
+    #[test]
+    fn retry_after_is_bounded_without_a_wall_clock_wait() {
+        let mut headers = HeaderMap::new();
+        headers.insert("retry-after", HeaderValue::from_static("3600"));
+        assert_eq!(parse_retry_after_ms(&headers), Some(MAX_RETRY_AFTER_MS));
+
+        headers.insert("retry-after", HeaderValue::from_static("0"));
+        assert_eq!(retry_delay_ms(&headers, 200), 0);
+
+        assert!(should_retry_server_error(
+            &Method::GET,
+            &RequestOptions::default(),
+            503,
+            1,
+            2
+        ));
+        assert!(!should_retry_server_error(
+            &Method::GET,
+            &RequestOptions::default(),
+            503,
+            2,
+            2
+        ));
+        assert!(!should_retry_server_error(
+            &Method::POST,
+            &RequestOptions::default(),
+            503,
+            0,
+            2
+        ));
+        assert!(should_retry_server_error(
+            &Method::POST,
+            &RequestOptions::with_idempotency_key("retry-374"),
+            503,
+            0,
+            2
+        ));
+    }
+
+    #[test]
+    fn response_metadata_is_trimmed_bounded_and_single_line() {
+        let mut headers = HeaderMap::new();
+        headers.insert("x-request-id", HeaderValue::from_static("  request-374  "));
+        assert_eq!(extract_request_id(&headers).as_deref(), Some("request-374"));
+        headers.remove("x-request-id");
+        headers.insert(
+            "x-correlation-id",
+            HeaderValue::from_static(" correlation-374 "),
+        );
+        assert_eq!(
+            extract_request_id(&headers).as_deref(),
+            Some("correlation-374")
+        );
+
+        let summary = error_body_summary("gateway marker-374\nnext\u{2028}line\u{2029}".as_bytes());
+        assert_eq!(summary, "gateway marker-374 next line");
     }
 }

--- a/packages/sdk-rust/src/credentials.rs
+++ b/packages/sdk-rust/src/credentials.rs
@@ -228,6 +228,8 @@ pub async fn bootstrap_session(
                         status: 401,
                         message: "no cached agent token for self-rollover".to_string(),
                         code: "agent_token_required".to_string(),
+                        request_id: None,
+                        attempts: 1,
                     }),
                 } {
                     Ok(result) => {
@@ -330,6 +332,8 @@ pub async fn bootstrap_session(
                              owner, audited) or register under a unique name"
                         ),
                         code: "agent_already_exists".to_string(),
+                        request_id: None,
+                        attempts: 1,
                     })?;
                 let rotate_result = relay
                     .rotate_agent_token(&name, existing_agent_token)

--- a/packages/sdk-rust/src/error.rs
+++ b/packages/sdk-rust/src/error.rs
@@ -14,6 +14,11 @@ pub enum RelayError {
         message: String,
         /// The HTTP status code.
         status: u16,
+        /// Correlation/request id echoed by the server, when it sent one.
+        request_id: Option<String>,
+        /// Number of HTTP attempts made (including the one that produced this
+        /// error) before it was returned to the caller.
+        attempts: u32,
     },
 
     /// An HTTP request error.
@@ -48,6 +53,8 @@ impl RelayError {
             code: code.into(),
             message: message.into(),
             status,
+            request_id: None,
+            attempts: 1,
         }
     }
 
@@ -98,6 +105,24 @@ impl RelayError {
     pub fn code(&self) -> Option<&str> {
         match self {
             Self::Api { code, .. } => Some(code),
+            _ => None,
+        }
+    }
+
+    /// Get the correlation/request id the server echoed back, if this is an
+    /// API error and the server sent one.
+    pub fn request_id(&self) -> Option<&str> {
+        match self {
+            Self::Api { request_id, .. } => request_id.as_deref(),
+            _ => None,
+        }
+    }
+
+    /// Get the number of HTTP attempts made before this API error was
+    /// returned to the caller.
+    pub fn attempts(&self) -> Option<u32> {
+        match self {
+            Self::Api { attempts, .. } => Some(*attempts),
             _ => None,
         }
     }

--- a/packages/sdk-rust/src/registration.rs
+++ b/packages/sdk-rust/src/registration.rs
@@ -62,6 +62,21 @@ fn registration_cli_from_hint(cli_hint: Option<&str>, default_cli: &str) -> Stri
         .unwrap_or_else(|| "claude".to_string())
 }
 
+fn api_error_detail(
+    message: String,
+    code: String,
+    request_id: Option<String>,
+    attempts: u32,
+) -> String {
+    let mut detail = format!("{message} (code: {code}");
+    detail.push_str(&format!("; attempts: {attempts}"));
+    if let Some(request_id) = request_id {
+        detail.push_str(&format!("; request_id: {request_id}"));
+    }
+    detail.push(')');
+    detail
+}
+
 /// Errors emitted by [`AgentRegistrationClient`].
 #[derive(Debug, Clone, Error, PartialEq, Eq)]
 pub enum AgentRegistrationError {
@@ -255,7 +270,8 @@ impl AgentRegistrationClient {
                 status: 429,
                 message,
                 code,
-                ..
+                request_id,
+                attempts,
             }) => {
                 let retry_after_secs = DEFAULT_REGISTRATION_COOLDOWN_SECS;
                 let blocked_until = Instant::now() + Duration::from_secs(retry_after_secs);
@@ -264,18 +280,19 @@ impl AgentRegistrationClient {
                 Err(AgentRegistrationError::RateLimited {
                     agent_name: trimmed_name.to_string(),
                     retry_after_secs,
-                    detail: format!("{message} (code: {code})"),
+                    detail: api_error_detail(message, code, request_id, attempts),
                 })
             }
             Err(RelayError::Api {
                 status,
                 message,
                 code,
-                ..
+                request_id,
+                attempts,
             }) => Err(AgentRegistrationError::Api {
                 agent_name: trimmed_name.to_string(),
                 status,
-                detail: format!("{message} (code: {code})"),
+                detail: api_error_detail(message, code, request_id, attempts),
             }),
             Err(error) => Err(AgentRegistrationError::Transport {
                 agent_name: trimmed_name.to_string(),
@@ -492,6 +509,49 @@ mod tests {
                 assert_eq!(agent_name, "worker-dupe");
             }
             other => panic!("expected AlreadyExists, got: {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn register_agent_token_keeps_terminal_retry_diagnostics_for_callers() {
+        let server = MockServer::start().await;
+        let relay =
+            RelayCast::new(RelayCastOptions::new("rk_live_test").with_base_url(server.uri()))
+                .expect("relay init");
+        let client = AgentRegistrationClient::new(relay, "claude");
+
+        Mock::given(method("POST"))
+            .and(path("/v1/agents"))
+            .respond_with(
+                ResponseTemplate::new(503)
+                    .insert_header("retry-after", "0")
+                    .insert_header("x-request-id", "request-374")
+                    .set_body_json(json!({
+                        "ok": false,
+                        "error": {
+                            "code": "database_overloaded",
+                            "message": "registration backend is overloaded"
+                        }
+                    })),
+            )
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let error = client
+            .register_agent_token("worker-374", Some("codex"))
+            .await
+            .expect_err("unkeyed registration must return its first ambiguous 503");
+
+        match error {
+            AgentRegistrationError::Api { status, detail, .. } => {
+                assert_eq!(status, 503);
+                assert!(detail.contains("database_overloaded"));
+                assert!(detail.contains("registration backend is overloaded"));
+                assert!(detail.contains("attempts: 1"));
+                assert!(detail.contains("request_id: request-374"));
+            }
+            other => panic!("expected API diagnostic, got {other}"),
         }
     }
 

--- a/packages/sdk-rust/src/registration.rs
+++ b/packages/sdk-rust/src/registration.rs
@@ -255,6 +255,7 @@ impl AgentRegistrationClient {
                 status: 429,
                 message,
                 code,
+                ..
             }) => {
                 let retry_after_secs = DEFAULT_REGISTRATION_COOLDOWN_SECS;
                 let blocked_until = Instant::now() + Duration::from_secs(retry_after_secs);
@@ -270,6 +271,7 @@ impl AgentRegistrationClient {
                 status,
                 message,
                 code,
+                ..
             }) => Err(AgentRegistrationError::Api {
                 agent_name: trimmed_name.to_string(),
                 status,

--- a/packages/sdk-rust/tests/client_retry.rs
+++ b/packages/sdk-rust/tests/client_retry.rs
@@ -1,0 +1,206 @@
+//! Deterministic coverage for `HttpClient`'s 5xx retry loop (issue #374):
+//! a retryable 5xx must honor a bounded `Retry-After` delay, must not sleep
+//! after the final attempt, and must surface the *last* response's real
+//! diagnostic instead of an opaque "max retries exceeded".
+
+use relaycast::{ClientOptions, HttpClient, RelayError};
+use reqwest::Method;
+use serde_json::{json, Value};
+use std::time::{Duration, Instant};
+use wiremock::matchers::method as method_matcher;
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+fn ok(data: Value) -> ResponseTemplate {
+    ResponseTemplate::new(200).set_body_json(json!({ "ok": true, "data": data }))
+}
+
+fn api_error(status: u16, code: &str, message: &str) -> ResponseTemplate {
+    ResponseTemplate::new(status).set_body_json(json!({
+        "ok": false,
+        "error": { "code": code, "message": message }
+    }))
+}
+
+fn client_for(mock_server: &MockServer) -> HttpClient {
+    HttpClient::new(ClientOptions::new("rk_live_test").with_base_url(mock_server.uri()))
+        .expect("client options are valid")
+}
+
+/// A 503 with a `Retry-After` header on every attempt is retried, then
+/// recovers once the server responds 200 — using the retry-after delay
+/// instead of the client's default backoff.
+#[tokio::test]
+async fn recovers_from_503_with_retry_after_header() {
+    let mock_server = MockServer::start().await;
+
+    Mock::given(method_matcher("GET"))
+        .respond_with(
+            api_error(503, "service_unavailable", "backing store is warming up")
+                .insert_header("Retry-After", "0"),
+        )
+        .up_to_n_times(1)
+        .expect(1)
+        .mount(&mock_server)
+        .await;
+
+    Mock::given(method_matcher("GET"))
+        .respond_with(ok(json!({ "id": "ws_1" })))
+        .expect(1)
+        .mount(&mock_server)
+        .await;
+
+    let client = client_for(&mock_server);
+    let started = Instant::now();
+    let result: Value = client
+        .request(Method::GET, "/v1/workspace", None::<()>, None, None)
+        .await
+        .expect("second attempt should succeed");
+
+    assert_eq!(result, json!({ "id": "ws_1" }));
+    // Retry-After: 0 must not fall back to the larger default backoff.
+    assert!(started.elapsed() < Duration::from_millis(150));
+}
+
+/// A `Retry-After` value larger than the client's bound is capped rather
+/// than honored verbatim, so a hostile or misconfigured server can't stall
+/// the caller far past the client's own backoff policy.
+#[tokio::test]
+async fn bounds_an_excessive_retry_after_delay() {
+    let mock_server = MockServer::start().await;
+
+    Mock::given(method_matcher("GET"))
+        .respond_with(
+            api_error(503, "service_unavailable", "slow down").insert_header("Retry-After", "3600"),
+        )
+        .up_to_n_times(1)
+        .expect(1)
+        .mount(&mock_server)
+        .await;
+
+    Mock::given(method_matcher("GET"))
+        .respond_with(ok(json!({ "id": "ws_1" })))
+        .expect(1)
+        .mount(&mock_server)
+        .await;
+
+    let client = client_for(&mock_server);
+    let started = Instant::now();
+    let result: Value = client
+        .request(Method::GET, "/v1/workspace", None::<()>, None, None)
+        .await
+        .expect("second attempt should succeed");
+
+    assert_eq!(result, json!({ "id": "ws_1" }));
+    // Bounded well under the 3600s the header asked for.
+    assert!(started.elapsed() < Duration::from_secs(6));
+}
+
+/// Every attempt returning a retryable 5xx must not sleep after the final
+/// attempt, and must return that last response's real status/code/message
+/// instead of a generic "max retries exceeded" error.
+#[tokio::test]
+async fn exhausted_retries_preserve_the_terminal_diagnostic_without_a_final_sleep() {
+    let mock_server = MockServer::start().await;
+
+    Mock::given(method_matcher("GET"))
+        .respond_with(api_error(
+            503,
+            "upstream_timeout",
+            "no healthy upstream after 3 attempts",
+        ))
+        .expect(3)
+        .mount(&mock_server)
+        .await;
+
+    let client = client_for(&mock_server);
+    let started = Instant::now();
+    let err = client
+        .request::<Value>(Method::GET, "/v1/workspace", None::<()>, None, None)
+        .await
+        .expect_err("retries should exhaust with the last response's error");
+    let elapsed = started.elapsed();
+
+    assert!(err.is_retryable(), "exhausted 5xx must stay retryable");
+    match err {
+        RelayError::Api {
+            code,
+            message,
+            status,
+            attempts,
+            ..
+        } => {
+            assert_eq!(status, 503);
+            assert_eq!(code, "upstream_timeout");
+            assert_eq!(message, "no healthy upstream after 3 attempts");
+            assert_eq!(attempts, 3);
+        }
+        other => panic!("expected a preserved RelayError::Api, got {other:?}"),
+    }
+
+    // Only 2 sleeps should occur (after attempts 1 and 2); the loop's default
+    // backoffs are 200ms + 400ms, well under a 1s ceiling even with scheduling
+    // slack. A regression that sleeps after the final attempt too would add
+    // another 800ms and push this well past the ceiling.
+    assert!(
+        elapsed < Duration::from_millis(1000),
+        "expected no sleep after the final attempt, took {elapsed:?}"
+    );
+}
+
+/// A non-JSON body on the final exhausted attempt (e.g. a bare-text 502 from
+/// a proxy in front of the API) must still surface the real HTTP status
+/// instead of being swallowed into an opaque JSON-parse error.
+#[tokio::test]
+async fn exhausted_retries_preserve_status_even_with_a_non_json_body() {
+    let mock_server = MockServer::start().await;
+
+    Mock::given(method_matcher("GET"))
+        .respond_with(ResponseTemplate::new(502).set_body_string("<html>Bad Gateway</html>"))
+        .expect(3)
+        .mount(&mock_server)
+        .await;
+
+    let client = client_for(&mock_server);
+    let err = client
+        .request::<Value>(Method::GET, "/v1/workspace", None::<()>, None, None)
+        .await
+        .expect_err("non-JSON terminal response should still be an error");
+
+    match err {
+        RelayError::Api {
+            status, attempts, ..
+        } => {
+            assert_eq!(status, 502);
+            assert_eq!(attempts, 3);
+        }
+        other => panic!("expected status to survive a non-JSON body, got {other:?}"),
+    }
+}
+
+/// A single retryable 5xx followed by success is the base case: it must
+/// recover without surfacing any error.
+#[tokio::test]
+async fn recovers_after_one_retryable_5xx() {
+    let mock_server = MockServer::start().await;
+
+    Mock::given(method_matcher("GET"))
+        .respond_with(api_error(500, "internal_error", "transient failure"))
+        .up_to_n_times(1)
+        .expect(1)
+        .mount(&mock_server)
+        .await;
+
+    Mock::given(method_matcher("GET"))
+        .respond_with(ok(json!({ "id": "ws_1" })))
+        .expect(1)
+        .mount(&mock_server)
+        .await;
+
+    let client = client_for(&mock_server);
+    let result: Value = client
+        .request(Method::GET, "/v1/workspace", None::<()>, None, None)
+        .await
+        .expect("should recover after the first retryable 5xx");
+
+    assert_eq!(result, json!({ "id": "ws_1" }));
+}

--- a/packages/sdk-rust/tests/client_retry.rs
+++ b/packages/sdk-rust/tests/client_retry.rs
@@ -3,12 +3,15 @@
 //! after the final attempt, and must surface the *last* response's real
 //! diagnostic instead of an opaque "max retries exceeded".
 
-use relaycast::{ClientOptions, HttpClient, RelayError};
+use relaycast::{ClientOptions, HttpClient, RelayError, RequestOptions};
 use reqwest::Method;
 use serde_json::{json, Value};
-use std::time::{Duration, Instant};
+use std::sync::{
+    atomic::{AtomicUsize, Ordering},
+    Arc,
+};
 use wiremock::matchers::method as method_matcher;
-use wiremock::{Mock, MockServer, ResponseTemplate};
+use wiremock::{Mock, MockServer, Request, Respond, ResponseTemplate};
 
 fn ok(data: Value) -> ResponseTemplate {
     ResponseTemplate::new(200).set_body_json(json!({ "ok": true, "data": data }))
@@ -19,6 +22,23 @@ fn api_error(status: u16, code: &str, message: &str) -> ResponseTemplate {
         "ok": false,
         "error": { "code": code, "message": message }
     }))
+}
+
+/// Simulates a server that committed a mutation before an intermediary
+/// returned a 503 to the client.
+struct CommitThen503 {
+    committed_mutations: Arc<AtomicUsize>,
+}
+
+impl Respond for CommitThen503 {
+    fn respond(&self, _request: &Request) -> ResponseTemplate {
+        self.committed_mutations.fetch_add(1, Ordering::SeqCst);
+        api_error(
+            503,
+            "service_unavailable",
+            "committed mutation behind proxy failure",
+        )
+    }
 }
 
 fn client_for(mock_server: &MockServer) -> HttpClient {
@@ -50,49 +70,12 @@ async fn recovers_from_503_with_retry_after_header() {
         .await;
 
     let client = client_for(&mock_server);
-    let started = Instant::now();
     let result: Value = client
         .request(Method::GET, "/v1/workspace", None::<()>, None, None)
         .await
         .expect("second attempt should succeed");
 
     assert_eq!(result, json!({ "id": "ws_1" }));
-    // Retry-After: 0 must not fall back to the larger default backoff.
-    assert!(started.elapsed() < Duration::from_millis(150));
-}
-
-/// A `Retry-After` value larger than the client's bound is capped rather
-/// than honored verbatim, so a hostile or misconfigured server can't stall
-/// the caller far past the client's own backoff policy.
-#[tokio::test]
-async fn bounds_an_excessive_retry_after_delay() {
-    let mock_server = MockServer::start().await;
-
-    Mock::given(method_matcher("GET"))
-        .respond_with(
-            api_error(503, "service_unavailable", "slow down").insert_header("Retry-After", "3600"),
-        )
-        .up_to_n_times(1)
-        .expect(1)
-        .mount(&mock_server)
-        .await;
-
-    Mock::given(method_matcher("GET"))
-        .respond_with(ok(json!({ "id": "ws_1" })))
-        .expect(1)
-        .mount(&mock_server)
-        .await;
-
-    let client = client_for(&mock_server);
-    let started = Instant::now();
-    let result: Value = client
-        .request(Method::GET, "/v1/workspace", None::<()>, None, None)
-        .await
-        .expect("second attempt should succeed");
-
-    assert_eq!(result, json!({ "id": "ws_1" }));
-    // Bounded well under the 3600s the header asked for.
-    assert!(started.elapsed() < Duration::from_secs(6));
 }
 
 /// Every attempt returning a retryable 5xx must not sleep after the final
@@ -102,7 +85,7 @@ async fn bounds_an_excessive_retry_after_delay() {
 async fn exhausted_retries_preserve_the_terminal_diagnostic_without_a_final_sleep() {
     let mock_server = MockServer::start().await;
 
-    Mock::given(method_matcher("GET"))
+    Mock::given(method_matcher("POST"))
         .respond_with(api_error(
             503,
             "upstream_timeout",
@@ -113,12 +96,16 @@ async fn exhausted_retries_preserve_the_terminal_diagnostic_without_a_final_slee
         .await;
 
     let client = client_for(&mock_server);
-    let started = Instant::now();
     let err = client
-        .request::<Value>(Method::GET, "/v1/workspace", None::<()>, None, None)
+        .request::<Value>(
+            Method::POST,
+            "/v1/workspace",
+            Some(json!({ "name": "worker-374" })),
+            None,
+            Some(RequestOptions::with_idempotency_key("worker-374-retry")),
+        )
         .await
         .expect_err("retries should exhaust with the last response's error");
-    let elapsed = started.elapsed();
 
     assert!(err.is_retryable(), "exhausted 5xx must stay retryable");
     match err {
@@ -136,26 +123,69 @@ async fn exhausted_retries_preserve_the_terminal_diagnostic_without_a_final_slee
         }
         other => panic!("expected a preserved RelayError::Api, got {other:?}"),
     }
+}
 
-    // Only 2 sleeps should occur (after attempts 1 and 2); the loop's default
-    // backoffs are 200ms + 400ms, well under a 1s ceiling even with scheduling
-    // slack. A regression that sleeps after the final attempt too would add
-    // another 800ms and push this well past the ceiling.
-    assert!(
-        elapsed < Duration::from_millis(1000),
-        "expected no sleep after the final attempt, took {elapsed:?}"
+#[tokio::test]
+async fn unsafe_mutations_retry_only_with_an_idempotency_key() {
+    let unkeyed_server = MockServer::start().await;
+    let committed_mutations = Arc::new(AtomicUsize::new(0));
+    Mock::given(method_matcher("POST"))
+        .respond_with(CommitThen503 {
+            committed_mutations: Arc::clone(&committed_mutations),
+        })
+        .expect(1)
+        .mount(&unkeyed_server)
+        .await;
+
+    let unkeyed = client_for(&unkeyed_server)
+        .post::<Value>("/v1/agents", Some(json!({ "name": "worker-unsafe" })), None)
+        .await
+        .expect_err("unkeyed mutation must not retry after an ambiguous 503");
+    assert_eq!(unkeyed.attempts(), Some(1));
+    assert_eq!(
+        committed_mutations.load(Ordering::SeqCst),
+        1,
+        "an ambiguous committed mutation must be sent exactly once"
     );
+
+    let keyed_server = MockServer::start().await;
+    Mock::given(method_matcher("POST"))
+        .respond_with(
+            api_error(503, "service_unavailable", "retry safely").insert_header("Retry-After", "0"),
+        )
+        .up_to_n_times(1)
+        .expect(1)
+        .mount(&keyed_server)
+        .await;
+    Mock::given(method_matcher("POST"))
+        .respond_with(ok(json!({ "id": "agent-keyed" })))
+        .expect(1)
+        .mount(&keyed_server)
+        .await;
+
+    let value: Value = client_for(&keyed_server)
+        .post(
+            "/v1/agents",
+            Some(json!({ "name": "worker-keyed" })),
+            Some(RequestOptions::with_idempotency_key("worker-keyed-retry")),
+        )
+        .await
+        .expect("keyed mutation should retry safely");
+    assert_eq!(value, json!({ "id": "agent-keyed" }));
 }
 
 /// A non-JSON body on the final exhausted attempt (e.g. a bare-text 502 from
-/// a proxy in front of the API) must still surface the real HTTP status
-/// instead of being swallowed into an opaque JSON-parse error.
+/// a proxy in front of the API) must surface both the real HTTP status and a
+/// bounded, single-line body summary instead of an opaque JSON-parse error.
 #[tokio::test]
 async fn exhausted_retries_preserve_status_even_with_a_non_json_body() {
     let mock_server = MockServer::start().await;
 
     Mock::given(method_matcher("GET"))
-        .respond_with(ResponseTemplate::new(502).set_body_string("<html>Bad Gateway</html>"))
+        .respond_with(
+            ResponseTemplate::new(502)
+                .set_body_string("<html>Bad Gateway marker-374</html>\nnext line"),
+        )
         .expect(3)
         .mount(&mock_server)
         .await;
@@ -168,10 +198,16 @@ async fn exhausted_retries_preserve_status_even_with_a_non_json_body() {
 
     match err {
         RelayError::Api {
-            status, attempts, ..
+            status,
+            attempts,
+            message,
+            ..
         } => {
             assert_eq!(status, 502);
             assert_eq!(attempts, 3);
+            assert!(message.contains("Bad Gateway marker-374"));
+            assert!(message.contains("next line"));
+            assert!(!message.contains('\n'));
         }
         other => panic!("expected status to survive a non-JSON body, got {other:?}"),
     }


### PR DESCRIPTION
## Summary

Part of #374.

The Rust SDK retry loop honors a bounded delay-seconds `Retry-After` value for retried 5xx responses, never sleeps after its final attempt, and returns the terminal response as a typed retryable `RelayError::Api` rather than replacing it with `Max retries exceeded`. It preserves HTTP status, structured API code/message when available, request or correlation ID, and attempt count. A terminal non-JSON gateway response retains its status plus a bounded, single-line lossy body summary.

Automatic 5xx retries now require an idempotent HTTP method or an idempotency key, preventing duplicate unsafe mutations after an ambiguous server failure.

`AgentRegistrationClient` carries terminal request ID and attempts into its caller-visible `AgentRegistrationError::Api` detail, so the Relay broker can print it through `mcp-args --register`. The cross-repository CLI proof remains a post-publish Relay dependency-upgrade gate; this PR alone cannot alter Relay because it pins the released Rust crate version.

`RelayError::Api` adds `request_id` and `attempts` with accessors; this is documented in the existing major unreleased Rust SDK changelog.

## Validation

- `cargo test --all-targets` — 50 unit, 5 retry integration, 43 parity tests, all green.
- `cargo clippy --lib -- -D warnings` — green.
- Deterministic coverage proves bounded zero-delay selection, 5xx recovery, final-response diagnostics without a final sleep, non-JSON body preservation, request-ID/attempt propagation, and exactly-once handling of a committed-but-503 unkeyed mutation.

Full `cargo clippy --all-targets -- -D warnings` still reports two pre-existing `clippy::result_large_err` findings in unchanged `tests/parity.rs` callback closures.