### PR TITLE
feat(sdk): document and expose node deletion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ Packages without a separate changelog are covered by the cross-package notes bel
 
 ### Added
 
-- Node operators can delete one workspace-scoped node through `DELETE /v1/nodes/:name` or `relay.nodes.delete()`, with safe online/action guards and an explicit force option.
+- Node operators can delete one workspace-scoped node through `DELETE /v1/nodes/:name` or `relay.nodes.delete()`, with safe online/action guards, an explicit force option, and no automatic replay of ambiguous SDK failures.
 
 ## [8.5.0] - 2026-09-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,11 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 Packages without a separate changelog are covered by the cross-package notes below.
 
-## [Unreleased]
+## [Unreleased - Minor]
+
+### Added
+
+- Node operators can delete one workspace-scoped node through `DELETE /v1/nodes/:name` or `relay.nodes.delete()`, with safe online/action guards and an explicit force option.
 
 ## [8.5.0] - 2026-09-06
 

--- a/README.md
+++ b/README.md
@@ -733,11 +733,14 @@ const node = await relay.nodes.create({
 await relay.nodes.bindAgent(node.name, { agentName: 'billing-agent' });
 
 // Safe by default: refuses online nodes and nodes with hosted actions.
-await relay.nodes.delete(node.name);
+await relay.nodes.delete(node.id);
 
 // Use only after deliberately choosing to detach a live node and remove its actions.
-await relay.nodes.delete(node.name, { force: true });
+await relay.nodes.delete(node.id, { force: true });
 ```
+
+Node deletion is not retried automatically. If a transport failure makes the
+result ambiguous, check the immutable node id before choosing whether to retry.
 
 The node delivery contract controls how Relaycast sends future deliveries for bound
 agents. Built-in HTTP push auth modes are `none`, `bearer`, `static_headers`, and

--- a/README.md
+++ b/README.md
@@ -731,6 +731,12 @@ const node = await relay.nodes.create({
 });
 
 await relay.nodes.bindAgent(node.name, { agentName: 'billing-agent' });
+
+// Safe by default: refuses online nodes and nodes with hosted actions.
+await relay.nodes.delete(node.name);
+
+// Use only after deliberately choosing to detach a live node and remove its actions.
+await relay.nodes.delete(node.name, { force: true });
 ```
 
 The node delivery contract controls how Relaycast sends future deliveries for bound

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -235,7 +235,6 @@ components:
             durably swept as `offline`.
         token:
           type: string
-          description: Node token for `/v1/node/ws`.
           description: Agent token (only returned on registration)
         metadata:
           type: object
@@ -1052,6 +1051,26 @@ components:
           properties:
             token:
               type: string
+
+    DeleteNodeResponse:
+      type: object
+      required:
+        - id
+        - name
+        - deleted
+        - cascaded_actions
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+        deleted:
+          type: boolean
+          enum: [true]
+        cascaded_actions:
+          type: integer
+          minimum: 0
+          description: Number of node-hosted actions removed with the node.
 
     NodeAgentBinding:
       type: object
@@ -4714,6 +4733,70 @@ paths:
                 $ref: '#/components/schemas/SuccessResponse'
         '404':
           description: Node not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+    delete:
+      summary: Delete node
+      description: >
+        Delete one workspace-scoped node by id or name. The deletion cascades
+        its agent bindings and provider attachments; agent records and queued
+        deliveries remain and have their node references cleared. By default,
+        an online node or a node that hosts registered actions is refused.
+        Set `force=true` to explicitly detach an online node and delete its
+        hosted actions. A concurrent heartbeat or action registration returns
+        `node_delete_conflict` instead of deleting newly live state.
+      tags:
+        - Nodes
+      security:
+        - workspaceKey: []
+      parameters:
+        - name: name
+          in: path
+          required: true
+          description: Node id or name. An exact id match takes precedence.
+          schema:
+            type: string
+        - name: force
+          in: query
+          required: false
+          description: Explicitly allow deletion of an online node or node-hosted actions.
+          schema:
+            type: boolean
+            default: false
+      responses:
+        '200':
+          description: Node deleted
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [ok, data]
+                properties:
+                  ok:
+                    type: boolean
+                    enum: [true]
+                  data:
+                    $ref: '#/components/schemas/DeleteNodeResponse'
+        '401':
+          description: Missing or invalid workspace key
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '404':
+          description: >
+            `node_not_found` — no matching node exists in the authenticated
+            workspace
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '409':
+          description: >
+            `node_online`, `node_has_actions`, or `node_delete_conflict` — the
+            node is unsafe to delete without force, or changed during deletion
           content:
             application/json:
               schema:

--- a/packages/sdk-typescript/CHANGELOG.md
+++ b/packages/sdk-typescript/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ### Added
 
-- `relay.nodes.delete(name, { force? })` removes a node and returns its cascade details; the safe default refuses online nodes and nodes with hosted actions.
+- `relay.nodes.delete(name, { force? })` removes a node and returns its cascade details; the safe default refuses online nodes and nodes with hosted actions, and the SDK does not replay ambiguous failures.
 
 ## [8.5.0] - 2026-09-06
 

--- a/packages/sdk-typescript/CHANGELOG.md
+++ b/packages/sdk-typescript/CHANGELOG.md
@@ -7,7 +7,11 @@ See the [root changelog](../../CHANGELOG.md) for cross-package release highlight
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [Unreleased - Minor]
+
+### Added
+
+- `relay.nodes.delete(name, { force? })` removes a node and returns its cascade details; the safe default refuses online nodes and nodes with hosted actions.
 
 ## [8.5.0] - 2026-09-06
 

--- a/packages/sdk-typescript/src/__tests__/relay.test.ts
+++ b/packages/sdk-typescript/src/__tests__/relay.test.ts
@@ -845,6 +845,50 @@ describe('RelayCast', () => {
     });
   });
 
+  describe('nodes', () => {
+    it('delete() URL-encodes the node name, forwards force, and returns cascade details', async () => {
+      const { RelayCast } = await import('../relay.js');
+      const relay = new RelayCast({ apiKey: 'rk_live_test123' });
+
+      mockFetch.mockImplementation(() => mockResponse({
+        id: 'node_1',
+        name: 'node/one',
+        deleted: true,
+        cascaded_actions: 2,
+      }));
+
+      const result = await relay.nodes.delete('node/one', { force: true });
+
+      const [url, init] = mockFetch.mock.calls[0]!;
+      expect(url).toBe('https://cast.agentrelay.com/v1/nodes/node%2Fone?force=true');
+      expect(init.method).toBe('DELETE');
+      expect(result).toEqual({
+        id: 'node_1',
+        name: 'node/one',
+        deleted: true,
+        cascadedActions: 2,
+      });
+    });
+
+    it('delete() omits the force query by default', async () => {
+      const { RelayCast } = await import('../relay.js');
+      const relay = new RelayCast({ apiKey: 'rk_live_test123' });
+
+      mockFetch.mockImplementation(() => mockResponse({
+        id: 'node_1',
+        name: 'node-one',
+        deleted: true,
+        cascaded_actions: 0,
+      }));
+
+      await relay.nodes.delete('node-one');
+
+      const [url, init] = mockFetch.mock.calls[0]!;
+      expect(url).toBe('https://cast.agentrelay.com/v1/nodes/node-one');
+      expect(init.method).toBe('DELETE');
+    });
+  });
+
   describe('error handling', () => {
     it('throws RelayError on API error', async () => {
       const { RelayCast } = await import('../relay.js');

--- a/packages/sdk-typescript/src/__tests__/relay.test.ts
+++ b/packages/sdk-typescript/src/__tests__/relay.test.ts
@@ -887,6 +887,39 @@ describe('RelayCast', () => {
       expect(url).toBe('https://cast.agentrelay.com/v1/nodes/node-one');
       expect(init.method).toBe('DELETE');
     });
+
+    it('delete() does not replay an ambiguous transport failure', async () => {
+      const { RelayCast } = await import('../relay.js');
+      const relay = new RelayCast({
+        apiKey: 'rk_live_test123',
+        retryPolicy: { maxRetries: 2, backoffMs: 0, jitter: false },
+      });
+      mockFetch.mockRejectedValue(new Error('response lost'));
+
+      await expect(relay.nodes.delete('node-one')).rejects.toMatchObject({
+        code: 'transport_error',
+      });
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+    });
+
+    it('delete() does not replay a retryable server response', async () => {
+      const { RelayCast } = await import('../relay.js');
+      const relay = new RelayCast({
+        apiKey: 'rk_live_test123',
+        retryPolicy: { maxRetries: 2, backoffMs: 0, jitter: false },
+      });
+      mockFetch.mockImplementation(() => mockResponse(
+        { code: 'internal_error', message: 'response unavailable' },
+        false,
+        503,
+      ));
+
+      await expect(relay.nodes.delete('node-one')).rejects.toMatchObject({
+        code: 'transport_error',
+        status: 503,
+      });
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+    });
   });
 
   describe('error handling', () => {

--- a/packages/sdk-typescript/src/__tests__/type-safety.test.ts
+++ b/packages/sdk-typescript/src/__tests__/type-safety.test.ts
@@ -6,6 +6,7 @@ import type {
   ActionInvocation,
   CompleteInvocationRequest,
   CreateNodeResponse,
+  DeleteNodeResponse,
   InvokeActionResult,
   DirectoryAgent,
   DirectorySearchResult,
@@ -49,6 +50,8 @@ describe('AgentClient return types', () => {
       .toEqualTypeOf<Promise<RoutingConfig>>();
     expectTypeOf<ReturnType<RelayCast['nodes']['create']>>()
       .toEqualTypeOf<Promise<CreateNodeResponse>>();
+    expectTypeOf<ReturnType<RelayCast['nodes']['delete']>>()
+      .toEqualTypeOf<Promise<DeleteNodeResponse>>();
     expectTypeOf<ReturnType<RelayCast['nodes']['listAgents']>>()
       .toEqualTypeOf<Promise<NodeAgentBinding[]>>();
     expectTypeOf<ReturnType<RelayCast['nodes']['bindAgent']>>()

--- a/packages/sdk-typescript/src/client.ts
+++ b/packages/sdk-typescript/src/client.ts
@@ -52,6 +52,8 @@ export interface ClientOptions {
 export interface RequestOptions {
   headers?: Record<string, string>;
   schema?: z.ZodType;
+  /** Whether this request may be retried automatically. Defaults to true. */
+  retry?: boolean;
 }
 
 export interface RetryPolicy {
@@ -278,6 +280,7 @@ export class HttpClient {
     const hasBody = body !== undefined && method.toUpperCase() !== 'GET';
     if (hasBody) headers['Content-Type'] = 'application/json';
     const wireBody = hasBody ? decamelizeKeys(body) : undefined;
+    const maxRetries = options?.retry === false ? 0 : this._retryPolicy.maxRetries;
 
     let attempt = 0;
 
@@ -290,7 +293,7 @@ export class HttpClient {
           body: hasBody ? JSON.stringify(wireBody) : undefined,
         });
       } catch (err) {
-        if (attempt < this._retryPolicy.maxRetries) {
+        if (attempt < maxRetries) {
           const waitMs = computeBackoffMs(this._retryPolicy, attempt);
           attempt += 1;
           await sleep(waitMs);
@@ -303,7 +306,7 @@ export class HttpClient {
         );
       }
 
-      if (this._retryPolicy.retryOn.includes(res.status) && attempt < this._retryPolicy.maxRetries) {
+      if (this._retryPolicy.retryOn.includes(res.status) && attempt < maxRetries) {
         const waitMs = res.status === 429
           ? parseRetryAfterMs(res) ?? computeBackoffMs(this._retryPolicy, attempt)
           : computeBackoffMs(this._retryPolicy, attempt);

--- a/packages/sdk-typescript/src/relay.ts
+++ b/packages/sdk-typescript/src/relay.ts
@@ -838,6 +838,7 @@ export class RelayCast {
         `/v1/nodes/${encodeURIComponent(name)}`,
         undefined,
         options?.force ? { force: 'true' } : undefined,
+        { retry: false },
       ),
 
     listAgents: (name: string): Promise<NodeAgentBinding[]> =>

--- a/packages/sdk-typescript/src/relay.ts
+++ b/packages/sdk-typescript/src/relay.ts
@@ -67,6 +67,8 @@ import type {
   BindAgentToNodeRequest,
   CreateNodeRequest,
   CreateNodeResponse,
+  DeleteNodeOptions,
+  DeleteNodeResponse,
   NodeAgentBinding,
   NodeListQuery,
   NodeRosterEntry,
@@ -829,6 +831,14 @@ export class RelayCast {
 
     get: (name: string): Promise<NodeRosterEntry> =>
       this.client.get(`/v1/nodes/${encodeURIComponent(name)}`),
+
+    delete: (name: string, options?: DeleteNodeOptions): Promise<DeleteNodeResponse> =>
+      this.client.request(
+        'DELETE',
+        `/v1/nodes/${encodeURIComponent(name)}`,
+        undefined,
+        options?.force ? { force: 'true' } : undefined,
+      ),
 
     listAgents: (name: string): Promise<NodeAgentBinding[]> =>
       this.client.get(`/v1/nodes/${encodeURIComponent(name)}/agents`),

--- a/packages/sdk-typescript/src/types.ts
+++ b/packages/sdk-typescript/src/types.ts
@@ -376,6 +376,22 @@ export interface CreateNodeResponse extends NodeRosterEntry {
   token: string;
 }
 
+export interface DeleteNodeOptions {
+  /**
+   * Explicitly detach an online node or delete a node that hosts registered
+   * actions. Omit this for the safe default, which refuses either case.
+   */
+  force?: boolean;
+}
+
+export interface DeleteNodeResponse {
+  id: string;
+  name: string;
+  deleted: true;
+  /** Number of node-hosted actions removed by the deletion. */
+  cascadedActions: number;
+}
+
 export interface NodeAgentBinding {
   id: string;
   agentId: string;


### PR DESCRIPTION
The node deletion endpoint shipped in AgentWorkforce/relaycast-cloud#101, but Relaycast did not document the contract or expose it through the TypeScript SDK. Operators can now call `relay.nodes.delete(name, { force? })`; the SDK URL-encodes the id/name, uses the safe unforced default, returns camel-cased cascade details, and disables automatic retries so a lost response cannot replay a name-based deletion.

The OpenAPI contract documents workspace-key authentication, exact-id precedence, the `force` query, cascade behavior, and the `node_not_found`, `node_online`, `node_has_actions`, and `node_delete_conflict` outcomes. README and changelogs include the new API.

Addresses #1689.

Validation:
- `npx turbo test` (18 tasks; engine 792 tests)
- `npm test --workspace @relaycast/sdk` (445 tests)
- `npx turbo build`
- `npx turbo lint`
- OpenAPI YAML parse and SDK/OpenAPI sync tests
- Mutation proof: focused SDK tests fail when the HTTP method, `force=true` forwarding, or no-retry guard is removed
