### PR TITLE
fix(engine): bound fleet replay and retention database work

### DIFF
--- a/.agentworkforce/bounded-d1-0908/compacted/compact_p3vncbjbhj8g_2026-09-08.json
+++ b/.agentworkforce/bounded-d1-0908/compacted/compact_p3vncbjbhj8g_2026-09-08.json
@@ -1,0 +1,59 @@
+{
+  "id": "compact_p3vncbjbhj8g",
+  "version": 1,
+  "type": "compacted",
+  "compactedAt": "2026-09-08T11:04:42.626Z",
+  "sourceTrajectories": [
+    "traj_8knm0tf1ogn1"
+  ],
+  "dateRange": {
+    "start": "2026-09-08T10:40:25.148Z",
+    "end": "2026-09-08T11:04:40.185Z"
+  },
+  "summary": {
+    "totalDecisions": 3,
+    "totalEvents": 3,
+    "uniqueAgents": [
+      "default"
+    ]
+  },
+  "decisionGroups": [
+    {
+      "category": "database",
+      "decisions": [
+        {
+          "question": "Use indexed per-agent replay pages and persisted round-robin retention cursors",
+          "chosen": "Use indexed per-agent replay pages and persisted round-robin retention cursors",
+          "reasoning": "D1 insights show millions of retained rows read per replay and empty retention pass; row deletion limits alone do not bound database work.",
+          "fromTrajectory": "traj_8knm0tf1ogn1"
+        }
+      ]
+    },
+    {
+      "category": "testing",
+      "decisions": [
+        {
+          "question": "Fence retention traversals and skip rows newer than every applicable TTL",
+          "chosen": "Fence retention traversals and skip rows newer than every applicable TTL",
+          "reasoning": "Bounded pages must still wrap under continuous arrivals; a shortest-policy cutoff avoids wasting cycles on millions of recent rows. Preserve the existing expiry capacity, which was sized for a 519k/day peak.",
+          "fromTrajectory": "traj_8knm0tf1ogn1"
+        }
+      ]
+    },
+    {
+      "category": "api",
+      "decisions": [
+        {
+          "question": "Require the engine release and staged D1 migration before the coordinated cloud rollout",
+          "chosen": "Require the engine release and staged D1 migration before the coordinated cloud rollout",
+          "reasoning": "Cloud currently pins 8.5.2; a merged coordinator PR cannot by itself deploy these new engine query plans. No production mutations or remote broker restarts authorized in this implementation.",
+          "fromTrajectory": "traj_8knm0tf1ogn1"
+        }
+      ]
+    }
+  ],
+  "keyLearnings": [],
+  "keyFindings": [],
+  "filesAffected": [],
+  "commits": []
+}

--- a/.agentworkforce/bounded-d1-0908/compacted/compact_p3vncbjbhj8g_2026-09-08.md
+++ b/.agentworkforce/bounded-d1-0908/compacted/compact_p3vncbjbhj8g_2026-09-08.md
@@ -1,0 +1,24 @@
+# Trajectory Compaction: Sep 8, 2026 - Sep 8, 2026
+
+## Summary
+- Sessions: 1
+- Decisions: 3
+- Events: 3
+- Agents: default
+- Files: 0
+- Commits: 0
+
+## Database
+- Use indexed per-agent replay pages and persisted round-robin retention cursors -> Use indexed per-agent replay pages and persisted round-robin retention cursors (traj_8knm0tf1ogn1)
+
+## Testing
+- Fence retention traversals and skip rows newer than every applicable TTL -> Fence retention traversals and skip rows newer than every applicable TTL (traj_8knm0tf1ogn1)
+
+## Api
+- Require the engine release and staged D1 migration before the coordinated cloud rollout -> Require the engine release and staged D1 migration before the coordinated cloud rollout (traj_8knm0tf1ogn1)
+
+## Key Learnings
+- None
+
+## Key Findings
+- None

--- a/.agentworkforce/bounded-d1-review-0908/compacted/compact_rgqh3r8ab36c_2026-09-08.json
+++ b/.agentworkforce/bounded-d1-review-0908/compacted/compact_rgqh3r8ab36c_2026-09-08.json
@@ -1,0 +1,43 @@
+{
+  "id": "compact_rgqh3r8ab36c",
+  "version": 1,
+  "type": "compacted",
+  "compactedAt": "2026-09-08T11:47:09.461Z",
+  "sourceTrajectories": [
+    "traj_wbn1nniel1t7"
+  ],
+  "dateRange": {
+    "start": "2026-09-08T11:32:54.311Z",
+    "end": "2026-09-08T11:47:08.980Z"
+  },
+  "summary": {
+    "totalDecisions": 2,
+    "totalEvents": 2,
+    "uniqueAgents": [
+      "default"
+    ]
+  },
+  "decisionGroups": [
+    {
+      "category": "database",
+      "decisions": [
+        {
+          "question": "Use append-only indexes plus persisted redrive candidate windows",
+          "chosen": "Use append-only indexes plus persisted redrive candidate windows",
+          "reasoning": "LIMIT after expiry filters did not bound reads. Partial route/workspace indexes remove unrelated queues; metadata pages advance durable advisory cursors before hydration, with finite fences to guarantee wraparound. Migration 0049 preserves existing 0048 installations. Replay cleanup is synchronous and owner-conditional; dispatch uses four rolling workers.",
+          "fromTrajectory": "traj_wbn1nniel1t7"
+        },
+        {
+          "question": "Chunk redrive attachment hydration at fifty IDs",
+          "chosen": "Chunk redrive attachment hydration at fifty IDs",
+          "reasoning": "Final bind-budget review found that maximum-size redrive still sent up to 201 attachment query parameters despite chunked delivery hydration. Added scoped and global 200-row regression tests asserting every query stays at or below 100 parameters.",
+          "fromTrajectory": "traj_wbn1nniel1t7"
+        }
+      ]
+    }
+  ],
+  "keyLearnings": [],
+  "keyFindings": [],
+  "filesAffected": [],
+  "commits": []
+}

--- a/.agentworkforce/bounded-d1-review-0908/compacted/compact_rgqh3r8ab36c_2026-09-08.md
+++ b/.agentworkforce/bounded-d1-review-0908/compacted/compact_rgqh3r8ab36c_2026-09-08.md
@@ -1,0 +1,19 @@
+# Trajectory Compaction: Sep 8, 2026 - Sep 8, 2026
+
+## Summary
+- Sessions: 1
+- Decisions: 2
+- Events: 2
+- Agents: default
+- Files: 0
+- Commits: 0
+
+## Database
+- Use append-only indexes plus persisted redrive candidate windows -> Use append-only indexes plus persisted redrive candidate windows (traj_wbn1nniel1t7)
+- Chunk redrive attachment hydration at fifty IDs -> Chunk redrive attachment hydration at fifty IDs (traj_wbn1nniel1t7)
+
+## Key Learnings
+- None
+
+## Key Findings
+- None

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,11 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 Packages without a separate changelog are covered by the cross-package notes below.
 
-## [Unreleased]
+## [Unreleased - Patch]
+
+### Fixed
+
+- Fleet delivery replay uses indexed mailbox pages; bounded, resumable retention and lower background dispatch concurrency reduce database pressure without shortening retention policies.
 
 ## [8.5.2] - 2026-09-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Packages without a separate changelog are covered by the cross-package notes bel
 ### Fixed
 
 - Fleet delivery replay uses indexed mailbox pages; bounded, resumable retention and lower background dispatch concurrency reduce database pressure without shortening retention policies.
+- Replay completion cannot lose a trailing trigger; maintenance recovers corrupt cursors and advances past expired-only redrive windows without scanning unrelated routes.
 
 ## [8.5.2] - 2026-09-07
 
@@ -420,7 +421,7 @@ Packages without a separate changelog are covered by the cross-package notes bel
 
 Earlier releases are available on the [GitHub releases page](https://github.com/AgentWorkforce/relaycast/releases).
 
-[Unreleased - Minor]: https://github.com/AgentWorkforce/relaycast/compare/v8.4.0...HEAD
+[Unreleased - Patch]: https://github.com/AgentWorkforce/relaycast/compare/v8.4.0...HEAD
 [6.0.3]: https://github.com/AgentWorkforce/relaycast/compare/v6.0.2...v6.0.3
 [6.0.2]: https://github.com/AgentWorkforce/relaycast/compare/v6.0.1...v6.0.2
 [6.0.1]: https://github.com/AgentWorkforce/relaycast/compare/v6.0.0...v6.0.1

--- a/packages/engine/CHANGELOG.md
+++ b/packages/engine/CHANGELOG.md
@@ -7,7 +7,17 @@ See the [root changelog](../../CHANGELOG.md) for cross-package release highlight
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [Unreleased - Patch]
+
+### Fixed
+
+- Node replay hydrates 50-row indexed mailbox pages, coalesces identical triggers, and stops at failed lower sequences; fanout depth checks and initial redrive use predicate-matched indexes.
+- Retention examines bounded candidate pages with durable round-robin cursors and finite traversal fences, preserving workspace TTL overrides and event high-water marks. `batchLimit` now limits candidates (cap 200), `maxBatches` is capped at five, and `maxDurationMs` bounds admission of new pages (default 10s).
+- Scheduled delivery redrive runs at most four dispatch pipelines concurrently.
+
+### Migration
+
+- Apply `0048_bounded_maintenance.sql` before upgrading: adds replay/retention indexes and the `maintenance_cursors` table. Existing history and TTL policies are unchanged.
 
 ## [8.5.2] - 2026-09-07
 

--- a/packages/engine/CHANGELOG.md
+++ b/packages/engine/CHANGELOG.md
@@ -14,10 +14,13 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 - Node replay hydrates 50-row indexed mailbox pages, coalesces identical triggers, and stops at failed lower sequences; fanout depth checks and initial redrive use predicate-matched indexes.
 - Retention examines bounded candidate pages with durable round-robin cursors and finite traversal fences, preserving workspace TTL overrides and event high-water marks. `batchLimit` now limits candidates (cap 200), `maxBatches` is capped at five, and `maxDurationMs` bounds admission of new pages (default 10s).
 - Scheduled delivery redrive runs at most four dispatch pipelines concurrently.
+- Replay removes its in-flight entry atomically with completion; corrupt retention cursors restart safely and invalid clocks fail clearly before mutation when a positive TTL is active.
+- Redrive scans bounded, resumable metadata windows through route- and workspace-matched indexes before expiry filtering and hydration. A rolling dispatch pool immediately reuses available slots.
 
 ### Migration
 
 - Apply `0048_bounded_maintenance.sql` before upgrading: adds replay/retention indexes and the `maintenance_cursors` table. Existing history and TTL policies are unchanged.
+- Also apply append-only `0049_redrive_review_hardening.sql`: adds predicate-matched redrive indexes and explicitly named delivery/read-receipt lookup indexes instead of relying on SQLite autoindex names.
 
 ## [8.5.2] - 2026-09-07
 

--- a/packages/engine/src/db/migrations/0048_bounded_maintenance.sql
+++ b/packages/engine/src/db/migrations/0048_bounded_maintenance.sql
@@ -1,0 +1,20 @@
+-- Apply before running the bounded replay/retention engine. No history is deleted.
+CREATE INDEX IF NOT EXISTS idx_deliveries_agent_active_seq
+  ON deliveries(workspace_id, agent_id, seq)
+  WHERE status IN ('queued', 'delivered');
+CREATE INDEX IF NOT EXISTS idx_deliveries_agent_active_expiry
+  ON deliveries(workspace_id, agent_id, expires_at)
+  WHERE status IN ('queued', 'delivered');
+CREATE INDEX IF NOT EXISTS idx_deliveries_initial_due
+  ON deliveries(status, created_at, id) WHERE next_attempt_at IS NULL;
+CREATE INDEX IF NOT EXISTS idx_deliveries_settled_retention
+  ON deliveries(created_at, id)
+  WHERE status IN ('acked', 'failed', 'dead_lettered');
+CREATE INDEX IF NOT EXISTS idx_workspace_events_retention
+  ON workspace_events(created_at, workspace_id, seq);
+CREATE INDEX IF NOT EXISTS idx_messages_retention ON messages(length(id), id);
+CREATE INDEX IF NOT EXISTS idx_message_logs_retention ON message_logs(length(id), id);
+CREATE TABLE IF NOT EXISTS maintenance_cursors (
+  id TEXT PRIMARY KEY NOT NULL,
+  cursor TEXT NOT NULL
+);

--- a/packages/engine/src/db/migrations/0049_redrive_review_hardening.sql
+++ b/packages/engine/src/db/migrations/0049_redrive_review_hardening.sql
@@ -1,0 +1,11 @@
+-- Append-only follow-up: 0048 may already exist on a developer/staging DB.
+CREATE UNIQUE INDEX IF NOT EXISTS idx_deliveries_id_lookup ON deliveries(id);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_read_receipts_retention ON read_receipts(message_id, agent_id);
+CREATE INDEX IF NOT EXISTS idx_deliveries_node_initial ON deliveries(created_at, id)
+  WHERE status = 'queued' AND route_node_kind IN ('http_push', 'ws', 'fleet_ws', 'direct_ws') AND next_attempt_at IS NULL;
+CREATE INDEX IF NOT EXISTS idx_deliveries_node_initial_workspace ON deliveries(workspace_id, created_at, id)
+  WHERE status = 'queued' AND route_node_kind IN ('http_push', 'ws', 'fleet_ws', 'direct_ws') AND next_attempt_at IS NULL;
+CREATE INDEX IF NOT EXISTS idx_deliveries_node_retry ON deliveries(next_attempt_at, created_at, id)
+  WHERE status = 'queued' AND route_node_kind IN ('http_push', 'ws', 'fleet_ws', 'direct_ws') AND next_attempt_at IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_deliveries_node_retry_workspace ON deliveries(workspace_id, next_attempt_at, created_at, id)
+  WHERE status = 'queued' AND route_node_kind IN ('http_push', 'ws', 'fleet_ws', 'direct_ws') AND next_attempt_at IS NOT NULL;

--- a/packages/engine/src/db/schema.ts
+++ b/packages/engine/src/db/schema.ts
@@ -648,6 +648,7 @@ export const messages = sqliteTable(
   },
   (table) => [
     index('idx_messages_channel_time').on(table.channelId, table.id),
+    index('idx_messages_retention').on(sql`length(${table.id})`, table.id),
     index('idx_messages_thread').on(table.threadId, table.id),
     index('idx_messages_workspace').on(table.workspaceId, table.id),
     index('idx_messages_workspace_session').on(
@@ -712,6 +713,7 @@ export const messageLogs = sqliteTable(
   (table) => [
     uniqueIndex('message_logs_message_unique').on(table.messageId),
     index('idx_message_logs_workspace_time').on(table.workspaceId, table.id),
+    index('idx_message_logs_retention').on(sql`length(${table.id})`, table.id),
     index('idx_message_logs_agent_time').on(table.agentId, table.id),
     index('idx_message_logs_channel_time').on(table.channelId, table.id),
     index('idx_message_logs_conversation_time').on(table.conversationId, table.id),
@@ -1188,6 +1190,12 @@ export const deliveries = sqliteTable(
     uniqueIndex('deliveries_agent_seq_unique').on(table.workspaceId, table.agentId, table.seq),
     index('idx_deliveries_agent').on(table.agentId, table.createdAt),
     index('idx_deliveries_agent_status_seq').on(table.workspaceId, table.agentId, table.status, table.seq),
+    index('idx_deliveries_agent_active_seq').on(table.workspaceId, table.agentId, table.seq)
+      .where(sql`${table.status} IN ('queued', 'delivered')`),
+    index('idx_deliveries_agent_active_expiry').on(table.workspaceId, table.agentId, table.expiresAt)
+      .where(sql`${table.status} IN ('queued', 'delivered')`),
+    index('idx_deliveries_settled_retention').on(table.createdAt, table.id)
+      .where(sql`${table.status} IN ('acked', 'failed', 'dead_lettered')`),
     index('idx_deliveries_agent_active_created')
       .on(table.workspaceId, table.agentId, table.createdAt, table.id)
       .where(sql`${table.status} IN ('queued', 'delivered')`),
@@ -1198,6 +1206,8 @@ export const deliveries = sqliteTable(
     index('idx_deliveries_retry_due')
       .on(table.status, table.nextAttemptAt, table.createdAt, table.id)
       .where(sql`${table.nextAttemptAt} IS NOT NULL`),
+    index('idx_deliveries_initial_due').on(table.status, table.createdAt, table.id)
+      .where(sql`${table.nextAttemptAt} IS NULL`),
     index('idx_deliveries_status').on(table.workspaceId, table.status, table.createdAt),
     index('idx_deliveries_http_push_due').on(table.workspaceId, table.routeNodeKind, table.status, table.nextAttemptAt),
   ],
@@ -1253,5 +1263,12 @@ export const workspaceEvents = sqliteTable(
   (table) => [
     primaryKey({ columns: [table.workspaceId, table.seq] }),
     index('idx_workspace_events_created').on(table.workspaceId, table.createdAt),
+    index('idx_workspace_events_retention').on(table.createdAt, table.workspaceId, table.seq),
   ],
 );
+
+/** Durable scan positions; never used as delivery ACKs or event sequence authority. */
+export const maintenanceCursors = sqliteTable('maintenance_cursors', {
+  id: text('id').primaryKey().notNull(),
+  cursor: text('cursor').notNull(),
+});

--- a/packages/engine/src/db/schema.ts
+++ b/packages/engine/src/db/schema.ts
@@ -906,6 +906,7 @@ export const readReceipts = sqliteTable(
   (table) => [
     primaryKey({ columns: [table.messageId, table.agentId] }),
     index('idx_read_receipts_message').on(table.messageId),
+    uniqueIndex('idx_read_receipts_retention').on(table.messageId, table.agentId),
     index('idx_read_receipts_agent').on(table.agentId, table.readAt),
   ],
 );
@@ -1187,6 +1188,7 @@ export const deliveries = sqliteTable(
   },
   (table) => [
     uniqueIndex('deliveries_message_agent_unique').on(table.messageId, table.agentId),
+    uniqueIndex('idx_deliveries_id_lookup').on(table.id),
     uniqueIndex('deliveries_agent_seq_unique').on(table.workspaceId, table.agentId, table.seq),
     index('idx_deliveries_agent').on(table.agentId, table.createdAt),
     index('idx_deliveries_agent_status_seq').on(table.workspaceId, table.agentId, table.status, table.seq),
@@ -1208,6 +1210,14 @@ export const deliveries = sqliteTable(
       .where(sql`${table.nextAttemptAt} IS NOT NULL`),
     index('idx_deliveries_initial_due').on(table.status, table.createdAt, table.id)
       .where(sql`${table.nextAttemptAt} IS NULL`),
+    index('idx_deliveries_node_initial').on(table.createdAt, table.id)
+      .where(sql`${table.status} = 'queued' AND ${table.routeNodeKind} IN ('http_push', 'ws', 'fleet_ws', 'direct_ws') AND ${table.nextAttemptAt} IS NULL`),
+    index('idx_deliveries_node_initial_workspace').on(table.workspaceId, table.createdAt, table.id)
+      .where(sql`${table.status} = 'queued' AND ${table.routeNodeKind} IN ('http_push', 'ws', 'fleet_ws', 'direct_ws') AND ${table.nextAttemptAt} IS NULL`),
+    index('idx_deliveries_node_retry').on(table.nextAttemptAt, table.createdAt, table.id)
+      .where(sql`${table.status} = 'queued' AND ${table.routeNodeKind} IN ('http_push', 'ws', 'fleet_ws', 'direct_ws') AND ${table.nextAttemptAt} IS NOT NULL`),
+    index('idx_deliveries_node_retry_workspace').on(table.workspaceId, table.nextAttemptAt, table.createdAt, table.id)
+      .where(sql`${table.status} = 'queued' AND ${table.routeNodeKind} IN ('http_push', 'ws', 'fleet_ws', 'direct_ws') AND ${table.nextAttemptAt} IS NOT NULL`),
     index('idx_deliveries_status').on(table.workspaceId, table.status, table.createdAt),
     index('idx_deliveries_http_push_due').on(table.workspaceId, table.routeNodeKind, table.status, table.nextAttemptAt),
   ],

--- a/packages/engine/src/engine/__tests__/boundedDatabaseWork.test.ts
+++ b/packages/engine/src/engine/__tests__/boundedDatabaseWork.test.ts
@@ -1,0 +1,186 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { drizzle } from 'drizzle-orm/better-sqlite3';
+import { getSqliteDb, runMigrations, type SqliteDbHandle } from '../../adapters/node/database.js';
+import * as schema from '../../db/schema.js';
+import type { EngineDb } from '../../ports/database.js';
+import type { NodeConnectionRegistry } from '../../ports/realtime.js';
+import { deliverPendingToNode, fetchDueNodeDeliveryEvents } from '../delivery.js';
+import { pruneExpired } from '../retention.js';
+
+const handles: SqliteDbHandle[] = [];
+afterEach(() => { vi.restoreAllMocks(); for (const handle of handles.splice(0)) handle.sqlite.close(); });
+
+function fixture(history = 10_000, active = 125) {
+  const handle = getSqliteDb(':memory:');
+  handles.push(handle);
+  runMigrations(handle);
+  const sqlite = handle.sqlite;
+  sqlite.exec(`
+    INSERT INTO workspaces(id,name,api_key_hash) VALUES ('ws','test','key');
+    INSERT INTO nodes(id,workspace_id,name,token_hash) VALUES ('node','ws','node','node-key');
+    INSERT INTO agents(id,workspace_id,name,token_hash,location_type,location_node_id,provider_name)
+      VALUES ('agent','ws','recipient','agent-key','via_node','node','provider');
+    INSERT INTO channels(id,workspace_id,name) VALUES ('channel','ws','general');
+  `);
+  const message = sqlite.prepare("INSERT INTO messages(id,workspace_id,channel_id,agent_id,body) VALUES (?,'ws','channel','agent','body')");
+  const delivery = sqlite.prepare(`INSERT INTO deliveries(id,workspace_id,message_id,agent_id,status,seq,route_node_kind)
+    VALUES (?,'ws',?,'agent',?,?,'ws')`);
+  sqlite.transaction(() => {
+    for (let n = 1; n <= history + active; n++) {
+      const id = String(n).padStart(10, '0');
+      message.run(id); delivery.run('d' + id, id, n <= history ? 'acked' : 'queued', n);
+    }
+  })();
+  sqlite.exec('ANALYZE');
+  const queries: { sql: string; params: unknown[] }[] = [];
+  const db = drizzle(sqlite, { schema, logger: { logQuery: (sql, params) => queries.push({ sql, params }) } }) as unknown as EngineDb;
+  const frames: { seq: number }[] = [];
+  const send = vi.fn(async (_ws, _node, _provider, frame) => { frames.push(frame); return true; });
+  const ready = vi.fn(() => true);
+  const registry = { sendToProvider: send, isProviderAgentDeliveryReady: ready } as unknown as NodeConnectionRegistry;
+  return { db, sqlite, queries, registry, send, ready, frames };
+}
+
+describe('bounded database work with retained history', () => {
+  it('replays every page in order using active-mailbox and primary-key seeks', async () => {
+    const f = fixture();
+    expect(await deliverPendingToNode(f.db, f.registry, 'ws', 'node', { providerName: 'provider' })).toBe(125);
+    expect(f.frames.map(frame => frame.seq)).toEqual(Array.from({ length: 125 }, (_, n) => 10_001 + n));
+    const pages = f.queries.filter(q => q.sql.includes('INDEXED BY idx_deliveries_agent_active_seq'));
+    expect(pages).toHaveLength(3);
+    for (const query of pages) {
+      expect(query.params.at(-1)).toBe(50);
+      const plan = JSON.stringify(f.sqlite.prepare('EXPLAIN QUERY PLAN ' + query.sql).all(...query.params));
+      expect(plan).toContain('SEARCH deliveries USING INDEX idx_deliveries_agent_active_seq');
+      expect(plan).not.toContain('USE TEMP B-TREE');
+    }
+    const hydration = f.queries.filter(q => q.sql.startsWith('select') && q.sql.includes('INDEXED BY sqlite_autoindex_deliveries_1'));
+    expect(hydration).toHaveLength(3);
+    for (const query of hydration) {
+      expect(query.params.length).toBeLessThan(100);
+      const plan = JSON.stringify(f.sqlite.prepare('EXPLAIN QUERY PLAN ' + query.sql).all(...query.params));
+      expect(plan).toContain('SEARCH deliveries USING INDEX sqlite_autoindex_deliveries_1');
+    }
+  });
+
+  it('does not overtake a failed lower sequence and resumes it on the next trigger', async () => {
+    const f = fixture(0, 125);
+    f.send.mockImplementation(async (_ws, _node, _provider, frame) => {
+      if (frame.seq === 3) return false;
+      f.frames.push(frame); return true;
+    });
+    expect(await deliverPendingToNode(f.db, f.registry, 'ws', 'node')).toBe(2);
+    expect(f.frames.map(frame => frame.seq)).toEqual([1, 2]);
+    f.send.mockImplementation(async (_ws, _node, _provider, frame) => { f.frames.push(frame); return true; });
+    expect(await deliverPendingToNode(f.db, f.registry, 'ws', 'node')).toBe(125);
+  });
+
+  it('rechecks cumulative ACKs between pages without stranding later work', async () => {
+    const f = fixture(0, 125);
+    f.send.mockImplementation(async (_ws, _node, _provider, frame) => {
+      f.frames.push(frame);
+      if (frame.seq === 50) f.sqlite.exec("UPDATE agents SET delivery_ack_seq = 100 WHERE id = 'agent'");
+      return true;
+    });
+    expect(await deliverPendingToNode(f.db, f.registry, 'ws', 'node')).toBe(75);
+    expect(f.frames.map(frame => frame.seq)).toEqual([
+      ...Array.from({ length: 50 }, (_, n) => n + 1), ...Array.from({ length: 25 }, (_, n) => n + 101),
+    ]);
+  });
+
+  it('coalesces concurrent triggers and schedules a trailing pass for changed readiness', async () => {
+    const f = fixture(0, 1);
+    let finish!: () => void;
+    f.send.mockImplementationOnce(() => new Promise<boolean>(resolve => { finish = () => resolve(true); }));
+    const first = deliverPendingToNode(f.db, f.registry, 'ws', 'node');
+    await vi.waitFor(() => expect(f.send).toHaveBeenCalledOnce());
+    const second = deliverPendingToNode(f.db, f.registry, 'ws', 'node');
+    expect(second).toBe(first);
+    finish();
+    await Promise.all([first, second]);
+    expect(f.send).toHaveBeenCalledTimes(2);
+  });
+
+  it('uses the initial-attempt seek rather than scanning settled history for cron redrive', async () => {
+    const f = fixture(10_000, 3);
+    expect(await fetchDueNodeDeliveryEvents(f.db)).toHaveLength(3);
+    const query = f.queries.find(q => q.sql.includes('INDEXED BY idx_deliveries_initial_due'))!;
+    expect(query).toBeDefined();
+    const plan = JSON.stringify(f.sqlite.prepare('EXPLAIN QUERY PLAN ' + query.sql).all(...query.params));
+    expect(plan).toContain('SEARCH deliveries USING INDEX idx_deliveries_initial_due');
+  });
+
+  it('advances retained-only candidate pages durably and never scans active deliveries for retention', async () => {
+    const f = fixture();
+    f.sqlite.exec(`UPDATE deliveries SET created_at = 1;
+      UPDATE workspaces SET retention = '{"delivery_ttl_days":null}'`);
+    const opts = { batchLimit: 10, maxBatches: 1 };
+    expect((await pruneExpired(f.db, opts)).deliveries).toBe(0);
+    const cursor = () => JSON.parse((f.sqlite.prepare("SELECT cursor FROM maintenance_cursors WHERE id = 'retention-v1'").get() as { cursor: string }).cursor);
+    expect(cursor().positions.deliveries[1]).toBe('d0000000010');
+    // A new handle simulates the next isolate; progress is not process memory.
+    const nextDb = drizzle(f.sqlite, { schema }) as unknown as EngineDb;
+    await pruneExpired(nextDb, opts);
+    expect(cursor().positions.deliveries[1]).toBe('d0000000020');
+    const pages = f.queries.filter(q => q.sql.includes('WITH page AS MATERIALIZED'));
+    expect(pages).toHaveLength(4); // globally disabled message retention does no candidate scan
+    for (const query of pages) {
+      expect(query.params.at(-1)).toBe(10);
+      expect(f.sqlite.prepare(query.sql).all(...query.params).length).toBeLessThanOrEqual(10);
+      expect(query.sql).not.toContain('SELECT *');
+    }
+  });
+
+  it('makes progress past event high-water rows and wraps without resetting event sequence authority', async () => {
+    const f = fixture(0, 0);
+    const insert = f.sqlite.prepare("INSERT INTO workspace_events(workspace_id,seq,type,payload,created_at) VALUES (?,?,'test','{}',1)");
+    f.sqlite.transaction(() => {
+      for (let n = 0; n < 250; n++) insert.run('retained-' + String(n).padStart(3, '0'), 1);
+      insert.run('z-target', 1); insert.run('z-target', 2);
+    })();
+    for (let pass = 0; pass < 6; pass++) await pruneExpired(f.db, { batchLimit: 50, maxBatches: 1 });
+    expect(f.sqlite.prepare("SELECT seq FROM workspace_events WHERE workspace_id = 'z-target'").all()).toEqual([{ seq: 2 }]);
+    expect(f.sqlite.prepare('SELECT COUNT(*) AS n FROM workspace_events').get()).toEqual({ n: 251 });
+    // Every candidate query stays bounded even though almost every row must remain.
+    const eventPages = f.queries.filter(q => q.sql.includes('WITH page AS MATERIALIZED') && q.sql.includes('idx_workspace_events_retention'));
+    expect(eventPages).toHaveLength(6);
+    for (const query of eventPages.slice(1)) {
+      const plan = JSON.stringify(f.sqlite.prepare('EXPLAIN QUERY PLAN ' + query.sql).all(...query.params));
+      expect(plan).toContain('SEARCH workspace_events USING COVERING INDEX idx_workspace_events_retention');
+    }
+  });
+
+  it('wraps a retained-only traversal at its captured fence despite continuous new arrivals', async () => {
+    const f = fixture(4, 0);
+    f.sqlite.exec(`UPDATE deliveries SET created_at = 1;
+      UPDATE workspaces SET retention = '{"delivery_ttl_days":null}'`);
+    const opts = { batchLimit: 2, maxBatches: 1 };
+    const cursor = () => JSON.parse((f.sqlite.prepare("SELECT cursor FROM maintenance_cursors WHERE id = 'retention-v1'").get() as { cursor: string }).cursor);
+    await pruneExpired(f.db, opts);
+    expect(cursor().positions.deliveries[1]).toBe('d0000000002');
+    expect(cursor().highs.deliveries[1]).toBe('d0000000004');
+    f.sqlite.exec(`
+      INSERT INTO messages(id,workspace_id,channel_id,agent_id,body) VALUES ('0000000005','ws','channel','agent','new');
+      INSERT INTO deliveries(id,workspace_id,message_id,agent_id,status,seq,created_at)
+        VALUES ('d0000000005','ws','0000000005','agent','acked',5,1);
+    `);
+    await pruneExpired(f.db, opts);
+    expect(cursor().positions.deliveries).toBeUndefined();
+    expect(cursor().highs.deliveries).toBeUndefined();
+    await pruneExpired(f.db, opts);
+    expect(cursor().positions.deliveries[1]).toBe('d0000000002');
+    expect(cursor().highs.deliveries[1]).toBe('d0000000005');
+  });
+
+  it('checkpoints the next table before yielding to the elapsed run budget', async () => {
+    const f = fixture(4, 0);
+    let clock = Date.now();
+    vi.spyOn(Date, 'now').mockImplementation(() => clock);
+    const original = f.db.run.bind(f.db);
+    vi.spyOn(f.db, 'run').mockImplementation((query) => { clock += 2; return original(query); });
+    await pruneExpired(f.db, { maxDurationMs: 1, defaults: { messageTtlDays: 30 } });
+    const state = JSON.parse((f.sqlite.prepare("SELECT cursor FROM maintenance_cursors WHERE id = 'retention-v1'").get() as { cursor: string }).cursor);
+    expect(state.next).toBe(1);
+    expect(f.queries.filter(q => q.sql.includes('WITH page AS MATERIALIZED'))).toHaveLength(1);
+  });
+});

--- a/packages/engine/src/engine/__tests__/boundedDatabaseWork.test.ts
+++ b/packages/engine/src/engine/__tests__/boundedDatabaseWork.test.ts
@@ -54,12 +54,12 @@ describe('bounded database work with retained history', () => {
       expect(plan).toContain('SEARCH deliveries USING INDEX idx_deliveries_agent_active_seq');
       expect(plan).not.toContain('USE TEMP B-TREE');
     }
-    const hydration = f.queries.filter(q => q.sql.startsWith('select') && q.sql.includes('INDEXED BY sqlite_autoindex_deliveries_1'));
+    const hydration = f.queries.filter(q => q.sql.startsWith('select') && q.sql.includes('INDEXED BY idx_deliveries_id_lookup'));
     expect(hydration).toHaveLength(3);
     for (const query of hydration) {
       expect(query.params.length).toBeLessThan(100);
       const plan = JSON.stringify(f.sqlite.prepare('EXPLAIN QUERY PLAN ' + query.sql).all(...query.params));
-      expect(plan).toContain('SEARCH deliveries USING INDEX sqlite_autoindex_deliveries_1');
+      expect(plan).toContain('SEARCH deliveries USING INDEX idx_deliveries_id_lookup');
     }
   });
 
@@ -104,10 +104,81 @@ describe('bounded database work with retained history', () => {
   it('uses the initial-attempt seek rather than scanning settled history for cron redrive', async () => {
     const f = fixture(10_000, 3);
     expect(await fetchDueNodeDeliveryEvents(f.db)).toHaveLength(3);
-    const query = f.queries.find(q => q.sql.includes('INDEXED BY idx_deliveries_initial_due'))!;
+    const query = f.queries.find(q => q.sql.includes('INDEXED BY idx_deliveries_node_initial') && !q.sql.includes('DESC'))!;
     expect(query).toBeDefined();
     const plan = JSON.stringify(f.sqlite.prepare('EXPLAIN QUERY PLAN ' + query.sql).all(...query.params));
-    expect(plan).toContain('SEARCH deliveries USING INDEX idx_deliveries_initial_due');
+    expect(plan).toContain('SEARCH deliveries USING INDEX idx_deliveries_node_initial');
+  });
+
+  it.each([undefined, 'ws'])('keeps maximum redrive hydration under the D1 bind limit (workspace=%s)', async (workspaceId) => {
+    const f = fixture(0, 200);
+    expect(await fetchDueNodeDeliveryEvents(f.db, { workspaceId, limit: 200 })).toHaveLength(200);
+    expect(f.queries.every(query => query.params.length <= 100)).toBe(true);
+    expect(f.queries.filter(query => query.sql.includes('from "message_attachments"'))).toHaveLength(4);
+  });
+
+  it.each([false, true])('bounds excluded candidates and resumes past expired rows (retry=%s)', async (retry) => {
+    const f = fixture(10_000, 55);
+    f.sqlite.exec(`UPDATE deliveries SET status = 'queued', route_node_kind = 'other' WHERE seq <= 10000;
+      UPDATE deliveries SET expires_at = 1 WHERE seq > 10000 AND seq <= 10050;`);
+    if (retry) f.sqlite.exec('UPDATE deliveries SET next_attempt_at = 1');
+    const opts = { limit: 25 };
+    expect(await fetchDueNodeDeliveryEvents(f.db, opts)).toHaveLength(0);
+    // A new adapter handle reads durable progress, not process-local state.
+    const nextDb = drizzle(f.sqlite, { schema }) as unknown as EngineDb;
+    expect(await fetchDueNodeDeliveryEvents(nextDb, opts)).toHaveLength(0);
+    const due = await fetchDueNodeDeliveryEvents(f.db, opts);
+    expect(due.map(event => event.delivery.seq)).toEqual([10051, 10052, 10053, 10054, 10055]);
+    const index = retry ? 'idx_deliveries_node_retry' : 'idx_deliveries_node_initial';
+    const scans = f.queries.filter(q => q.sql.includes('INDEXED BY ' + index) && !q.sql.includes('DESC'));
+    for (const query of scans) {
+      expect(query.params.at(-1)).toBe(25);
+      expect(f.sqlite.prepare(query.sql).all(...query.params).length).toBeLessThanOrEqual(25);
+      expect(query.sql.split('WHERE')[1]).not.toContain('expires_at');
+      const plan = JSON.stringify(f.sqlite.prepare('EXPLAIN QUERY PLAN ' + query.sql).all(...query.params));
+      expect(plan).toContain('SEARCH deliveries USING INDEX ' + index);
+      expect(plan).not.toContain('USE TEMP B-TREE');
+    }
+  });
+
+  it('seeks scoped redrive without traversing another workspace or advancing its cursor', async () => {
+    const f = fixture(10_000, 3);
+    f.sqlite.exec(`INSERT INTO workspaces(id,name,api_key_hash) VALUES ('other','other','other-key');
+      UPDATE deliveries SET workspace_id = 'other', status = 'queued' WHERE seq <= 10000;`);
+    expect(await fetchDueNodeDeliveryEvents(f.db, { workspaceId: 'ws' })).toHaveLength(3);
+    const query = f.queries.find(q => q.sql.includes('INDEXED BY idx_deliveries_node_initial_workspace') && !q.sql.includes('DESC'))!;
+    const plan = JSON.stringify(f.sqlite.prepare('EXPLAIN QUERY PLAN ' + query.sql).all(...query.params));
+    expect(plan).toContain('workspace_id=?');
+    expect(f.sqlite.prepare("SELECT count(*) AS n FROM maintenance_cursors WHERE id LIKE '%other%'").get()).toEqual({ n: 0 });
+  });
+
+  it('wraps redrive at its captured fence even if more queued rows arrive', async () => {
+    const f = fixture(0, 4);
+    const opts = { limit: 2 };
+    expect((await fetchDueNodeDeliveryEvents(f.db, opts)).map(e => e.delivery.seq)).toEqual([1, 2]);
+    f.sqlite.exec(`INSERT INTO messages(id,workspace_id,channel_id,agent_id,body) VALUES ('0000000005','ws','channel','agent','new');
+      INSERT INTO deliveries(id,workspace_id,message_id,agent_id,status,seq,route_node_kind)
+      VALUES ('d0000000005','ws','0000000005','agent','queued',5,'ws');`);
+    expect((await fetchDueNodeDeliveryEvents(f.db, opts)).map(e => e.delivery.seq)).toEqual([3, 4]);
+    expect((await fetchDueNodeDeliveryEvents(f.db, opts)).map(e => e.delivery.seq)).toEqual([1, 2]);
+  });
+
+  it.each(['{broken', 'null', '{"next":99}', '[]'])('repairs a malformed retention cursor: %s', async (cursor) => {
+    const f = fixture(1, 0);
+    f.sqlite.prepare("INSERT INTO maintenance_cursors(id,cursor) VALUES ('retention-v1',?)").run(cursor);
+    await expect(pruneExpired(f.db)).resolves.toMatchObject({ deliveries: 0 });
+    const saved = f.sqlite.prepare("SELECT cursor FROM maintenance_cursors WHERE id = 'retention-v1'").get() as { cursor: string };
+    expect(JSON.parse(saved.cursor)).toMatchObject({ next: 0, positions: {}, highs: {} });
+  });
+
+  it('rejects invalid retention clocks before mutation when a default or workspace TTL is active', async () => {
+    const f = fixture(1, 0);
+    await expect(pruneExpired(f.db, { now: new Date(NaN) })).rejects.toThrow('Invalid retention clock');
+    expect(f.queries.some(q => /^(DELETE|INSERT|UPDATE)/i.test(q.sql.trim()))).toBe(false);
+    const defaults = { messageTtlDays: null, deliveryTtlDays: null, messageLogTtlDays: null, workspaceEventTtlDays: null };
+    await expect(pruneExpired(f.db, { now: new Date(NaN), defaults })).resolves.toMatchObject({ deliveries: 0 });
+    f.sqlite.exec(`UPDATE workspaces SET retention = '{"message_ttl_days":7}'`);
+    await expect(pruneExpired(f.db, { now: new Date(NaN), defaults })).rejects.toThrow('Invalid retention clock');
   });
 
   it('advances retained-only candidate pages durably and never scans active deliveries for retention', async () => {

--- a/packages/engine/src/engine/boundedRetention.ts
+++ b/packages/engine/src/engine/boundedRetention.ts
@@ -46,15 +46,17 @@ const tables: Table[] = [
     keys: ['created_at', 'workspace_id', 'seq'], setting: 'workspace_event_ttl_days',
     fallback: 'workspaceEventTtlDays',
     eligible: 'EXISTS (SELECT 1 FROM workspace_events hw WHERE hw.workspace_id = page.workspace_id AND hw.seq > page.seq LIMIT 1)' },
-  { result: 'readReceipts', name: 'read_receipts', index: 'sqlite_autoindex_read_receipts_1',
+  { result: 'readReceipts', name: 'read_receipts', index: 'idx_read_receipts_retention',
     keys: ['message_id', 'agent_id'],
     eligible: 'NOT EXISTS (SELECT 1 FROM messages m WHERE m.id = page.message_id)' },
 ];
 
+/** Project a candidate onto its table's ordered keyset cursor. */
 function key(row: Candidate, table: Table): (string | number)[] {
   return table.keys.map(k => k === 'length(id)' ? row.id.length : row[k as keyof Candidate] as string | number);
 }
 
+/** Apply exact workspace policy after the bounded candidate read. */
 function expired(row: Candidate, table: Table, defaults: Required<RetentionDefaults>, nowMs: number): boolean {
   if (!row.eligible) return false;
   if (!table.setting || !table.fallback) return true;
@@ -70,6 +72,7 @@ function expired(row: Candidate, table: Table, defaults: Required<RetentionDefau
   return row.created_at * 1000 < cutoff;
 }
 
+/** Construct a bound primary-key predicate without interpolating user SQL. */
 function identity(row: Candidate, table: Table): SQL {
   if (table.result === 'workspaceEvents') return sql`(workspace_id = ${row.workspace_id} AND seq = ${row.seq})`;
   if (table.result === 'readReceipts') return sql`(message_id = ${row.message_id} AND agent_id = ${row.agent_id})`;
@@ -104,8 +107,13 @@ export async function pruneBounded(db: EngineDb, opts: PruneOptions): Promise<Pr
     ${sql.join(ttlTables.map(table => sql.raw(
       `MIN(CASE WHEN json_extract(retention, '$.${table.setting}') > 0 THEN json_extract(retention, '$.${table.setting}') END) AS "${table.result}"`,
     )), sql`, `)} FROM workspaces`);
+  if (!Number.isFinite(nowMs) && [
+    ...Object.values(defaults), ...Object.values(minimums ?? {}),
+  ].some(ttl => typeof ttl === 'number' && Number.isFinite(ttl) && ttl > 0)) {
+    throw new Error('Invalid retention clock: expected a finite Date when a positive TTL is active');
+  }
   const saved = await db.all<{ cursor: string }>(sql`SELECT cursor FROM maintenance_cursors WHERE id = 'retention-v1'`);
-  const parsed = saved[0] ? stateSchema.safeParse(JSON.parse(saved[0].cursor)) : undefined;
+  const parsed = saved[0] ? stateSchema.safeParse(decodeCursor(saved[0].cursor)) : undefined;
   const state: State = parsed?.success ? parsed.data : { next: 0, positions: {}, highs: {} };
   const result: PruneResult = { messages: 0, deliveries: 0, messageLogs: 0, readReceipts: 0, workspaceEvents: 0 };
   const finished = new Set<number>();
@@ -142,14 +150,12 @@ export async function pruneBounded(db: EngineDb, opts: PruneOptions): Promise<Pr
     const predicates: SQL[] = [];
     if (table.predicate) predicates.push(sql.raw(table.predicate));
     if (table.fallback) {
-      {
-        const cutoff = nowMs - Math.min(...positiveTtls) * DAY_MS;
-        if (table.keys[0] === 'length(id)') {
-          const bound = snowflakeIdLowerBound(cutoff);
-          predicates.push(sql`(length(id), id) < (${bound.length}, ${bound})`);
-        } else {
-          predicates.push(sql`created_at < ${Math.ceil(cutoff / 1000)}`);
-        }
+      const cutoff = nowMs - Math.min(...positiveTtls) * DAY_MS;
+      if (table.keys[0] === 'length(id)') {
+        const bound = snowflakeIdLowerBound(cutoff);
+        predicates.push(sql`(length(id), id) < (${bound.length}, ${bound})`);
+      } else {
+        predicates.push(sql`created_at < ${Math.ceil(cutoff / 1000)}`);
       }
     }
     if (cursor?.length === table.keys.length) {
@@ -204,6 +210,12 @@ export async function pruneBounded(db: EngineDb, opts: PruneOptions): Promise<Pr
   return result;
 }
 
+/** Decode advisory scan state; corrupt text restarts a safe traversal. */
+function decodeCursor(raw: string): unknown {
+  try { return JSON.parse(raw); } catch { return undefined; }
+}
+
+/** Clamp caller tuning to the supported finite maintenance budget. */
 function boundedInteger(value: number | undefined, fallback: number, maximum: number): number {
   return value !== undefined && Number.isFinite(value) ? Math.max(1, Math.min(maximum, Math.floor(value))) : fallback;
 }

--- a/packages/engine/src/engine/boundedRetention.ts
+++ b/packages/engine/src/engine/boundedRetention.ts
@@ -1,0 +1,209 @@
+import { sql, type SQL } from 'drizzle-orm';
+import { z } from 'zod';
+import type { EngineDb } from '../ports/database.js';
+import type { WorkspaceRetentionSettings } from '../db/schema.js';
+import type { PruneOptions, PruneResult, RetentionDefaults } from './retention.js';
+import { snowflakeIdLowerBound } from './snowflake.js';
+
+const DAY_MS = 86_400_000;
+const position = z.array(z.union([z.string(), z.number()]));
+const stateSchema = z.object({
+  next: z.number().int().min(0).max(4),
+  positions: z.record(z.string(), position),
+  highs: z.record(z.string(), position).default({}),
+});
+type State = z.infer<typeof stateSchema>;
+type Candidate = {
+  id: string;
+  workspace_id: string;
+  created_at: number;
+  seq: number;
+  message_id: string;
+  agent_id: string;
+  retention: string | null;
+  eligible: number;
+};
+type Table = {
+  result: keyof PruneResult;
+  name: string;
+  index: string;
+  keys: string[];
+  setting?: keyof WorkspaceRetentionSettings;
+  fallback?: keyof RetentionDefaults;
+  predicate?: string;
+  eligible?: string;
+};
+const tables: Table[] = [
+  { result: 'messages', name: 'messages', index: 'idx_messages_retention',
+    keys: ['length(id)', 'id'], setting: 'message_ttl_days', fallback: 'messageTtlDays',
+    eligible: 'NOT EXISTS (SELECT 1 FROM messages replies WHERE replies.thread_id = page.id)' },
+  { result: 'deliveries', name: 'deliveries', index: 'idx_deliveries_settled_retention',
+    keys: ['created_at', 'id'], setting: 'delivery_ttl_days', fallback: 'deliveryTtlDays',
+    predicate: "status IN ('acked', 'failed', 'dead_lettered')" },
+  { result: 'messageLogs', name: 'message_logs', index: 'idx_message_logs_retention',
+    keys: ['length(id)', 'id'], setting: 'message_log_ttl_days', fallback: 'messageLogTtlDays' },
+  { result: 'workspaceEvents', name: 'workspace_events', index: 'idx_workspace_events_retention',
+    keys: ['created_at', 'workspace_id', 'seq'], setting: 'workspace_event_ttl_days',
+    fallback: 'workspaceEventTtlDays',
+    eligible: 'EXISTS (SELECT 1 FROM workspace_events hw WHERE hw.workspace_id = page.workspace_id AND hw.seq > page.seq LIMIT 1)' },
+  { result: 'readReceipts', name: 'read_receipts', index: 'sqlite_autoindex_read_receipts_1',
+    keys: ['message_id', 'agent_id'],
+    eligible: 'NOT EXISTS (SELECT 1 FROM messages m WHERE m.id = page.message_id)' },
+];
+
+function key(row: Candidate, table: Table): (string | number)[] {
+  return table.keys.map(k => k === 'length(id)' ? row.id.length : row[k as keyof Candidate] as string | number);
+}
+
+function expired(row: Candidate, table: Table, defaults: Required<RetentionDefaults>, nowMs: number): boolean {
+  if (!row.eligible) return false;
+  if (!table.setting || !table.fallback) return true;
+  const settings = row.retention ? JSON.parse(row.retention) as WorkspaceRetentionSettings : {};
+  const override = settings[table.setting];
+  const ttl = override === undefined ? defaults[table.fallback] : override;
+  if (ttl == null || !Number.isFinite(ttl) || ttl <= 0) return false;
+  const cutoff = nowMs - ttl * DAY_MS;
+  if (table.keys[0] === 'length(id)') {
+    const bound = snowflakeIdLowerBound(cutoff);
+    return row.id.length < bound.length || (row.id.length === bound.length && row.id < bound);
+  }
+  return row.created_at * 1000 < cutoff;
+}
+
+function identity(row: Candidate, table: Table): SQL {
+  if (table.result === 'workspaceEvents') return sql`(workspace_id = ${row.workspace_id} AND seq = ${row.seq})`;
+  if (table.result === 'readReceipts') return sql`(message_id = ${row.message_id} AND agent_id = ${row.agent_id})`;
+  return sql`id = ${row.id}`;
+}
+
+/**
+ * Bound candidate reads, not just returned/deleted rows. Persist progress even
+ * when a page contains only retained rows, so disabled TTLs, live receipts and
+ * event high-water marks cannot pin a scan to the beginning forever.
+ *
+ * Each table completes at most one traversal per run; cursors wrap at EOF.
+ * Cursor commits follow successful deletion. A crash can replay a page (safe),
+ * never skip an uncommitted deletion. Hosts should serialize maintenance runs.
+ */
+export async function pruneBounded(db: EngineDb, opts: PruneOptions): Promise<PruneResult> {
+  const limit = boundedInteger(opts.batchLimit, 200, 200);
+  const rounds = boundedInteger(opts.maxBatches, 5, 5);
+  const started = Date.now();
+  const budget = boundedInteger(opts.maxDurationMs, 10_000, 30_000);
+  const nowMs = (opts.now ?? new Date()).getTime();
+  const defaults: Required<RetentionDefaults> = {
+    messageTtlDays: null, deliveryTtlDays: 90, messageLogTtlDays: 90, workspaceEventTtlDays: 30,
+    ...Object.fromEntries(Object.entries(opts.defaults ?? {}).filter(([, value]) => value !== undefined)),
+  };
+  // One small policy aggregate (no workspace-ID bind list), not one history
+  // scan per workspace. The shortest positive TTL provides a safe global index
+  // cutoff; exact per-workspace policy is still checked on each candidate.
+  // This avoids walking millions of recent rows that no policy can expire.
+  const ttlTables = tables.filter(table => table.setting);
+  const [minimums] = await db.all<Record<string, number | null>>(sql`SELECT
+    ${sql.join(ttlTables.map(table => sql.raw(
+      `MIN(CASE WHEN json_extract(retention, '$.${table.setting}') > 0 THEN json_extract(retention, '$.${table.setting}') END) AS "${table.result}"`,
+    )), sql`, `)} FROM workspaces`);
+  const saved = await db.all<{ cursor: string }>(sql`SELECT cursor FROM maintenance_cursors WHERE id = 'retention-v1'`);
+  const parsed = saved[0] ? stateSchema.safeParse(JSON.parse(saved[0].cursor)) : undefined;
+  const state: State = parsed?.success ? parsed.data : { next: 0, positions: {}, highs: {} };
+  const result: PruneResult = { messages: 0, deliveries: 0, messageLogs: 0, readReceipts: 0, workspaceEvents: 0 };
+  const finished = new Set<number>();
+  for (let step = 0; step < rounds * tables.length && Date.now() - started < budget; step++) {
+    const index = state.next;
+    state.next = (index + 1) % tables.length;
+    if (finished.has(index)) continue;
+    const table = tables[index]!;
+    const cursor = state.positions[table.name];
+    const positiveTtls = table.fallback
+      ? [defaults[table.fallback], minimums?.[table.result]].filter((ttl): ttl is number =>
+        typeof ttl === 'number' && Number.isFinite(ttl) && ttl > 0)
+      : [];
+    if (table.fallback && !positiveTtls.length) {
+      delete state.positions[table.name];
+      delete state.highs[table.name];
+      finished.add(index);
+      await db.run(sql`INSERT INTO maintenance_cursors (id, cursor) VALUES ('retention-v1', ${JSON.stringify(state)})
+        ON CONFLICT(id) DO UPDATE SET cursor = excluded.cursor`);
+      continue;
+    }
+    const columns = sql.raw(table.result === 'readReceipts' ? 'message_id, agent_id'
+      : table.result === 'workspaceEvents' ? 'workspace_id, seq, created_at'
+        : 'id, workspace_id, created_at');
+    // A traversal has a finite end even while new rows keep arriving. Without
+    // this fence the cursor might never wrap to retained rows that later age out.
+    if (!state.highs[table.name]) {
+      const [last] = await db.all<Candidate>(sql`SELECT ${columns}
+        FROM ${sql.raw(table.name)} INDEXED BY ${sql.raw(table.index)}
+        ${table.predicate ? sql`WHERE ${sql.raw(table.predicate)}` : sql``}
+        ORDER BY ${sql.raw(table.keys.map(k => k + ' DESC').join(', '))} LIMIT 1`);
+      if (last) state.highs[table.name] = key(last, table);
+    }
+    const predicates: SQL[] = [];
+    if (table.predicate) predicates.push(sql.raw(table.predicate));
+    if (table.fallback) {
+      {
+        const cutoff = nowMs - Math.min(...positiveTtls) * DAY_MS;
+        if (table.keys[0] === 'length(id)') {
+          const bound = snowflakeIdLowerBound(cutoff);
+          predicates.push(sql`(length(id), id) < (${bound.length}, ${bound})`);
+        } else {
+          predicates.push(sql`created_at < ${Math.ceil(cutoff / 1000)}`);
+        }
+      }
+    }
+    if (cursor?.length === table.keys.length) {
+      predicates.push(sql`(${sql.raw(table.keys.join(', '))}) > (${sql.join(cursor.map(v => sql`${v}`), sql`, `)})`);
+    }
+    const high = state.highs[table.name];
+    if (high?.length === table.keys.length) {
+      predicates.push(sql`(${sql.raw(table.keys.join(', '))}) <= (${sql.join(high.map(v => sql`${v}`), sql`, `)})`);
+    }
+    // MATERIALIZED prevents the planner pushing eligibility/TTL checks ahead
+    // of LIMIT. The keyset seek and covering index bound candidate traversal.
+    const page = await db.all<Candidate>(sql`
+      WITH page AS MATERIALIZED (
+        SELECT ${columns}
+        FROM ${sql.raw(table.name)} INDEXED BY ${sql.raw(table.index)}
+        ${predicates.length ? sql`WHERE ${sql.join(predicates, sql` AND `)}` : sql``}
+        ORDER BY ${sql.raw(table.keys.join(', '))} LIMIT ${limit}
+      )
+      SELECT page.*, ${sql.raw(table.eligible ?? '1')} AS eligible,
+        ${table.setting ? sql`w.retention` : sql`NULL`} AS retention
+      FROM page
+      ${table.setting ? sql`LEFT JOIN workspaces w ON w.id = page.workspace_id` : sql``}
+      ORDER BY ${sql.raw(table.keys.map(k => k === 'length(id)' ? 'length(page.id)' : 'page.' + k).join(', '))}
+    `);
+    const removable = page.filter(row => expired(row, table, defaults, nowMs));
+    // Two-key identities need two bindings each; leave room under D1's 100.
+    for (let offset = 0; offset < removable.length; offset += 40) {
+      const chunk = removable.slice(offset, offset + 40);
+      const guard = table.result === 'messages'
+        ? sql`AND NOT EXISTS (SELECT 1 FROM messages replies WHERE replies.thread_id = messages.id)`
+        : table.result === 'readReceipts'
+          ? sql`AND NOT EXISTS (SELECT 1 FROM messages m WHERE m.id = read_receipts.message_id)`
+        : table.result === 'workspaceEvents'
+          ? sql`AND EXISTS (SELECT 1 FROM workspace_events hw WHERE hw.workspace_id = workspace_events.workspace_id AND hw.seq > workspace_events.seq LIMIT 1)`
+        : table.predicate ? sql`AND ${sql.raw(table.predicate)}` : sql``;
+      const deleted = await db.all(sql`DELETE FROM ${sql.raw(table.name)}
+        WHERE (${sql.join(chunk.map(row => identity(row, table)), sql` OR `)}) ${guard}
+        RETURNING 1`);
+      result[table.result] += deleted.length;
+    }
+    if (page.length < limit || JSON.stringify(key(page[page.length - 1]!, table)) === JSON.stringify(high)) {
+      delete state.positions[table.name];
+      delete state.highs[table.name];
+      finished.add(index);
+    } else {
+      state.positions[table.name] = key(page[page.length - 1]!, table);
+    }
+    await db.run(sql`INSERT INTO maintenance_cursors (id, cursor) VALUES ('retention-v1', ${JSON.stringify(state)})
+      ON CONFLICT(id) DO UPDATE SET cursor = excluded.cursor`);
+    if (finished.size === tables.length) break;
+  }
+  return result;
+}
+
+function boundedInteger(value: number | undefined, fallback: number, maximum: number): number {
+  return value !== undefined && Number.isFinite(value) ? Math.max(1, Math.min(maximum, Math.floor(value))) : fallback;
+}

--- a/packages/engine/src/engine/delivery.ts
+++ b/packages/engine/src/engine/delivery.ts
@@ -1,4 +1,4 @@
-import { eq, and, not, asc, isNull, inArray, notInArray, lte, gt, sql, type SQL } from 'drizzle-orm';
+import { eq, and, not, asc, isNull, inArray, notInArray, lte, gt, sql, getTableColumns, type SQL } from 'drizzle-orm';
 import type { getDb } from '../db/index.js';
 import { deliveries, messages, agents, readReceipts, channelMembers, channels, dmConversations } from '../db/schema.js';
 import type { DeliveryStatus } from '@relaycast/types';
@@ -14,6 +14,11 @@ import type { DeliveryFanoutRecord } from './deliveryWrites.js';
 type Db = ReturnType<typeof getDb>;
 
 type DeliveryRow = typeof deliveries.$inferSelect;
+// SQL-wrapped columns retain Drizzle's timestamp/boolean decoders when FROM
+// includes an explicit SQLite INDEXED BY clause rather than a table object.
+const indexedDeliveryColumns = Object.fromEntries(
+  Object.entries(getTableColumns(deliveries)).map(([name, column]) => [name, sql`${column}`.mapWith(column)]),
+) as { [K in keyof DeliveryRow]: SQL<DeliveryRow[K]> };
 type DeliveryWithChannel = DeliveryRow & { channelId: string };
 type PendingDeliveryRow = {
   delivery: DeliveryRow;
@@ -422,23 +427,25 @@ export async function markDeliveriesDelivered(
   workspaceId: string,
   deliveryIds: string[],
 ): Promise<number> {
-  if (deliveryIds.length === 0) return 0;
-  const updated = await db
-    .update(deliveries)
-    .set({
-      status: 'delivered',
-      nextAttemptAt: null,
-      lastDispatchError: null,
-      deliveredAt: new Date(),
-      updatedAt: new Date(),
-    })
-    .where(and(
-      eq(deliveries.workspaceId, workspaceId),
-      inArray(deliveries.id, deliveryIds),
-      eq(deliveries.status, 'queued'),
-    ))
-    .returning();
-  return updated.length;
+  let count = 0;
+  const ids = [...new Set(deliveryIds)];
+  const now = Math.floor(Date.now() / 1000);
+  // Force primary-key writes too: a bounded replay read is not enough if its
+  // status UPDATE chooses a workspace/status index and scans retained history.
+  for (let offset = 0; offset < ids.length; offset += 50) {
+    const page = ids.slice(offset, offset + 50);
+    const updated = await db.all<{ id: string }>(sql`
+      UPDATE deliveries INDEXED BY sqlite_autoindex_deliveries_1
+      SET status = 'delivered', next_attempt_at = NULL, last_dispatch_error = NULL,
+          delivered_at = ${now}, updated_at = ${now}
+      WHERE workspace_id = ${workspaceId}
+        AND id IN (${sql.join(page.map(id => sql`${id}`), sql`, `)})
+        AND status = 'queued'
+      RETURNING id
+    `);
+    count += updated.length;
+  }
+  return count;
 }
 
 export interface DeliveryFailureNotice {
@@ -692,7 +699,7 @@ export async function fetchDueNodeDeliveryEvents(
 
   const fetchRows = (attemptCondition: SQL, queryLimit: number, orderByRetryAt: boolean) => db
     .select({
-      delivery: deliveries,
+      delivery: indexedDeliveryColumns,
       recipientAgentName: agents.name,
       body: messages.body,
       blocks: messages.blocks,
@@ -709,7 +716,7 @@ export async function fetchDueNodeDeliveryEvents(
         SELECT a.name FROM agents a WHERE a.id = ${messages.agentId}
       )`,
     })
-    .from(deliveries)
+    .from(sql`${deliveries} INDEXED BY ${sql.raw(orderByRetryAt ? 'idx_deliveries_retry_due' : 'idx_deliveries_initial_due')}`)
     .innerJoin(agents, eq(deliveries.agentId, agents.id))
     .innerJoin(messages, eq(deliveries.messageId, messages.id))
     .innerJoin(channels, eq(messages.channelId, channels.id))
@@ -869,95 +876,145 @@ export interface NodeDeliveryReplayScope {
   agentIds?: readonly string[];
 }
 
-export async function deliverPendingToNode(
+const replayFlights = new WeakMap<NodeConnectionRegistry, Map<string, { dirty: boolean; promise: Promise<number> }>>();
+
+/** Coalesce identical triggers at the socket owner, including a trailing replay
+ * when readiness/cursors changed during an outstanding drain. This is local
+ * replay coordination, not a global database admission semaphore. */
+export function deliverPendingToNode(
   db: Db,
   registry: NodeConnectionRegistry,
   workspaceId: string,
   nodeId: string,
   scope: NodeDeliveryReplayScope = {},
 ): Promise<number> {
-  const agentIds = scope.agentIds ? [...new Set(scope.agentIds)] : undefined;
-  if (agentIds?.length === 0) return 0;
-
-  const nowSeconds = Math.floor(Date.now() / 1000);
-  const conditions = [
-    eq(deliveries.workspaceId, workspaceId),
-    eq(agents.locationType, 'via_node'),
-    eq(agents.locationNodeId, nodeId),
-    inArray(deliveries.status, [...ACTIVE_DELIVERY_STATUSES]),
-    gt(deliveries.seq, agents.deliveryAckSeq),
-    sql`(${deliveries.expiresAt} IS NULL OR ${deliveries.expiresAt} > ${nowSeconds})`,
-  ];
-  if (scope.providerName !== undefined) {
-    conditions.push(eq(agents.providerName, scope.providerName));
-  }
-  if (agentIds) {
-    conditions.push(inArray(agents.id, agentIds));
-  }
-
-  const rows = await db
-    .select({
-      delivery: deliveries,
-      recipientAgentName: agents.name,
-      recipientProviderName: agents.providerName,
-      ackSeq: agents.deliveryAckSeq,
-      body: messages.body,
-      blocks: messages.blocks,
-      metadata: messages.metadata,
-      hasAttachments: messages.hasAttachments,
-      threadId: messages.threadId,
-      createdAt: messages.createdAt,
-      channelId: messages.channelId,
-      channelName: channels.name,
-      conversationId: dmConversations.id,
-      dmType: dmConversations.dmType,
-      senderAgentId: messages.agentId,
-      senderAgentName: sql<string | null>`(
-        SELECT a.name FROM agents a WHERE a.id = ${messages.agentId}
-      )`,
-    })
-    .from(deliveries)
-    .innerJoin(agents, eq(deliveries.agentId, agents.id))
-    .innerJoin(messages, eq(deliveries.messageId, messages.id))
-    .innerJoin(channels, eq(messages.channelId, channels.id))
-    .leftJoin(dmConversations, eq(dmConversations.channelId, messages.channelId))
-    .where(and(...conditions))
-    .orderBy(asc(agents.name), asc(deliveries.seq));
-
-  const attachmentsByMessageId = await fetchAttachmentsBatch(db, workspaceId, [...new Set(rows.map((row) => row.delivery.messageId))]);
-
-  const deliveredIds: string[] = [];
-  for (const row of rows) {
-    if (!isProviderAgentDeliveryReady(
-      registry,
-      workspaceId,
-      nodeId,
-      row.recipientProviderName,
-      row.delivery.agentId,
-    )) {
-      continue;
-    }
-    const attachments = attachmentsByMessageId.get(row.delivery.messageId) ?? [];
-    const { eventType, eventData } = buildRoutableDeliveryEvent(row, attachments);
-
-    const sent = await registry.sendToProvider(workspaceId, nodeId, row.recipientProviderName, buildDeliverFrame({
-      delivery_id: row.delivery.id,
-      agent_id: row.delivery.agentId,
-      agent: row.recipientAgentName,
-      msg_id: row.delivery.messageId,
-      seq: row.delivery.seq,
-      mode: wireMode(row.delivery.mode),
-      payload: buildDeliverPayload(eventType, eventData),
-    }));
-    if (sent) deliveredIds.push(row.delivery.id);
-  }
-
-  await markDeliveriesDelivered(db, workspaceId, deliveredIds);
-  return deliveredIds.length;
+  let flights = replayFlights.get(registry);
+  if (!flights) { flights = new Map(); replayFlights.set(registry, flights); }
+  const key = JSON.stringify([workspaceId, nodeId, scope.providerName,
+    scope.agentIds ? [...new Set(scope.agentIds)].sort() : null]);
+  const existing = flights.get(key);
+  if (existing) { existing.dirty = true; return existing.promise; }
+  const flight = { dirty: false, promise: Promise.resolve(0) };
+  // Defer entry until the flight is visible to reentrant/concurrent callers.
+  flight.promise = Promise.resolve().then(async () => {
+    let count = 0;
+    do {
+      flight.dirty = false;
+      count += await replayPendingToNode(db, registry, workspaceId, nodeId, scope);
+    } while (flight.dirty);
+    return count;
+  }).finally(() => { flights!.delete(key); });
+  flights.set(key, flight);
+  return flight.promise;
 }
 
+async function replayPendingToNode(
+  db: Db,
+  registry: NodeConnectionRegistry,
+  workspaceId: string,
+  nodeId: string,
+  scope: NodeDeliveryReplayScope = {},
+): Promise<number> {
+  const wantedIds = scope.agentIds ? new Set(scope.agentIds) : undefined;
+  if (wantedIds?.size === 0) return 0;
+
+  // Resolve the small node roster first. A delivery-first join lets SQLite
+  // choose the workspace/status index and scan millions of retained rows.
+  const recipients = await db.select({
+    id: agents.id, name: agents.name, providerName: agents.providerName,
+    ackSeq: agents.deliveryAckSeq,
+  }).from(agents).where(and(
+    eq(agents.workspaceId, workspaceId),
+    eq(agents.locationType, 'via_node'),
+    eq(agents.locationNodeId, nodeId),
+    scope.providerName === undefined ? undefined : eq(agents.providerName, scope.providerName),
+  )).orderBy(asc(agents.name));
+
+  let delivered = 0;
+  for (const recipient of recipients) {
+    if (wantedIds && !wantedIds.has(recipient.id)) continue;
+    const ready = () => isProviderAgentDeliveryReady(
+      registry, workspaceId, nodeId, recipient.providerName, recipient.id,
+    );
+    if (!ready()) continue;
+    // Capture a finite high-water mark: arrivals during replay are handled by
+    // live dispatch/the next reconnect, not an indefinitely growing drain.
+    const [highWater] = await db.select({ seq: deliveries.seq })
+      .from(deliveries).where(and(
+        eq(deliveries.workspaceId, workspaceId), eq(deliveries.agentId, recipient.id),
+      )).orderBy(sql`${deliveries.seq} DESC`).limit(1);
+    if (!highWater) continue;
+    let cursor = recipient.ackSeq;
+    while (cursor < highWater.seq && ready()) {
+      // The literal predicate is essential: SQLite must prove that this
+      // query qualifies for the partial index even with bound parameters.
+      const page = await db.select({ id: sql<string>`${deliveries.id}`, seq: sql<number>`${deliveries.seq}` })
+        .from(sql`${deliveries} INDEXED BY idx_deliveries_agent_active_seq`)
+        .where(and(
+          eq(deliveries.workspaceId, workspaceId), eq(deliveries.agentId, recipient.id),
+          sql`${deliveries.status} IN ('queued', 'delivered')`,
+          gt(deliveries.seq, cursor), lte(deliveries.seq, highWater.seq),
+        )).orderBy(asc(deliveries.seq)).limit(50);
+      if (!page.length) break;
+      cursor = page[page.length - 1]!.seq;
+      // Hydrate only this bounded ID page. Re-check ownership, ACK, expiry and
+      // status here because each await can race a handoff or cumulative ACK.
+      const rows = await db.select({
+        delivery: indexedDeliveryColumns,
+        recipientAgentName: agents.name,
+        recipientProviderName: agents.providerName,
+        ackSeq: agents.deliveryAckSeq,
+        body: messages.body, blocks: messages.blocks, metadata: messages.metadata,
+        hasAttachments: messages.hasAttachments, threadId: messages.threadId,
+        createdAt: messages.createdAt, channelId: messages.channelId,
+        channelName: channels.name, conversationId: dmConversations.id,
+        dmType: dmConversations.dmType, senderAgentId: messages.agentId,
+        senderAgentName: sql<string | null>`(
+          SELECT a.name FROM agents a WHERE a.id = ${messages.agentId}
+        )`,
+      }).from(sql`${deliveries} INDEXED BY sqlite_autoindex_deliveries_1`)
+        .innerJoin(agents, eq(deliveries.agentId, agents.id))
+        .innerJoin(messages, eq(deliveries.messageId, messages.id))
+        .innerJoin(channels, eq(messages.channelId, channels.id))
+        .leftJoin(dmConversations, eq(dmConversations.channelId, messages.channelId))
+        .where(and(
+          inArray(deliveries.id, page.map(row => row.id)),
+          eq(deliveries.workspaceId, workspaceId),
+          eq(agents.locationType, 'via_node'), eq(agents.locationNodeId, nodeId),
+          eq(agents.id, recipient.id),
+          recipient.providerName === null
+            ? isNull(agents.providerName) : eq(agents.providerName, recipient.providerName),
+          inArray(deliveries.status, [...ACTIVE_DELIVERY_STATUSES]),
+          gt(deliveries.seq, agents.deliveryAckSeq),
+          sql`(${deliveries.expiresAt} IS NULL OR ${deliveries.expiresAt} > ${Math.floor(Date.now() / 1000)})`,
+        )).orderBy(asc(deliveries.seq));
+
+      const attachments = await fetchAttachmentsBatch(db, workspaceId, [...new Set(rows.map(row => row.delivery.messageId))]);
+      const deliveredIds: string[] = [];
+      let interrupted = false;
+      for (const row of rows) {
+        if (!ready()) { interrupted = true; break; }
+        const { eventType, eventData } = buildRoutableDeliveryEvent(row, attachments.get(row.delivery.messageId) ?? []);
+        const sent = await registry.sendToProvider(workspaceId, nodeId, recipient.providerName, buildDeliverFrame({
+          delivery_id: row.delivery.id, agent_id: recipient.id,
+          agent: row.recipientAgentName, msg_id: row.delivery.messageId,
+          seq: row.delivery.seq, mode: wireMode(row.delivery.mode),
+          payload: buildDeliverPayload(eventType, eventData),
+        }));
+        // Never send a higher sequence past a failed lower one: a cumulative
+        // ACK for it would make the unsent lower delivery replay-invisible.
+        if (!sent) { interrupted = true; break; }
+        deliveredIds.push(row.delivery.id);
+      }
+      await markDeliveriesDelivered(db, workspaceId, deliveredIds);
+      delivered += deliveredIds.length;
+      if (interrupted) break;
+    }
+  }
+  return delivered;
+}
 /**
- * Resolve the result of a status-guarded transition: when the write landed,
+ * Resolve a status-guarded transition: when the write landed,
  * report the updated row as changed. When it did not (the row was deleted, or a
  * concurrent ack won the race and the row is now terminal), re-read and return
  * the current state as unchanged — never resurrecting it or emitting an event.

--- a/packages/engine/src/engine/delivery.ts
+++ b/packages/engine/src/engine/delivery.ts
@@ -8,6 +8,8 @@ import { isProviderAgentDeliveryReady } from '../ports/realtime.js';
 import { buildDeliverFrame, buildDeliverPayload, buildMessageCreatedEventData, buildThreadReplyEventData, buildDmReceivedEventData, buildGroupDmReceivedEventData } from './deliveryWire.js';
 import { publicMessageMetadata } from './messageMetadata.js';
 import { toIso } from '../lib/serialize.js';
+import { trailingSingleFlight } from '../lib/singleFlight.js';
+import { readNodeRedriveCandidates } from './nodeRedriveCandidates.js';
 import { fetchAttachmentsBatch, type AttachmentRow } from './attachments.js';
 import type { DeliveryFanoutRecord } from './deliveryWrites.js';
 
@@ -422,6 +424,7 @@ export async function ackDeliveriesUpToSeq(
   return { agent_id: agent.id, agent_name: agent.name, up_to_seq: upToSeq, acked: updated.length };
 }
 
+/** Mark still-queued rows delivered using bounded, explicit ID-index writes. */
 export async function markDeliveriesDelivered(
   db: Db,
   workspaceId: string,
@@ -435,7 +438,7 @@ export async function markDeliveriesDelivered(
   for (let offset = 0; offset < ids.length; offset += 50) {
     const page = ids.slice(offset, offset + 50);
     const updated = await db.all<{ id: string }>(sql`
-      UPDATE deliveries INDEXED BY sqlite_autoindex_deliveries_1
+      UPDATE deliveries INDEXED BY idx_deliveries_id_lookup
       SET status = 'delivered', next_attempt_at = NULL, last_dispatch_error = NULL,
           delivered_at = ${now}, updated_at = ${now}
       WHERE workspace_id = ${workspaceId}
@@ -681,13 +684,15 @@ function fanoutRecordFromDeliveryRow(row: PendingDeliveryRow): DeliveryFanoutRec
 // `WS_NODE_KINDS` in `nodeDeliver.ts`.
 const NODE_REDRIVE_KINDS = ['http_push', 'ws', 'fleet_ws', 'direct_ws'] as const;
 
+/** Hydrate bounded resumable redrive windows; empty windows resume next sweep. */
 export async function fetchDueNodeDeliveryEvents(
   db: Db,
   opts: { workspaceId?: string; now?: Date; limit?: number } = {},
 ): Promise<RoutableDeliveryEvent[]> {
-  const limit = Math.min(Math.max(opts.limit ?? 50, 1), 200);
+  const limit = Number.isFinite(opts.limit) ? Math.min(Math.max(Math.floor(opts.limit!), 1), 200) : 50;
   const now = opts.now ?? new Date();
   const nowSeconds = Math.floor(now.getTime() / 1000);
+  if (!Number.isFinite(nowSeconds)) throw new Error('Invalid node redrive clock: expected a finite Date');
   const conditions = [
     eq(deliveries.status, 'queued'),
     inArray(deliveries.routeNodeKind, [...NODE_REDRIVE_KINDS]),
@@ -697,7 +702,7 @@ export async function fetchDueNodeDeliveryEvents(
     conditions.push(eq(deliveries.workspaceId, opts.workspaceId));
   }
 
-  const fetchRows = (attemptCondition: SQL, queryLimit: number, orderByRetryAt: boolean) => db
+  const fetchRows = (ids: string[]) => db
     .select({
       delivery: indexedDeliveryColumns,
       recipientAgentName: agents.name,
@@ -716,32 +721,42 @@ export async function fetchDueNodeDeliveryEvents(
         SELECT a.name FROM agents a WHERE a.id = ${messages.agentId}
       )`,
     })
-    .from(sql`${deliveries} INDEXED BY ${sql.raw(orderByRetryAt ? 'idx_deliveries_retry_due' : 'idx_deliveries_initial_due')}`)
+    .from(sql`${deliveries} INDEXED BY idx_deliveries_id_lookup`)
     .innerJoin(agents, eq(deliveries.agentId, agents.id))
     .innerJoin(messages, eq(deliveries.messageId, messages.id))
     .innerJoin(channels, eq(messages.channelId, channels.id))
     .leftJoin(dmConversations, eq(dmConversations.channelId, messages.channelId))
-    .where(and(...conditions, attemptCondition))
+    .where(and(...conditions, inArray(deliveries.id, ids),
+      sql`(${deliveries.nextAttemptAt} IS NULL OR ${deliveries.nextAttemptAt} <= ${nowSeconds})`))
     .orderBy(
-      ...(orderByRetryAt ? [asc(deliveries.nextAttemptAt)] : []),
+      asc(deliveries.nextAttemptAt),
       asc(deliveries.createdAt),
       asc(deliveries.id),
-    )
-    .limit(queryLimit);
+    );
 
-  // SQLite orders NULL before timestamps, so preserve the former OR query's
-  // ordering by filling the page with never-attempted rows first. Splitting the
-  // branches lets the due-retry half use idx_deliveries_retry_due; a partial
-  // non-NULL index cannot serve an OR that also asks for NULL rows.
-  const neverAttempted = await fetchRows(isNull(deliveries.nextAttemptAt), limit, false);
+  // Scan at most one metadata window per lane. Expiry is checked AFTER LIMIT,
+  // and a durable cursor advances past excluded rows instead of repeatedly
+  // scanning the same prefix. Hydration rechecks mutable eligibility by ID.
+  const neverAttempted = await readNodeRedriveCandidates(db, { workspaceId: opts.workspaceId, retry: false, limit, nowSeconds });
   const dueRetries = neverAttempted.length < limit
-    ? await fetchRows(
-      sql`${deliveries.nextAttemptAt} IS NOT NULL AND ${deliveries.nextAttemptAt} <= ${nowSeconds}`,
-      limit - neverAttempted.length,
-      true,
-    )
+    ? await readNodeRedriveCandidates(db, { workspaceId: opts.workspaceId, retry: true, limit: limit - neverAttempted.length, nowSeconds })
     : [];
-  const rows = [...neverAttempted, ...dueRetries];
+  const ids = [...neverAttempted, ...dueRetries];
+  const rows: Awaited<ReturnType<typeof fetchRows>> = [];
+  for (let offset = 0; offset < ids.length; offset += 50) {
+    rows.push(...await fetchRows(ids.slice(offset, offset + 50)));
+  }
+
+  // Attachment hydration must respect the same bind budget as delivery rows.
+  const fetchRedriveAttachments = async (workspaceId: string, messageIds: string[]) => {
+    const attachments = new Map<string, AttachmentRow[]>();
+    const uniqueIds = [...new Set(messageIds)];
+    for (let offset = 0; offset < uniqueIds.length; offset += 50) {
+      const page = await fetchAttachmentsBatch(db, workspaceId, uniqueIds.slice(offset, offset + 50));
+      for (const [id, items] of page) attachments.set(id, items);
+    }
+    return attachments;
+  };
 
   if (!opts.workspaceId && rows.length > 0) {
     const workspaceAttachments = new Map<string, AttachmentRow[]>();
@@ -749,7 +764,7 @@ export async function fetchDueNodeDeliveryEvents(
       const workspaceMessageIds = rows
         .filter((row) => row.delivery.workspaceId === workspaceId)
         .map((row) => row.delivery.messageId);
-      const batch = await fetchAttachmentsBatch(db, workspaceId, [...new Set(workspaceMessageIds)]);
+      const batch = await fetchRedriveAttachments(workspaceId, workspaceMessageIds);
       for (const [messageId, attachments] of batch) workspaceAttachments.set(messageId, attachments);
     }
     return rows.map((row) => {
@@ -768,7 +783,7 @@ export async function fetchDueNodeDeliveryEvents(
   }
 
   const attachmentsByMessageId = opts.workspaceId
-    ? await fetchAttachmentsBatch(db, opts.workspaceId, [...new Set(rows.map((row) => row.delivery.messageId))])
+    ? await fetchRedriveAttachments(opts.workspaceId, rows.map((row) => row.delivery.messageId))
     : new Map<string, AttachmentRow[]>();
 
   return rows.map((row) => {
@@ -892,22 +907,10 @@ export function deliverPendingToNode(
   if (!flights) { flights = new Map(); replayFlights.set(registry, flights); }
   const key = JSON.stringify([workspaceId, nodeId, scope.providerName,
     scope.agentIds ? [...new Set(scope.agentIds)].sort() : null]);
-  const existing = flights.get(key);
-  if (existing) { existing.dirty = true; return existing.promise; }
-  const flight = { dirty: false, promise: Promise.resolve(0) };
-  // Defer entry until the flight is visible to reentrant/concurrent callers.
-  flight.promise = Promise.resolve().then(async () => {
-    let count = 0;
-    do {
-      flight.dirty = false;
-      count += await replayPendingToNode(db, registry, workspaceId, nodeId, scope);
-    } while (flight.dirty);
-    return count;
-  }).finally(() => { flights!.delete(key); });
-  flights.set(key, flight);
-  return flight.promise;
+  return trailingSingleFlight(flights, key, () => replayPendingToNode(db, registry, workspaceId, nodeId, scope));
 }
 
+/** Drain a finite per-agent high-water mark in ordered, readiness-checked pages. */
 async function replayPendingToNode(
   db: Db,
   registry: NodeConnectionRegistry,
@@ -972,7 +975,7 @@ async function replayPendingToNode(
         senderAgentName: sql<string | null>`(
           SELECT a.name FROM agents a WHERE a.id = ${messages.agentId}
         )`,
-      }).from(sql`${deliveries} INDEXED BY sqlite_autoindex_deliveries_1`)
+      }).from(sql`${deliveries} INDEXED BY idx_deliveries_id_lookup`)
         .innerJoin(agents, eq(deliveries.agentId, agents.id))
         .innerJoin(messages, eq(deliveries.messageId, messages.id))
         .innerJoin(channels, eq(messages.channelId, channels.id))

--- a/packages/engine/src/engine/deliveryWrites.ts
+++ b/packages/engine/src/engine/deliveryWrites.ts
@@ -89,12 +89,20 @@ function belowDepthCapSql(workspaceId: string, agentId: unknown, depthCap: numbe
   // recipient would otherwise keep rejecting new sends as `depth_cap` long after
   // its queued rows should have dead-lettered. Exclude expired rows from the count.
   return sql`(
-    SELECT COUNT(*)
-    FROM deliveries d
-    WHERE d.workspace_id = ${workspaceId}
-      AND d.agent_id = ${agentId}
-      AND d.status IN ('queued', 'delivered')
-      AND (d.expires_at IS NULL OR d.expires_at > unixepoch())
+    SELECT COUNT(*) FROM (
+      SELECT 1 FROM deliveries d INDEXED BY idx_deliveries_agent_active_expiry
+      WHERE d.workspace_id = ${workspaceId}
+        AND d.agent_id = ${agentId}
+        AND d.status IN ('queued', 'delivered')
+        AND d.expires_at IS NULL
+      UNION ALL
+      SELECT 1 FROM deliveries d INDEXED BY idx_deliveries_agent_active_expiry
+      WHERE d.workspace_id = ${workspaceId}
+        AND d.agent_id = ${agentId}
+        AND d.status IN ('queued', 'delivered')
+        AND d.expires_at > unixepoch()
+      LIMIT ${depthCap}
+    )
   ) < ${depthCap}`;
 }
 

--- a/packages/engine/src/engine/deliveryWrites.ts
+++ b/packages/engine/src/engine/deliveryWrites.ts
@@ -83,6 +83,7 @@ function nextDeliverySeqSql() {
   return sql<number>`MAX(${agents.deliverySeq}, ${agents.deliveryAckSeq}) + 1`;
 }
 
+/** Test live mailbox depth with indexed branches capped at the admission limit. */
 function belowDepthCapSql(workspaceId: string, agentId: unknown, depthCap: number) {
   // Expired-but-not-yet-swept rows are not active mailbox depth: TTL expiry is
   // only swept lazily (GET /deliveries, /inbox, node replay), so an idle/offline

--- a/packages/engine/src/engine/nodeRedriveCandidates.ts
+++ b/packages/engine/src/engine/nodeRedriveCandidates.ts
@@ -1,0 +1,72 @@
+import { sql } from 'drizzle-orm';
+import { z } from 'zod';
+import type { EngineDb } from '../ports/database.js';
+
+const position = z.union([
+  z.tuple([z.number(), z.string()]),
+  z.tuple([z.number(), z.number(), z.string()]),
+]);
+const cursorSchema = z.object({ after: position.optional(), high: position.optional() });
+type Candidate = { id: string; created_at: number; next_attempt_at: number | null; expires_at: number | null };
+
+/**
+ * Examine one indexed metadata window before applying expiry or hydrating.
+ * Persist its keyset position even for an expired-only window. A short/empty
+ * result is not proof that the queue is empty: the next scheduled sweep resumes.
+ * The fixed high-water fence guarantees wraparound under continuous arrivals.
+ * Cursors are advisory: retries/crashes may repeat work, never acknowledge it.
+ */
+export async function readNodeRedriveCandidates(
+  db: EngineDb,
+  opts: { workspaceId?: string; retry: boolean; limit: number; nowSeconds: number },
+): Promise<string[]> {
+  const lane = opts.retry ? 'retry' : 'initial';
+  const cursorId = JSON.stringify(['node-redrive-v1', opts.workspaceId ?? null, lane]);
+  const [saved] = await db.all<{ cursor: string }>(sql`SELECT cursor FROM maintenance_cursors WHERE id = ${cursorId}`);
+  let cursor: z.infer<typeof cursorSchema> = {};
+  try {
+    const parsed = cursorSchema.safeParse(saved ? JSON.parse(saved.cursor) : {});
+    if (parsed.success) cursor = parsed.data;
+  } catch { /* A damaged advisory cursor safely restarts traversal. */ }
+  const keys = opts.retry ? ['next_attempt_at', 'created_at', 'id'] : ['created_at', 'id'];
+  const key = (row: Candidate): z.infer<typeof position> => opts.retry
+    ? [row.next_attempt_at!, row.created_at, row.id] : [row.created_at, row.id];
+  const index = 'idx_deliveries_node_' + lane + (opts.workspaceId === undefined ? '' : '_workspace');
+  // Literal predicates match the partial indexes; other route kinds never
+  // enter the scan, and the workspace variant seeks past other tenants.
+  const conditions = [sql.raw(`status = 'queued'
+    AND route_node_kind IN ('http_push', 'ws', 'fleet_ws', 'direct_ws')
+    AND next_attempt_at IS ${opts.retry ? 'NOT NULL' : 'NULL'}`)];
+  if (opts.workspaceId !== undefined) conditions.push(sql`workspace_id = ${opts.workspaceId}`);
+  if (opts.retry) conditions.push(sql`next_attempt_at <= ${opts.nowSeconds}`);
+  if (!cursor.high || cursor.high.length !== keys.length) {
+    cursor = {};
+    const [last] = await db.all<Candidate>(sql`
+      SELECT id, created_at, next_attempt_at, expires_at
+      FROM deliveries INDEXED BY ${sql.raw(index)}
+      WHERE ${sql.join(conditions, sql` AND `)}
+      ORDER BY ${sql.raw(keys.map(k => k + ' DESC').join(', '))} LIMIT 1
+    `);
+    if (last) cursor.high = key(last);
+  }
+  if (cursor.after?.length === keys.length) {
+    conditions.push(sql`(${sql.raw(keys.join(', '))}) > (${sql.join(cursor.after.map(v => sql`${v}`), sql`, `)})`);
+  }
+  if (cursor.high) {
+    conditions.push(sql`(${sql.raw(keys.join(', '))}) <= (${sql.join(cursor.high.map(v => sql`${v}`), sql`, `)})`);
+  }
+  const page = await db.all<Candidate>(sql`
+    SELECT id, created_at, next_attempt_at, expires_at
+    FROM deliveries INDEXED BY ${sql.raw(index)}
+    WHERE ${sql.join(conditions, sql` AND `)}
+    ORDER BY ${sql.raw(keys.join(', '))} LIMIT ${opts.limit}
+  `);
+  if (page.length < opts.limit || JSON.stringify(key(page[page.length - 1]!)) === JSON.stringify(cursor.high)) {
+    cursor = {};
+  } else {
+    cursor.after = key(page[page.length - 1]!);
+  }
+  await db.run(sql`INSERT INTO maintenance_cursors(id, cursor) VALUES (${cursorId}, ${JSON.stringify(cursor)})
+    ON CONFLICT(id) DO UPDATE SET cursor = excluded.cursor`);
+  return page.filter(row => row.expires_at === null || row.expires_at > opts.nowSeconds).map(row => row.id);
+}

--- a/packages/engine/src/engine/retention.ts
+++ b/packages/engine/src/engine/retention.ts
@@ -1,41 +1,17 @@
-import { and, eq, inArray, isNotNull, isNull, lt, notInArray, sql, type SQL } from 'drizzle-orm';
+import { eq, sql, type SQL } from 'drizzle-orm';
+import { pruneBounded } from './boundedRetention.js';
 import type { SQLiteColumn } from 'drizzle-orm/sqlite-core';
 import type { EffectiveMessageRetention } from '@relaycast/types';
 import type { getDb } from '../db/index.js';
-import {
-  deliveries,
-  messageLogs,
-  messages,
-  readReceipts,
-  workspaceEvents,
-  workspaces,
-  type WorkspaceRetentionSettings,
-} from '../db/schema.js';
+import { workspaces } from '../db/schema.js';
 import { snowflakeIdLowerBound } from './snowflake.js';
 
 type Db = ReturnType<typeof getDb>;
 
-const DAY_MS = 24 * 60 * 60 * 1000;
-
-/** Settled deliveries are operational tracking rows, pruned after 90 days by default. */
+const DAY_MS = 86_400_000;
 export const DEFAULT_DELIVERY_TTL_DAYS = 90;
-/** Message logs are operational telemetry (duplicate bodies), pruned after 90 days by default. */
 export const DEFAULT_MESSAGE_LOG_TTL_DAYS = 90;
-/** Workspace event log rows are a reconciliation window, pruned after 30 days by default. */
 export const DEFAULT_WORKSPACE_EVENT_TTL_DAYS = 30;
-
-const DEFAULT_BATCH_LIMIT = 200;
-const DEFAULT_MAX_BATCHES = 5;
-
-/**
- * Delivery statuses that are terminal — the row is only kept as history.
- * Mirrors the engine's settled set (delivery.ts): `acked` (recipient
- * acknowledged), `dead_lettered` (TTL expiry), and `failed`. NOTE: `delivered`
- * is NOT terminal under the durable-mailbox model — it means "sent to the
- * current location, awaiting cumulative ack" (in-flight), so it must never be
- * pruned here; only `acked` is terminal success.
- */
-const SETTLED_DELIVERY_STATUSES = ['acked', 'failed', 'dead_lettered'];
 
 /**
  * Deployment-wide TTL fallbacks, applied to workspaces without their own
@@ -53,9 +29,11 @@ export interface RetentionDefaults {
 }
 
 export interface PruneOptions {
-  /** Max rows deleted per table per batch (the SQL LIMIT). Default 200. */
+  /** Stop starting candidate pages after this elapsed budget (default 10s, capped at 30s). */
+  maxDurationMs?: number;
+  /** Max candidate rows examined per table per batch. Default/cap 200. */
   batchLimit?: number;
-  /** Max batches per table per call, bounding total work per run. Default 5. */
+  /** Max candidate batches per table per call. Default/cap 5; durable cursors resume on the next call. */
   maxBatches?: number;
   /** Clock override for tests. */
   now?: Date;
@@ -147,20 +125,6 @@ export async function resolveEffectiveMessageRetention(
   };
 }
 
-/**
- * `column < snowflakeIdLowerBound(cutoff)` compared numerically.
- *
- * Snowflake IDs are stored as decimal TEXT without leading zeros, and their
- * digit count grows over time — plain lexicographic `<` would mis-order a
- * short (older) ID against a longer bound. For non-negative decimals without
- * leading zeros, "shorter string" implies "smaller number", so length-then-lex
- * comparison is numerically exact.
- */
-function olderThanSnowflake(column: SQLiteColumn, cutoffMs: number): SQL {
-  const bound = snowflakeIdLowerBound(cutoffMs);
-  return sql`(length(${column}) < ${bound.length} OR (length(${column}) = ${bound.length} AND ${column} < ${bound}))`;
-}
-
 /** Numeric `column >= snowflakeIdLowerBound(cutoff)` for decimal TEXT ids. */
 export function atOrAfterSnowflake(column: SQLiteColumn, cutoffMs: number): SQL {
   const bound = snowflakeIdLowerBound(cutoffMs);
@@ -172,210 +136,7 @@ export function afterSnowflake(column: SQLiteColumn, cursor: string): SQL {
   return sql`(length(${column}), ${column}) > (${cursor.length}, ${cursor})`;
 }
 
-interface PrunePass {
-  cutoff: Date;
-  /** Workspace predicate, or undefined for the unscoped default pass. */
-  scope: SQL | undefined;
-}
-
-/**
- * Delete expired rows in bounded batches.
- *
- * Per-workspace TTLs come from `workspaces.retention` (see
- * {@link WorkspaceRetentionSettings}); workspaces without settings inherit
- * `opts.defaults`. Out of the box only operational tables are pruned
- * (settled `deliveries` and `message_logs`, 90 days; `workspace_events`,
- * 30 days); `messages` retention is
- * strictly opt-in — no workspace loses message history unless its settings
- * (or an explicit deployment default) say so. Deployments can set a
- * deployment-wide message default via `defaults.messageTtlDays` (the hosted
- * gateway uses 30 days); self-host exposes the `RELAYCAST_MESSAGE_TTL_DAYS`
- * env knob.
- *
- * What a run does, per table, oldest rows first:
- * - `messages` older than the effective TTL, leaf-first: a message still
- *   referenced as a `thread_id` parent is skipped until its replies age out,
- *   so the self-referencing FK never breaks mid-batch. Cascades take the
- *   message's receipts, reactions, attachments, deliveries, and log row.
- * - settled `deliveries` (`acked`/`failed`/`dead_lettered`) older than the
- *   effective TTL. In-flight rows (`queued`/`delivered`) are never touched.
- * - `message_logs` older than the effective TTL.
- * - `read_receipts` whose message no longer exists (defensive sweep for rows
- *   written while FK enforcement was off).
- *
- * Every DELETE is a single `id IN (SELECT ... LIMIT n)` statement, capped at
- * `batchLimit` rows and `maxBatches` passes per table, so a run is always
- * short-lived and D1-friendly. Callers run it on a cadence (the Node adapter's
- * outbox cleanup tick, or a cloud scheduled handler) and backlogs drain over
- * successive runs.
- */
+/** Bounded, resumable retention; preserves TTL overrides and event high-water marks. */
 export async function pruneExpired(db: Db, opts: PruneOptions = {}): Promise<PruneResult> {
-  const now = opts.now ?? new Date();
-  const batchLimit = Math.max(1, opts.batchLimit ?? DEFAULT_BATCH_LIMIT);
-  const maxBatches = Math.max(1, opts.maxBatches ?? DEFAULT_MAX_BATCHES);
-  const defaults: Required<RetentionDefaults> = {
-    messageTtlDays: opts.defaults?.messageTtlDays ?? null,
-    deliveryTtlDays:
-      opts.defaults?.deliveryTtlDays !== undefined
-        ? opts.defaults.deliveryTtlDays
-        : DEFAULT_DELIVERY_TTL_DAYS,
-    messageLogTtlDays:
-      opts.defaults?.messageLogTtlDays !== undefined
-        ? opts.defaults.messageLogTtlDays
-        : DEFAULT_MESSAGE_LOG_TTL_DAYS,
-    workspaceEventTtlDays:
-      opts.defaults?.workspaceEventTtlDays !== undefined
-        ? opts.defaults.workspaceEventTtlDays
-        : DEFAULT_WORKSPACE_EVENT_TTL_DAYS,
-  };
-
-  // Workspaces with explicit settings get their own pass; everyone else is
-  // covered by one unscoped pass per table using the deployment default.
-  const overrides = await db
-    .select({ id: workspaces.id, retention: workspaces.retention })
-    .from(workspaces)
-    .where(isNotNull(workspaces.retention));
-  const overrideIds = overrides.map((o) => o.id);
-
-  function passes(
-    defaultTtlDays: number | null,
-    pick: (settings: WorkspaceRetentionSettings) => number | null | undefined,
-    workspaceIdColumn: SQLiteColumn,
-  ): PrunePass[] {
-    const out: PrunePass[] = [];
-    if (defaultTtlDays != null && defaultTtlDays > 0) {
-      out.push({
-        cutoff: new Date(now.getTime() - defaultTtlDays * DAY_MS),
-        scope: overrideIds.length > 0 ? notInArray(workspaceIdColumn, overrideIds) : undefined,
-      });
-    }
-    for (const override of overrides) {
-      const setting = pick(override.retention ?? {});
-      // undefined inherits the default; explicit null disables pruning.
-      const ttlDays = setting === undefined ? defaultTtlDays : setting;
-      if (ttlDays != null && ttlDays > 0) {
-        out.push({
-          cutoff: new Date(now.getTime() - ttlDays * DAY_MS),
-          scope: eq(workspaceIdColumn, override.id),
-        });
-      }
-    }
-    return out;
-  }
-
-  async function drain(deleteBatch: () => Promise<number>): Promise<number> {
-    let total = 0;
-    for (let i = 0; i < maxBatches; i++) {
-      const deleted = await deleteBatch();
-      total += deleted;
-      if (deleted < batchLimit) break;
-    }
-    return total;
-  }
-
-  const result: PruneResult = { messages: 0, deliveries: 0, messageLogs: 0, readReceipts: 0, workspaceEvents: 0 };
-
-  // Messages — leaf-first so the self-referencing thread FK never breaks.
-  for (const pass of passes(defaults.messageTtlDays, (s) => s.message_ttl_days, messages.workspaceId)) {
-    result.messages += await drain(async () => {
-      const batch = db
-        .select({ id: messages.id })
-        .from(messages)
-        .where(
-          and(
-            olderThanSnowflake(messages.id, pass.cutoff.getTime()),
-            sql`NOT EXISTS (SELECT 1 FROM messages replies WHERE replies.thread_id = ${messages.id})`,
-            pass.scope,
-          ),
-        )
-        .limit(batchLimit);
-      const deleted = await db
-        .delete(messages)
-        .where(inArray(messages.id, batch))
-        .returning({ id: messages.id });
-      return deleted.length;
-    });
-  }
-
-  // Settled deliveries.
-  for (const pass of passes(defaults.deliveryTtlDays, (s) => s.delivery_ttl_days, deliveries.workspaceId)) {
-    result.deliveries += await drain(async () => {
-      const batch = db
-        .select({ id: deliveries.id })
-        .from(deliveries)
-        .where(
-          and(
-            inArray(deliveries.status, SETTLED_DELIVERY_STATUSES),
-            lt(deliveries.createdAt, pass.cutoff),
-            pass.scope,
-          ),
-        )
-        .limit(batchLimit);
-      const deleted = await db
-        .delete(deliveries)
-        .where(inArray(deliveries.id, batch))
-        .returning({ id: deliveries.id });
-      return deleted.length;
-    });
-  }
-
-  // Message logs.
-  for (const pass of passes(defaults.messageLogTtlDays, (s) => s.message_log_ttl_days, messageLogs.workspaceId)) {
-    result.messageLogs += await drain(async () => {
-      const batch = db
-        .select({ id: messageLogs.id })
-        .from(messageLogs)
-        .where(and(olderThanSnowflake(messageLogs.id, pass.cutoff.getTime()), pass.scope))
-        .limit(batchLimit);
-      const deleted = await db
-        .delete(messageLogs)
-        .where(inArray(messageLogs.id, batch))
-        .returning({ id: messageLogs.id });
-      return deleted.length;
-    });
-  }
-
-  // Workspace event log (durable observer plane; composite PK, batched via rowid).
-  // Each workspace's highest-seq row is always retained as the seq high-water
-  // mark: seq is assigned as MAX(seq)+1, so pruning a workspace to zero rows
-  // would reset the sequence and strand every persisted observer cursor (and
-  // confuse live-frame dedupe). One stale row per workspace is the cheap price.
-  for (const pass of passes(defaults.workspaceEventTtlDays, (s) => s.workspace_event_ttl_days, workspaceEvents.workspaceId)) {
-    result.workspaceEvents += await drain(async () => {
-      const batch = db
-        .select({ rowid: sql<number>`rowid` })
-        .from(workspaceEvents)
-        .where(and(
-          lt(workspaceEvents.createdAt, pass.cutoff),
-          pass.scope,
-          sql`${workspaceEvents.seq} < (
-            SELECT MAX(hw.seq) FROM workspace_events hw
-            WHERE hw.workspace_id = ${workspaceEvents.workspaceId}
-          )`,
-        ))
-        .limit(batchLimit);
-      const deleted = await db
-        .delete(workspaceEvents)
-        .where(inArray(sql`rowid`, batch))
-        .returning({ seq: workspaceEvents.seq });
-      return deleted.length;
-    });
-  }
-
-  // Orphaned read receipts (referential garbage, always swept).
-  result.readReceipts += await drain(async () => {
-    const orphaned = db
-      .select({ messageId: readReceipts.messageId })
-      .from(readReceipts)
-      .leftJoin(messages, eq(messages.id, readReceipts.messageId))
-      .where(isNull(messages.id))
-      .limit(batchLimit);
-    const deleted = await db
-      .delete(readReceipts)
-      .where(inArray(readReceipts.messageId, orphaned))
-      .returning({ messageId: readReceipts.messageId });
-    return deleted.length;
-  });
-
-  return result;
+  return pruneBounded(db, opts);
 }

--- a/packages/engine/src/lib/__tests__/settlePool.test.ts
+++ b/packages/engine/src/lib/__tests__/settlePool.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it, vi } from 'vitest';
+import { settlePool } from '../settlePool.js';
+
+describe('rolling all-settled pool', () => {
+  it('uses free slots without waiting for the slowest task, including after failure', async () => {
+    const started: number[] = [];
+    const finish: Array<() => void> = [];
+    const reject: Array<() => void> = [];
+    let active = 0;
+    let peak = 0;
+    const tasks = Array.from({ length: 6 }, (_, n) => async () => {
+      started.push(n); active++; peak = Math.max(peak, active);
+      try {
+        await new Promise<void>((resolve, fail) => {
+          finish[n] = resolve; reject[n] = () => fail(new Error('dispatch failed'));
+        });
+      } finally { active--; }
+    });
+    const result = settlePool(tasks, 4);
+    expect(started).toEqual([0, 1, 2, 3]);
+    finish[1]!();
+    await vi.waitFor(() => expect(started).toEqual([0, 1, 2, 3, 4]));
+    reject[2]!();
+    await vi.waitFor(() => expect(started).toEqual([0, 1, 2, 3, 4, 5]));
+    for (const n of [0, 3, 4, 5]) finish[n]!();
+    await result;
+    expect(peak).toBe(4);
+    expect(active).toBe(0);
+  });
+
+  it('settles an empty list and synchronous task throws', async () => {
+    await settlePool([], 4);
+    const next = vi.fn().mockResolvedValue(undefined);
+    await settlePool([() => { throw new Error('sync'); }, next], 1);
+    expect(next).toHaveBeenCalledOnce();
+  });
+});

--- a/packages/engine/src/lib/__tests__/settlePool.test.ts
+++ b/packages/engine/src/lib/__tests__/settlePool.test.ts
@@ -2,6 +2,12 @@ import { describe, expect, it, vi } from 'vitest';
 import { settlePool } from '../settlePool.js';
 
 describe('rolling all-settled pool', () => {
+  it.each([0, -1, NaN, Infinity, 0.5, 1.5])('rejects invalid concurrency %s before starting tasks', async (concurrency) => {
+    const task = vi.fn().mockResolvedValue(undefined);
+    await expect(settlePool([task], concurrency)).rejects.toThrow('positive finite integer');
+    expect(task).not.toHaveBeenCalled();
+  });
+
   it('uses free slots without waiting for the slowest task, including after failure', async () => {
     const started: number[] = [];
     const finish: Array<() => void> = [];

--- a/packages/engine/src/lib/__tests__/singleFlight.test.ts
+++ b/packages/engine/src/lib/__tests__/singleFlight.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it, vi } from 'vitest';
+import { trailingSingleFlight } from '../singleFlight.js';
+
+describe('trailing single flight', () => {
+  it('admits a new trigger in the completion microtask without stale cleanup deleting it', async () => {
+    const flights = new Map<string, { dirty: boolean; promise: Promise<number> }>();
+    let finishFirst!: (n: number) => void;
+    let finishSecond!: (n: number) => void;
+    const run = vi.fn()
+      .mockImplementationOnce(() => new Promise<number>(resolve => { finishFirst = resolve; }))
+      .mockImplementationOnce(() => new Promise<number>(resolve => { finishSecond = resolve; }));
+    const first = trailingSingleFlight(flights, 'node', run);
+    await Promise.resolve(); // first run is awaiting its source promise
+    let second!: Promise<number>;
+    finishFirst(1);
+    // Queued after run's resolution, BEFORE any external promise .finally.
+    await new Promise<void>(resolve => queueMicrotask(() => {
+      second = trailingSingleFlight(flights, 'node', run);
+      resolve();
+    }));
+    expect(second).not.toBe(first);
+    expect(await first).toBe(1);
+    expect(flights.get('node')?.promise).toBe(second);
+    finishSecond(2);
+    expect(await second).toBe(2);
+    expect(flights.size).toBe(0);
+    expect(run).toHaveBeenCalledTimes(2);
+  });
+
+  it('cleans up a rejected flight so a later trigger can recover', async () => {
+    const flights = new Map<string, { dirty: boolean; promise: Promise<number> }>();
+    await expect(trailingSingleFlight(flights, 'node', async () => { throw new Error('offline'); })).rejects.toThrow('offline');
+    expect(flights.size).toBe(0);
+    expect(await trailingSingleFlight(flights, 'node', async () => 1)).toBe(1);
+  });
+});

--- a/packages/engine/src/lib/__tests__/singleFlight.test.ts
+++ b/packages/engine/src/lib/__tests__/singleFlight.test.ts
@@ -2,6 +2,23 @@ import { describe, expect, it, vi } from 'vitest';
 import { trailingSingleFlight } from '../singleFlight.js';
 
 describe('trailing single flight', () => {
+  it.each([false, true])('honors a queued trigger after failure and propagates the final outcome (fails=%s)', async (fails) => {
+    const flights = new Map<string, { dirty: boolean; promise: Promise<number> }>();
+    let rejectFirst!: (error: Error) => void;
+    const finalError = new Error('final failure');
+    const run = vi.fn()
+      .mockImplementationOnce(() => new Promise<number>((_resolve, reject) => { rejectFirst = reject; }))
+      .mockImplementationOnce(async () => { if (fails) throw finalError; return 2; });
+    const first = trailingSingleFlight(flights, 'node', run);
+    await Promise.resolve();
+    expect(trailingSingleFlight(flights, 'node', run)).toBe(first);
+    rejectFirst(new Error('transient failure'));
+    if (fails) await expect(first).rejects.toBe(finalError);
+    else expect(await first).toBe(2);
+    expect(run).toHaveBeenCalledTimes(2);
+    expect(flights.size).toBe(0);
+  });
+
   it('admits a new trigger in the completion microtask without stale cleanup deleting it', async () => {
     const flights = new Map<string, { dirty: boolean; promise: Promise<number> }>();
     let finishFirst!: (n: number) => void;

--- a/packages/engine/src/lib/settlePool.ts
+++ b/packages/engine/src/lib/settlePool.ts
@@ -1,5 +1,8 @@
 /** Settle independent tasks with a rolling concurrency cap; never fail fast. */
 export async function settlePool(tasks: readonly (() => Promise<unknown>)[], concurrency: number): Promise<void> {
+  if (!Number.isInteger(concurrency) || concurrency < 1) {
+    throw new RangeError('concurrency must be a positive finite integer');
+  }
   let next = 0;
   const workers = Array.from({ length: Math.min(concurrency, tasks.length) }, async () => {
     while (next < tasks.length) {

--- a/packages/engine/src/lib/settlePool.ts
+++ b/packages/engine/src/lib/settlePool.ts
@@ -1,0 +1,11 @@
+/** Settle independent tasks with a rolling concurrency cap; never fail fast. */
+export async function settlePool(tasks: readonly (() => Promise<unknown>)[], concurrency: number): Promise<void> {
+  let next = 0;
+  const workers = Array.from({ length: Math.min(concurrency, tasks.length) }, async () => {
+    while (next < tasks.length) {
+      const run = tasks[next++]!;
+      try { await run(); } catch { /* Preserve independent all-settled failure handling. */ }
+    }
+  });
+  await Promise.all(workers);
+}

--- a/packages/engine/src/lib/singleFlight.ts
+++ b/packages/engine/src/lib/singleFlight.ts
@@ -12,7 +12,13 @@ export function trailingSingleFlight<K>(
       let count = 0;
       do {
         flight.dirty = false;
-        count += await run();
+        try {
+          count += await run();
+        } catch (error) {
+          // A queued trigger still owns a trailing pass after transient failure.
+          // Never retry without a new trigger, or hide the final failed pass.
+          if (!flight.dirty) throw error;
+        }
       } while (flight.dirty);
       return count;
     } finally {

--- a/packages/engine/src/lib/singleFlight.ts
+++ b/packages/engine/src/lib/singleFlight.ts
@@ -1,0 +1,26 @@
+/** Coalesce triggers while work runs, including a trailing pass for new triggers. */
+export function trailingSingleFlight<K>(
+  flights: Map<K, { dirty: boolean; promise: Promise<number> }>,
+  key: K,
+  run: () => Promise<number>,
+): Promise<number> {
+  const existing = flights.get(key);
+  if (existing) { existing.dirty = true; return existing.promise; }
+  const flight = { dirty: false, promise: Promise.resolve(0) };
+  flight.promise = Promise.resolve().then(async () => {
+    try {
+      let count = 0;
+      do {
+        flight.dirty = false;
+        count += await run();
+      } while (flight.dirty);
+      return count;
+    } finally {
+      // No await between the last dirty check and deletion. An external promise
+      // finalizer would leave a microtask window where triggers can be lost.
+      if (flights.get(key) === flight) flights.delete(key);
+    }
+  });
+  flights.set(key, flight);
+  return flight.promise;
+}

--- a/packages/engine/src/routes/deliveryRouting.ts
+++ b/packages/engine/src/routes/deliveryRouting.ts
@@ -10,6 +10,7 @@ import type {
 import { agents, agentNodeBindings, deliveries as deliveryRows, nodes } from '../db/schema.js';
 import { buildHttpPushHeaders, resolveHttpPushProxy } from '../engine/httpPushDispatch.js';
 import { isSafeExternalUrl } from '../lib/ssrf.js';
+import { settlePool } from '../lib/settlePool.js';
 import { isProviderAgentDeliveryReady, type EngineDb, type EngineDeps } from '../ports/index.js';
 import { fanoutToAgents } from './fanout.js';
 import { publishEvent, publishEventsToAgents } from '../engine/eventDispatch.js';
@@ -585,9 +586,7 @@ export async function sweepDueNodeDeliveries(
   ];
   // A single cron must not fan out up to 50 simultaneous D1-heavy dispatch
   // pipelines. Preserve independent failure handling and per-agent ordering.
-  for (let offset = 0; offset < tasks.length; offset += 4) {
-    await Promise.allSettled(tasks.slice(offset, offset + 4).map(run => run()));
-  }
+  await settlePool(tasks, 4);
   return due.length;
 }
 

--- a/packages/engine/src/routes/deliveryRouting.ts
+++ b/packages/engine/src/routes/deliveryRouting.ts
@@ -566,8 +566,8 @@ export async function sweepDueNodeDeliveries(
     wsAgents.push({ workspaceId: event.workspaceId, agentId: event.delivery.agentId });
   }
 
-  await Promise.allSettled([
-    ...httpPushEvents.map((event) => (
+  const tasks = [
+    ...httpPushEvents.map((event) => () => (
       routeDeliveryOutcomesForContext(
         { db: engine.db, workspaceId: event.workspaceId, engine },
         [event.delivery],
@@ -575,14 +575,19 @@ export async function sweepDueNodeDeliveries(
         event.eventData,
       )
     )),
-    ...wsAgents.map((agent) => (
+    ...wsAgents.map((agent) => () => (
       redriveWsBacklogForAgent(
         { db: engine.db, workspaceId: agent.workspaceId, engine },
         agent.agentId,
         now,
       )
     )),
-  ]);
+  ];
+  // A single cron must not fan out up to 50 simultaneous D1-heavy dispatch
+  // pipelines. Preserve independent failure handling and per-agent ordering.
+  for (let offset = 0; offset < tasks.length; offset += 4) {
+    await Promise.allSettled(tasks.slice(offset, offset + 4).map(run => run()));
+  }
   return due.length;
 }
 


### PR DESCRIPTION
## Why

The Sep 8 fleet incident's D1 insights showed replay averaging ~3.3 million rows read per call, long fanout depth-count queries, and retention deletes scanning millions of rows even when deleting nothing. Broker isolation in AgentWorkforce/relay#1706 prevents a registration stall from freezing local control, but does not remove this server-side load.

## Changes

- Resolve the node roster first, then seek 50-row active-mailbox pages and hydrate/write by primary key. Preserve provider readiness, current ownership, expiry, cumulative ACKs, ordering, and a finite replay high-water mark. Stop after a failed lower sequence. Coalesce identical replay triggers with a trailing pass.
- Cap depth checks with indexed NULL/future-expiry branches; scan bounded redrive metadata windows through route/workspace partial indexes, persist progress past expired-only pages, and use four rolling dispatch workers.
- Replace delete-count-only retention limits with bounded metadata candidate pages, shortest-policy time cutoffs, durable round-robin cursors, and finite traversal fences. Preserve TTL overrides, leaf-first message deletion, and event high-water marks. Disabled message retention does not scan message history.
- Add migration `0048_bounded_maintenance.sql`: seven indexes plus `maintenance_cursors`; no history deletion or policy shortening.
- Append migration `0049_redrive_review_hardening.sql`: named delivery/receipt lookup indexes and predicate-matched redrive indexes. Fix replay completion's lost-trigger race, malformed cursor recovery, invalid retention-clock errors, and the changelog reference label.

## Verification

- Engine typecheck, build, changed-source ESLint, and **876 tests pass**.
- Final review follow-up rejects invalid pool concurrency and preserves already-queued replay triggers through transient failures; the final failed pass still propagates without unrequested retries.
- Real SQLite regressions with 10,000 retained deliveries: all 125 pending rows drain in three indexed pages; EXPLAIN confirms mailbox/primary-key/initial-redrive seeks.
- Tests cover failed-send ordering, ACK races between pages, trigger coalescing, retained-only progress, restart persistence, continuously arriving rows, elapsed budgets, TTL overrides, and event sequence preservation.
- Follow-up regressions cover completion-microtask triggers, worker-slot reuse, corrupt cursor repair, invalid clocks, 10,000 unrelated queued routes/workspaces, expired-only candidate windows, redrive cursor restart/fence wraparound, and D1 bind limits through attachment hydration at the maximum 200-row redrive size.
- Veto tools are unavailable in this session; manually reviewed the diff. No merge/deploy performed.

## Rollout constraints

Apply migrations 0048 and 0049 before running this engine. Publish the engine, pin that release in AgentWorkforce/relaycast-cloud#105, stage the migrations, then validate query-insight rows/duration and attach under maintenance load. Index creation itself consumes D1 writer capacity and needs an observed rollout window. All 47 cloud workerd integration tests also passed with this locally built engine candidate installed alongside the coordinator.

Candidate limits do not cap FK cascade size, cancel an outstanding query, or provide a global interactive-request semaphore. Replay coalescing is per registry/scope; the companion cloud actor coordinates cron admission across isolates. Monitor retention traversal/backlog age; this is not a reason to reduce the existing 519k/day-sized expiry capacity. No production database writes or sf-mini/finn-mini broker restarts were performed.
