### PR TITLE
fix(engine): compact maintenance migration allocation before rollout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,11 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 Packages without a separate changelog are covered by the cross-package notes below.
 
-## [Unreleased]
+## [Unreleased - Patch]
+
+### Fixed
+
+- Maintenance migrations reuse obsolete index space before creating replacements, reducing upgrade storage pressure without deleting history or changing retention.
 
 ## [8.5.3] - 2026-09-08
 

--- a/docs/compact-maintenance-migrations.md
+++ b/docs/compact-maintenance-migrations.md
@@ -46,13 +46,28 @@ retired indexes on a nearly full database.
 ## Capacity and rollout
 
 Run the local-only model with
-`node scripts/measure-compact-migrations.mjs 100000 0.5`.
-It creates synthetic SQLite data, not a production copy. On September 8, 2026:
+`node scripts/measure-compact-migrations.mjs 100000 0.5 0.5`.
+The third argument is the retry fraction within queued rows (default 0.5).
+The model verifies both retry indexes contain the requested population and
+reports actual integer row counts. It creates synthetic SQLite data, not a
+production copy. On September 8, 2026:
 
 | 100k-delivery model | Legacy peak growth | Compact peak growth | Reduction |
 | --- | ---: | ---: | ---: |
 | 50% active | 29,323,264 bytes | 6,672,384 bytes | 77% |
 | 100% active | 36,741,120 bytes | 15,659,008 bytes | 57% |
+
+The two original cases above have **no retry rows**. Review-expanded scenarios:
+
+| Active / retry fraction | Legacy peak growth | Compact peak growth | Reduction |
+| --- | ---: | ---: | ---: |
+| 50% active / 50% retry | 28,037,120 bytes | 6,664,192 bytes | 76% |
+| 100% active / 50% retry | 34,156,544 bytes | 15,683,584 bytes | 54% |
+| 100% active / 100% retry | 31,539,200 bytes | 15,790,080 bytes | 50% |
+
+At eight million deliveries, the all-retry model projects about 1.26 GB growth.
+Production's later read-only check measured 8,977,735,680 bytes; that model plus
+the 500 MB reserve does **not** fit. Do not approve the migration from this model.
 
 Freed pages are reused without VACUUM. These figures measure allocated SQLite
 pages, not D1 execution time, temporary sort space, or the live population's

--- a/docs/compact-maintenance-migrations.md
+++ b/docs/compact-maintenance-migrations.md
@@ -1,0 +1,72 @@
+# Compact maintenance migration
+
+`0050_compact_maintenance_indexes.sql` provides the indexes and cursor table
+needed by engine 8.5.3, without first allocating all of 0048/0049. It changes
+only indexes and adds the cursor table: no history deletion, TTL changes,
+foreign-key changes, or removal of uniqueness constraints.
+
+## Upgrade paths
+
+The Node adapter validates `migrations/supersessions.json` before running pending
+SQL. It skips unapplied 0048/0049 only when their explicit replacement 0050 is
+present. Missing or edited metadata fails closed. Only executed migrations enter
+the journal; existing 0048/0049 journal entries remain unchanged.
+
+Fresh, pre-0048, partially upgraded, and fully 0048/0049-upgraded installations
+converge to the same schema. Original published SQL files remain byte-identical.
+Custom migration runners must implement the same explicit skip policy, or apply
+the complete historical chain and accept its higher temporary storage cost.
+For Wrangler, archive the superseded files outside its applied directory and
+apply 0050; do not fabricate migration-history rows or edit published SQL.
+
+Rollback must retain the new migration planner. An older Node binary (including
+8.5.3) will see the intentionally absent 0048/0049 journal entries and execute
+their high-storage SQL on startup. Likewise, do not roll back cloud's applied
+migration directory. Roll back runtime code only through the compact-aware
+deployment path; do not downgrade the migration runner on a compact-only database.
+
+## Index changes
+
+0050 drops these non-unique indexes **before** creating replacements:
+
+| Retired index | Remaining coverage |
+| --- | --- |
+| `idx_deliveries_message` | Unique `(message_id, agent_id)` prefix covers message lookup/FK probes |
+| `idx_read_receipts_message` | Existing composite primary key and named receipt lookup |
+| `idx_deliveries_route_node` | No runtime hint or route-ID query requires this legacy workspace-leading index |
+| `idx_deliveries_next_attempt` | Predicate-matched global/workspace node retry indexes |
+| `idx_deliveries_http_push_due` | Predicate-matched global/workspace node redrive indexes |
+| `idx_deliveries_initial_due` | 0049's node-initial indexes; do not allocate the obsolete broad index |
+
+Every runtime-named index remains available, including `idx_deliveries_id_lookup`.
+Runtime SQL does not change. Old code's planner choices may differ after these
+drops; test rollback code against the compact schema. Do not automatically rebuild
+retired indexes on a nearly full database.
+
+## Capacity and rollout
+
+Run the local-only model with
+`node scripts/measure-compact-migrations.mjs 100000 0.5`.
+It creates synthetic SQLite data, not a production copy. On September 8, 2026:
+
+| 100k-delivery model | Legacy peak growth | Compact peak growth | Reduction |
+| --- | ---: | ---: | ---: |
+| 50% active | 29,323,264 bytes | 6,672,384 bytes | 77% |
+| 100% active | 36,741,120 bytes | 15,659,008 bytes | 57% |
+
+Freed pages are reused without VACUUM. These figures measure allocated SQLite
+pages, not D1 execution time, temporary sort space, or the live population's
+distribution. They are not production capacity approval.
+
+Before DDL, require a reviewed worst-case growth budget, current database size,
+and explicit reserve for concurrent growth. Cloud's rollout gate requires
+`size + approved growth + 500 MB <= 10 GB`; missing approval blocks promotion.
+Production measured about 8.94 GB on September 8 and may have grown since.
+Do not set the budget from high-water row IDs or small samples alone.
+
+Index construction still consumes the D1 writer and may exceed query-duration
+limits. Schedule and observe the migration; verify schema, migration journal,
+bounded query plans, and interactive attach latency before worker promotion.
+If capacity or duration cannot be demonstrated safe, obtain approval for a
+separate capacity plan (for example migration to a new database or an explicitly
+approved retention cleanup). This migration does not authorize either action.

--- a/packages/engine/CHANGELOG.md
+++ b/packages/engine/CHANGELOG.md
@@ -7,7 +7,11 @@ See the [root changelog](../../CHANGELOG.md) for cross-package release highlight
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [Unreleased - Patch]
+
+### Migration
+
+- `0050_compact_maintenance_indexes.sql` replaces the unapplied 0048/0049 path and retires six obsolete non-unique indexes before allocating bounded-query indexes. Published SQL stays immutable; Node migration planning validates explicit supersessions and journals only executed SQL. Existing 0048/0049 installations converge without changing rows, TTLs, foreign keys, or unique constraints. See the [rollout guide](../../docs/compact-maintenance-migrations.md).
 
 ## [8.5.3] - 2026-09-08
 

--- a/packages/engine/CHANGELOG.md
+++ b/packages/engine/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ### Migration
 
-- `0050_compact_maintenance_indexes.sql` replaces the unapplied 0048/0049 path and retires six obsolete non-unique indexes before allocating bounded-query indexes. Published SQL stays immutable; Node migration planning validates explicit supersessions and journals only executed SQL. Existing 0048/0049 installations converge without changing rows, TTLs, foreign keys, or unique constraints. See the [rollout guide](../../docs/compact-maintenance-migrations.md).
+- Adds migration `0050_compact_maintenance_indexes.sql` to reduce upgrade storage pressure without deleting history. See the [rollout guide](../../docs/compact-maintenance-migrations.md) for migration and rollback requirements.
 
 ## [8.5.3] - 2026-09-08
 

--- a/packages/engine/src/adapters/node/database.ts
+++ b/packages/engine/src/adapters/node/database.ts
@@ -5,6 +5,7 @@ import { fileURLToPath } from 'node:url';
 import Database, { type RunResult } from 'better-sqlite3';
 import { drizzle } from 'drizzle-orm/better-sqlite3';
 import * as schema from '../../db/schema.js';
+import { planMigrations } from '../../db/migrationPlan.js';
 import type { EngineDb, TransactionCapability } from '../../ports/database.js';
 
 /**
@@ -315,14 +316,15 @@ export function runMigrations(handle: SqliteDbHandle): { applied: string[] } {
   const files = readdirSync(dir)
     .filter((f) => f.endsWith('.sql'))
     .sort();
+  const supersessionsPath = join(dir, 'supersessions.json');
+  const pending = planMigrations(files, done, JSON.parse(readFileSync(supersessionsPath, 'utf8')));
 
   const applied: string[] = [];
   const insert = sqlite.prepare(
     `INSERT INTO _engine_migrations (name, applied_at) VALUES (?, ?)`,
   );
 
-  for (const file of files) {
-    if (done.has(file)) continue;
+  for (const file of pending) {
     // drizzle-kit separates statements with `--> statement-breakpoint`; SQLite's
     // `exec` runs the whole script. Apply the DDL and record the migration as
     // applied in one transaction so a crash mid-migration can't leave the schema

--- a/packages/engine/src/db/__tests__/compactMigrations.test.ts
+++ b/packages/engine/src/db/__tests__/compactMigrations.test.ts
@@ -1,0 +1,120 @@
+import { readdirSync, readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { createHash } from 'node:crypto';
+import { afterEach, describe, expect, it } from 'vitest';
+import { getSqliteDb, runMigrations, type SqliteDbHandle } from '../../adapters/node/database.js';
+import { planMigrations } from '../migrationPlan.js';
+
+const directory = fileURLToPath(new URL('../migrations/', import.meta.url));
+const files = readdirSync(directory).filter(name => name.endsWith('.sql')).sort();
+const replacement = '0050_compact_maintenance_indexes.sql';
+const older = ['0048_bounded_maintenance.sql', '0049_redrive_review_hardening.sql'];
+const metadata: unknown = JSON.parse(readFileSync(directory + 'supersessions.json', 'utf8'));
+const ddl = (name: string) => readFileSync(directory + name, 'utf8');
+const handles: SqliteDbHandle[] = [];
+afterEach(() => { for (const handle of handles.splice(0)) handle.sqlite.close(); });
+
+/** Build the deployed pre-0048 shape with live and terminal rows, no remote data. */
+function fixture(count = 20) {
+  const handle = getSqliteDb(':memory:');
+  handles.push(handle);
+  const db = handle.sqlite;
+  db.exec('CREATE TABLE _engine_migrations(name TEXT PRIMARY KEY, applied_at INTEGER NOT NULL)');
+  for (const name of files.filter(name => name < older[0]!)) {
+    db.exec(ddl(name));
+    db.prepare('INSERT INTO _engine_migrations VALUES (?,0)').run(name);
+  }
+  db.exec(`INSERT INTO workspaces(id,name,api_key_hash) VALUES ('workspace11','fixture','key');
+    INSERT INTO nodes(id,workspace_id,name,token_hash) VALUES ('node0000011','workspace11','node','node-key');
+    INSERT INTO agents(id,workspace_id,name,token_hash) VALUES ('agent0000000000000','workspace11','agent','agent-key');
+    INSERT INTO channels(id,workspace_id,name) VALUES ('channel','workspace11','general');`);
+  const message = db.prepare("INSERT INTO messages(id,workspace_id,channel_id,agent_id,body) VALUES (?,'workspace11','channel','agent0000000000000','preserve me')");
+  const delivery = db.prepare(`INSERT INTO deliveries(id,workspace_id,message_id,agent_id,status,seq,route_node_id,route_node_kind,expires_at)
+    VALUES (?,'workspace11',?,'agent0000000000000',?,?,'node0000011','ws',1788000000)`);
+  db.transaction(() => {
+    for (let n = 1; n <= count; n++) {
+      const id = String(n).padStart(19, '0');
+      message.run(id);
+      delivery.run('d_' + id + '_' + 'agent0000000000000', id, n % 2 ? 'queued' : 'dead_lettered', n);
+    }
+  })();
+  return handle;
+}
+
+/** Compare durable rows/constraints, excluding the intentionally different journal. */
+function snapshot(handle: SqliteDbHandle) {
+  const tables = handle.sqlite.prepare("SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%' AND name NOT IN ('_engine_migrations','maintenance_cursors') ORDER BY name").all() as { name: string }[];
+  return tables.map(({ name }) => {
+    const rows = handle.sqlite.prepare(`SELECT * FROM "${name}"`).all().map(row => JSON.stringify(row)).sort();
+    return [name, rows.length, createHash('sha256').update(JSON.stringify(rows)).digest('hex')];
+  });
+}
+
+describe('compact maintenance migration path', () => {
+  it('boots an empty database without applying superseded SQL', () => {
+    const handle = getSqliteDb(':memory:');
+    handles.push(handle);
+    expect(runMigrations(handle).applied).toEqual(files.filter(name => !older.includes(name)));
+    expect(runMigrations(handle).applied).toEqual([]);
+    expect(handle.sqlite.pragma('foreign_key_check')).toEqual([]);
+  });
+
+  it.each([[], [older[0]!], [older[1]!], older].map(already => ({ already })))('preserves every row and converges from $already', ({ already }) => {
+    const handle = fixture();
+    for (const name of already) {
+      handle.sqlite.exec(ddl(name));
+      handle.sqlite.prepare('INSERT INTO _engine_migrations VALUES (?,0)').run(name);
+    }
+    const before = snapshot(handle);
+    expect(runMigrations(handle).applied).toEqual([replacement]);
+    expect(snapshot(handle)).toEqual(before);
+    expect(handle.sqlite.pragma('foreign_key_check')).toEqual([]);
+    const retained = handle.sqlite.prepare("SELECT name FROM _engine_migrations WHERE name IN (?,?) ORDER BY name").all(...older);
+    expect(retained).toEqual([...already].sort().map(name => ({ name })));
+    expect(runMigrations(handle).applied).toEqual([]);
+    const indexes = handle.sqlite.pragma('index_list(deliveries)') as { name: string; unique: number }[];
+    expect(indexes.find(index => index.name === 'deliveries_message_agent_unique')?.unique).toBe(1);
+    expect(indexes.find(index => index.name === 'deliveries_agent_seq_unique')?.unique).toBe(1);
+    expect(indexes.find(index => index.name === 'idx_deliveries_id_lookup')?.unique).toBe(1);
+    expect(indexes.some(index => index.name === 'idx_deliveries_initial_due')).toBe(false);
+    const lookup = JSON.stringify(handle.sqlite.prepare('EXPLAIN QUERY PLAN SELECT id FROM deliveries WHERE message_id = ?').all('0000000000000000001'));
+    expect(lookup).toContain('deliveries_message_agent_unique');
+    expect(lookup).not.toContain('SCAN deliveries');
+  });
+
+  it('gives the identical schema through legacy and compact paths', () => {
+    const legacy = fixture();
+    const compact = fixture();
+    for (const name of [...older, replacement]) legacy.sqlite.exec(ddl(name));
+    compact.sqlite.exec(ddl(replacement));
+    const schema = (handle: SqliteDbHandle) => handle.sqlite.prepare("SELECT name,sql FROM sqlite_master WHERE name NOT LIKE 'sqlite_%' ORDER BY name").all();
+    expect(schema(compact)).toEqual(schema(legacy));
+  });
+
+  it('reduces peak allocation without deleting data or relying on VACUUM', () => {
+    const legacy = fixture(10_000);
+    const compact = fixture(10_000);
+    const before = snapshot(compact);
+    const size = (handle: SqliteDbHandle) => Number(handle.sqlite.pragma('page_count', { simple: true })) * Number(handle.sqlite.pragma('page_size', { simple: true }));
+    const baseline = size(compact);
+    for (const name of older) legacy.sqlite.exec(ddl(name));
+    const legacyGrowth = size(legacy) - baseline;
+    let peak = baseline;
+    compact.sqlite.exec('BEGIN');
+    for (const statement of ddl(replacement).replace(/^--.*$/gm, '').split(';').filter(part => part.trim())) {
+      compact.sqlite.exec(statement);
+      peak = Math.max(peak, size(compact));
+    }
+    compact.sqlite.exec('COMMIT');
+    expect(legacyGrowth).toBeGreaterThan(0);
+    expect(peak - baseline).toBeLessThan(legacyGrowth * 0.6);
+    expect(snapshot(compact)).toEqual(before);
+  }, 30_000);
+
+  it('fails closed when the replacement is missing or metadata points backwards', () => {
+    expect(() => planMigrations(files.filter(name => name !== replacement), new Set(), metadata)).toThrow('Invalid migration supersession');
+    expect(() => planMigrations(files, new Set(), { [replacement]: older[0] })).toThrow();
+    expect(() => planMigrations(files, new Set(), {})).toThrow();
+    expect(() => planMigrations(files, new Set(), { '../unsafe.sql': replacement })).toThrow();
+  });
+});

--- a/packages/engine/src/db/__tests__/compactMigrations.test.ts
+++ b/packages/engine/src/db/__tests__/compactMigrations.test.ts
@@ -1,6 +1,7 @@
 import { readdirSync, readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { createHash } from 'node:crypto';
+import { execFileSync } from 'node:child_process';
 import { afterEach, describe, expect, it } from 'vitest';
 import { getSqliteDb, runMigrations, type SqliteDbHandle } from '../../adapters/node/database.js';
 import { planMigrations } from '../migrationPlan.js';
@@ -41,13 +42,39 @@ function fixture(count = 20) {
   return handle;
 }
 
-/** Compare durable rows/constraints, excluding the intentionally different journal. */
+/** Compare durable rows, excluding the intentionally different journal. */
 function snapshot(handle: SqliteDbHandle) {
   const tables = handle.sqlite.prepare("SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%' AND name NOT IN ('_engine_migrations','maintenance_cursors') ORDER BY name").all() as { name: string }[];
   return tables.map(({ name }) => {
     const rows = handle.sqlite.prepare(`SELECT * FROM "${name}"`).all().map(row => JSON.stringify(row)).sort();
     return [name, rows.length, createHash('sha256').update(JSON.stringify(rows)).digest('hex')];
   });
+}
+
+/** Preserve every existing table definition, FK, and unique index, not selected names. */
+function constraints(handle: SqliteDbHandle) {
+  const db = handle.sqlite;
+  const tables = db.prepare("SELECT name,sql FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%' AND name != '_engine_migrations' ORDER BY name").all() as { name: string; sql: string }[];
+  return tables.map(({ name, sql }) => ({
+    name, sql,
+    foreignKeys: db.pragma(`foreign_key_list("${name}")`),
+    uniqueIndexes: (db.pragma(`index_list("${name}")`) as { name: string; unique: number; origin: string; partial: number }[])
+      .filter(index => index.unique === 1)
+      .map(index => ({ name: index.name, origin: index.origin, partial: index.partial,
+        sql: db.prepare('SELECT sql FROM sqlite_master WHERE type = ? AND name = ?').get('index', index.name),
+        columns: db.pragma(`index_xinfo("${index.name}")`),
+      })).sort((a, b) => a.name.localeCompare(b.name)),
+  }));
+}
+
+function expectConstraintsPreserved(before: ReturnType<typeof constraints>, after: ReturnType<typeof constraints>) {
+  // 0050 may add these redundant named lookup indexes, but must not alter any
+  // original constraint (including a lookup that already existed via 0049).
+  expect(after.filter(table => table.name !== 'maintenance_cursors' || before.some(original => original.name === table.name))
+    .map(table => ({ ...table, uniqueIndexes: table.uniqueIndexes.filter(index =>
+    !['idx_deliveries_id_lookup', 'idx_read_receipts_retention'].includes(index.name)
+      || before.find(original => original.name === table.name)!.uniqueIndexes.some(original => original.name === index.name),
+  ) }))).toEqual(before);
 }
 
 describe('compact maintenance migration path', () => {
@@ -65,9 +92,14 @@ describe('compact maintenance migration path', () => {
       handle.sqlite.exec(ddl(name));
       handle.sqlite.prepare('INSERT INTO _engine_migrations VALUES (?,0)').run(name);
     }
+    const cursorRows = already.includes(older[0]!) ? [{ id: 'fixture', cursor: 'preserve-existing-progress' }] : [];
+    if (cursorRows.length) handle.sqlite.prepare('INSERT INTO maintenance_cursors VALUES (?,?)').run(cursorRows[0]!.id, cursorRows[0]!.cursor);
     const before = snapshot(handle);
+    const beforeConstraints = constraints(handle);
     expect(runMigrations(handle).applied).toEqual([replacement]);
     expect(snapshot(handle)).toEqual(before);
+    expectConstraintsPreserved(beforeConstraints, constraints(handle));
+    expect(handle.sqlite.prepare('SELECT * FROM maintenance_cursors ORDER BY id').all()).toEqual(cursorRows);
     expect(handle.sqlite.pragma('foreign_key_check')).toEqual([]);
     const retained = handle.sqlite.prepare("SELECT name FROM _engine_migrations WHERE name IN (?,?) ORDER BY name").all(...older);
     expect(retained).toEqual([...already].sort().map(name => ({ name })));
@@ -80,6 +112,26 @@ describe('compact maintenance migration path', () => {
     const lookup = JSON.stringify(handle.sqlite.prepare('EXPLAIN QUERY PLAN SELECT id FROM deliveries WHERE message_id = ?').all('0000000000000000001'));
     expect(lookup).toContain('deliveries_message_agent_unique');
     expect(lookup).not.toContain('SCAN deliveries');
+  });
+
+  it('constraint regression guard rejects a dropped unique index and changed foreign key', () => {
+    const handle = fixture();
+    const before = constraints(handle);
+    handle.sqlite.exec('DROP INDEX deliveries_message_agent_unique');
+    expect(() => expectConstraintsPreserved(before, constraints(handle))).toThrow();
+    const changedForeignKey = structuredClone(before);
+    changedForeignKey.find(table => table.name === 'deliveries')!.foreignKeys = [];
+    expect(() => expectConstraintsPreserved(before, changedForeignKey)).toThrow();
+  });
+
+  it.each([0, 0.5, 1])('capacity model populates retry indexes for fraction %s and reports odd row counts accurately', retryFraction => {
+    const script = fileURLToPath(new URL('../../../../../scripts/measure-compact-migrations.mjs', import.meta.url));
+    const result = JSON.parse(execFileSync(process.execPath, [script, '1001', '1', String(retryFraction)], { encoding: 'utf8' }));
+    const expectedRetries = Math.floor(1001 * retryFraction);
+    expect(result.scenario.eventRows).toBe(500);
+    expect(result.scenario.retryRows).toBe(expectedRetries);
+    expect(result.scenario.initialRows).toBe(1001 - expectedRetries);
+    expect(Object.values(result.retryIndexRows)).toEqual([expectedRetries, expectedRetries]);
   });
 
   it('gives the identical schema through legacy and compact paths', () => {

--- a/packages/engine/src/db/migrationPlan.ts
+++ b/packages/engine/src/db/migrationPlan.ts
@@ -1,0 +1,20 @@
+import { z } from 'zod';
+
+// Only these reviewed DDL-only replacements are authorized. A missing or
+// edited manifest must fail closed, never silently revert to the high peak.
+const supersessionsSchema = z.object({
+  '0048_bounded_maintenance.sql': z.literal('0050_compact_maintenance_indexes.sql'),
+  '0049_redrive_review_hardening.sql': z.literal('0050_compact_maintenance_indexes.sql'),
+}).strict();
+
+/** Plan explicit replacements without claiming skipped SQL was applied. */
+export function planMigrations(files: string[], applied: ReadonlySet<string>, metadata: unknown): string[] {
+  const supersessions = supersessionsSchema.parse(metadata);
+  const available = new Set(files);
+  for (const [older, replacement] of Object.entries(supersessions)) {
+    if (!available.has(older) || !available.has(replacement) || replacement <= older) {
+      throw new Error(`Invalid migration supersession: ${older} -> ${replacement}`);
+    }
+  }
+  return [...files].sort().filter(file => !applied.has(file) && !Object.hasOwn(supersessions, file));
+}

--- a/packages/engine/src/db/migrations/0050_compact_maintenance_indexes.sql
+++ b/packages/engine/src/db/migrations/0050_compact_maintenance_indexes.sql
@@ -1,0 +1,42 @@
+-- Supersedes 0048/0049 for installations that have not applied them. Published
+-- migration files stay immutable; the explicit planner records only SQL run.
+-- Release obsolete non-unique indexes BEFORE allocating their replacements.
+-- No rows, retention policy, foreign keys, or uniqueness constraints change.
+-- Message lookup/FK probes remain covered by deliveries_message_agent_unique.
+DROP INDEX IF EXISTS idx_deliveries_message;
+DROP INDEX IF EXISTS idx_read_receipts_message;
+-- These legacy route/redrive indexes have no runtime hints; bounded redrive
+-- uses the route-matched global/workspace indexes created below instead.
+DROP INDEX IF EXISTS idx_deliveries_route_node;
+DROP INDEX IF EXISTS idx_deliveries_next_attempt;
+DROP INDEX IF EXISTS idx_deliveries_http_push_due;
+-- 0049 replaced this broad initial-attempt index; never allocate it anew.
+DROP INDEX IF EXISTS idx_deliveries_initial_due;
+
+CREATE INDEX IF NOT EXISTS idx_deliveries_agent_active_seq
+  ON deliveries(workspace_id, agent_id, seq)
+  WHERE status IN ('queued', 'delivered');
+CREATE INDEX IF NOT EXISTS idx_deliveries_agent_active_expiry
+  ON deliveries(workspace_id, agent_id, expires_at)
+  WHERE status IN ('queued', 'delivered');
+CREATE INDEX IF NOT EXISTS idx_deliveries_settled_retention
+  ON deliveries(created_at, id)
+  WHERE status IN ('acked', 'failed', 'dead_lettered');
+CREATE INDEX IF NOT EXISTS idx_workspace_events_retention
+  ON workspace_events(created_at, workspace_id, seq);
+CREATE INDEX IF NOT EXISTS idx_messages_retention ON messages(length(id), id);
+CREATE INDEX IF NOT EXISTS idx_message_logs_retention ON message_logs(length(id), id);
+CREATE TABLE IF NOT EXISTS maintenance_cursors (
+  id TEXT PRIMARY KEY NOT NULL,
+  cursor TEXT NOT NULL
+);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_deliveries_id_lookup ON deliveries(id);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_read_receipts_retention ON read_receipts(message_id, agent_id);
+CREATE INDEX IF NOT EXISTS idx_deliveries_node_initial ON deliveries(created_at, id)
+  WHERE status = 'queued' AND route_node_kind IN ('http_push', 'ws', 'fleet_ws', 'direct_ws') AND next_attempt_at IS NULL;
+CREATE INDEX IF NOT EXISTS idx_deliveries_node_initial_workspace ON deliveries(workspace_id, created_at, id)
+  WHERE status = 'queued' AND route_node_kind IN ('http_push', 'ws', 'fleet_ws', 'direct_ws') AND next_attempt_at IS NULL;
+CREATE INDEX IF NOT EXISTS idx_deliveries_node_retry ON deliveries(next_attempt_at, created_at, id)
+  WHERE status = 'queued' AND route_node_kind IN ('http_push', 'ws', 'fleet_ws', 'direct_ws') AND next_attempt_at IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_deliveries_node_retry_workspace ON deliveries(workspace_id, next_attempt_at, created_at, id)
+  WHERE status = 'queued' AND route_node_kind IN ('http_push', 'ws', 'fleet_ws', 'direct_ws') AND next_attempt_at IS NOT NULL;

--- a/packages/engine/src/db/migrations/supersessions.json
+++ b/packages/engine/src/db/migrations/supersessions.json
@@ -1,0 +1,4 @@
+{
+  "0048_bounded_maintenance.sql": "0050_compact_maintenance_indexes.sql",
+  "0049_redrive_review_hardening.sql": "0050_compact_maintenance_indexes.sql"
+}

--- a/packages/engine/src/db/schema.ts
+++ b/packages/engine/src/db/schema.ts
@@ -905,7 +905,6 @@ export const readReceipts = sqliteTable(
   },
   (table) => [
     primaryKey({ columns: [table.messageId, table.agentId] }),
-    index('idx_read_receipts_message').on(table.messageId),
     uniqueIndex('idx_read_receipts_retention').on(table.messageId, table.agentId),
     index('idx_read_receipts_agent').on(table.agentId, table.readAt),
   ],
@@ -1208,8 +1207,6 @@ export const deliveries = sqliteTable(
     index('idx_deliveries_retry_due')
       .on(table.status, table.nextAttemptAt, table.createdAt, table.id)
       .where(sql`${table.nextAttemptAt} IS NOT NULL`),
-    index('idx_deliveries_initial_due').on(table.status, table.createdAt, table.id)
-      .where(sql`${table.nextAttemptAt} IS NULL`),
     index('idx_deliveries_node_initial').on(table.createdAt, table.id)
       .where(sql`${table.status} = 'queued' AND ${table.routeNodeKind} IN ('http_push', 'ws', 'fleet_ws', 'direct_ws') AND ${table.nextAttemptAt} IS NULL`),
     index('idx_deliveries_node_initial_workspace').on(table.workspaceId, table.createdAt, table.id)
@@ -1219,7 +1216,6 @@ export const deliveries = sqliteTable(
     index('idx_deliveries_node_retry_workspace').on(table.workspaceId, table.nextAttemptAt, table.createdAt, table.id)
       .where(sql`${table.status} = 'queued' AND ${table.routeNodeKind} IN ('http_push', 'ws', 'fleet_ws', 'direct_ws') AND ${table.nextAttemptAt} IS NOT NULL`),
     index('idx_deliveries_status').on(table.workspaceId, table.status, table.createdAt),
-    index('idx_deliveries_http_push_due').on(table.workspaceId, table.routeNodeKind, table.status, table.nextAttemptAt),
   ],
 );
 

--- a/scripts/measure-compact-migrations.mjs
+++ b/scripts/measure-compact-migrations.mjs
@@ -1,14 +1,18 @@
 // Synthetic local-only allocation model. Never connects to D1 or copies user data.
-// Usage: node scripts/measure-compact-migrations.mjs [rows=100000] [activeFraction=0.5]
+// Usage: node scripts/measure-compact-migrations.mjs [rows=100000] [activeFraction=0.5] [retryFraction=0.5]
+// retryFraction is the fraction of queued (active) rows with next_attempt_at set.
 import Database from 'better-sqlite3';
 import { readdirSync, readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 
 const rows = Number(process.argv[2] ?? 100000);
 const activeFraction = Number(process.argv[3] ?? 0.5);
-if (!Number.isInteger(rows) || rows < 1000 || rows > 200000 || !Number.isFinite(activeFraction) || activeFraction < 0 || activeFraction > 1) {
-  throw new Error('Expected 1000..200000 rows and activeFraction 0..1');
+const retryFraction = Number(process.argv[4] ?? 0.5);
+if (!Number.isInteger(rows) || rows < 1000 || rows > 200000 || [activeFraction, retryFraction].some(value => !Number.isFinite(value) || value < 0 || value > 1)) {
+  throw new Error('Expected 1000..200000 rows, activeFraction 0..1, and retryFraction 0..1');
 }
+const activeRows = Math.floor(rows * activeFraction);
+const retryRows = Math.floor(activeRows * retryFraction);
 const directory = fileURLToPath(new URL('../packages/engine/src/db/migrations/', import.meta.url));
 const files = readdirSync(directory).filter(name => name.endsWith('.sql')).sort();
 const sql = name => readFileSync(directory + name, 'utf8');
@@ -20,14 +24,14 @@ db.exec(`INSERT INTO workspaces(id,name,api_key_hash) VALUES ('workspace11','fix
   INSERT INTO agents(id,workspace_id,name,token_hash) VALUES ('agent0000000000000','workspace11','agent','agent-key');
   INSERT INTO channels(id,workspace_id,name) VALUES ('channel','workspace11','general');`);
 const message = db.prepare("INSERT INTO messages(id,workspace_id,channel_id,agent_id,body) VALUES (?,'workspace11','channel','agent0000000000000','synthetic')");
-const delivery = db.prepare(`INSERT INTO deliveries(id,workspace_id,message_id,agent_id,status,seq,route_node_id,route_node_kind,expires_at)
-  VALUES (?,'workspace11',?,'agent0000000000000',?,?,'node0000011','ws',1788000000)`);
+const delivery = db.prepare(`INSERT INTO deliveries(id,workspace_id,message_id,agent_id,status,seq,route_node_id,route_node_kind,expires_at,next_attempt_at)
+  VALUES (?,'workspace11',?,'agent0000000000000',?,?,'node0000011','ws',1788000000,?)`);
 const event = db.prepare("INSERT INTO workspace_events(workspace_id,seq,type,payload) VALUES ('workspace11',?,'message.created','{}')");
 db.transaction(() => {
   for (let n = 1; n <= rows; n++) {
     const id = String(n).padStart(20, '0');
     message.run(id);
-    delivery.run('d_' + id + '_agent0000000000000', id, n / rows <= activeFraction ? 'queued' : 'dead_lettered', n);
+    delivery.run('d_' + id + '_agent0000000000000', id, n <= activeRows ? 'queued' : 'dead_lettered', n, n <= retryRows ? 1787999900 : null);
     if (n % 2 === 0) event.run(n / 2);
   }
 })();
@@ -50,8 +54,14 @@ for (const statement of sql('0050_compact_maintenance_indexes.sql').replace(/^--
 db.exec('COMMIT');
 const legacyGrowth = legacyPeak - baseline;
 const compactGrowth = compactPeak - baseline;
+// Verify actual indexed populations, not just requested scenario fractions.
+const retryIndexRows = Object.fromEntries(['idx_deliveries_node_retry', 'idx_deliveries_node_retry_workspace'].map(index => [index,
+  db.prepare(`SELECT COUNT(*) AS n FROM deliveries INDEXED BY ${index}
+    WHERE status = 'queued' AND route_node_kind IN ('http_push','ws','fleet_ws','direct_ws') AND next_attempt_at IS NOT NULL`).get().n,
+]));
 console.log(JSON.stringify({
-  scenario: { rows, activeFraction, eventRows: rows / 2, deliveryIdBytes: 41, workspaceIdBytes: 11, agentIdBytes: 18 },
+  scenario: { rows, activeFraction, retryFraction, activeRows, retryRows, initialRows: activeRows - retryRows, eventRows: Math.floor(rows / 2), deliveryIdBytes: 41, workspaceIdBytes: 11, agentIdBytes: 18 },
+  retryIndexRows,
   baseline, legacyPeak, compactPeak, legacyGrowth, compactGrowth,
   growthReductionPercent: 100 * (1 - compactGrowth / legacyGrowth),
   projectedCompactGrowthAt8m: compactGrowth * 8000000 / rows,

--- a/scripts/measure-compact-migrations.mjs
+++ b/scripts/measure-compact-migrations.mjs
@@ -1,0 +1,61 @@
+// Synthetic local-only allocation model. Never connects to D1 or copies user data.
+// Usage: node scripts/measure-compact-migrations.mjs [rows=100000] [activeFraction=0.5]
+import Database from 'better-sqlite3';
+import { readdirSync, readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+const rows = Number(process.argv[2] ?? 100000);
+const activeFraction = Number(process.argv[3] ?? 0.5);
+if (!Number.isInteger(rows) || rows < 1000 || rows > 200000 || !Number.isFinite(activeFraction) || activeFraction < 0 || activeFraction > 1) {
+  throw new Error('Expected 1000..200000 rows and activeFraction 0..1');
+}
+const directory = fileURLToPath(new URL('../packages/engine/src/db/migrations/', import.meta.url));
+const files = readdirSync(directory).filter(name => name.endsWith('.sql')).sort();
+const sql = name => readFileSync(directory + name, 'utf8');
+const db = new Database(':memory:');
+db.pragma('foreign_keys = ON');
+for (const file of files.filter(name => name < '0048')) db.exec(sql(file));
+db.exec(`INSERT INTO workspaces(id,name,api_key_hash) VALUES ('workspace11','fixture','key');
+  INSERT INTO nodes(id,workspace_id,name,token_hash) VALUES ('node0000011','workspace11','node','node-key');
+  INSERT INTO agents(id,workspace_id,name,token_hash) VALUES ('agent0000000000000','workspace11','agent','agent-key');
+  INSERT INTO channels(id,workspace_id,name) VALUES ('channel','workspace11','general');`);
+const message = db.prepare("INSERT INTO messages(id,workspace_id,channel_id,agent_id,body) VALUES (?,'workspace11','channel','agent0000000000000','synthetic')");
+const delivery = db.prepare(`INSERT INTO deliveries(id,workspace_id,message_id,agent_id,status,seq,route_node_id,route_node_kind,expires_at)
+  VALUES (?,'workspace11',?,'agent0000000000000',?,?,'node0000011','ws',1788000000)`);
+const event = db.prepare("INSERT INTO workspace_events(workspace_id,seq,type,payload) VALUES ('workspace11',?,'message.created','{}')");
+db.transaction(() => {
+  for (let n = 1; n <= rows; n++) {
+    const id = String(n).padStart(20, '0');
+    message.run(id);
+    delivery.run('d_' + id + '_agent0000000000000', id, n / rows <= activeFraction ? 'queued' : 'dead_lettered', n);
+    if (n % 2 === 0) event.run(n / 2);
+  }
+})();
+const size = () => Number(db.pragma('page_count', { simple: true })) * Number(db.pragma('page_size', { simple: true }));
+const baseline = size();
+// Roll back the legacy comparison, including the allocation it caused.
+db.exec('BEGIN');
+db.exec(sql('0048_bounded_maintenance.sql'));
+db.exec(sql('0049_redrive_review_hardening.sql'));
+const legacyPeak = size();
+db.exec('ROLLBACK');
+let compactPeak = size();
+const steps = [];
+db.exec('BEGIN');
+for (const statement of sql('0050_compact_maintenance_indexes.sql').replace(/^--.*$/gm, '').split(';').filter(part => part.trim())) {
+  db.exec(statement);
+  compactPeak = Math.max(compactPeak, size());
+  steps.push({ operation: statement.trim().split('\n')[0], allocatedBytes: size() });
+}
+db.exec('COMMIT');
+const legacyGrowth = legacyPeak - baseline;
+const compactGrowth = compactPeak - baseline;
+console.log(JSON.stringify({
+  scenario: { rows, activeFraction, eventRows: rows / 2, deliveryIdBytes: 41, workspaceIdBytes: 11, agentIdBytes: 18 },
+  baseline, legacyPeak, compactPeak, legacyGrowth, compactGrowth,
+  growthReductionPercent: 100 * (1 - compactGrowth / legacyGrowth),
+  projectedCompactGrowthAt8m: compactGrowth * 8000000 / rows,
+  caveat: 'Local synthetic projection, not production capacity proof. Includes one synthetic message per delivery and one event per two deliveries. Does not bound D1 build duration or concurrent growth.',
+  steps,
+}, null, 2));
+db.close();


### PR DESCRIPTION
## Summary

Follow-up to #386 / release 8.5.3. Production cloud is still held: the live D1
database measured about 8.94 GB, so blindly allocating the original migration
indexes risks the 10 GB database limit.

- Add DDL-only 0050: retire six obsolete/redundant non-unique indexes before
  allocating the required bounded replay, retention, and redrive indexes.
- Preserve all data rows, TTL policies, FKs, uniqueness constraints, and runtime
  named lookup indexes. Runtime SQL is unchanged.
- Keep published 0048/0049 files immutable. Validate an explicit supersession
  manifest, skip only their unapplied SQL, and journal only executed migrations.
- Add schema/journal/data preservation tests across fresh and all partial upgrade
  states, allocation regression coverage, a local-only capacity model, and a
  rollback/capacity runbook.

Cloud companion: AgentWorkforce/relaycast-cloud#105 (draft, production hold).

## Verification

- Engine full suite: **888 tests pass**, including retry-population CLI tests and
  complete preexisting table/FK/unique-index preservation with negative controls.
- All three Cubic findings and the CodeRabbit changelog nit are addressed in
  2a5172c5; the original review threads are resolved.
- Engine build, lint, and typecheck pass.
- The packed engine contains the manifest and replacement SQL; packaged Node
  boots with 51 actually executed migrations (0048/0049 skipped).
- Cloud migration parity passes against published 8.5.3 and this candidate pack.
- Candidate-pack cloud worker typecheck and all **47 workerd tests pass**; the
  installed published package was restored afterward.
- Cloud published-engine verification: 286 unit + 47 workerd + 15 legacy-router
  tests pass, as do worker/router/infra typechecks.
- Synthetic 100k-delivery SQLite allocation, inside one compact transaction:
  50% active: 29,323,264 -> 6,672,384 bytes growth (77% reduction).
  100% active: 36,741,120 -> 15,659,008 bytes growth (57% reduction).
  These original cases contain no retries. New mixed-active/50%-retry growth is
  28,037,120 -> 6,664,192 bytes (76%); all-active/50%-retry is 34,156,544 ->
  15,683,584 (54%); all-active/all-retry is 31,539,200 -> 15,790,080 (50%).
  The last case projects ~1.26 GB growth at 8m deliveries. Production measured
  8,977,735,680 bytes afterward, so this still does not clear the capacity gate.

## Risks / rollout boundary

- Production remains unmodified. Cloud adds a fail-closed gate requiring an
  approved worst-case growth budget plus 500 MB reserve against current D1 size.
  The budget is intentionally unset; do not infer approval from the model.
- Large index DDL still consumes the writer and can exceed query-duration limits.
  Production migration needs an observed capacity/duration window.
- Keep the compact-aware migration runner/directory during runtime rollback:
  older runners can reapply intentionally skipped 0048/0049 and recreate the
  storage spike. No fake history entries are used to conceal that behavior.
- Veto tools are unavailable; manual diff review performed. No broker restarts,
  production data deletion, TTL changes, or production DDL performed.
- Schema-independent coordinator relief is split into cloud PR #107, retaining
  published engine 8.5.2 and all existing D1 migrations. It does not replace this
  PR's bounded-query work or clear #105's production capacity gate.
