### PR TITLE
fix(engine): preserve reviewed replay guards on mainline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Packages without a separate changelog are covered by the cross-package notes bel
 
 ### Fixed
 
+- Serialize overlapping reconnect replays and honor acknowledgements and provider handoffs before each send.
 - Prevent node removal from scanning unrelated retained deliveries and agent records across workspaces.
 
 ## [8.5.4] - 2026-09-08

--- a/packages/engine/CHANGELOG.md
+++ b/packages/engine/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ### Fixed
 
+- Forward-port per-node replay serialization with independent scope results and exact-ID acknowledgement, expiry, and provider-handoff checks before each send.
 - Add migration `0051_node_foreign_key_indexes.sql` so node deletion uses child-key lookups for delivery, agent, binding, and provider foreign keys; preserve existing `SET NULL` and cascade behavior.
 
 ## [8.5.4] - 2026-09-08

--- a/packages/engine/CHANGELOG.md
+++ b/packages/engine/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ### Fixed
 
-- Forward-port per-node replay serialization with independent scope results and exact-ID acknowledgement, expiry, and provider-handoff checks before each send.
+- Reconnect replay preserves each caller's result and skips deliveries acknowledged, expired, or handed to another provider before sending.
 - Add migration `0051_node_foreign_key_indexes.sql` so node deletion uses child-key lookups for delivery, agent, binding, and provider foreign keys; preserve existing `SET NULL` and cascade behavior.
 
 ## [8.5.4] - 2026-09-08

--- a/packages/engine/src/engine/__tests__/boundedDatabaseWork.test.ts
+++ b/packages/engine/src/engine/__tests__/boundedDatabaseWork.test.ts
@@ -54,9 +54,13 @@ describe('bounded database work with retained history', () => {
       expect(plan).toContain('SEARCH deliveries USING INDEX idx_deliveries_agent_active_seq');
       expect(plan).not.toContain('USE TEMP B-TREE');
     }
-    const hydration = f.queries.filter(q => q.sql.startsWith('select') && q.sql.includes('INDEXED BY idx_deliveries_id_lookup'));
+    const idReads = f.queries.filter(q => q.sql.startsWith('select') && q.sql.includes('INDEXED BY idx_deliveries_id_lookup'));
+    const hydration = idReads.filter(q => q.sql.includes('inner join "messages"'));
     expect(hydration).toHaveLength(3);
-    for (const query of hydration) {
+    const revalidation = idReads.filter(q => !q.sql.includes('inner join "messages"'));
+    expect(revalidation).toHaveLength(125);
+    for (const query of revalidation) expect(query.params.at(-1)).toBe(1);
+    for (const query of idReads) {
       expect(query.params.length).toBeLessThan(100);
       const plan = JSON.stringify(f.sqlite.prepare('EXPLAIN QUERY PLAN ' + query.sql).all(...query.params));
       expect(plan).toContain('SEARCH deliveries USING INDEX idx_deliveries_id_lookup');
@@ -95,7 +99,7 @@ describe('bounded database work with retained history', () => {
     const first = deliverPendingToNode(f.db, f.registry, 'ws', 'node');
     await vi.waitFor(() => expect(f.send).toHaveBeenCalledOnce());
     const second = deliverPendingToNode(f.db, f.registry, 'ws', 'node');
-    expect(second).toBe(first);
+    expect(second).not.toBe(first);
     finish();
     await Promise.all([first, second]);
     expect(f.send).toHaveBeenCalledTimes(2);

--- a/packages/engine/src/engine/__tests__/replayScopeGuards.test.ts
+++ b/packages/engine/src/engine/__tests__/replayScopeGuards.test.ts
@@ -42,7 +42,7 @@ function fixture(history = 10_000, active = 125) {
 }
 
 describe('mainline replay scope and handoff guards', () => {
-  it('coalesces concurrent triggers and schedules a trailing pass for changed readiness', async () => {
+  it('keeps a distinct result for a trigger arriving during an active replay', async () => {
     const f = fixture(0, 1);
     let finish!: () => void;
     f.send.mockImplementationOnce(() => new Promise<boolean>(resolve => { finish = () => resolve(true); }));

--- a/packages/engine/src/engine/__tests__/replayScopeGuards.test.ts
+++ b/packages/engine/src/engine/__tests__/replayScopeGuards.test.ts
@@ -1,0 +1,113 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { drizzle } from 'drizzle-orm/better-sqlite3';
+import { getSqliteDb, runMigrations, type SqliteDbHandle } from '../../adapters/node/database.js';
+import * as schema from '../../db/schema.js';
+import type { EngineDb } from '../../ports/database.js';
+import type { NodeConnectionRegistry } from '../../ports/realtime.js';
+import { deliverPendingToNode } from '../delivery.js';
+
+const handles: SqliteDbHandle[] = [];
+afterEach(() => { vi.restoreAllMocks(); for (const handle of handles.splice(0)) handle.sqlite.close(); });
+
+function fixture(history = 10_000, active = 125) {
+  const handle = getSqliteDb(':memory:');
+  handles.push(handle);
+  runMigrations(handle);
+  const sqlite = handle.sqlite;
+  sqlite.exec(`
+    INSERT INTO workspaces(id,name,api_key_hash) VALUES ('ws','test','key');
+    INSERT INTO nodes(id,workspace_id,name,token_hash) VALUES ('node','ws','node','node-key');
+    INSERT INTO agents(id,workspace_id,name,token_hash,location_type,location_node_id,provider_name)
+      VALUES ('agent','ws','recipient','agent-key','via_node','node','provider');
+    INSERT INTO channels(id,workspace_id,name) VALUES ('channel','ws','general');
+  `);
+  const message = sqlite.prepare("INSERT INTO messages(id,workspace_id,channel_id,agent_id,body) VALUES (?,'ws','channel','agent','body')");
+  const delivery = sqlite.prepare(`INSERT INTO deliveries(id,workspace_id,message_id,agent_id,status,seq,route_node_kind)
+    VALUES (?,'ws',?,'agent',?,?,'ws')`);
+  sqlite.transaction(() => {
+    for (let n = 1; n <= history + active; n++) {
+      const id = String(n).padStart(10, '0');
+      message.run(id); delivery.run('d' + id, id, n <= history ? 'acked' : 'queued', n);
+    }
+  })();
+  sqlite.prepare('UPDATE agents SET delivery_ack_seq = ? WHERE id = ?').run(history, 'agent');
+  sqlite.exec('ANALYZE');
+  const queries: { sql: string; params: unknown[] }[] = [];
+  const db = drizzle(sqlite, { schema, logger: { logQuery: (sql, params) => queries.push({ sql, params }) } }) as unknown as EngineDb;
+  const frames: { seq: number }[] = [];
+  const send = vi.fn(async (_ws, _node, _provider, frame) => { frames.push(frame); return true; });
+  const ready = vi.fn(() => true);
+  const registry = { sendToProvider: send, isProviderAgentDeliveryReady: ready } as unknown as NodeConnectionRegistry;
+  return { db, sqlite, queries, registry, send, ready, frames };
+}
+
+describe('mainline replay scope and handoff guards', () => {
+  it('coalesces concurrent triggers and schedules a trailing pass for changed readiness', async () => {
+    const f = fixture(0, 1);
+    let finish!: () => void;
+    f.send.mockImplementationOnce(() => new Promise<boolean>(resolve => { finish = () => resolve(true); }));
+    const first = deliverPendingToNode(f.db, f.registry, 'ws', 'node');
+    await vi.waitFor(() => expect(f.send).toHaveBeenCalledOnce());
+    const second = deliverPendingToNode(f.db, f.registry, 'ws', 'node');
+    expect(second).not.toBe(first);
+    finish();
+    await Promise.all([first, second]);
+    expect(f.send).toHaveBeenCalledTimes(2);
+  });
+
+  it('serializes overlapping node and agent scopes without dropping the trailing scope', async () => {
+    const f = fixture(0, 2);
+    let finish!: () => void;
+    f.send.mockImplementationOnce(() => new Promise<boolean>(resolve => { finish = () => resolve(true); }));
+    const first = deliverPendingToNode(f.db, f.registry, 'ws', 'node', { agentIds: ['agent'], providerName: 'provider' });
+    await vi.waitFor(() => expect(f.send).toHaveBeenCalledOnce());
+    const second = deliverPendingToNode(f.db, f.registry, 'ws', 'node');
+    expect(second).not.toBe(first);
+    await Promise.resolve();
+    expect(f.send).toHaveBeenCalledOnce();
+    finish();
+    await Promise.all([first, second]);
+    expect(f.send.mock.calls.map(call => call[3].seq)).toEqual([1, 2, 1, 2]);
+  });
+
+  it('reports errors only to their scope and continues queued work after failure', async () => {
+    const f = fixture(0, 1);
+    let fail!: () => void;
+    f.send.mockImplementationOnce(() => new Promise<boolean>((_resolve, reject) => {
+      fail = () => reject(new Error('first scope failed'));
+    }));
+    const first = deliverPendingToNode(f.db, f.registry, 'ws', 'node', { agentIds: ['agent'] });
+    const firstResult = first.catch(error => error.message);
+    await vi.waitFor(() => expect(f.send).toHaveBeenCalledOnce());
+    const second = deliverPendingToNode(f.db, f.registry, 'ws', 'node');
+    const duplicate = deliverPendingToNode(f.db, f.registry, 'ws', 'node');
+    expect(duplicate).toBe(second);
+    fail();
+    expect(await firstResult).toBe('first scope failed');
+    expect(await second).toBe(1);
+    expect(f.send).toHaveBeenCalledTimes(2);
+  });
+
+  it('rechecks cumulative ACKs after a send within a hydrated page', async () => {
+    const f = fixture(0, 4);
+    f.send.mockImplementation(async (_ws, _node, _provider, frame) => {
+      f.frames.push(frame);
+      if (frame.seq === 1) f.sqlite.exec("UPDATE agents SET delivery_ack_seq = 3 WHERE id = 'agent'");
+      return true;
+    });
+    expect(await deliverPendingToNode(f.db, f.registry, 'ws', 'node')).toBe(2);
+    expect(f.frames.map(frame => frame.seq)).toEqual([1, 4]);
+  });
+
+  it('does not send remaining hydrated rows to the old provider after handoff', async () => {
+    const f = fixture(0, 4);
+    f.send.mockImplementation(async (_ws, _node, _provider, frame) => {
+      f.frames.push(frame);
+      f.sqlite.exec("UPDATE agents SET provider_name = 'new-provider' WHERE id = 'agent'");
+      return true;
+    });
+    expect(await deliverPendingToNode(f.db, f.registry, 'ws', 'node')).toBe(1);
+    expect(f.frames.map(frame => frame.seq)).toEqual([1]);
+  });
+
+});

--- a/packages/engine/src/engine/delivery.ts
+++ b/packages/engine/src/engine/delivery.ts
@@ -8,7 +8,6 @@ import { isProviderAgentDeliveryReady } from '../ports/realtime.js';
 import { buildDeliverFrame, buildDeliverPayload, buildMessageCreatedEventData, buildThreadReplyEventData, buildDmReceivedEventData, buildGroupDmReceivedEventData } from './deliveryWire.js';
 import { publicMessageMetadata } from './messageMetadata.js';
 import { toIso } from '../lib/serialize.js';
-import { trailingSingleFlight } from '../lib/singleFlight.js';
 import { readNodeRedriveCandidates } from './nodeRedriveCandidates.js';
 import { fetchAttachmentsBatch, type AttachmentRow } from './attachments.js';
 import type { DeliveryFanoutRecord } from './deliveryWrites.js';
@@ -891,9 +890,16 @@ export interface NodeDeliveryReplayScope {
   agentIds?: readonly string[];
 }
 
-const replayFlights = new WeakMap<NodeConnectionRegistry, Map<string, { dirty: boolean; promise: Promise<number> }>>();
+type ReplayJob = {
+  scope: NodeDeliveryReplayScope;
+  promise: Promise<number>;
+  resolve: (count: number) => void;
+  reject: (error: unknown) => void;
+};
+type ReplayFlight = { pending: Map<string, ReplayJob> };
+const replayFlights = new WeakMap<NodeConnectionRegistry, Map<string, ReplayFlight>>();
 
-/** Coalesce identical triggers at the socket owner, including a trailing replay
+/** Serialize overlapping scopes at the socket owner, including a trailing replay
  * when readiness/cursors changed during an outstanding drain. This is local
  * replay coordination, not a global database admission semaphore. */
 export function deliverPendingToNode(
@@ -905,9 +911,41 @@ export function deliverPendingToNode(
 ): Promise<number> {
   let flights = replayFlights.get(registry);
   if (!flights) { flights = new Map(); replayFlights.set(registry, flights); }
-  const key = JSON.stringify([workspaceId, nodeId, scope.providerName,
-    scope.agentIds ? [...new Set(scope.agentIds)].sort() : null]);
-  return trailingSingleFlight(flights, key, () => replayPendingToNode(db, registry, workspaceId, nodeId, scope));
+  const key = JSON.stringify([workspaceId, nodeId]);
+  const snapshot = { ...scope, agentIds: scope.agentIds ? [...new Set(scope.agentIds)].sort() : undefined };
+  const scopeKey = JSON.stringify([snapshot.providerName, snapshot.agentIds]);
+  let flight = flights.get(key);
+  const existing = flight?.pending.get(scopeKey);
+  if (existing) return existing.promise;
+  let resolve!: ReplayJob['resolve'];
+  let reject!: ReplayJob['reject'];
+  const promise = new Promise<number>((done, fail) => { resolve = done; reject = fail; });
+  const job: ReplayJob = { scope: snapshot, promise, resolve, reject };
+  if (flight) {
+    flight.pending.set(scopeKey, job);
+    return promise;
+  }
+  flight = { pending: new Map([[scopeKey, job]]) };
+  const activeFlight = flight;
+  flights.set(key, activeFlight);
+  void Promise.resolve().then(async () => {
+    try {
+      while (activeFlight.pending.size) {
+        const [pendingKey, pendingJob] = activeFlight.pending.entries().next().value!;
+        // A trigger during this pass queues a new trailing job. Identical
+        // not-yet-started jobs coalesce, but each scope owns its own result.
+        activeFlight.pending.delete(pendingKey);
+        try {
+          pendingJob.resolve(await replayPendingToNode(db, registry, workspaceId, nodeId, pendingJob.scope));
+        } catch (error) {
+          pendingJob.reject(error);
+        }
+      }
+    } finally {
+      if (flights.get(key) === activeFlight) flights.delete(key);
+    }
+  });
+  return promise;
 }
 
 /** Drain a finite per-agent high-water mark in ordered, readiness-checked pages. */
@@ -996,6 +1034,22 @@ async function replayPendingToNode(
       const deliveredIds: string[] = [];
       let interrupted = false;
       for (const row of rows) {
+        // ACKs and handoffs can race attachment hydration or an earlier send.
+        // Revalidate one exact ID without scanning mailbox history.
+        const [current] = await db.select({ id: sql<string>`${deliveries.id}` })
+          .from(sql`${deliveries} INDEXED BY idx_deliveries_id_lookup`)
+          .innerJoin(agents, eq(deliveries.agentId, agents.id))
+          .where(and(
+            eq(deliveries.id, row.delivery.id), eq(deliveries.workspaceId, workspaceId),
+            eq(agents.id, recipient.id), eq(agents.locationType, 'via_node'),
+            eq(agents.locationNodeId, nodeId),
+            recipient.providerName === null
+              ? isNull(agents.providerName) : eq(agents.providerName, recipient.providerName),
+            gt(deliveries.seq, agents.deliveryAckSeq),
+            inArray(deliveries.status, [...ACTIVE_DELIVERY_STATUSES]),
+            sql`(${deliveries.expiresAt} IS NULL OR ${deliveries.expiresAt} > ${Math.floor(Date.now() / 1000)})`,
+          )).limit(1);
+        if (!current) continue;
         if (!ready()) { interrupted = true; break; }
         const { eventType, eventData } = buildRoutableDeliveryEvent(row, attachments.get(row.delivery.messageId) ?? []);
         const sent = await registry.sendToProvider(workspaceId, nodeId, recipient.providerName, buildDeliverFrame({


### PR DESCRIPTION
## Summary
Forward-port the reviewed 8.5.2-hotfix.1 replay concurrency and pre-send guards into main before the next full engine promotion. Keep mainline active-index replay, bounded redrive, retention, and migrations intact.

- Serialize overlapping replay scopes per registry/workspace/node, with independent results and errors for queued scopes.
- Coalesce identical pending work and preserve a trailing trigger during an active pass.
- Recheck exact delivery identity, cumulative ACK, expiry, node location, and provider immediately before each send through the existing mainline ID index.
- Retain sequence ordering and stop on lower-sequence send failure.

## Verification
- Three regressions failed on the pre-fix mainline: trailing result identity, ACK within a hydrated page, and provider handoff.
- All 895 engine tests pass across 81 files.
- Engine typecheck and targeted runtime lint pass.
- Query-plan tests verify all 125 pre-send checks use exact ID lookups with LIMIT 1 and fewer than 100 binds.
- No schema, dependency, publishing-workflow, retention, or production changes.

## Incident scope
Prevents a later full promotion from regressing the live hotfix. Does not claim to fix remaining channel fan-out pressure or implement per-workspace database isolation. Veto is unavailable; manual diff/security review used. An unrelated active Trail trajectory was preserved.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/AgentWorkforce/relaycast/pull/394?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

