### PR TITLE
fix(release): make fixture cleanup race-safe

### DIFF
--- a/scripts/release-workflow-contract.test.mjs
+++ b/scripts/release-workflow-contract.test.mjs
@@ -1,9 +1,11 @@
 import assert from "node:assert/strict";
 import { spawnSync } from "node:child_process";
+import { randomUUID } from "node:crypto";
 import {
   mkdirSync,
   mkdtempSync,
   readFileSync,
+  renameSync,
   rmSync,
   symlinkSync,
   writeFileSync,
@@ -85,16 +87,30 @@ function git(cwd, args, options = {}) {
 }
 
 // Git may still be settling a temporary object/lock entry when a fixture is
-// removed, especially on hosted Linux runners. Retry the recursive removal so
-// a transient ENOTEMPTY/EBUSY does not turn an otherwise passing contract test
-// into a false failure.
+// removed, especially on hosted Linux runners. Move the fixture out of the
+// namespace used by the test before removing it, then retry only filesystem
+// contention errors. This keeps cleanup from racing a child Git process while
+// still surfacing unexpected failures.
 function removeTemporaryDirectory(directory) {
-  rmSync(directory, {
-    recursive: true,
-    force: true,
-    maxRetries: 20,
-    retryDelay: 100,
-  });
+  const cleanupDirectory = `${directory}.cleanup-${process.pid}-${randomUUID()}`;
+  try {
+    renameSync(directory, cleanupDirectory);
+  } catch (error) {
+    if (error?.code === "ENOENT") return;
+    throw error;
+  }
+
+  const retryableErrors = new Set(["EBUSY", "EMFILE", "ENFILE", "ENOTEMPTY"]);
+  for (let attempt = 0; ; attempt += 1) {
+    try {
+      rmSync(cleanupDirectory, { recursive: true, force: true });
+      return;
+    } catch (error) {
+      if (!retryableErrors.has(error?.code) || attempt >= 120) throw error;
+      const wait = new Int32Array(new SharedArrayBuffer(4));
+      Atomics.wait(wait, 0, 0, 250);
+    }
+  }
 }
 
 function archiveRevision(revision, target) {


### PR DESCRIPTION
## Summary
- atomically move temporary release fixtures before recursive cleanup
- retry only bounded transient filesystem contention errors so unexpected cleanup failures remain visible

## Evidence
- Node 22 targeted cleanup tests: 2/2 passed
- Node 22 concurrent stress: 12 parallel runs, 24/24 targeted tests passed
- Node 22 npm run test:release: 72/72 passed
- Veto diff review: PASS (code 97/100, security 99/100, secrets clean, no drift)

Fixes the intermittent ENOTEMPTY cleanup failures at scripts/release-workflow-contract.test.mjs:552 and :614.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/AgentWorkforce/relaycast/pull/395?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

