### PR TITLE
fix(release): refresh Docker engine lock artifact

### DIFF
--- a/.agentworkforce/trajectories/completed/2026-09/traj_okwn1jyy9sla/summary.md
+++ b/.agentworkforce/trajectories/completed/2026-09/traj_okwn1jyy9sla/summary.md
@@ -1,0 +1,33 @@
+# Trajectory: Fix Relaycast Docker lock release refresh
+
+> **Status:** ✅ Completed
+> **Task:** relaycast#397
+> **Confidence:** 97%
+> **Started:** September 9, 2026 at 06:26 AM
+> **Completed:** September 9, 2026 at 06:35 AM
+
+---
+
+## Summary
+
+Changed Relaycast release Docker lock refresh to targeted npm update and added regression contract coverage.
+
+**Approach:** Standard approach
+
+---
+
+## Key Decisions
+
+### Use targeted npm update for the Docker engine lock
+- **Chose:** Use targeted npm update for the Docker engine lock
+- **Reasoning:** The release artifact pre-bumps the lock entry version, so generic npm install trusts the placeholder and retains the old resolved tarball. Targeted npm update re-resolves the published 8.6.0 artifact while preserving the exact package.json pin.
+
+---
+
+## Chapters
+
+### 1. Work
+*Agent: default*
+
+- Use targeted npm update for the Docker engine lock: Use targeted npm update for the Docker engine lock
+- Production failure reproduced from the exact build artifact; generic install stayed stale, targeted update refreshed version, URL, integrity, and internal dependency pins. Base contract red, head contract and full release suite green.

--- a/.agentworkforce/trajectories/completed/2026-09/traj_okwn1jyy9sla/trajectory.json
+++ b/.agentworkforce/trajectories/completed/2026-09/traj_okwn1jyy9sla/trajectory.json
@@ -1,0 +1,69 @@
+{
+  "id": "traj_okwn1jyy9sla",
+  "version": 1,
+  "task": {
+    "title": "Fix Relaycast Docker lock release refresh",
+    "source": {
+      "system": "plain",
+      "id": "relaycast#397"
+    }
+  },
+  "status": "completed",
+  "startedAt": "2026-09-09T04:26:42.507Z",
+  "completedAt": "2026-09-09T04:35:54.575Z",
+  "agents": [
+    {
+      "name": "default",
+      "role": "lead",
+      "joinedAt": "2026-09-09T04:35:48.377Z"
+    }
+  ],
+  "chapters": [
+    {
+      "id": "chap_1oi1i10x8h6o",
+      "title": "Work",
+      "agentName": "default",
+      "startedAt": "2026-09-09T04:35:48.377Z",
+      "endedAt": "2026-09-09T04:35:54.575Z",
+      "events": [
+        {
+          "ts": 1788928548378,
+          "type": "decision",
+          "content": "Use targeted npm update for the Docker engine lock: Use targeted npm update for the Docker engine lock",
+          "raw": {
+            "question": "Use targeted npm update for the Docker engine lock",
+            "chosen": "Use targeted npm update for the Docker engine lock",
+            "alternatives": [],
+            "reasoning": "The release artifact pre-bumps the lock entry version, so generic npm install trusts the placeholder and retains the old resolved tarball. Targeted npm update re-resolves the published 8.6.0 artifact while preserving the exact package.json pin."
+          },
+          "significance": "high"
+        },
+        {
+          "ts": 1788928551806,
+          "type": "reflection",
+          "content": "Production failure reproduced from the exact build artifact; generic install stayed stale, targeted update refreshed version, URL, integrity, and internal dependency pins. Base contract red, head contract and full release suite green.",
+          "raw": {
+            "confidence": 0.97
+          },
+          "significance": "high",
+          "tags": [
+            "confidence:0.97"
+          ]
+        }
+      ]
+    }
+  ],
+  "retrospective": {
+    "summary": "Changed Relaycast release Docker lock refresh to targeted npm update and added regression contract coverage.",
+    "approach": "Standard approach",
+    "confidence": 0.97
+  },
+  "commits": [],
+  "filesChanged": [],
+  "projectId": "AgentWorkforce/relaycast",
+  "tags": [],
+  "_trace": {
+    "startRef": "c970697358a43c35f9990043f77561280c7b49d4",
+    "endRef": "c970697358a43c35f9990043f77561280c7b49d4"
+  }
+}

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -630,7 +630,13 @@ jobs:
           if [ "${REUSE_EXISTING_RELEASE_TAG:-false}" = "true" ]; then
             echo "existing release tag restored; leaving its lockfile tree unchanged"
           else
-            npm install --package-lock-only --ignore-scripts
+            # The build artifact deliberately gives the engine lock entry the
+            # target version before that registry artifact exists. A generic
+            # install trusts that placeholder version and can retain the old
+            # resolved tarball/integrity. Updating the exact dependency forces
+            # npm to resolve the newly published immutable artifact while
+            # preserving docker/package.json's exact version pin.
+            npm update --package-lock-only --ignore-scripts @relaycast/engine
           fi
 
       - name: Re-validate release contract with the refreshed lockfile

--- a/scripts/release-workflow-contract.test.mjs
+++ b/scripts/release-workflow-contract.test.mjs
@@ -491,6 +491,25 @@ describe("publish workflow safety contract", () => {
     assert.match(verify, /dist\.integrity/);
   });
 
+  it("refreshes the Docker engine lock entry instead of trusting its placeholder version", () => {
+    const createRelease = jobBlock("create-release");
+    const refreshStart = createRelease.indexOf("- name: Refresh self-host image lockfile");
+    const validateStart = createRelease.indexOf(
+      "- name: Re-validate release contract with the refreshed lockfile",
+      refreshStart,
+    );
+    assert.ok(refreshStart !== -1, "Docker lock refresh step not found");
+    assert.ok(validateStart > refreshStart, "release validation must follow Docker lock refresh");
+
+    const refresh = createRelease.slice(refreshStart, validateStart);
+    assert.match(refresh, /working-directory: docker/);
+    assert.match(
+      refresh,
+      /npm update --package-lock-only --ignore-scripts @relaycast\/engine/,
+    );
+    assert.doesNotMatch(refresh, /npm install --package-lock-only/);
+  });
+
   it("reuses a matching tagged tree on rerun and tags before reconciling main", () => {
     const createRelease = jobBlock("create-release");
     // Rebasing a release commit after packages have already been published


### PR DESCRIPTION
Fixes #397.

The release build deliberately writes a placeholder target version into the Docker lock entry before the registry artifact exists. A generic package-lock-only install then trusts that version and can retain the prior resolved tarball and integrity. The Create Release job now uses a targeted package-lock-only npm update for @relaycast/engine, which re-resolves the already-published immutable artifact while preserving the exact manifest pin.

Proof:
- Exact 8.6.0 build artifact reproduced the stale 8.5.5 resolved URL after the old generic install.
- The targeted update produced engine 8.6.0, the 8.6.0 registry URL/integrity, and internal 8.6.0 pins; the release contract passed.
- New regression contract is base-red and head-green.
- Full release suite: 73/73.
- Veto: PASS 98/98/100; TruffleHog: zero findings.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/AgentWorkforce/relaycast/pull/398?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

