### PR TITLE
fix(engine): preserve published migration bytes

### DIFF
--- a/.agentworkforce/trajectories/active/traj_i9ox2watzqom/trajectory.json
+++ b/.agentworkforce/trajectories/active/traj_i9ox2watzqom/trajectory.json
@@ -1,0 +1,66 @@
+{
+  "id": "traj_i9ox2watzqom",
+  "version": 1,
+  "task": {
+    "title": "Restore immutable Relaycast migration 0045 after 8.6.0 release regression"
+  },
+  "status": "active",
+  "startedAt": "2026-09-09T05:16:24.450Z",
+  "agents": [
+    {
+      "name": "default",
+      "role": "lead",
+      "joinedAt": "2026-09-09T05:34:15.464Z"
+    }
+  ],
+  "chapters": [
+    {
+      "id": "chap_t9mly2cwjdc5",
+      "title": "Work",
+      "agentName": "default",
+      "startedAt": "2026-09-09T05:34:15.464Z",
+      "events": [
+        {
+          "ts": 1788932055465,
+          "type": "decision",
+          "content": "Restore migration 0045 to the 8.5.5 canonical bytes and gate releases against npm latest: Restore migration 0045 to the 8.5.5 canonical bytes and gate releases against npm latest",
+          "raw": {
+            "question": "Restore migration 0045 to the 8.5.5 canonical bytes and gate releases against npm latest",
+            "chosen": "Restore migration 0045 to the 8.5.5 canonical bytes and gate releases against npm latest",
+            "alternatives": [],
+            "reasoning": "Mutating relaycast-cloud's applied migration or weakening byte-parity would hide the release regression. The release gate allows only the exact 8.6.0 bad-hash to canonical-hash recovery, then compares every published SQL migration on future releases."
+          },
+          "significance": "high"
+        },
+        {
+          "ts": 1788932491495,
+          "type": "reflection",
+          "content": "Restored the canonical published migration bytes and added a release-time registry comparison with an exact 8.6.0 recovery exception. Full Node 22 suite, release contracts, build, lint, and the live npm comparison are green.",
+          "raw": {
+            "focalPoints": [
+              "migration-immutability",
+              "release-safety",
+              "regression-proof"
+            ],
+            "confidence": 0.9
+          },
+          "significance": "high",
+          "tags": [
+            "focal:migration-immutability",
+            "focal:release-safety",
+            "focal:regression-proof",
+            "confidence:0.9"
+          ]
+        }
+      ]
+    }
+  ],
+  "commits": [],
+  "filesChanged": [],
+  "projectId": "AgentWorkforce/relaycast",
+  "tags": [],
+  "_trace": {
+    "startRef": "19139b68159d3e9d242358269951c349efe9b1f0",
+    "endRef": "19139b68159d3e9d242358269951c349efe9b1f0"
+  }
+}

--- a/.agentworkforce/trajectories/completed/2026-09/traj_i9ox2watzqom.trace.json
+++ b/.agentworkforce/trajectories/completed/2026-09/traj_i9ox2watzqom.trace.json
@@ -1,0 +1,181 @@
+{
+  "version": "1.0.0",
+  "id": "3777f51a-242f-4034-9392-11543ae0483e",
+  "timestamp": "2026-09-09T05:58:26.416Z",
+  "trajectory": "traj_i9ox2watzqom",
+  "files": [
+    {
+      "path": ".agentworkforce/trajectories/active/traj_i9ox2watzqom/trajectory.json",
+      "conversations": [
+        {
+          "contributor": {
+            "type": "ai"
+          },
+          "ranges": [
+            {
+              "start_line": 1,
+              "end_line": 66,
+              "revision": "5bb8337168296b2ba77d50015f5f9eb459347e45"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "path": ".github/workflows/publish-npm.yml",
+      "conversations": [
+        {
+          "contributor": {
+            "type": "ai"
+          },
+          "ranges": [
+            {
+              "start_line": 93,
+              "end_line": 101,
+              "revision": "5bb8337168296b2ba77d50015f5f9eb459347e45"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "path": "CHANGELOG.md",
+      "conversations": [
+        {
+          "contributor": {
+            "type": "ai"
+          },
+          "ranges": [
+            {
+              "start_line": 16,
+              "end_line": 26,
+              "revision": "5bb8337168296b2ba77d50015f5f9eb459347e45"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "path": "package.json",
+      "conversations": [
+        {
+          "contributor": {
+            "type": "ai"
+          },
+          "ranges": [
+            {
+              "start_line": 10,
+              "end_line": 16,
+              "revision": "5bb8337168296b2ba77d50015f5f9eb459347e45"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "path": "packages/engine/CHANGELOG.md",
+      "conversations": [
+        {
+          "contributor": {
+            "type": "ai"
+          },
+          "ranges": [
+            {
+              "start_line": 7,
+              "end_line": 17,
+              "revision": "5bb8337168296b2ba77d50015f5f9eb459347e45"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "path": "packages/engine/src/db/migrations/0045_workspace_create_idempotency.sql",
+      "conversations": [
+        {
+          "contributor": {
+            "type": "ai"
+          },
+          "ranges": [
+            {
+              "start_line": 1,
+              "end_line": 5,
+              "revision": "5bb8337168296b2ba77d50015f5f9eb459347e45"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "path": "scripts/check-published-engine-migrations.mjs",
+      "conversations": [
+        {
+          "contributor": {
+            "type": "ai"
+          },
+          "ranges": [
+            {
+              "start_line": 1,
+              "end_line": 198,
+              "revision": "5bb8337168296b2ba77d50015f5f9eb459347e45"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "path": "scripts/check-published-engine-migrations.test.mjs",
+      "conversations": [
+        {
+          "contributor": {
+            "type": "ai"
+          },
+          "ranges": [
+            {
+              "start_line": 1,
+              "end_line": 146,
+              "revision": "5bb8337168296b2ba77d50015f5f9eb459347e45"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "path": "scripts/release-workflow-contract.test.mjs",
+      "conversations": [
+        {
+          "contributor": {
+            "type": "ai"
+          },
+          "ranges": [
+            {
+              "start_line": 2,
+              "end_line": 12,
+              "revision": "5bb8337168296b2ba77d50015f5f9eb459347e45"
+            },
+            {
+              "start_line": 129,
+              "end_line": 143,
+              "revision": "5bb8337168296b2ba77d50015f5f9eb459347e45"
+            },
+            {
+              "start_line": 207,
+              "end_line": 226,
+              "revision": "5bb8337168296b2ba77d50015f5f9eb459347e45"
+            },
+            {
+              "start_line": 268,
+              "end_line": 280,
+              "revision": "5bb8337168296b2ba77d50015f5f9eb459347e45"
+            },
+            {
+              "start_line": 385,
+              "end_line": 403,
+              "revision": "5bb8337168296b2ba77d50015f5f9eb459347e45"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/.agentworkforce/trajectories/completed/2026-09/traj_i9ox2watzqom/summary.md
+++ b/.agentworkforce/trajectories/completed/2026-09/traj_i9ox2watzqom/summary.md
@@ -1,0 +1,44 @@
+# Trajectory: Restore immutable Relaycast migration 0045 after 8.6.0 release regression
+
+> **Status:** ✅ Completed
+> **Confidence:** 92%
+> **Started:** September 9, 2026 at 07:16 AM
+> **Completed:** September 9, 2026 at 07:58 AM
+
+---
+
+## Summary
+
+Restored migration 0045 canonical bytes and added stable/prerelease published-migration immutability gates
+
+**Approach:** Standard approach
+
+---
+
+## Key Decisions
+
+### Restore migration 0045 to the 8.5.5 canonical bytes and gate releases against npm latest
+- **Chose:** Restore migration 0045 to the 8.5.5 canonical bytes and gate releases against npm latest
+- **Reasoning:** Mutating relaycast-cloud's applied migration or weakening byte-parity would hide the release regression. The release gate allows only the exact 8.6.0 bad-hash to canonical-hash recovery, then compares every published SQL migration on future releases.
+
+### Protect every active npm release stream, not only latest
+- **Chose:** Protect every active npm release stream, not only latest
+- **Reasoning:** Published prerelease migrations may already be applied by users; checking the deduplicated latest/next/beta/alpha tag heads prevents later prerelease or stable releases from rewriting them while keeping registry cost bounded.
+
+---
+
+## Chapters
+
+### 1. Work
+*Agent: default*
+
+- Restore migration 0045 to the 8.5.5 canonical bytes and gate releases against npm latest: Restore migration 0045 to the 8.5.5 canonical bytes and gate releases against npm latest
+- Restored the canonical published migration bytes and added a release-time registry comparison with an exact 8.6.0 recovery exception. Full Node 22 suite, release contracts, build, lint, and the live npm comparison are green.
+- Protect every active npm release stream, not only latest: Protect every active npm release stream, not only latest
+
+---
+
+## Artifacts
+
+**Commits:** 5bb83371
+**Files changed:** 9

--- a/.agentworkforce/trajectories/completed/2026-09/traj_i9ox2watzqom/trajectory.json
+++ b/.agentworkforce/trajectories/completed/2026-09/traj_i9ox2watzqom/trajectory.json
@@ -4,8 +4,9 @@
   "task": {
     "title": "Restore immutable Relaycast migration 0045 after 8.6.0 release regression"
   },
-  "status": "active",
+  "status": "completed",
   "startedAt": "2026-09-09T05:16:24.450Z",
+  "completedAt": "2026-09-09T05:58:26.337Z",
   "agents": [
     {
       "name": "default",
@@ -19,6 +20,7 @@
       "title": "Work",
       "agentName": "default",
       "startedAt": "2026-09-09T05:34:15.464Z",
+      "endedAt": "2026-09-09T05:58:26.337Z",
       "events": [
         {
           "ts": 1788932055465,
@@ -51,16 +53,46 @@
             "focal:regression-proof",
             "confidence:0.9"
           ]
+        },
+        {
+          "ts": 1788933505938,
+          "type": "decision",
+          "content": "Protect every active npm release stream, not only latest: Protect every active npm release stream, not only latest",
+          "raw": {
+            "question": "Protect every active npm release stream, not only latest",
+            "chosen": "Protect every active npm release stream, not only latest",
+            "alternatives": [],
+            "reasoning": "Published prerelease migrations may already be applied by users; checking the deduplicated latest/next/beta/alpha tag heads prevents later prerelease or stable releases from rewriting them while keeping registry cost bounded."
+          },
+          "significance": "high"
         }
       ]
     }
   ],
-  "commits": [],
-  "filesChanged": [],
+  "retrospective": {
+    "summary": "Restored migration 0045 canonical bytes and added stable/prerelease published-migration immutability gates",
+    "approach": "Standard approach",
+    "confidence": 0.92
+  },
+  "commits": [
+    "5bb83371"
+  ],
+  "filesChanged": [
+    ".agentworkforce/trajectories/active/traj_i9ox2watzqom/trajectory.json",
+    ".github/workflows/publish-npm.yml",
+    "CHANGELOG.md",
+    "package.json",
+    "packages/engine/CHANGELOG.md",
+    "packages/engine/src/db/migrations/0045_workspace_create_idempotency.sql",
+    "scripts/check-published-engine-migrations.mjs",
+    "scripts/check-published-engine-migrations.test.mjs",
+    "scripts/release-workflow-contract.test.mjs"
+  ],
   "projectId": "AgentWorkforce/relaycast",
   "tags": [],
   "_trace": {
     "startRef": "19139b68159d3e9d242358269951c349efe9b1f0",
-    "endRef": "19139b68159d3e9d242358269951c349efe9b1f0"
+    "endRef": "5bb8337168296b2ba77d50015f5f9eb459347e45",
+    "traceId": "3777f51a-242f-4034-9392-11543ae0483e"
   }
 }

--- a/.agentworkforce/trajectories/completed/2026-09/traj_poanyuhwylp7/summary.md
+++ b/.agentworkforce/trajectories/completed/2026-09/traj_poanyuhwylp7/summary.md
@@ -1,0 +1,32 @@
+# Trajectory: Fail closed when published Relaycast migrations are absent
+
+> **Status:** ✅ Completed
+> **Task:** relaycast#400
+> **Confidence:** 96%
+> **Started:** September 9, 2026 at 08:09 AM
+> **Completed:** September 9, 2026 at 08:09 AM
+
+---
+
+## Summary
+
+Made the published-engine migration release gate fail closed on absent migration directories and added a regression test; focused, release-contract, and live registry stream checks passed.
+
+**Approach:** Standard approach
+
+---
+
+## Key Decisions
+
+### Treat a missing published migrations directory as malformed
+- **Chose:** Treat a missing published migrations directory as malformed
+- **Reasoning:** Interpreting it as an empty baseline would allow a release to remove all published migration history without detection.
+
+---
+
+## Chapters
+
+### 1. Work
+*Agent: default*
+
+- Treat a missing published migrations directory as malformed: Treat a missing published migrations directory as malformed

--- a/.agentworkforce/trajectories/completed/2026-09/traj_poanyuhwylp7/trajectory.json
+++ b/.agentworkforce/trajectories/completed/2026-09/traj_poanyuhwylp7/trajectory.json
@@ -1,0 +1,57 @@
+{
+  "id": "traj_poanyuhwylp7",
+  "version": 1,
+  "task": {
+    "title": "Fail closed when published Relaycast migrations are absent",
+    "source": {
+      "system": "plain",
+      "id": "relaycast#400"
+    }
+  },
+  "status": "completed",
+  "startedAt": "2026-09-09T06:09:52.010Z",
+  "completedAt": "2026-09-09T06:09:52.880Z",
+  "agents": [
+    {
+      "name": "default",
+      "role": "lead",
+      "joinedAt": "2026-09-09T06:09:52.505Z"
+    }
+  ],
+  "chapters": [
+    {
+      "id": "chap_m9bexqgs84wq",
+      "title": "Work",
+      "agentName": "default",
+      "startedAt": "2026-09-09T06:09:52.505Z",
+      "endedAt": "2026-09-09T06:09:52.880Z",
+      "events": [
+        {
+          "ts": 1788934192505,
+          "type": "decision",
+          "content": "Treat a missing published migrations directory as malformed: Treat a missing published migrations directory as malformed",
+          "raw": {
+            "question": "Treat a missing published migrations directory as malformed",
+            "chosen": "Treat a missing published migrations directory as malformed",
+            "alternatives": [],
+            "reasoning": "Interpreting it as an empty baseline would allow a release to remove all published migration history without detection."
+          },
+          "significance": "high"
+        }
+      ]
+    }
+  ],
+  "retrospective": {
+    "summary": "Made the published-engine migration release gate fail closed on absent migration directories and added a regression test; focused, release-contract, and live registry stream checks passed.",
+    "approach": "Standard approach",
+    "confidence": 0.96
+  },
+  "commits": [],
+  "filesChanged": [],
+  "projectId": "AgentWorkforce/relaycast",
+  "tags": [],
+  "_trace": {
+    "startRef": "d9189126752b0301d3c4112d5d6738174b3ad22a",
+    "endRef": "d9189126752b0301d3c4112d5d6738174b3ad22a"
+  }
+}

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -93,6 +93,9 @@ jobs:
       - name: Test release workflow contracts
         run: npm run test:release
 
+      - name: Published engine migrations are immutable
+        run: node scripts/check-published-engine-migrations.mjs
+
       - name: Version all packages
         id: bump
         env:

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -93,7 +93,7 @@ jobs:
       - name: Test release workflow contracts
         run: npm run test:release
 
-      - name: Published engine migrations are immutable
+      - name: Published engine migrations are immutable across release streams
         run: node scripts/check-published-engine-migrations.mjs
 
       - name: Version all packages

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,11 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 Packages without a separate changelog are covered by the cross-package notes below.
 
-## [Unreleased]
+## [Unreleased - Patch]
+
+### Fixed
+
+- NPM releases now preserve every published engine migration byte-for-byte, including the canonical `0045_workspace_create_idempotency.sql` artifact.
 
 ## [8.6.0] - 2026-09-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ Packages without a separate changelog are covered by the cross-package notes bel
 
 ### Fixed
 
-- NPM releases now preserve every published engine migration byte-for-byte, including the canonical `0045_workspace_create_idempotency.sql` artifact.
+- NPM releases now preserve every stable and prerelease engine migration byte-for-byte, including the canonical `0045_workspace_create_idempotency.sql` artifact.
 
 ## [8.6.0] - 2026-09-09
 

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "build": "turbo build",
     "test": "turbo test",
-    "test:release": "node --test scripts/npm-dist-tag.test.mjs scripts/release-contract.test.mjs scripts/release-workflow-contract.test.mjs",
+    "test:release": "node --test scripts/check-published-engine-migrations.test.mjs scripts/npm-dist-tag.test.mjs scripts/release-contract.test.mjs scripts/release-workflow-contract.test.mjs",
     "test:container": "node --test test/container-entrypoint.test.mjs",
     "test:container-image": "node --test test/container-image-integration.test.mjs",
     "lint": "turbo lint",

--- a/packages/engine/CHANGELOG.md
+++ b/packages/engine/CHANGELOG.md
@@ -7,7 +7,11 @@ See the [root changelog](../../CHANGELOG.md) for cross-package release highlight
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [Unreleased - Patch]
+
+### Fixed
+
+- Restore migration `0045_workspace_create_idempotency.sql` to its original published bytes and reject future edits to published migrations before NPM release.
 
 ## [8.6.0] - 2026-09-09
 

--- a/packages/engine/CHANGELOG.md
+++ b/packages/engine/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ### Fixed
 
-- Restore migration `0045_workspace_create_idempotency.sql` to its original published bytes and reject future edits to published migrations before NPM release.
+- Restore migration `0045_workspace_create_idempotency.sql` to its original published bytes and reject future edits across stable and prerelease NPM streams.
 
 ## [8.6.0] - 2026-09-09
 

--- a/packages/engine/src/db/migrations/0045_workspace_create_idempotency.sql
+++ b/packages/engine/src/db/migrations/0045_workspace_create_idempotency.sql
@@ -1,7 +1,5 @@
--- relaycast#371/#379: bind delegated and anonymous bootstrap workspace
--- creation to a scoped, request-digested idempotency key. Owner scopes are
--- the hash of the authenticated owner key; bootstrap scopes are the hash of
--- `bootstrap:<idempotency-key>`. The child bearer key is derived at replay
+-- relaycast#371: bind delegated workspace creation to an owner-scoped,
+-- request-digested idempotency key. The child bearer key is derived at replay
 -- time and is never persisted in plaintext.
 CREATE TABLE workspace_create_idempotency (
   owner_scope_hash TEXT NOT NULL,

--- a/scripts/check-published-engine-migrations.mjs
+++ b/scripts/check-published-engine-migrations.mjs
@@ -31,15 +31,10 @@ function sha256(path) {
   return createHash("sha256").update(readFileSync(path)).digest("hex");
 }
 
-function sqlFiles(directory, { allowMissing = false } = {}) {
-  try {
-    return readdirSync(directory)
-      .filter((filename) => filename.endsWith(".sql"))
-      .sort();
-  } catch (error) {
-    if (allowMissing && error?.code === "ENOENT") return [];
-    throw error;
-  }
+function sqlFiles(directory) {
+  return readdirSync(directory)
+    .filter((filename) => filename.endsWith(".sql"))
+    .sort();
 }
 
 function isKnownRecovery({
@@ -67,7 +62,9 @@ export function comparePublishedMigrations({
   const changed = [];
   const missing = [];
   const restored = [];
-  const publishedFiles = sqlFiles(publishedDirectory, { allowMissing: true });
+  // A published engine without its migration directory is malformed, not an
+  // empty baseline. Fail closed so every published stream remains protected.
+  const publishedFiles = sqlFiles(publishedDirectory);
 
   for (const filename of publishedFiles) {
     const publishedPath = join(publishedDirectory, filename);

--- a/scripts/check-published-engine-migrations.mjs
+++ b/scripts/check-published-engine-migrations.mjs
@@ -1,0 +1,198 @@
+import { execFileSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import { mkdtempSync, readdirSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { basename, join, resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+
+const ENGINE_PACKAGE = "@relaycast/engine";
+
+// v8.6.0 accidentally rewrote only the header comments of migration 0045.
+// Permit exactly the one-way restoration to the v8.5.5 bytes. Any other
+// published migration rewrite remains a hard release failure.
+export const KNOWN_RECOVERIES = Object.freeze([
+  Object.freeze({
+    publishedVersion: "8.6.0",
+    filename: "0045_workspace_create_idempotency.sql",
+    publishedSha256:
+      "2746d085bc27c5e43af1e6352df8a7979bf06a8b8f482b52ebd4d9d8d01defc6",
+    sourceSha256:
+      "7e510f55ea30f74c8e06fa6cfa80395dbb8038dc13877b948266d5eecf12c243",
+  }),
+]);
+
+function sha256(path) {
+  return createHash("sha256").update(readFileSync(path)).digest("hex");
+}
+
+function sqlFiles(directory) {
+  return readdirSync(directory)
+    .filter((filename) => filename.endsWith(".sql"))
+    .sort();
+}
+
+function isKnownRecovery({
+  publishedVersion,
+  filename,
+  publishedSha256,
+  sourceSha256,
+  recoveries,
+}) {
+  return recoveries.some(
+    (recovery) =>
+      recovery.publishedVersion === publishedVersion &&
+      recovery.filename === filename &&
+      recovery.publishedSha256 === publishedSha256 &&
+      recovery.sourceSha256 === sourceSha256,
+  );
+}
+
+export function comparePublishedMigrations({
+  sourceDirectory,
+  publishedDirectory,
+  publishedVersion,
+  recoveries = KNOWN_RECOVERIES,
+}) {
+  const changed = [];
+  const missing = [];
+  const restored = [];
+  const publishedFiles = sqlFiles(publishedDirectory);
+
+  for (const filename of publishedFiles) {
+    const publishedPath = join(publishedDirectory, filename);
+    const sourcePath = join(sourceDirectory, filename);
+    let sourceDigest;
+    try {
+      sourceDigest = sha256(sourcePath);
+    } catch (error) {
+      if (error?.code === "ENOENT") {
+        missing.push(filename);
+        continue;
+      }
+      throw error;
+    }
+
+    const publishedDigest = sha256(publishedPath);
+    if (sourceDigest === publishedDigest) continue;
+    if (
+      isKnownRecovery({
+        publishedVersion,
+        filename,
+        publishedSha256: publishedDigest,
+        sourceSha256: sourceDigest,
+        recoveries,
+      })
+    ) {
+      restored.push(filename);
+      continue;
+    }
+    changed.push({ filename, publishedDigest, sourceDigest });
+  }
+
+  return {
+    checked: publishedFiles.length,
+    added: sqlFiles(sourceDirectory).filter(
+      (filename) => !publishedFiles.includes(filename),
+    ),
+    changed,
+    missing,
+    restored,
+  };
+}
+
+export function assertPublishedMigrationsImmutable(options) {
+  const result = comparePublishedMigrations(options);
+  const problems = [
+    ...result.missing.map(
+      (filename) => `${filename}: missing from the release source`,
+    ),
+    ...result.changed.map(
+      ({ filename, publishedDigest, sourceDigest }) =>
+        `${filename}: published sha256 ${publishedDigest}, source sha256 ${sourceDigest}`,
+    ),
+  ];
+  if (problems.length > 0) {
+    throw new Error(
+      `published engine migrations are immutable:\n${problems
+        .map((problem) => `- ${problem}`)
+        .join("\n")}`,
+    );
+  }
+  return result;
+}
+
+export function downloadPublishedEngine(spec = `${ENGINE_PACKAGE}@latest`) {
+  const directory = mkdtempSync(join(tmpdir(), "relaycast-engine-published-"));
+  try {
+    const packed = JSON.parse(
+      execFileSync(
+        "npm",
+        [
+          "pack",
+          spec,
+          "--json",
+          "--ignore-scripts",
+          "--pack-destination",
+          directory,
+        ],
+        { encoding: "utf8" },
+      ),
+    );
+    const metadata = Array.isArray(packed)
+      ? packed[0]
+      : Object.values(packed)[0];
+    if (!metadata?.filename) {
+      throw new Error(`npm pack returned no artifact metadata for ${spec}`);
+    }
+    const tarball = join(directory, basename(metadata.filename));
+    execFileSync("tar", ["-xzf", tarball, "-C", directory]);
+    const packageDirectory = join(directory, "package");
+    const manifest = JSON.parse(
+      readFileSync(join(packageDirectory, "package.json"), "utf8"),
+    );
+    if (
+      manifest.name !== ENGINE_PACKAGE ||
+      typeof manifest.version !== "string"
+    ) {
+      throw new Error(`npm pack returned an unexpected package for ${spec}`);
+    }
+    return {
+      cleanup: () => rmSync(directory, { recursive: true, force: true }),
+      migrationsDirectory: join(packageDirectory, "dist", "db", "migrations"),
+      version: manifest.version,
+    };
+  } catch (error) {
+    rmSync(directory, { recursive: true, force: true });
+    throw error;
+  }
+}
+
+function main() {
+  const published = downloadPublishedEngine(
+    process.argv[2] || `${ENGINE_PACKAGE}@latest`,
+  );
+  try {
+    const result = assertPublishedMigrationsImmutable({
+      sourceDirectory: resolve("packages/engine/src/db/migrations"),
+      publishedDirectory: published.migrationsDirectory,
+      publishedVersion: published.version,
+    });
+    for (const filename of result.restored) {
+      console.warn(
+        `approved recovery: restored ${filename} from published ${published.version} to its canonical bytes`,
+      );
+    }
+    console.log(
+      `ok — ${result.checked} published engine migration(s) are immutable; ${result.added.length} append-only migration(s) added`,
+    );
+  } finally {
+    published.cleanup();
+  }
+}
+
+if (
+  process.argv[1] &&
+  pathToFileURL(resolve(process.argv[1])).href === import.meta.url
+) {
+  main();
+}

--- a/scripts/check-published-engine-migrations.mjs
+++ b/scripts/check-published-engine-migrations.mjs
@@ -6,6 +6,12 @@ import { basename, join, resolve } from "node:path";
 import { pathToFileURL } from "node:url";
 
 const ENGINE_PACKAGE = "@relaycast/engine";
+export const PUBLISHED_STREAM_TAGS = Object.freeze([
+  "latest",
+  "next",
+  "beta",
+  "alpha",
+]);
 
 // v8.6.0 accidentally rewrote only the header comments of migration 0045.
 // Permit exactly the one-way restoration to the v8.5.5 bytes. Any other
@@ -25,10 +31,15 @@ function sha256(path) {
   return createHash("sha256").update(readFileSync(path)).digest("hex");
 }
 
-function sqlFiles(directory) {
-  return readdirSync(directory)
-    .filter((filename) => filename.endsWith(".sql"))
-    .sort();
+function sqlFiles(directory, { allowMissing = false } = {}) {
+  try {
+    return readdirSync(directory)
+      .filter((filename) => filename.endsWith(".sql"))
+      .sort();
+  } catch (error) {
+    if (allowMissing && error?.code === "ENOENT") return [];
+    throw error;
+  }
 }
 
 function isKnownRecovery({
@@ -56,7 +67,7 @@ export function comparePublishedMigrations({
   const changed = [];
   const missing = [];
   const restored = [];
-  const publishedFiles = sqlFiles(publishedDirectory);
+  const publishedFiles = sqlFiles(publishedDirectory, { allowMissing: true });
 
   for (const filename of publishedFiles) {
     const publishedPath = join(publishedDirectory, filename);
@@ -167,26 +178,100 @@ export function downloadPublishedEngine(spec = `${ENGINE_PACKAGE}@latest`) {
   }
 }
 
-function main() {
-  const published = downloadPublishedEngine(
-    process.argv[2] || `${ENGINE_PACKAGE}@latest`,
-  );
+export function parsePublishedEngineDistTags(output) {
+  let parsed;
   try {
-    const result = assertPublishedMigrationsImmutable({
-      sourceDirectory: resolve("packages/engine/src/db/migrations"),
-      publishedDirectory: published.migrationsDirectory,
-      publishedVersion: published.version,
-    });
-    for (const filename of result.restored) {
+    parsed = JSON.parse(String(output));
+  } catch {
+    throw new Error("npm returned invalid engine dist-tag JSON");
+  }
+  if (Array.isArray(parsed) && parsed.length === 1) parsed = parsed[0];
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new Error("npm returned ambiguous engine dist-tag metadata");
+  }
+
+  const streams = [];
+  const seenVersions = new Set();
+  for (const tag of PUBLISHED_STREAM_TAGS) {
+    if (!Object.hasOwn(parsed, tag)) continue;
+    const version = parsed[tag];
+    if (
+      typeof version !== "string" ||
+      version.length === 0 ||
+      version.trim() !== version ||
+      /[\u0000-\u0020]/u.test(version)
+    ) {
+      throw new Error(`npm returned an invalid engine ${tag} dist-tag`);
+    }
+    if (seenVersions.has(version)) continue;
+    seenVersions.add(version);
+    streams.push({ tag, version, spec: `${ENGINE_PACKAGE}@${version}` });
+  }
+  if (streams.length === 0) {
+    throw new Error("npm returned no recognized published engine streams");
+  }
+  return streams;
+}
+
+export function readPublishedEngineStreams() {
+  return parsePublishedEngineDistTags(
+    execFileSync(
+      "npm",
+      ["view", ENGINE_PACKAGE, "dist-tags", "--json", "--prefer-online"],
+      { encoding: "utf8" },
+    ),
+  );
+}
+
+export function verifyPublishedEngineStreams({
+  sourceDirectory,
+  streams,
+  loadPublishedEngine = downloadPublishedEngine,
+  recoveries = KNOWN_RECOVERIES,
+}) {
+  return streams.map((stream) => {
+    const published = loadPublishedEngine(stream.spec);
+    try {
+      const result = assertPublishedMigrationsImmutable({
+        sourceDirectory,
+        publishedDirectory: published.migrationsDirectory,
+        publishedVersion: published.version,
+        recoveries,
+      });
+      return { ...stream, publishedVersion: published.version, result };
+    } catch (error) {
+      throw new Error(
+        `published engine stream ${stream.tag} (${published.version}) failed: ${error instanceof Error ? error.message : String(error)}`,
+        { cause: error },
+      );
+    } finally {
+      published.cleanup();
+    }
+  });
+}
+
+function main() {
+  const requestedSpecs = process.argv.slice(2);
+  const streams =
+    requestedSpecs.length > 0
+      ? requestedSpecs.map((spec, index) => ({
+          tag: `explicit-${index + 1}`,
+          spec,
+        }))
+      : readPublishedEngineStreams();
+  const verified = verifyPublishedEngineStreams({
+    sourceDirectory: resolve("packages/engine/src/db/migrations"),
+    streams,
+  });
+  for (const stream of verified) {
+    for (const filename of stream.result.restored) {
       console.warn(
-        `approved recovery: restored ${filename} from published ${published.version} to its canonical bytes`,
+        `approved recovery: restored ${filename} from published ${stream.publishedVersion} to its canonical bytes`,
       );
     }
     console.log(
-      `ok — ${result.checked} published engine migration(s) are immutable; ${result.added.length} append-only migration(s) added`,
+      `ok — ${stream.tag} (${stream.publishedVersion}): ${stream.result.checked} published engine migration(s) are immutable; ${stream.result.added.length} append-only migration(s) added`,
     );
-  } finally {
-    published.cleanup();
   }
 }
 

--- a/scripts/check-published-engine-migrations.test.mjs
+++ b/scripts/check-published-engine-migrations.test.mjs
@@ -14,6 +14,8 @@ import { fileURLToPath } from "node:url";
 import {
   KNOWN_RECOVERIES,
   assertPublishedMigrationsImmutable,
+  parsePublishedEngineDistTags,
+  verifyPublishedEngineStreams,
 } from "./check-published-engine-migrations.mjs";
 
 const temporaryDirectories = [];
@@ -115,6 +117,88 @@ describe("published engine migration immutability", () => {
           recoveries: [recovery],
         }),
       /published engine migrations are immutable/,
+    );
+  });
+
+  it("protects migrations published only on a prerelease stream", () => {
+    const latest = fixture({
+      published: { "0001_stable.sql": "SELECT 1;\n" },
+      source: {
+        "0001_stable.sql": "SELECT 1;\n",
+        "0002_prerelease.sql": "SELECT 2;\n",
+      },
+    });
+    const beta = fixture({
+      published: {
+        "0001_stable.sql": "SELECT 1;\n",
+        "0002_prerelease.sql": "SELECT 'published beta bytes';\n",
+      },
+      source: {
+        "0001_stable.sql": "SELECT 1;\n",
+        "0002_prerelease.sql": "SELECT 2;\n",
+      },
+    });
+    const directories = new Map([
+      ["@relaycast/engine@8.5.5", latest.publishedDirectory],
+      ["@relaycast/engine@8.6.0-beta.1", beta.publishedDirectory],
+    ]);
+
+    assert.throws(
+      () =>
+        verifyPublishedEngineStreams({
+          sourceDirectory: latest.sourceDirectory,
+          streams: [
+            {
+              tag: "latest",
+              version: "8.5.5",
+              spec: "@relaycast/engine@8.5.5",
+            },
+            {
+              tag: "beta",
+              version: "8.6.0-beta.1",
+              spec: "@relaycast/engine@8.6.0-beta.1",
+            },
+          ],
+          loadPublishedEngine: (spec) => ({
+            cleanup() {},
+            migrationsDirectory: directories.get(spec),
+            version: spec.slice(spec.lastIndexOf("@") + 1),
+          }),
+        }),
+      /published engine stream beta \(8\.6\.0-beta\.1\)[\s\S]*0002_prerelease\.sql/,
+    );
+  });
+
+  it("reads every recognized dist-tag head and deduplicates versions", () => {
+    assert.deepEqual(
+      parsePublishedEngineDistTags(
+        JSON.stringify([
+          {
+            latest: "8.6.0",
+            next: "8.7.0-beta.1",
+            beta: "8.7.0-beta.1",
+            alpha: "8.8.0-alpha.1",
+            legacy: "1.0.0",
+          },
+        ]),
+      ),
+      [
+        {
+          tag: "latest",
+          version: "8.6.0",
+          spec: "@relaycast/engine@8.6.0",
+        },
+        {
+          tag: "next",
+          version: "8.7.0-beta.1",
+          spec: "@relaycast/engine@8.7.0-beta.1",
+        },
+        {
+          tag: "alpha",
+          version: "8.8.0-alpha.1",
+          spec: "@relaycast/engine@8.8.0-alpha.1",
+        },
+      ],
     );
   });
 

--- a/scripts/check-published-engine-migrations.test.mjs
+++ b/scripts/check-published-engine-migrations.test.mjs
@@ -88,6 +88,23 @@ describe("published engine migration immutability", () => {
     );
   });
 
+  it("rejects a published engine package without a migrations directory", () => {
+    const directories = fixture({
+      published: {},
+      source: { "0001_old.sql": "SELECT 1;\n" },
+    });
+    rmSync(directories.publishedDirectory, { recursive: true });
+
+    assert.throws(
+      () =>
+        assertPublishedMigrationsImmutable({
+          ...directories,
+          publishedVersion: "1.0.0",
+        }),
+      (error) => error?.code === "ENOENT",
+    );
+  });
+
   it("allows only an exact, version-bound recovery", () => {
     const published = "bad published bytes\n";
     const source = "canonical restored bytes\n";

--- a/scripts/check-published-engine-migrations.test.mjs
+++ b/scripts/check-published-engine-migrations.test.mjs
@@ -1,0 +1,146 @@
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { afterEach, describe, it } from "node:test";
+import { fileURLToPath } from "node:url";
+import {
+  KNOWN_RECOVERIES,
+  assertPublishedMigrationsImmutable,
+} from "./check-published-engine-migrations.mjs";
+
+const temporaryDirectories = [];
+
+function sha256(value) {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+function fixture({ source, published }) {
+  const root = mkdtempSync(join(tmpdir(), "relaycast-migrations-test-"));
+  temporaryDirectories.push(root);
+  const sourceDirectory = join(root, "source");
+  const publishedDirectory = join(root, "published");
+  mkdirSync(sourceDirectory);
+  mkdirSync(publishedDirectory);
+  for (const [filename, contents] of Object.entries(source)) {
+    writeFileSync(join(sourceDirectory, filename), contents);
+  }
+  for (const [filename, contents] of Object.entries(published)) {
+    writeFileSync(join(publishedDirectory, filename), contents);
+  }
+  return { sourceDirectory, publishedDirectory };
+}
+
+afterEach(() => {
+  for (const directory of temporaryDirectories.splice(0)) {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+describe("published engine migration immutability", () => {
+  it("accepts unchanged published migrations and append-only additions", () => {
+    const directories = fixture({
+      published: { "0001_old.sql": "SELECT 1;\n" },
+      source: {
+        "0001_old.sql": "SELECT 1;\n",
+        "0002_new.sql": "SELECT 2;\n",
+      },
+    });
+    assert.deepEqual(
+      assertPublishedMigrationsImmutable({
+        ...directories,
+        publishedVersion: "1.0.0",
+      }),
+      {
+        checked: 1,
+        added: ["0002_new.sql"],
+        changed: [],
+        missing: [],
+        restored: [],
+      },
+    );
+  });
+
+  it("rejects changed and removed published migrations", () => {
+    const directories = fixture({
+      published: {
+        "0001_changed.sql": "SELECT 1;\n",
+        "0002_missing.sql": "SELECT 2;\n",
+      },
+      source: { "0001_changed.sql": "SELECT 3;\n" },
+    });
+    assert.throws(
+      () =>
+        assertPublishedMigrationsImmutable({
+          ...directories,
+          publishedVersion: "1.0.0",
+        }),
+      /0002_missing\.sql[\s\S]*0001_changed\.sql/,
+    );
+  });
+
+  it("allows only an exact, version-bound recovery", () => {
+    const published = "bad published bytes\n";
+    const source = "canonical restored bytes\n";
+    const directories = fixture({
+      published: { "0045_fixture.sql": published },
+      source: { "0045_fixture.sql": source },
+    });
+    const recovery = {
+      publishedVersion: "8.6.0",
+      filename: "0045_fixture.sql",
+      publishedSha256: sha256(published),
+      sourceSha256: sha256(source),
+    };
+
+    const result = assertPublishedMigrationsImmutable({
+      ...directories,
+      publishedVersion: "8.6.0",
+      recoveries: [recovery],
+    });
+    assert.deepEqual(result.restored, ["0045_fixture.sql"]);
+
+    assert.throws(
+      () =>
+        assertPublishedMigrationsImmutable({
+          ...directories,
+          publishedVersion: "8.6.1",
+          recoveries: [recovery],
+        }),
+      /published engine migrations are immutable/,
+    );
+  });
+
+  it("pins the one production recovery to the observed registry digests", () => {
+    assert.deepEqual(KNOWN_RECOVERIES, [
+      {
+        publishedVersion: "8.6.0",
+        filename: "0045_workspace_create_idempotency.sql",
+        publishedSha256:
+          "2746d085bc27c5e43af1e6352df8a7979bf06a8b8f482b52ebd4d9d8d01defc6",
+        sourceSha256:
+          "7e510f55ea30f74c8e06fa6cfa80395dbb8038dc13877b948266d5eecf12c243",
+      },
+    ]);
+
+    const recovery = KNOWN_RECOVERIES[0];
+    const sourcePath = join(
+      dirname(fileURLToPath(import.meta.url)),
+      "..",
+      "packages",
+      "engine",
+      "src",
+      "db",
+      "migrations",
+      recovery.filename,
+    );
+    assert.equal(sha256(readFileSync(sourcePath)), recovery.sourceSha256);
+  });
+});

--- a/scripts/release-workflow-contract.test.mjs
+++ b/scripts/release-workflow-contract.test.mjs
@@ -2,9 +2,11 @@ import assert from "node:assert/strict";
 import { spawnSync } from "node:child_process";
 import { randomUUID } from "node:crypto";
 import {
+  existsSync,
   mkdirSync,
   mkdtempSync,
   readFileSync,
+  readdirSync,
   renameSync,
   rmSync,
   symlinkSync,
@@ -127,9 +129,15 @@ function archiveRevision(revision, target) {
 }
 
 function bumpFixtureVersion(root, version, dockerIntegrities) {
-  const packageDirs = git(root, ["ls-files", "packages/*/package.json"])
-    .split("\n")
-    .filter(Boolean);
+  const packageDirs = readdirSync(path.join(root, "packages"), {
+    withFileTypes: true,
+  })
+    .filter(
+      (entry) =>
+        entry.isDirectory() &&
+        existsSync(path.join(root, "packages", entry.name, "package.json")),
+    )
+    .map((entry) => `packages/${entry.name}/package.json`);
   for (const file of packageDirs) {
     const manifestPath = path.join(root, file);
     const manifest = JSON.parse(readFileSync(manifestPath, "utf8"));
@@ -199,6 +207,20 @@ function bumpFixtureVersion(root, version, dockerIntegrities) {
   writeFileSync(runbookPath, runbook);
 }
 
+function seedFixtureChangelogs(root) {
+  const contents =
+    "# Changelog\n\n## [Unreleased - Patch]\n\n### Fixed\n\n- Release fixture.\n\n## [8.5.4] - 2026-09-08\n\n### Fixed\n\n- Previous release.\n";
+  for (const relativePath of [
+    "CHANGELOG.md",
+    ...PUBLISHED_PACKAGE_DIRS.map(
+      (directory) => `packages/${directory}/CHANGELOG.md`,
+    ),
+  ]) {
+    const changelogPath = path.join(root, relativePath);
+    if (existsSync(changelogPath)) writeFileSync(changelogPath, contents);
+  }
+}
+
 function releaseTagMessage(fixture) {
   return [
     `Release v${fixture.version}`,
@@ -246,9 +268,13 @@ function releaseTagFixture({ alteredSource = false, mutateReleaseFile, versionBu
   git(root, ["init", "-q"]);
   git(root, ["config", "user.email", "release-test@example.com"]);
   git(root, ["config", "user.name", "Release Test"]);
-  if (versionBump) {
-    bumpFixtureVersion(root, "8.5.4", NPM_REGISTRY_DOCKER_INTEGRITIES["8.5.4"]);
-  }
+  const sourceVersion = versionBump ? "8.5.4" : version;
+  bumpFixtureVersion(
+    root,
+    sourceVersion,
+    NPM_REGISTRY_DOCKER_INTEGRITIES[sourceVersion],
+  );
+  seedFixtureChangelogs(root);
   git(root, ["add", "."]);
   git(root, ["commit", "-qm", "source"]);
   const sourceCommit = git(root, ["rev-parse", "HEAD"]);
@@ -359,11 +385,19 @@ describe("publish workflow safety contract", () => {
 
   it("runs deterministic release checks before any publish job", () => {
     const tests = workflow.indexOf("npm run test:release");
+    const migrationImmutability = workflow.indexOf(
+      "node scripts/check-published-engine-migrations.mjs",
+    );
     const validation = workflow.indexOf(
       'node scripts/check-release-contract.mjs --version "$NEW_VERSION" --allow-placeholder-docker-lock',
     );
     const publishJob = workflow.indexOf("  publish-packages:");
-    assert.ok(tests > 0 && validation > tests && publishJob > validation);
+    assert.ok(
+      tests > 0 &&
+        migrationImmutability > tests &&
+        validation > migrationImmutability &&
+        publishJob > validation,
+    );
     assert.match(
       jobBlock("create-release"),
       /Re-validate release contract with the refreshed lockfile[\s\S]*check-release-contract\.mjs --version/,


### PR DESCRIPTION
## Summary

- restore `0045_workspace_create_idempotency.sql` to the exact bytes published in `@relaycast/engine@8.5.5`
- fail releases when any migration at the deduplicated `latest`, `next`, `beta`, or `alpha` stream heads is removed or changed
- fail closed when a published engine package omits its migration directory
- permit only the exact one-way 8.6.0 recovery, pinned by version, filename, published digest, and canonical source digest
- make release-workflow fixtures independent of the current repository release state

## Exact-head proof (`fcd595f2`)

- live npm comparison: `latest` 55 migrations, `next` 14, and `alpha` 50; only the exact 8.6.0 recovery accepted
- focused migration immutability tests: 7/7, including prerelease-only mutation and missing-directory regressions
- `npm run test:release`: 80/80
- `git diff --check`
- Veto: PASS; code 99/100, security 100/100, secrets clean

## Broader proof (preceding head; final delta is isolated to the fail-closed migration check and its regression)

- Node 22 `npx turbo test`: 18/18 tasks; engine 913/913
- `npx turbo build`: 9/9
- `npx turbo lint`: 13/13

Fixes #399