### PR TITLE
fix(engine): schema-free resumable retention scans for production recovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Packages without a separate changelog are covered by the cross-package notes bel
 
 ### Fixed
 
+- Hosts can bound retention candidate scans with persisted rowid cursors without schema changes, preserving workspace TTLs and table fairness.
 - Node replay uses bounded, ordered database pages with existing indexes, reducing shared-database contention without requiring schema changes.
 
 ## [8.5.2] - 2026-09-07

--- a/packages/engine/CHANGELOG.md
+++ b/packages/engine/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ### Fixed
 
+- `pruneExpired` accepts a host-owned `cursorStore` for schema-free bounded rowid candidate scans and a `maxDurationMs` admission budget. Serialize calls and persist state durably; TTL policies are unchanged. In-flight SQL and message cascades are not canceled or write-bounded.
 - Node replay uses bounded, ordered database pages with existing indexes, reducing shared-database contention without requiring schema changes.
 
 ## [8.5.2] - 2026-09-07

--- a/packages/engine/src/engine/__tests__/rowidRetention.test.ts
+++ b/packages/engine/src/engine/__tests__/rowidRetention.test.ts
@@ -120,6 +120,13 @@ describe('schema-free retention candidate pages', () => {
     expect(high).toBe(3);
   });
 
+  it('prunes orphaned workspace events under the default policy while keeping high-water', async () => {
+    const f = fixture();
+    for (let seq = 1; seq <= 2; seq++) f.sqlite.prepare("INSERT INTO workspace_events(workspace_id,seq,type,payload,created_at) VALUES ('missing-workspace',?,'test','{}',?)").run(seq, old);
+    expect((await f.run()).workspaceEvents).toBe(1);
+    expect(f.sqlite.prepare("SELECT seq FROM workspace_events WHERE workspace_id='missing-workspace'").all()).toEqual([{ seq: 2 }]);
+  });
+
   it('persists table fairness but not candidate progress after an ambiguous failure', async () => {
     const f = fixture(); const msg = f.message();
     const execute = f.db.all.bind(f.db);

--- a/packages/engine/src/engine/__tests__/rowidRetention.test.ts
+++ b/packages/engine/src/engine/__tests__/rowidRetention.test.ts
@@ -1,0 +1,190 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { drizzle } from 'drizzle-orm/better-sqlite3';
+import { getSqliteDb, runMigrations, type SqliteDbHandle } from '../../adapters/node/database.js';
+import * as schema from '../../db/schema.js';
+import type { EngineDb } from '../../ports/database.js';
+import { pruneExpired, type PruneOptions } from '../retention.js';
+import type { RetentionCursorStore, RowidRetentionState } from '../rowidRetention.js';
+import { snowflakeIdLowerBound } from '../snowflake.js';
+
+const now = new Date('2026-09-09T14:00:00Z');
+const seconds = Math.floor(now.getTime() / 1000);
+const old = seconds - 110 * 86400;
+const handles: SqliteDbHandle[] = [];
+afterEach(() => { for (const handle of handles.splice(0)) handle.sqlite.close(); vi.useRealTimers(); });
+
+function fixture() {
+  const handle = getSqliteDb(':memory:'); handles.push(handle); runMigrations(handle);
+  const queries: Array<{ sql: string; params: unknown[] }> = [];
+  const db = drizzle(handle.sqlite, { schema, logger: { logQuery: (sql, params) => queries.push({ sql, params }) } }) as unknown as EngineDb;
+  for (const ws of ['one', 'two']) {
+    handle.sqlite.prepare('INSERT INTO workspaces(id,name,api_key_hash) VALUES (?,?,?)').run(ws, ws, ws);
+    handle.sqlite.prepare('INSERT INTO agents(id,workspace_id,name,token_hash) VALUES (?,?,?,?)').run(ws, ws, ws, ws);
+    handle.sqlite.prepare('INSERT INTO channels(id,workspace_id,name) VALUES (?,?,?)').run(ws, ws, ws);
+  }
+  let sequence = 0;
+  const message = (days = 110, ws = 'one', thread: string | null = null) => {
+    const id = String(BigInt(snowflakeIdLowerBound(now.getTime() - days * 86400000)) + BigInt(++sequence));
+    handle.sqlite.prepare('INSERT INTO messages(id,workspace_id,channel_id,agent_id,body,thread_id) VALUES (?,?,?,?,?,?)').run(id, ws, ws, ws, 'body', thread);
+    return id;
+  };
+  const delivery = (msg: string, status = 'acked', created = old, ws = 'one') => {
+    const id = `delivery-${++sequence}`;
+    // A distinct agent is needed for each message/agent delivery uniqueness.
+    const agent = `agent-${sequence}`;
+    handle.sqlite.prepare('INSERT INTO agents(id,workspace_id,name,token_hash) VALUES (?,?,?,?)').run(agent, ws, agent, agent);
+    handle.sqlite.prepare('INSERT INTO deliveries(id,workspace_id,message_id,agent_id,seq,status,created_at) VALUES (?,?,?,?,?,?,?)').run(id, ws, msg, agent, sequence, status, created);
+    return id;
+  };
+  let state: RowidRetentionState | undefined;
+  const store: RetentionCursorStore = {
+    load: vi.fn(async () => structuredClone(state)),
+    save: vi.fn(async (value) => { state = structuredClone(value); }),
+  };
+  const run = (opts: PruneOptions = {}) => pruneExpired(db, { cursorStore: store, batchLimit: 2, maxBatches: 1, now, ...opts });
+  return { ...handle, db, queries, message, delivery, store, run, state: () => state };
+}
+
+describe('schema-free retention candidate pages', () => {
+  it('bounds reads through retained history, advances cursors and issues no no-op writes', async () => {
+    const f = fixture(); const msg = f.message(1);
+    f.sqlite.transaction(() => { for (let i = 0; i < 1000; i++) f.delivery(msg, 'acked', seconds); })();
+    expect((await f.run()).deliveries).toBe(0);
+    expect(f.queries.filter(q => /^DELETE/i.test(q.sql))).toEqual([]);
+    const first = f.state()!.tables.deliveries!.cursor;
+    await f.run();
+    expect(f.state()!.tables.deliveries!.cursor).toBeGreaterThan(first!);
+    expect(f.queries.filter(q => /^DELETE/i.test(q.sql))).toEqual([]);
+    const reads = f.queries.filter(q => q.sql.includes('FROM deliveries NOT INDEXED') && q.sql.includes('WITH page'));
+    expect(reads.length).toBe(2);
+    expect(reads.every(q => q.sql.includes('AS MATERIALIZED') && q.params.at(-1) === 2)).toBe(true);
+    const plan = f.sqlite.prepare('EXPLAIN QUERY PLAN ' + reads[1]!.sql).all(...reads[1]!.params) as Array<{ detail: string }>;
+    expect(plan.some(row => /SEARCH deliveries USING INTEGER PRIMARY KEY/.test(row.detail))).toBe(true);
+    expect(f.sqlite.prepare("SELECT count(*) n FROM sqlite_master WHERE name='maintenance_cursors'").get()).toEqual({ n: 0 });
+  });
+
+  it('preserves policy overrides, unsettled rows, messages and sequence counters', async () => {
+    const f = fixture();
+    const a = f.message(), b = f.message(110, 'two');
+    f.sqlite.prepare('UPDATE workspaces SET retention=? WHERE id=?').run(JSON.stringify({ delivery_ttl_days: null }), 'two');
+    const expired = [f.delivery(a), f.delivery(a, 'failed'), f.delivery(a, 'dead_lettered')];
+    const kept = [f.delivery(a, 'queued'), f.delivery(a, 'delivered'), f.delivery(a, 'acked', seconds), f.delivery(b, 'acked', old, 'two')];
+    const counters = f.sqlite.prepare('SELECT id,delivery_seq,delivery_ack_seq FROM agents ORDER BY id').all();
+    for (let i = 0; i < 5; i++) await f.run();
+    const remaining = f.sqlite.prepare('SELECT id FROM deliveries ORDER BY id').all() as Array<{ id: string }>;
+    expect(remaining.map(r => r.id).sort()).toEqual(kept.sort());
+    expect(remaining.some(r => expired.includes(r.id))).toBe(false);
+    expect(f.sqlite.prepare('SELECT count(*) n FROM messages').get()).toEqual({ n: 2 });
+    expect(f.sqlite.prepare('SELECT id,delivery_seq,delivery_ack_seq FROM agents ORDER BY id').all()).toEqual(counters);
+  });
+
+  it('uses bounded variable counts and rowid seeks for multi-row deletes', async () => {
+    const f = fixture(); const msg = f.message(1);
+    for (let i = 0; i < 23; i++) f.delivery(msg);
+    expect((await f.run({ batchLimit: 200 })).deliveries).toBe(23);
+    const deletes = f.queries.filter(q => q.sql.startsWith('DELETE FROM deliveries'));
+    expect(deletes.length).toBe(3);
+    for (const query of deletes) {
+      expect(query.params.length).toBeLessThanOrEqual(100);
+      const plan = JSON.stringify(f.sqlite.prepare('EXPLAIN QUERY PLAN ' + query.sql).all(...query.params));
+      expect(plan).toMatch(/SEARCH deliveries USING INTEGER PRIMARY KEY/);
+      expect(plan).not.toMatch(/SCAN deliveries|USING INDEX idx_deliveries/);
+    }
+  });
+
+  it('retains event high-water, live receipts, and thread parents until replies expire', async () => {
+    const f = fixture(); const parent = f.message(), reply = f.message(110, 'one', parent);
+    for (let seq = 1; seq <= 3; seq++) f.sqlite.prepare("INSERT INTO workspace_events(workspace_id,seq,type,payload,created_at) VALUES ('one',?,'test','{}',?)").run(seq, old);
+    f.sqlite.prepare("INSERT INTO read_receipts(message_id,agent_id) VALUES (?,'one')").run(parent);
+    const result = await f.run({ batchLimit: 200, defaults: { messageTtlDays: 30 } });
+    expect(result.messages).toBe(1);
+    expect(f.sqlite.prepare('SELECT id FROM messages').all()).toEqual([{ id: parent }]);
+    expect(f.sqlite.prepare('SELECT seq FROM workspace_events').all()).toEqual([{ seq: 3 }]);
+    expect(f.sqlite.prepare('SELECT message_id FROM read_receipts').all()).toEqual([{ message_id: parent }]);
+    await f.run({ batchLimit: 200, defaults: { messageTtlDays: 30 } });
+    expect(f.sqlite.prepare('SELECT id FROM messages').all()).toEqual([]);
+    expect(reply).not.toEqual(parent);
+    expect(f.sqlite.pragma('foreign_key_check')).toEqual([]);
+  });
+
+  it('wraps a finite high-water even while new rows arrive, revisiting retained rows', async () => {
+    const f = fixture(); const msg = f.message(1);
+    const retained = f.delivery(msg, 'delivered'); f.delivery(msg); f.delivery(msg);
+    await f.run(); const high = f.state()!.tables.deliveries!.high;
+    for (let i = 0; i < 4; i++) f.delivery(msg);
+    await f.run();
+    expect(f.state()!.tables.deliveries).toBeUndefined();
+    f.sqlite.prepare("UPDATE deliveries SET status='acked' WHERE id=?").run(retained);
+    await f.run();
+    expect(f.sqlite.prepare('SELECT id FROM deliveries WHERE id=?').get(retained)).toBeUndefined();
+    expect(high).toBe(3);
+  });
+
+  it('persists table fairness but not candidate progress after an ambiguous failure', async () => {
+    const f = fixture(); const msg = f.message();
+    const execute = f.db.all.bind(f.db);
+    const spy = vi.spyOn(f.db, 'all').mockImplementation((query) => {
+      const text = f.db.dialect.sqlToQuery(query as never).sql;
+      if (text.startsWith('DELETE FROM messages')) throw new Error('D1 failure');
+      return execute(query);
+    });
+    await expect(f.run({ defaults: { messageTtlDays: 30 } })).rejects.toThrow('D1 failure');
+    expect(f.state()!.next).toBe(1);
+    expect(f.state()!.tables.messages?.cursor).toBeUndefined();
+    spy.mockRestore();
+    await f.run({ defaults: { messageTtlDays: 30 } });
+    expect(f.sqlite.prepare('SELECT id FROM messages WHERE id=?').get(msg)).toBeUndefined();
+  });
+
+  it('awaits an admitted write but stops new SQL after the elapsed budget', async () => {
+    const f = fixture(); for (let i = 0; i < 11; i++) f.message();
+    vi.useFakeTimers(); vi.setSystemTime(now);
+    const execute = f.db.all.bind(f.db);
+    vi.spyOn(f.db, 'all').mockImplementation((query) => {
+      const result = execute(query);
+      if (f.db.dialect.sqlToQuery(query as never).sql.startsWith('DELETE FROM messages')) vi.advanceTimersByTime(11_000);
+      return result;
+    });
+    expect((await f.run({ batchLimit: 200, defaults: { messageTtlDays: 30 } })).messages).toBe(10);
+    expect(f.queries.filter(q => q.sql.startsWith('DELETE')).length).toBe(1);
+    expect(f.state()!.tables.messages?.cursor).toBeUndefined();
+    expect(f.state()!.next).toBe(1);
+  });
+
+  it('fails closed on corrupt durable state, invalid clocks and cursor persistence errors', async () => {
+    const f = fixture();
+    await expect(f.run({ now: new Date(NaN) })).rejects.toThrow('Invalid retention clock');
+    vi.mocked(f.store.load).mockResolvedValueOnce({ version: 9 });
+    await expect(f.run()).rejects.toThrow();
+    vi.mocked(f.store.save).mockRejectedValueOnce(new Error('storage unavailable'));
+    await expect(f.run()).rejects.toThrow('storage unavailable');
+    expect(f.queries).toEqual([]);
+  });
+
+  it.each(['policy', 'status', 'rowid', 'created_at'])(
+    'rechecks %s at mutation time rather than deleting from a stale candidate', async (change) => {
+      const f = fixture(); const msg = f.message(); const id = f.delivery(msg);
+      const execute = f.db.all.bind(f.db);
+      let changed = false;
+      vi.spyOn(f.db, 'all').mockImplementation((query) => {
+        const text = f.db.dialect.sqlToQuery(query as never).sql;
+        if (text.startsWith('DELETE FROM deliveries') && !changed) {
+          changed = true;
+          if (change === 'policy') f.sqlite.prepare("UPDATE workspaces SET retention=? WHERE id='one'").run(JSON.stringify({ delivery_ttl_days: null }));
+          if (change === 'status') f.sqlite.prepare("UPDATE deliveries SET status='queued' WHERE id=?").run(id);
+          if (change === 'created_at') f.sqlite.prepare('UPDATE deliveries SET created_at=? WHERE id=?').run(seconds, id);
+          if (change === 'rowid') {
+            const row = f.sqlite.prepare('SELECT rowid AS r FROM deliveries WHERE id=?').get(id) as { r: number };
+            f.sqlite.prepare('DELETE FROM deliveries WHERE id=?').run(id);
+            const replacement = f.delivery(msg);
+            expect(f.sqlite.prepare('SELECT rowid AS r FROM deliveries WHERE id=?').get(replacement)).toEqual(row);
+          }
+        }
+        return execute(query);
+      });
+      expect((await f.run()).deliveries).toBe(0);
+      expect(changed).toBe(true);
+      expect(f.sqlite.prepare('SELECT count(*) n FROM deliveries').get()).toEqual({ n: 1 });
+    },
+  );
+});

--- a/packages/engine/src/engine/retention.ts
+++ b/packages/engine/src/engine/retention.ts
@@ -12,6 +12,7 @@ import {
   type WorkspaceRetentionSettings,
 } from '../db/schema.js';
 import { snowflakeIdLowerBound } from './snowflake.js';
+import { pruneRowidPages, type RetentionCursorStore } from './rowidRetention.js';
 
 type Db = ReturnType<typeof getDb>;
 
@@ -53,6 +54,10 @@ export interface RetentionDefaults {
 }
 
 export interface PruneOptions {
+  /** Optional schema-free, candidate-bounded mode. Host must serialize callers and durably persist this cursor outside D1. */
+  cursorStore?: RetentionCursorStore;
+  /** Admission budget for cursor mode; does not cancel in-flight SQL. Default 10s, capped at 30s. */
+  maxDurationMs?: number;
   /** Max rows deleted per table per batch (the SQL LIMIT). Default 200. */
   batchLimit?: number;
   /** Max batches per table per call, bounding total work per run. Default 5. */
@@ -210,6 +215,7 @@ interface PrunePass {
  * successive runs.
  */
 export async function pruneExpired(db: Db, opts: PruneOptions = {}): Promise<PruneResult> {
+  if (opts.cursorStore) return pruneRowidPages(db, { ...opts, cursorStore: opts.cursorStore });
   const now = opts.now ?? new Date();
   const batchLimit = Math.max(1, opts.batchLimit ?? DEFAULT_BATCH_LIMIT);
   const maxBatches = Math.max(1, opts.maxBatches ?? DEFAULT_MAX_BATCHES);

--- a/packages/engine/src/engine/rowidRetention.ts
+++ b/packages/engine/src/engine/rowidRetention.ts
@@ -1,0 +1,166 @@
+import { sql } from 'drizzle-orm';
+import { z } from 'zod';
+import type { EngineDb } from '../ports/database.js';
+import type { WorkspaceRetentionSettings } from '../db/schema.js';
+import type { PruneOptions, PruneResult, RetentionDefaults } from './retention.js';
+import { snowflakeIdLowerBound } from './snowflake.js';
+
+const safeRowid = z.number().int().min(Number.MIN_SAFE_INTEGER).max(Number.MAX_SAFE_INTEGER);
+const stateSchema = z.object({
+  version: z.literal(1),
+  next: z.number().int().min(0).max(4),
+  tables: z.record(z.string(), z.object({ cursor: safeRowid.optional(), high: safeRowid.optional() })),
+});
+export type RowidRetentionState = z.infer<typeof stateSchema>;
+
+/** Host-owned durable state; the host MUST serialize callers for this database.
+ * save resolves only after persistence. No new engine table/index is required.
+ */
+export interface RetentionCursorStore {
+  load(): Promise<unknown>;
+  save(state: RowidRetentionState): Promise<void>;
+}
+
+type Candidate = {
+  _rowid: number;
+  id: string;
+  workspace_id: string;
+  created_at: number;
+  seq: number;
+  message_id: string;
+  agent_id: string;
+  status: string;
+  retention: string | null;
+  eligible: number;
+};
+type Table = {
+  name: string;
+  result: keyof PruneResult;
+  columns: string;
+  setting?: keyof WorkspaceRetentionSettings;
+  fallback?: keyof RetentionDefaults;
+  snowflake?: boolean;
+  guard: string;
+};
+const settled = "status IN ('acked', 'failed', 'dead_lettered')";
+const tables: Table[] = [
+  { name: 'messages', result: 'messages', columns: 'id, workspace_id',
+    setting: 'message_ttl_days', fallback: 'messageTtlDays', snowflake: true,
+    guard: 'NOT EXISTS (SELECT 1 FROM messages replies WHERE replies.thread_id = messages.id)' },
+  { name: 'deliveries', result: 'deliveries', columns: 'id, workspace_id, created_at, status',
+    setting: 'delivery_ttl_days', fallback: 'deliveryTtlDays', guard: settled },
+  { name: 'message_logs', result: 'messageLogs', columns: 'id, workspace_id',
+    setting: 'message_log_ttl_days', fallback: 'messageLogTtlDays', snowflake: true, guard: '1' },
+  { name: 'workspace_events', result: 'workspaceEvents', columns: 'workspace_id, seq, created_at',
+    setting: 'workspace_event_ttl_days', fallback: 'workspaceEventTtlDays',
+    guard: 'EXISTS (SELECT 1 FROM workspace_events hw WHERE hw.workspace_id = workspace_events.workspace_id AND hw.seq > workspace_events.seq LIMIT 1)' },
+  { name: 'read_receipts', result: 'readReceipts', columns: 'message_id, agent_id',
+    guard: 'NOT EXISTS (SELECT 1 FROM messages m WHERE m.id = read_receipts.message_id)' },
+];
+
+function bounded(value: number | undefined, fallback: number, max: number): number {
+  return value !== undefined && Number.isFinite(value) ? Math.max(1, Math.min(max, Math.floor(value))) : fallback;
+}
+
+function expired(row: Candidate, table: Table, defaults: Required<RetentionDefaults>, now: number): boolean {
+  if (!table.setting || !table.fallback) return true;
+  const settings = row.retention ? JSON.parse(row.retention) as WorkspaceRetentionSettings : {};
+  const override = settings?.[table.setting];
+  const days = override === undefined ? defaults[table.fallback] : override;
+  if (days == null || !Number.isFinite(days) || days <= 0) return false;
+  const cutoff = now - days * 86_400_000;
+  if (!Number.isFinite(cutoff)) return false;
+  if (!table.snowflake) return row.created_at * 1000 < cutoff;
+  const bound = snowflakeIdLowerBound(cutoff);
+  return row.id.length < bound.length || (row.id.length === bound.length && row.id < bound);
+}
+
+/**
+ * Schema-free recovery mode. Rowid keyset pages bound candidate READS even when
+ * no history is expired. TTLs/eligibility are applied AFTER the materialized
+ * page, so LIMIT cannot hide a full-history scan. This deliberately trades scan
+ * throughput for predictable candidate work while compact indexes are blocked.
+ *
+ * Rowid high-water makes each traversal finite under new writes. Retained rows
+ * are revisited after wrap. Fairness is persisted before a page; its cursor only
+ * moves after all admitted deletes settle. Failures replay a page, never skip
+ * uncommitted rows. Message DELETE cascades may still be large; this is NOT a
+ * bound on cascade writes or a replacement for per-tenant database isolation.
+ */
+export async function pruneRowidPages(db: EngineDb, opts: PruneOptions & { cursorStore: RetentionCursorStore }): Promise<PruneResult> {
+  const now = (opts.now ?? new Date()).getTime();
+  if (!Number.isFinite(now)) throw new Error('Invalid retention clock');
+  const limit = bounded(opts.batchLimit, 200, 200);
+  const pages = bounded(opts.maxBatches, 5, 5) * tables.length;
+  const deadline = Date.now() + bounded(opts.maxDurationMs, 10_000, 30_000);
+  const defaults: Required<RetentionDefaults> = {
+    messageTtlDays: null, deliveryTtlDays: 90, messageLogTtlDays: 90, workspaceEventTtlDays: 30,
+    ...Object.fromEntries(Object.entries(opts.defaults ?? {}).filter(([, value]) => value !== undefined)),
+  };
+  const saved = await opts.cursorStore.load();
+  // Corrupt state is an error, not permission to restart expensive work or
+  // drop an unknown future cursor format during a rollback.
+  const state: RowidRetentionState = saved == null
+    ? { version: 1, next: 0, tables: {} } : stateSchema.parse(saved);
+  const save = () => opts.cursorStore.save(structuredClone(state));
+  const result: PruneResult = { messages: 0, deliveries: 0, messageLogs: 0, readReceipts: 0, workspaceEvents: 0 };
+  const finished = new Set<number>();
+  for (let step = 0; step < pages && Date.now() < deadline; step++) {
+    const index = state.next;
+    state.next = (index + 1) % tables.length;
+    if (finished.has(index)) continue;
+    const table = tables[index]!;
+    await save();
+    const position = state.tables[table.name] ??= {};
+    if (Date.now() >= deadline) break;
+    if (position.high === undefined) {
+      const [last] = await db.all<{ _rowid: number }>(sql`SELECT rowid AS _rowid FROM ${sql.raw(table.name)} NOT INDEXED ORDER BY rowid DESC LIMIT 1`);
+      if (!last) { delete state.tables[table.name]; finished.add(index); await save(); continue; }
+      position.high = safeRowid.parse(last._rowid);
+    }
+    if (Date.now() >= deadline) break;
+    const page = await db.all<Candidate>(sql`
+      WITH page AS MATERIALIZED (
+        SELECT rowid AS _rowid, ${sql.raw(table.columns)} FROM ${sql.raw(table.name)} NOT INDEXED
+        WHERE rowid <= ${position.high}
+        ${position.cursor === undefined ? sql`` : sql`AND rowid > ${position.cursor}`}
+        ORDER BY rowid LIMIT ${limit}
+      ) SELECT page.*, ${sql.raw(table.guard.replaceAll(table.name + '.', 'page.'))} AS eligible,
+        ${table.setting ? sql`w.retention` : sql`NULL`} AS retention FROM page
+      ${table.setting ? sql`LEFT JOIN workspaces w ON w.id = page.workspace_id` : sql``}
+      ORDER BY page._rowid`);
+    for (const row of page) safeRowid.parse(row._rowid);
+    // Keep exact row identities alongside rowid: SQLite may reuse a deleted
+    // rowid between the candidate read and a later DELETE.
+    const removable = page.filter(row => row.eligible && expired(row, table, defaults, now));
+    // At most seven bindings per row, kept below D1's 100-variable limit.
+    // Small atomic chunks also avoid one subrequest per retained-history row.
+    for (let offset = 0; offset < removable.length; offset += 10) {
+      if (Date.now() >= deadline) { await save(); return result; }
+      const chunk = removable.slice(offset, offset + 10);
+      const guarded = chunk.map(row => {
+        const identity = table.result === 'workspaceEvents'
+          ? sql`workspace_id = ${row.workspace_id} AND seq = ${row.seq}`
+          : table.result === 'readReceipts'
+            ? sql`message_id = ${row.message_id} AND agent_id = ${row.agent_id}`
+            : sql`id = ${row.id} AND workspace_id = ${row.workspace_id}`;
+        // A policy edit after the read must not authorize a stale deletion.
+        // Exact raw-policy comparison is conservative (even whitespace edits
+        // defer the row to the next traversal), and uses the workspace PK.
+        const policyGuard = table.setting ? sql`AND EXISTS (SELECT 1 FROM workspaces w
+          WHERE w.id = ${row.workspace_id} AND w.retention IS ${row.retention})` : sql``;
+        const timeGuard = table.setting && !table.snowflake ? sql`AND created_at = ${row.created_at}` : sql``;
+        return sql`(rowid = ${row._rowid} AND ${identity} ${policyGuard} ${timeGuard})`;
+      });
+      const deleted = await db.all(sql`DELETE FROM ${sql.raw(table.name)} NOT INDEXED
+        WHERE (${sql.join(guarded, sql` OR `)}) AND ${sql.raw(table.guard)} RETURNING 1`);
+      result[table.result] += deleted.length;
+    }
+    if (page.length < limit || page.at(-1)?._rowid === position.high) {
+      delete state.tables[table.name]; finished.add(index);
+    } else position.cursor = page.at(-1)!._rowid;
+    await save();
+    if (finished.size === tables.length) break;
+  }
+  return result;
+}

--- a/packages/engine/src/engine/rowidRetention.ts
+++ b/packages/engine/src/engine/rowidRetention.ts
@@ -147,8 +147,12 @@ export async function pruneRowidPages(db: EngineDb, opts: PruneOptions & { curso
         // A policy edit after the read must not authorize a stale deletion.
         // Exact raw-policy comparison is conservative (even whitespace edits
         // defer the row to the next traversal), and uses the workspace PK.
-        const policyGuard = table.setting ? sql`AND EXISTS (SELECT 1 FROM workspaces w
-          WHERE w.id = ${row.workspace_id} AND w.retention IS ${row.retention})` : sql``;
+        // A missing workspace also has the default policy. workspace_events
+        // intentionally has no workspace FK, so its orphan rows must age out.
+        // The scalar PK lookup returns NULL for absence, but a newly installed
+        // non-default policy still prevents deletion from the stale snapshot.
+        const policyGuard = table.setting ? sql`AND (SELECT w.retention FROM workspaces w
+          WHERE w.id = ${row.workspace_id}) IS ${row.retention}` : sql``;
         const timeGuard = table.setting && !table.snowflake ? sql`AND created_at = ${row.created_at}` : sql``;
         return sql`(rowid = ${row._rowid} AND ${identity} ${policyGuard} ${timeGuard})`;
       });

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -47,6 +47,7 @@ export * as schema from './db/schema.js';
 // Webhook delivery + scheduled-task helpers adapters wire to their queue/cron.
 export { deliverEvent } from './engine/eventDelivery.js';
 export { runA2aHealthChecks } from './engine/a2a-health.js';
+export type { RetentionCursorStore, RowidRetentionState } from './engine/rowidRetention.js';
 
 // Node delivery redrive: queue/cron-backed deployments call this from a
 // scheduled handler to retry queued node deliveries (http_push and ws-node)


### PR DESCRIPTION
## Incident
Production D1 is near 9.90 GB. The compact-index upgrade is correctly capacity-held. Live maintenance logged a 71-second retention_prune failure; limiting DELETE results did not bound candidate scans through retained history.

## Schema-free backport
An optional host-owned cursorStore switches pruneExpired to materialized rowid keyset candidate pages using existing table rowids. No migration files, TTL defaults, dependency versions or stable release tags change. The host must serialize calls and persist cursors durably outside D1. Legacy callers remain unchanged.

- At most 200 candidates per page, five rounds across five tables, finite rowid high-water and persisted table fairness.
- Eligibility and workspace TTLs are checked after the bounded page. Retained/live rows do not issue no-op DELETEs.
- Guarded 10-row atomic deletes seek exact rowids and identities, recheck policy/status/time and preserve event sequence high-water and thread parents.
- Cursor advances only after admitted deletes settle; failures replay safely. Deadline stops new SQL, never cancels/retries an ambiguous mutation.

## Verification
854 engine tests pass, full typecheck/lint/diff checks pass. Twelve new regressions cover existing-index plans, D1 bind limits, TTL overrides, active deliveries, ACK/sequence preservation, high-water wrap, failure recovery, elapsed budget, rowid reuse, concurrent status/policy/time edits, and invalid state. Disabling the new mode makes the retained-history regression fail. All 50 migration files are unchanged.

## Limits / rollout
Candidate reads are bounded; message cascades and an already-running SQL call are not bounded/canceled. Traversal is intentionally slower than the compact indexed path. This is containment, not production tenant isolation or incident closure. Intended publication is engine-only 8.5.2-hotfix.2 / alpha from the maintenance branch, followed by an exact Cloud pin and MaintenanceDO cursor wiring. Keep latest and types/a2a unchanged. Veto unavailable; manual review plus fresh external reviews required before merge.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches data-deletion paths and introduces durable cursor semantics hosts must implement correctly; mistakes could skip pruning or delete rows incorrectly, though guarded deletes and fail-closed state parsing mitigate stale deletes.
> 
> **Overview**
> Adds an **opt-in recovery path** for retention pruning when full-table candidate scans through retained history can stall D1: passing a host-owned **`cursorStore`** switches `pruneExpired` to **`pruneRowidPages`**, which walks fixed-size **rowid keyset pages** (no new migrations or engine tables) and applies the same TTL/eligibility rules after each materialized page.
> 
> The host must **serialize** prune calls and **durably persist** cursor/fairness state outside the database. New **`maxDurationMs`** caps how much new SQL is admitted per run (default 10s, max 30s) without canceling an in-flight delete. Deletes use small guarded chunks (rowid + identity, policy/status/time rechecks) so stale candidates are not removed; cursors advance only after admitted deletes complete, with safe replay on failure.
> 
> **`RetentionCursorStore`** / **`RowidRetentionState`** are exported for adapters. Legacy `pruneExpired` behavior is unchanged when `cursorStore` is omitted. Regression tests cover bounded reads, TTL overrides, high-water events, thread parents, budgets, and corrupt state.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 839df97f37220a796d31b618245f5ad656e46fc3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/AgentWorkforce/relaycast/pull/402?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

