### PR TITLE
fix(engine): reap long-expired active deliveries in bounded retention

### DIFF
--- a/packages/engine/src/engine/__tests__/retention.test.ts
+++ b/packages/engine/src/engine/__tests__/retention.test.ts
@@ -81,14 +81,20 @@ async function insertMessage(db: Db, base: Seeded, id: string, threadId?: string
 // agent can no longer share the default seq of 0.
 let deliverySeqCounter = 0;
 
-async function insertDelivery(
+  async function insertDelivery(
   db: Db,
   base: Seeded,
   messageId: string,
   status: string,
   daysAgo: number,
+    expiresAtDays?: number | null,
 ): Promise<string> {
   const id = `del_${messageId}_${base.agent}`;
+  const expiresAt = expiresAtDays === undefined
+    ? null
+    : expiresAtDays === null
+      ? null
+      : Math.floor((Date.now() - expiresAtDays * DAY_MS) / 1000);
   await db.insert(deliveries).values({
     id,
     workspaceId: base.ws,
@@ -97,6 +103,7 @@ async function insertDelivery(
     status,
     seq: ++deliverySeqCounter,
     createdAt: new Date(Date.now() - daysAgo * DAY_MS),
+    expiresAt,
   });
   return id;
 }
@@ -148,7 +155,14 @@ describe('pruneExpired', () => {
       },
     });
 
-    expect(result).toEqual({ messages: 0, deliveries: 0, messageLogs: 0, readReceipts: 0, workspaceEvents: 0 });
+    expect(result).toEqual({
+      messages: 0,
+      deliveries: 0,
+      expiredDeliveries: 0,
+      messageLogs: 0,
+      readReceipts: 0,
+      workspaceEvents: 0,
+    });
     expect(await db.select().from(messages)).toHaveLength(1);
     expect(await db.select().from(deliveries)).toHaveLength(1);
     expect(await db.select().from(messageLogs)).toHaveLength(1);
@@ -165,6 +179,7 @@ describe('pruneExpired', () => {
 
     expect(result.messages).toBe(0);
     expect(result.deliveries).toBe(1);
+    expect(result.expiredDeliveries).toBe(0);
     expect(result.messageLogs).toBe(1);
     expect(await db.select().from(messages)).toHaveLength(1);
     expect(await db.select().from(deliveries)).toHaveLength(0);
@@ -297,8 +312,157 @@ describe('pruneExpired', () => {
     const result = await pruneExpired(db);
 
     expect(result.deliveries).toBe(2);
+    expect(result.expiredDeliveries).toBe(0);
     const remaining = (await db.select({ status: deliveries.status }).from(deliveries)).map((r) => r.status);
     expect(remaining.sort()).toEqual(['acked', 'queued']);
+  });
+
+  it('deletes a queued delivery expired longer than the grace window', async () => {
+    const { db } = track(openDb());
+    const base = await seedWorkspace(db);
+    const now = new Date('2026-01-01T00:00:00.000Z');
+
+    await insertDelivery(db, base, await insertMessage(db, base, idAt(1)), 'queued', 1, 20);
+    // Ensure settled-delivery TTL is disabled so only the new entry can delete.
+    const result = await pruneExpired(db, {
+      now,
+      expiredDeliveryGraceDays: 7,
+      defaults: {
+        deliveryTtlDays: null,
+        messageLogTtlDays: null,
+        workspaceEventTtlDays: null,
+        messageTtlDays: null,
+      },
+    });
+
+    expect(result.expiredDeliveries).toBe(1);
+    expect(await db.select().from(deliveries)).toHaveLength(0);
+  });
+
+  it('does not delete a queued delivery expired inside the grace window', async () => {
+    const { db } = track(openDb());
+    const base = await seedWorkspace(db);
+    const now = new Date('2026-01-01T00:00:00.000Z');
+
+    await insertDelivery(db, base, await insertMessage(db, base, idAt(1)), 'queued', 1, 3);
+    const result = await pruneExpired(db, {
+      now,
+      expiredDeliveryGraceDays: 7,
+      defaults: {
+        deliveryTtlDays: null,
+        messageLogTtlDays: null,
+        workspaceEventTtlDays: null,
+        messageTtlDays: null,
+      },
+    });
+
+    expect(result.expiredDeliveries).toBe(0);
+    expect(await db.select().from(deliveries)).toHaveLength(1);
+  });
+
+  it('does not delete a queued delivery with expires_at NULL', async () => {
+    const { db } = track(openDb());
+    const base = await seedWorkspace(db);
+    const now = new Date('2026-01-01T00:00:00.000Z');
+
+    await insertDelivery(db, base, await insertMessage(db, base, idAt(1)), 'queued', 1, null);
+    const result = await pruneExpired(db, {
+      now,
+      expiredDeliveryGraceDays: 7,
+      defaults: {
+        deliveryTtlDays: null,
+        messageLogTtlDays: null,
+        workspaceEventTtlDays: null,
+        messageTtlDays: null,
+      },
+    });
+
+    expect(result.expiredDeliveries).toBe(0);
+    expect(await db.select().from(deliveries)).toHaveLength(1);
+  });
+
+  it('deletes a delivered delivery long past expiry', async () => {
+    const { db } = track(openDb());
+    const base = await seedWorkspace(db);
+    const now = new Date('2026-01-01T00:00:00.000Z');
+
+    await insertDelivery(db, base, await insertMessage(db, base, idAt(1)), 'delivered', 1, 20);
+    const result = await pruneExpired(db, {
+      now,
+      expiredDeliveryGraceDays: 7,
+      defaults: {
+        deliveryTtlDays: null,
+        messageLogTtlDays: null,
+        workspaceEventTtlDays: null,
+        messageTtlDays: null,
+      },
+    });
+
+    expect(result.expiredDeliveries).toBe(1);
+    expect(await db.select().from(deliveries)).toHaveLength(0);
+  });
+
+  it('leaves an acked delivery untouched by the new entry', async () => {
+    const { db } = track(openDb());
+    const base = await seedWorkspace(db);
+    const now = new Date('2026-01-01T00:00:00.000Z');
+
+    const msg = await insertMessage(db, base, idAt(1));
+    await insertDelivery(db, base, msg, 'acked', 1, 20);
+    const result = await pruneExpired(db, {
+      now,
+      expiredDeliveryGraceDays: 7,
+      defaults: {
+        deliveryTtlDays: null,
+        messageLogTtlDays: null,
+        workspaceEventTtlDays: null,
+        messageTtlDays: null,
+      },
+    });
+
+    expect(result.expiredDeliveries).toBe(0);
+    expect((await db.select().from(deliveries)).map((r) => r.status)).toEqual(['acked']);
+  });
+
+  it('advances cursor paging across pages for expired active deliveries', async () => {
+    const { db } = track(openDb());
+    const base = await seedWorkspace(db);
+    const now = new Date('2026-01-01T00:00:00.000Z');
+
+    for (let i = 0; i < 3; i++) {
+      const msg = await insertMessage(db, base, idAt(1, i));
+      await insertDelivery(db, base, msg, 'queued', 1, 20);
+    }
+
+    const first = await pruneExpired(db, {
+      now,
+      expiredDeliveryGraceDays: 7,
+      batchLimit: 1,
+      maxBatches: 1,
+      defaults: {
+        deliveryTtlDays: null,
+        messageLogTtlDays: null,
+        workspaceEventTtlDays: null,
+        messageTtlDays: null,
+      },
+    });
+    expect(first.expiredDeliveries).toBe(1);
+    expect(await db.select().from(deliveries)).toHaveLength(2);
+
+    const second = await pruneExpired(db, {
+      now,
+      expiredDeliveryGraceDays: 7,
+      batchLimit: 1,
+      maxBatches: 5,
+      defaults: {
+        deliveryTtlDays: null,
+        messageLogTtlDays: null,
+        workspaceEventTtlDays: null,
+        messageTtlDays: null,
+      },
+    });
+    expect(second.expiredDeliveries).toBe(2);
+    expect(await db.select().from(deliveries)).toHaveLength(0);
   });
 
   it('does not reuse a delivery sequence after settled delivery retention', async () => {

--- a/packages/engine/src/engine/boundedRetention.ts
+++ b/packages/engine/src/engine/boundedRetention.ts
@@ -17,6 +17,7 @@ type Candidate = {
   id: string;
   workspace_id: string;
   created_at: number;
+  expires_at: number | null;
   seq: number;
   message_id: string;
   agent_id: string;
@@ -40,6 +41,9 @@ const tables: Table[] = [
   { result: 'deliveries', name: 'deliveries', index: 'idx_deliveries_settled_retention',
     keys: ['created_at', 'id'], setting: 'delivery_ttl_days', fallback: 'deliveryTtlDays',
     predicate: "status IN ('acked', 'failed', 'dead_lettered')" },
+  { result: 'expiredDeliveries', name: 'deliveries', index: 'idx_deliveries_active_expiry',
+    keys: ['expires_at', 'id'],
+    predicate: "status IN ('queued', 'delivered') AND expires_at IS NOT NULL" },
   { result: 'messageLogs', name: 'message_logs', index: 'idx_message_logs_retention',
     keys: ['length(id)', 'id'], setting: 'message_log_ttl_days', fallback: 'messageLogTtlDays' },
   { result: 'workspaceEvents', name: 'workspace_events', index: 'idx_workspace_events_retention',
@@ -53,13 +57,28 @@ const tables: Table[] = [
 
 /** Project a candidate onto its table's ordered keyset cursor. */
 function key(row: Candidate, table: Table): (string | number)[] {
-  return table.keys.map(k => k === 'length(id)' ? row.id.length : row[k as keyof Candidate] as string | number);
+  return table.keys.map(k => {
+    if (k === 'length(id)') return row.id.length;
+    return row[k as keyof Candidate] as string | number;
+  });
 }
 
 /** Apply exact workspace policy after the bounded candidate read. */
-function expired(row: Candidate, table: Table, defaults: Required<RetentionDefaults>, nowMs: number): boolean {
+function expired(
+  row: Candidate,
+  table: Table,
+  defaults: Required<RetentionDefaults>,
+  nowMs: number,
+  expiredDeliveryGraceDays: number,
+): boolean {
   if (!row.eligible) return false;
   if (!table.setting || !table.fallback) return true;
+  if (table.result === 'expiredDeliveries') {
+    const graceMs = Math.max(0, Math.floor(expiredDeliveryGraceDays * DAY_MS));
+    // expires_at is stored as a unix timestamp (seconds), so multiply by 1000.
+    if (row.expires_at == null) return false;
+    return row.expires_at * 1000 < nowMs - graceMs;
+  }
   const settings = row.retention ? JSON.parse(row.retention) as WorkspaceRetentionSettings : {};
   const override = settings[table.setting];
   const ttl = override === undefined ? defaults[table.fallback] : override;
@@ -94,6 +113,7 @@ export async function pruneBounded(db: EngineDb, opts: PruneOptions): Promise<Pr
   const started = Date.now();
   const budget = boundedInteger(opts.maxDurationMs, 10_000, 30_000);
   const nowMs = (opts.now ?? new Date()).getTime();
+  const expiredDeliveryGraceDays = opts.expiredDeliveryGraceDays ?? 7;
   const defaults: Required<RetentionDefaults> = {
     messageTtlDays: null, deliveryTtlDays: 90, messageLogTtlDays: 90, workspaceEventTtlDays: 30,
     ...Object.fromEntries(Object.entries(opts.defaults ?? {}).filter(([, value]) => value !== undefined)),
@@ -115,7 +135,7 @@ export async function pruneBounded(db: EngineDb, opts: PruneOptions): Promise<Pr
   const saved = await db.all<{ cursor: string }>(sql`SELECT cursor FROM maintenance_cursors WHERE id = 'retention-v1'`);
   const parsed = saved[0] ? stateSchema.safeParse(decodeCursor(saved[0].cursor)) : undefined;
   const state: State = parsed?.success ? parsed.data : { next: 0, positions: {}, highs: {} };
-  const result: PruneResult = { messages: 0, deliveries: 0, messageLogs: 0, readReceipts: 0, workspaceEvents: 0 };
+  const result: PruneResult = { messages: 0, deliveries: 0, expiredDeliveries: 0, messageLogs: 0, readReceipts: 0, workspaceEvents: 0 };
   const finished = new Set<number>();
   for (let step = 0; step < rounds * tables.length && Date.now() - started < budget; step++) {
     const index = state.next;
@@ -137,6 +157,7 @@ export async function pruneBounded(db: EngineDb, opts: PruneOptions): Promise<Pr
     }
     const columns = sql.raw(table.result === 'readReceipts' ? 'message_id, agent_id'
       : table.result === 'workspaceEvents' ? 'workspace_id, seq, created_at'
+      : table.result === 'expiredDeliveries' ? 'id, workspace_id, created_at, expires_at'
         : 'id, workspace_id, created_at');
     // A traversal has a finite end even while new rows keep arriving. Without
     // this fence the cursor might never wrap to retained rows that later age out.
@@ -180,7 +201,7 @@ export async function pruneBounded(db: EngineDb, opts: PruneOptions): Promise<Pr
       ${table.setting ? sql`LEFT JOIN workspaces w ON w.id = page.workspace_id` : sql``}
       ORDER BY ${sql.raw(table.keys.map(k => k === 'length(id)' ? 'length(page.id)' : 'page.' + k).join(', '))}
     `);
-    const removable = page.filter(row => expired(row, table, defaults, nowMs));
+    const removable = page.filter(row => expired(row, table, defaults, nowMs, expiredDeliveryGraceDays));
     // Two-key identities need two bindings each; leave room under D1's 100.
     for (let offset = 0; offset < removable.length; offset += 40) {
       const chunk = removable.slice(offset, offset + 40);

--- a/packages/engine/src/engine/retention.ts
+++ b/packages/engine/src/engine/retention.ts
@@ -37,6 +37,12 @@ export interface PruneOptions {
   maxBatches?: number;
   /** Clock override for tests. */
   now?: Date;
+  /**
+   * Grace window (days) for expiring long-expired ACTIVE deliveries in bounded
+   * retention. A delivery is eligible when `expires_at * 1000 < nowMs - graceMs`.
+   * Defaults to 7 days.
+   */
+  expiredDeliveryGraceDays?: number;
   /** Deployment-wide TTL fallbacks; see {@link RetentionDefaults}. */
   defaults?: RetentionDefaults;
 }
@@ -45,6 +51,8 @@ export interface PruneOptions {
 export interface PruneResult {
   messages: number;
   deliveries: number;
+  /** Long-expired ACTIVE deliveries (queued/delivered) pruned by bounded retention. */
+  expiredDeliveries: number;
   messageLogs: number;
   readReceipts: number;
   workspaceEvents: number;


### PR DESCRIPTION
In prod D1, there are 4,409,692 queued deliveries with expires_at in the past. They never qualify for bounded retention today because the deliveries boundedRetention entry only lists status IN ('acked','failed','dead_lettered'), so they accumulate and fill the 10GB D1 disk.

This adds a SECOND bounded retention table entry for long-expired ACTIVE deliveries (queued/delivered) gated by a new prune option expiredDeliveryGraceDays (default 7).

No new migration is required because idx_deliveries_active_expiry already exists (migration 0031).

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/AgentWorkforce/relaycast/pull/403?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

