### PR TITLE
fix(engine): reap long-expired active deliveries in bounded retention

### DIFF
--- a/packages/engine/src/engine/__tests__/boundedDatabaseWork.test.ts
+++ b/packages/engine/src/engine/__tests__/boundedDatabaseWork.test.ts
@@ -185,7 +185,7 @@ describe('bounded database work with retained history', () => {
     await expect(pruneExpired(f.db, { now: new Date(NaN), defaults })).rejects.toThrow('Invalid retention clock');
   });
 
-  it('advances retained-only candidate pages durably and never scans active deliveries for retention', async () => {
+  it('advances retained-only candidate pages durably and scans active deliveries only through the expiry index', async () => {
     const f = fixture();
     f.sqlite.exec(`UPDATE deliveries SET created_at = 1;
       UPDATE workspaces SET retention = '{"delivery_ttl_days":null}'`);
@@ -198,7 +198,19 @@ describe('bounded database work with retained history', () => {
     await pruneExpired(nextDb, opts);
     expect(cursor().positions.deliveries[1]).toBe('d0000000020');
     const pages = f.queries.filter(q => q.sql.includes('WITH page AS MATERIALIZED'));
-    expect(pages).toHaveLength(4); // globally disabled message retention does no candidate scan
+    // Globally disabled message retention still does no candidate scan. The
+    // fifth page is the expired-active-delivery entry, which reclaims rows the
+    // settled entry can never see: a `queued` delivery is not covered by any
+    // `delivery_ttl_days` policy, so before this entry existed those rows were
+    // unreclaimable at any TTL and simply accumulated.
+    expect(pages).toHaveLength(5);
+    const activePages = pages.filter(q => q.sql.includes('idx_deliveries_active_expiry'));
+    expect(activePages).toHaveLength(1);
+    // The active set is only ever reached through the partial expiry index —
+    // never an unindexed scan of live deliveries.
+    for (const query of activePages) {
+      expect(query.sql).toContain("status IN ('queued', 'delivered') AND expires_at IS NOT NULL");
+    }
     for (const query of pages) {
       expect(query.params.at(-1)).toBe(10);
       expect(f.sqlite.prepare(query.sql).all(...query.params).length).toBeLessThanOrEqual(10);

--- a/packages/engine/src/engine/__tests__/retention.test.ts
+++ b/packages/engine/src/engine/__tests__/retention.test.ts
@@ -87,8 +87,14 @@ async function insertDelivery(
   messageId: string,
   status: string,
   daysAgo: number,
+  expiresAtDays?: number | null,
 ): Promise<string> {
   const id = `del_${messageId}_${base.agent}`;
+  // `deliveries.expiresAt` is a timestamp column, so drizzle maps a Date to the
+  // stored unix seconds. Passing the seconds directly throws at bind time.
+  const expiresAt = expiresAtDays == null
+    ? null
+    : new Date(Date.now() - expiresAtDays * DAY_MS);
   await db.insert(deliveries).values({
     id,
     workspaceId: base.ws,
@@ -97,6 +103,7 @@ async function insertDelivery(
     status,
     seq: ++deliverySeqCounter,
     createdAt: new Date(Date.now() - daysAgo * DAY_MS),
+    expiresAt,
   });
   return id;
 }
@@ -148,7 +155,14 @@ describe('pruneExpired', () => {
       },
     });
 
-    expect(result).toEqual({ messages: 0, deliveries: 0, messageLogs: 0, readReceipts: 0, workspaceEvents: 0 });
+    expect(result).toEqual({
+      messages: 0,
+      deliveries: 0,
+      expiredDeliveries: 0,
+      messageLogs: 0,
+      readReceipts: 0,
+      workspaceEvents: 0,
+    });
     expect(await db.select().from(messages)).toHaveLength(1);
     expect(await db.select().from(deliveries)).toHaveLength(1);
     expect(await db.select().from(messageLogs)).toHaveLength(1);
@@ -165,6 +179,7 @@ describe('pruneExpired', () => {
 
     expect(result.messages).toBe(0);
     expect(result.deliveries).toBe(1);
+    expect(result.expiredDeliveries).toBe(0);
     expect(result.messageLogs).toBe(1);
     expect(await db.select().from(messages)).toHaveLength(1);
     expect(await db.select().from(deliveries)).toHaveLength(0);
@@ -297,8 +312,175 @@ describe('pruneExpired', () => {
     const result = await pruneExpired(db);
 
     expect(result.deliveries).toBe(2);
+    expect(result.expiredDeliveries).toBe(0);
     const remaining = (await db.select({ status: deliveries.status }).from(deliveries)).map((r) => r.status);
     expect(remaining.sort()).toEqual(['acked', 'queued']);
+  });
+
+  it('deletes a queued delivery expired longer than the grace window', async () => {
+    const { db } = track(openDb());
+    const base = await seedWorkspace(db);
+    // The delivery fixtures below derive `expires_at` from the real clock,
+    // so the prune must read the same reference or nothing is ever past
+    // its grace window.
+    const now = new Date();
+
+    await insertDelivery(db, base, await insertMessage(db, base, idAt(1)), 'queued', 1, 20);
+    // Ensure settled-delivery TTL is disabled so only the new entry can delete.
+    const result = await pruneExpired(db, {
+      now,
+      expiredDeliveryGraceDays: 7,
+      defaults: {
+        deliveryTtlDays: null,
+        messageLogTtlDays: null,
+        workspaceEventTtlDays: null,
+        messageTtlDays: null,
+      },
+    });
+
+    expect(result.expiredDeliveries).toBe(1);
+    expect(await db.select().from(deliveries)).toHaveLength(0);
+  });
+
+  it('does not delete a queued delivery expired inside the grace window', async () => {
+    const { db } = track(openDb());
+    const base = await seedWorkspace(db);
+    // The delivery fixtures below derive `expires_at` from the real clock,
+    // so the prune must read the same reference or nothing is ever past
+    // its grace window.
+    const now = new Date();
+
+    await insertDelivery(db, base, await insertMessage(db, base, idAt(1)), 'queued', 1, 3);
+    const result = await pruneExpired(db, {
+      now,
+      expiredDeliveryGraceDays: 7,
+      defaults: {
+        deliveryTtlDays: null,
+        messageLogTtlDays: null,
+        workspaceEventTtlDays: null,
+        messageTtlDays: null,
+      },
+    });
+
+    expect(result.expiredDeliveries).toBe(0);
+    expect(await db.select().from(deliveries)).toHaveLength(1);
+  });
+
+  it('does not delete a queued delivery with expires_at NULL', async () => {
+    const { db } = track(openDb());
+    const base = await seedWorkspace(db);
+    // The delivery fixtures below derive `expires_at` from the real clock,
+    // so the prune must read the same reference or nothing is ever past
+    // its grace window.
+    const now = new Date();
+
+    await insertDelivery(db, base, await insertMessage(db, base, idAt(1)), 'queued', 1, null);
+    const result = await pruneExpired(db, {
+      now,
+      expiredDeliveryGraceDays: 7,
+      defaults: {
+        deliveryTtlDays: null,
+        messageLogTtlDays: null,
+        workspaceEventTtlDays: null,
+        messageTtlDays: null,
+      },
+    });
+
+    expect(result.expiredDeliveries).toBe(0);
+    expect(await db.select().from(deliveries)).toHaveLength(1);
+  });
+
+  it('deletes a delivered delivery long past expiry', async () => {
+    const { db } = track(openDb());
+    const base = await seedWorkspace(db);
+    // The delivery fixtures below derive `expires_at` from the real clock,
+    // so the prune must read the same reference or nothing is ever past
+    // its grace window.
+    const now = new Date();
+
+    await insertDelivery(db, base, await insertMessage(db, base, idAt(1)), 'delivered', 1, 20);
+    const result = await pruneExpired(db, {
+      now,
+      expiredDeliveryGraceDays: 7,
+      defaults: {
+        deliveryTtlDays: null,
+        messageLogTtlDays: null,
+        workspaceEventTtlDays: null,
+        messageTtlDays: null,
+      },
+    });
+
+    expect(result.expiredDeliveries).toBe(1);
+    expect(await db.select().from(deliveries)).toHaveLength(0);
+  });
+
+  it('leaves an acked delivery untouched by the new entry', async () => {
+    const { db } = track(openDb());
+    const base = await seedWorkspace(db);
+    // The delivery fixtures below derive `expires_at` from the real clock,
+    // so the prune must read the same reference or nothing is ever past
+    // its grace window.
+    const now = new Date();
+
+    const msg = await insertMessage(db, base, idAt(1));
+    await insertDelivery(db, base, msg, 'acked', 1, 20);
+    const result = await pruneExpired(db, {
+      now,
+      expiredDeliveryGraceDays: 7,
+      defaults: {
+        deliveryTtlDays: null,
+        messageLogTtlDays: null,
+        workspaceEventTtlDays: null,
+        messageTtlDays: null,
+      },
+    });
+
+    expect(result.expiredDeliveries).toBe(0);
+    expect((await db.select().from(deliveries)).map((r) => r.status)).toEqual(['acked']);
+  });
+
+  it('advances cursor paging across pages for expired active deliveries', async () => {
+    const { db } = track(openDb());
+    const base = await seedWorkspace(db);
+    // The delivery fixtures below derive `expires_at` from the real clock,
+    // so the prune must read the same reference or nothing is ever past
+    // its grace window.
+    const now = new Date();
+
+    for (let i = 0; i < 3; i++) {
+      const msg = await insertMessage(db, base, idAt(1, i));
+      await insertDelivery(db, base, msg, 'queued', 1, 20);
+    }
+
+    const first = await pruneExpired(db, {
+      now,
+      expiredDeliveryGraceDays: 7,
+      batchLimit: 1,
+      maxBatches: 1,
+      defaults: {
+        deliveryTtlDays: null,
+        messageLogTtlDays: null,
+        workspaceEventTtlDays: null,
+        messageTtlDays: null,
+      },
+    });
+    expect(first.expiredDeliveries).toBe(1);
+    expect(await db.select().from(deliveries)).toHaveLength(2);
+
+    const second = await pruneExpired(db, {
+      now,
+      expiredDeliveryGraceDays: 7,
+      batchLimit: 1,
+      maxBatches: 5,
+      defaults: {
+        deliveryTtlDays: null,
+        messageLogTtlDays: null,
+        workspaceEventTtlDays: null,
+        messageTtlDays: null,
+      },
+    });
+    expect(second.expiredDeliveries).toBe(2);
+    expect(await db.select().from(deliveries)).toHaveLength(0);
   });
 
   it('does not reuse a delivery sequence after settled delivery retention', async () => {

--- a/packages/engine/src/engine/boundedRetention.ts
+++ b/packages/engine/src/engine/boundedRetention.ts
@@ -6,17 +6,12 @@ import type { PruneOptions, PruneResult, RetentionDefaults } from './retention.j
 import { snowflakeIdLowerBound } from './snowflake.js';
 
 const DAY_MS = 86_400_000;
-const position = z.array(z.union([z.string(), z.number()]));
-const stateSchema = z.object({
-  next: z.number().int().min(0).max(4),
-  positions: z.record(z.string(), position),
-  highs: z.record(z.string(), position).default({}),
-});
-type State = z.infer<typeof stateSchema>;
+
 type Candidate = {
   id: string;
   workspace_id: string;
   created_at: number;
+  expires_at: number | null;
   seq: number;
   message_id: string;
   agent_id: string;
@@ -40,6 +35,9 @@ const tables: Table[] = [
   { result: 'deliveries', name: 'deliveries', index: 'idx_deliveries_settled_retention',
     keys: ['created_at', 'id'], setting: 'delivery_ttl_days', fallback: 'deliveryTtlDays',
     predicate: "status IN ('acked', 'failed', 'dead_lettered')" },
+  { result: 'expiredDeliveries', name: 'deliveries', index: 'idx_deliveries_active_expiry',
+    keys: ['expires_at', 'id'],
+    predicate: "status IN ('queued', 'delivered') AND expires_at IS NOT NULL" },
   { result: 'messageLogs', name: 'message_logs', index: 'idx_message_logs_retention',
     keys: ['length(id)', 'id'], setting: 'message_log_ttl_days', fallback: 'messageLogTtlDays' },
   { result: 'workspaceEvents', name: 'workspace_events', index: 'idx_workspace_events_retention',
@@ -51,14 +49,44 @@ const tables: Table[] = [
     eligible: 'NOT EXISTS (SELECT 1 FROM messages m WHERE m.id = page.message_id)' },
 ];
 
+const position = z.array(z.union([z.string(), z.number()]));
+// Declared after `tables` so the rotation bound tracks the table count. A
+// hard-coded bound silently rejects every persisted cursor once an entry is
+// added, which resets the traversal on every run instead of resuming it.
+const stateSchema = z.object({
+  next: z.number().int().min(0),
+  positions: z.record(z.string(), position),
+  highs: z.record(z.string(), position).default({}),
+}).refine(state => state.next < tables.length, { path: ['next'] });
+type State = z.infer<typeof stateSchema>;
+
 /** Project a candidate onto its table's ordered keyset cursor. */
 function key(row: Candidate, table: Table): (string | number)[] {
-  return table.keys.map(k => k === 'length(id)' ? row.id.length : row[k as keyof Candidate] as string | number);
+  return table.keys.map(k => {
+    if (k === 'length(id)') return row.id.length;
+    return row[k as keyof Candidate] as string | number;
+  });
 }
 
 /** Apply exact workspace policy after the bounded candidate read. */
-function expired(row: Candidate, table: Table, defaults: Required<RetentionDefaults>, nowMs: number): boolean {
+function expired(
+  row: Candidate,
+  table: Table,
+  defaults: Required<RetentionDefaults>,
+  nowMs: number,
+  expiredDeliveryGraceDays: number,
+): boolean {
   if (!row.eligible) return false;
+  // MUST precede the `!table.setting` fallthrough below. This entry carries no
+  // workspace TTL setting, so reaching that line would return `true` for every
+  // row on the page and delete live, unexpired deliveries.
+  if (table.result === 'expiredDeliveries') {
+    if (row.expires_at == null) return false;
+    const graceMs = Math.max(0, Math.floor(expiredDeliveryGraceDays * DAY_MS));
+    // `expires_at` is a unix timestamp in seconds; this page comes from a raw
+    // SELECT, so it arrives as an integer rather than a mapped Date.
+    return row.expires_at * 1000 < nowMs - graceMs;
+  }
   if (!table.setting || !table.fallback) return true;
   const settings = row.retention ? JSON.parse(row.retention) as WorkspaceRetentionSettings : {};
   const override = settings[table.setting];
@@ -94,6 +122,7 @@ export async function pruneBounded(db: EngineDb, opts: PruneOptions): Promise<Pr
   const started = Date.now();
   const budget = boundedInteger(opts.maxDurationMs, 10_000, 30_000);
   const nowMs = (opts.now ?? new Date()).getTime();
+  const expiredDeliveryGraceDays = opts.expiredDeliveryGraceDays ?? 7;
   const defaults: Required<RetentionDefaults> = {
     messageTtlDays: null, deliveryTtlDays: 90, messageLogTtlDays: 90, workspaceEventTtlDays: 30,
     ...Object.fromEntries(Object.entries(opts.defaults ?? {}).filter(([, value]) => value !== undefined)),
@@ -115,21 +144,27 @@ export async function pruneBounded(db: EngineDb, opts: PruneOptions): Promise<Pr
   const saved = await db.all<{ cursor: string }>(sql`SELECT cursor FROM maintenance_cursors WHERE id = 'retention-v1'`);
   const parsed = saved[0] ? stateSchema.safeParse(decodeCursor(saved[0].cursor)) : undefined;
   const state: State = parsed?.success ? parsed.data : { next: 0, positions: {}, highs: {} };
-  const result: PruneResult = { messages: 0, deliveries: 0, messageLogs: 0, readReceipts: 0, workspaceEvents: 0 };
+  const result: PruneResult = { messages: 0, deliveries: 0, expiredDeliveries: 0, messageLogs: 0, readReceipts: 0, workspaceEvents: 0 };
   const finished = new Set<number>();
   for (let step = 0; step < rounds * tables.length && Date.now() - started < budget; step++) {
     const index = state.next;
     state.next = (index + 1) % tables.length;
     if (finished.has(index)) continue;
     const table = tables[index]!;
-    const cursor = state.positions[table.name];
+    // Keyed by `result`, not `name`: two entries can traverse the SAME table
+    // through different indexes and key tuples (`deliveries` is walked by
+    // (created_at, id) for settled rows and by (expires_at, id) for expired
+    // active ones). Sharing a cursor between them would feed one entry's
+    // keyset position to the other and silently filter out every candidate.
+    const stateKey = table.result;
+    const cursor = state.positions[stateKey];
     const positiveTtls = table.fallback
       ? [defaults[table.fallback], minimums?.[table.result]].filter((ttl): ttl is number =>
         typeof ttl === 'number' && Number.isFinite(ttl) && ttl > 0)
       : [];
     if (table.fallback && !positiveTtls.length) {
-      delete state.positions[table.name];
-      delete state.highs[table.name];
+      delete state.positions[stateKey];
+      delete state.highs[stateKey];
       finished.add(index);
       await db.run(sql`INSERT INTO maintenance_cursors (id, cursor) VALUES ('retention-v1', ${JSON.stringify(state)})
         ON CONFLICT(id) DO UPDATE SET cursor = excluded.cursor`);
@@ -137,15 +172,16 @@ export async function pruneBounded(db: EngineDb, opts: PruneOptions): Promise<Pr
     }
     const columns = sql.raw(table.result === 'readReceipts' ? 'message_id, agent_id'
       : table.result === 'workspaceEvents' ? 'workspace_id, seq, created_at'
+      : table.result === 'expiredDeliveries' ? 'id, workspace_id, created_at, expires_at'
         : 'id, workspace_id, created_at');
     // A traversal has a finite end even while new rows keep arriving. Without
     // this fence the cursor might never wrap to retained rows that later age out.
-    if (!state.highs[table.name]) {
+    if (!state.highs[stateKey]) {
       const [last] = await db.all<Candidate>(sql`SELECT ${columns}
         FROM ${sql.raw(table.name)} INDEXED BY ${sql.raw(table.index)}
         ${table.predicate ? sql`WHERE ${sql.raw(table.predicate)}` : sql``}
         ORDER BY ${sql.raw(table.keys.map(k => k + ' DESC').join(', '))} LIMIT 1`);
-      if (last) state.highs[table.name] = key(last, table);
+      if (last) state.highs[stateKey] = key(last, table);
     }
     const predicates: SQL[] = [];
     if (table.predicate) predicates.push(sql.raw(table.predicate));
@@ -161,7 +197,7 @@ export async function pruneBounded(db: EngineDb, opts: PruneOptions): Promise<Pr
     if (cursor?.length === table.keys.length) {
       predicates.push(sql`(${sql.raw(table.keys.join(', '))}) > (${sql.join(cursor.map(v => sql`${v}`), sql`, `)})`);
     }
-    const high = state.highs[table.name];
+    const high = state.highs[stateKey];
     if (high?.length === table.keys.length) {
       predicates.push(sql`(${sql.raw(table.keys.join(', '))}) <= (${sql.join(high.map(v => sql`${v}`), sql`, `)})`);
     }
@@ -180,7 +216,7 @@ export async function pruneBounded(db: EngineDb, opts: PruneOptions): Promise<Pr
       ${table.setting ? sql`LEFT JOIN workspaces w ON w.id = page.workspace_id` : sql``}
       ORDER BY ${sql.raw(table.keys.map(k => k === 'length(id)' ? 'length(page.id)' : 'page.' + k).join(', '))}
     `);
-    const removable = page.filter(row => expired(row, table, defaults, nowMs));
+    const removable = page.filter(row => expired(row, table, defaults, nowMs, expiredDeliveryGraceDays));
     // Two-key identities need two bindings each; leave room under D1's 100.
     for (let offset = 0; offset < removable.length; offset += 40) {
       const chunk = removable.slice(offset, offset + 40);
@@ -197,11 +233,11 @@ export async function pruneBounded(db: EngineDb, opts: PruneOptions): Promise<Pr
       result[table.result] += deleted.length;
     }
     if (page.length < limit || JSON.stringify(key(page[page.length - 1]!, table)) === JSON.stringify(high)) {
-      delete state.positions[table.name];
-      delete state.highs[table.name];
+      delete state.positions[stateKey];
+      delete state.highs[stateKey];
       finished.add(index);
     } else {
-      state.positions[table.name] = key(page[page.length - 1]!, table);
+      state.positions[stateKey] = key(page[page.length - 1]!, table);
     }
     await db.run(sql`INSERT INTO maintenance_cursors (id, cursor) VALUES ('retention-v1', ${JSON.stringify(state)})
       ON CONFLICT(id) DO UPDATE SET cursor = excluded.cursor`);

--- a/packages/engine/src/engine/retention.ts
+++ b/packages/engine/src/engine/retention.ts
@@ -37,6 +37,12 @@ export interface PruneOptions {
   maxBatches?: number;
   /** Clock override for tests. */
   now?: Date;
+  /**
+   * Grace window (days) for expiring long-expired ACTIVE deliveries in bounded
+   * retention. A delivery is eligible when `expires_at * 1000 < nowMs - graceMs`.
+   * Defaults to 7 days.
+   */
+  expiredDeliveryGraceDays?: number;
   /** Deployment-wide TTL fallbacks; see {@link RetentionDefaults}. */
   defaults?: RetentionDefaults;
 }
@@ -45,6 +51,8 @@ export interface PruneOptions {
 export interface PruneResult {
   messages: number;
   deliveries: number;
+  /** Long-expired ACTIVE deliveries (queued/delivered) pruned by bounded retention. */
+  expiredDeliveries: number;
   messageLogs: number;
   readReceipts: number;
   workspaceEvents: number;


### PR DESCRIPTION
## Why

`boundedRetention` only ever covered **settled** deliveries — `status IN ('acked','failed','dead_lettered')`. A `queued` or `delivered` row whose `expires_at` has long passed is covered by no `delivery_ttl_days` policy **at any value**, so it was unreclaimable and simply accumulated.

Relaycast production, measured today:

| status | rows | reapable before this PR |
|---|---|---|
| `queued` (4,409,692 already past `expires_at`) | 4,409,767 | **never, at any TTL** |
| `dead_lettered` | 4,197,199 | not until ~Nov 8 (90d default, oldest row 30d old) |
| acked / delivered / failed | 41,037 | yes |

8.65M rows in a **9.9 GB database against D1's 10 GB cap**, ~99% owned by a single workspace. `min(rowid)` on `deliveries` did not move all day.

## What

A second `tables` entry for expired active deliveries, keyed `(expires_at, id)` on the **existing** `idx_deliveries_active_expiry` partial index from migration 0031. **No new migration, no DDL** — which matters, because D1 capacity currently blocks migrations. Eligibility is `expires_at` older than `expiredDeliveryGraceDays` (default 7), independent of any workspace TTL.

## Three defects fixed to make it correct

1. **`expired()` must test this entry before the `!table.setting` fallthrough.** The entry carries no workspace TTL setting, so reaching that guard returns `true` for every row on the page — deleting `queued` deliveries that had not expired at all.
2. **Cursors are keyed by `table.result`, not `table.name`.** Two entries now traverse `deliveries` through different indexes and key tuples — `(created_at, id)` and `(expires_at, id)` — and sharing one cursor fed each entry the other's keyset position, filtering out every candidate.
3. **`stateSchema` bounded `next` at a hard-coded `4`,** sized for five entries. With six, any persisted cursor reaching the new entry failed validation and silently reset the whole traversal on every run.

## Invariant change, stated explicitly

`boundedDatabaseWork.test.ts` asserted that retention *never* scans active deliveries. That invariant is **narrowed, not dropped**: the active set is now reached only through the partial expiry index, never an unindexed scan, and the test asserts exactly that. Reviewers should confirm they're happy with that narrowing — it is the point of the PR.

## Verification

951 engine tests, typecheck, and lint pass. The six behavioural tests are red against the parent commit:
- expired beyond the grace window is deleted; inside it is not
- `expires_at IS NULL` is never deleted
- `delivered` long past expiry is deleted
- `acked` stays with the settled entry
- cursor paging advances across pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YFC87QQoACaBWwonRBWTEb

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/AgentWorkforce/relaycast/pull/404?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes bounded retention deletion rules and cursor persistence for maintenance; incorrect eligibility or cursor sharing could delete or skip live deliveries, though behavior is heavily tested and scoped to index-backed expired-active rows.
> 
> **Overview**
> Bounded retention now deletes **queued** and **delivered** rows whose `expires_at` is well past due, using the existing `idx_deliveries_active_expiry` partial index and a configurable grace window (`expiredDeliveryGraceDays`, default **7**). Deletes are reported separately as `expiredDeliveries` on `PruneResult`; settled delivery TTL pruning is unchanged.
> 
> Supporting fixes keep the new pass safe and resumable: `expired()` handles this table before the no-setting fallthrough, maintenance cursors are keyed by `table.result` (so two `deliveries` walks do not share keyset state), and cursor validation’s rotation bound follows `tables.length` instead of a hard-coded cap.
> 
> Tests cover grace inside/outside the window, `expires_at` null, status boundaries (`acked` vs active), batched cursor paging, and the narrowed invariant that active deliveries are only touched via the expiry index—not a full-table scan.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 50755ef76bf3f8af7c4d03d3fc7c846d2873e011. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->