### PR TITLE
fix(engine): reap long-expired active deliveries on the deployed retention path (8.5.2-hotfix.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Packages without a separate changelog are covered by the cross-package notes bel
 
 - Hosts can bound retention candidate scans with persisted rowid cursors without schema changes, preserving workspace TTLs and table fairness.
 - Node replay uses bounded, ordered database pages with existing indexes, reducing shared-database contention without requiring schema changes.
+- Opt-in schema-free retention can safely delete active `queued`/`delivered` deliveries after the grace window without emitting `delivery.failed` notices (preserving rollback compatibility for `cursorStore` v1).
 
 ## [8.5.2] - 2026-09-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Packages without a separate changelog are covered by the cross-package notes bel
 - Hosts can bound retention candidate scans with persisted rowid cursors without schema changes, preserving workspace TTLs and table fairness.
 - Node replay uses bounded, ordered database pages with existing indexes, reducing shared-database contention without requiring schema changes.
 - Opt-in schema-free retention can safely delete active `queued`/`delivered` deliveries after the grace window without emitting `delivery.failed` notices (preserving rollback compatibility for `cursorStore` v1).
+- Node queued backlog sweeps can opt into a bounded per-agent `wsBacklogLimit` so hosts control how many `ws-node` backlog rows are redriven per sweep.
 
 ## [8.5.2] - 2026-09-07
 

--- a/packages/engine/CHANGELOG.md
+++ b/packages/engine/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 - `pruneExpired` accepts a host-owned `cursorStore` for schema-free bounded rowid candidate scans and a `maxDurationMs` admission budget. Serialize calls and persist state durably; TTL policies are unchanged. In-flight SQL and message cascades are not canceled or write-bounded.
 - Node replay uses bounded, ordered database pages with existing indexes, reducing shared-database contention without requiring schema changes.
 - Opt-in schema-free retention can safely delete active `queued`/`delivered` deliveries after the grace window via a set-based `idx_deliveries_active_expiry` path that skips `delivery.failed` notices (cursorStore v1 rollback compatibility preserved).
+- `sweepDueNodeDeliveries` can now opt into a bounded per-agent `wsBacklogLimit` for redriving `ws-node` backlog rows.
 
 ## [8.5.2] - 2026-09-07
 

--- a/packages/engine/CHANGELOG.md
+++ b/packages/engine/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 - `pruneExpired` accepts a host-owned `cursorStore` for schema-free bounded rowid candidate scans and a `maxDurationMs` admission budget. Serialize calls and persist state durably; TTL policies are unchanged. In-flight SQL and message cascades are not canceled or write-bounded.
 - Node replay uses bounded, ordered database pages with existing indexes, reducing shared-database contention without requiring schema changes.
+- Opt-in schema-free retention can safely delete active `queued`/`delivered` deliveries after the grace window via a set-based `idx_deliveries_active_expiry` path that skips `delivery.failed` notices (cursorStore v1 rollback compatibility preserved).
 
 ## [8.5.2] - 2026-09-07
 

--- a/packages/engine/src/__tests__/conformance/delivery.test.ts
+++ b/packages/engine/src/__tests__/conformance/delivery.test.ts
@@ -1588,11 +1588,12 @@ describe('durable delivery api', () => {
     expect(row3.nextAttemptAt).toBeNull();
   });
 
-  it('sweepDueNodeDeliveries respects wsBacklogLimit ordering and later drains, and a capped undeliverable row fails only after expiry', async () => {
+  it('sweepDueNodeDeliveries respects wsBacklogLimit ordering and later drains, emits no delivery.failed for capped rows, and emits exactly one expiry delivery.failed', async () => {
     const ws = await createWorkspace(stack.app, 'mailbox-ws-sweep-backlog-limit');
     const alice = await registerAgent(stack.app, ws.workspaceKey, 'alice');
     const node = await enrollAndAttachNode(ws, { cursorHandshake: true });
     const bob = await registerViaNode(node, 'bob');
+    const { sock: aliceSock } = await attachDirectNodeSocket(stack, ws.workspaceId, alice);
 
     // Queue 3 deliveries seq 1..3 by sending 3 messages.
     for (const text of ['one', 'two', 'three']) {
@@ -1616,16 +1617,6 @@ describe('durable delivery api', () => {
       .set({ status: 'queued', nextAttemptAt: null, dispatchAttempts: 0, deliveredAt: null, lastDispatchError: null })
       .where(and(eq(deliveries.workspaceId, ws.workspaceId), eq(deliveries.agentId, bob.agentId)));
 
-    // Make the 3rd send throw. With wsBacklogLimit=2, the sweep must not
-    // attempt seq 3 in this invocation.
-    let sendCount = 0;
-    const originalSend = node.sock.send.bind(node.sock);
-    node.sock.send = ((frame: unknown) => {
-      sendCount++;
-      if (sendCount === 3) throw new Error('socket write failed');
-      return originalSend(frame);
-    }) as typeof node.sock.send;
-
     const beforeDeliver = node.sock.ofType('deliver').length;
     const swept = await sweepDueNodeDeliveries(stack.runtime.deps, { now: new Date(), wsBacklogLimit: 2 });
     expect(swept).toBe(3);
@@ -1640,24 +1631,26 @@ describe('durable delivery api', () => {
     expect(row1.status).toBe('delivered');
     expect(row2.status).toBe('delivered');
     expect(row3.status).toBe('queued');
+    expect(contextUpdatesOfType(aliceSock, 'delivery.failed')).toHaveLength(0);
 
-    // Restore send and drain the remaining backlog on the next sweep.
-    node.sock.send = originalSend;
+    // Drain the remaining backlog on the next sweep.
     const secondSwept = await sweepDueNodeDeliveries(stack.runtime.deps, { now: new Date(Date.now() + 1_000) });
     expect(secondSwept).toBe(1);
     const [row3After] = await db.select().from(deliveries).where(seq3);
     expect(row3After.status).toBe('delivered');
 
-    // Expiry check: reset seq3 again, then fast-forward beyond TTL expiry
-    // so sweepExpiredDeliveries dead-letters it (one expiry failure).
-    await db.update(deliveries).set({ status: 'queued', nextAttemptAt: null, dispatchAttempts: 0, deliveredAt: null, lastDispatchError: null })
-      .where(seq3);
+    // Expiry check: reset seq3 again, expire it, then sweepExpiredDeliveries
+    // should dead-letter it and emit exactly one delivery.failed.
+    await db.update(deliveries).set({
+      status: 'queued', nextAttemptAt: null, dispatchAttempts: 0, deliveredAt: null, lastDispatchError: null, expiresAt: new Date(Date.now() - 60_000),
+    }).where(seq3);
     await stack.settle();
-    const expiredNow = new Date(Date.now() + 120 * 86_400_000);
+    const expiredNow = new Date(Date.now() + 60_000);
     const expired = await sweepExpiredDeliveries(stack.runtime.deps, { now: expiredNow, maxBatches: 5 });
     expect(expired).toBeGreaterThanOrEqual(1);
     const [row3Dead] = await db.select().from(deliveries).where(seq3);
     expect(row3Dead.status).toBe('dead_lettered');
+    expect(contextUpdatesOfType(aliceSock, 'delivery.failed')).toHaveLength(1);
   });
 
   it('honors recorded route metadata when live binding changes before fanout', async () => {

--- a/packages/engine/src/__tests__/conformance/delivery.test.ts
+++ b/packages/engine/src/__tests__/conformance/delivery.test.ts
@@ -1588,6 +1588,78 @@ describe('durable delivery api', () => {
     expect(row3.nextAttemptAt).toBeNull();
   });
 
+  it('sweepDueNodeDeliveries respects wsBacklogLimit ordering and later drains, and a capped undeliverable row fails only after expiry', async () => {
+    const ws = await createWorkspace(stack.app, 'mailbox-ws-sweep-backlog-limit');
+    const alice = await registerAgent(stack.app, ws.workspaceKey, 'alice');
+    const node = await enrollAndAttachNode(ws, { cursorHandshake: true });
+    const bob = await registerViaNode(node, 'bob');
+
+    // Queue 3 deliveries seq 1..3 by sending 3 messages.
+    for (const text of ['one', 'two', 'three']) {
+      const post = await stack.app.request('/v1/channels/general/messages', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json', authorization: `Bearer ${alice.token}` },
+        body: JSON.stringify({ text }),
+      });
+      expect(post.status).toBe(201);
+    }
+    await waitForAssertion(() => expect(node.sock.ofType('deliver')).toHaveLength(3));
+
+    const db = stack.runtime.deps.db;
+    const seq1 = and(eq(deliveries.workspaceId, ws.workspaceId), eq(deliveries.agentId, bob.agentId), eq(deliveries.seq, 1));
+    const seq2 = and(eq(deliveries.workspaceId, ws.workspaceId), eq(deliveries.agentId, bob.agentId), eq(deliveries.seq, 2));
+    const seq3 = and(eq(deliveries.workspaceId, ws.workspaceId), eq(deliveries.agentId, bob.agentId), eq(deliveries.seq, 3));
+
+    // Reset deliveries so the sweep must redrive the backlog.
+    await db
+      .update(deliveries)
+      .set({ status: 'queued', nextAttemptAt: null, dispatchAttempts: 0, deliveredAt: null, lastDispatchError: null })
+      .where(and(eq(deliveries.workspaceId, ws.workspaceId), eq(deliveries.agentId, bob.agentId)));
+
+    // Make the 3rd send throw. With wsBacklogLimit=2, the sweep must not
+    // attempt seq 3 in this invocation.
+    let sendCount = 0;
+    const originalSend = node.sock.send.bind(node.sock);
+    node.sock.send = ((frame: unknown) => {
+      sendCount++;
+      if (sendCount === 3) throw new Error('socket write failed');
+      return originalSend(frame);
+    }) as typeof node.sock.send;
+
+    const beforeDeliver = node.sock.ofType('deliver').length;
+    const swept = await sweepDueNodeDeliveries(stack.runtime.deps, { now: new Date(), wsBacklogLimit: 2 });
+    expect(swept).toBe(3);
+
+    // Only two frames emitted due to wsBacklogLimit; seq 3 untouched.
+    const redriven = node.sock.ofType('deliver').slice(beforeDeliver);
+    expect(redriven.map((frame) => frame.seq)).toEqual([1, 2]);
+
+    const [row1] = await db.select().from(deliveries).where(seq1);
+    const [row2] = await db.select().from(deliveries).where(seq2);
+    const [row3] = await db.select().from(deliveries).where(seq3);
+    expect(row1.status).toBe('delivered');
+    expect(row2.status).toBe('delivered');
+    expect(row3.status).toBe('queued');
+
+    // Restore send and drain the remaining backlog on the next sweep.
+    node.sock.send = originalSend;
+    const secondSwept = await sweepDueNodeDeliveries(stack.runtime.deps, { now: new Date(Date.now() + 1_000) });
+    expect(secondSwept).toBe(1);
+    const [row3After] = await db.select().from(deliveries).where(seq3);
+    expect(row3After.status).toBe('delivered');
+
+    // Expiry check: reset seq3 again, then fast-forward beyond TTL expiry
+    // so sweepExpiredDeliveries dead-letters it (one expiry failure).
+    await db.update(deliveries).set({ status: 'queued', nextAttemptAt: null, dispatchAttempts: 0, deliveredAt: null, lastDispatchError: null })
+      .where(seq3);
+    await stack.settle();
+    const expiredNow = new Date(Date.now() + 120 * 86_400_000);
+    const expired = await sweepExpiredDeliveries(stack.runtime.deps, { now: expiredNow, maxBatches: 5 });
+    expect(expired).toBeGreaterThanOrEqual(1);
+    const [row3Dead] = await db.select().from(deliveries).where(seq3);
+    expect(row3Dead.status).toBe('dead_lettered');
+  });
+
   it('honors recorded route metadata when live binding changes before fanout', async () => {
     const ws = await createWorkspace(stack.app, 'mailbox-reroute');
     const alice = await registerAgent(stack.app, ws.workspaceKey, 'alice');

--- a/packages/engine/src/engine/__tests__/rowidRetention.test.ts
+++ b/packages/engine/src/engine/__tests__/rowidRetention.test.ts
@@ -331,25 +331,6 @@ describe('schema-free retention candidate pages', () => {
     expect(statements.length).toBeLessThanOrEqual(4);
   });
 
-  it('does not delete an expired queued row that was acked after the candidate read', async () => {
-    const f = fixture(); const msg = f.message(1);
-    const raced = f.delivery(msg, 'queued', seconds, 'one', seconds - 30 * 86400);
-    const original = f.sqlite.prepare.bind(f.sqlite);
-    // Flip the row to `acked` between the page read and the DELETE. The widened
-    // guard still matches it (acked is settled), so without a status guard it
-    // would be deleted under the expiry rule with its own TTL never checked.
-    let flipped = false;
-    (f.sqlite as unknown as { prepare: typeof original }).prepare = ((query: string) => {
-      if (!flipped && /^DELETE FROM deliveries/i.test(query)) {
-        flipped = true;
-        original("UPDATE deliveries SET status = 'acked' WHERE id = ?").run(raced);
-      }
-      return original(query);
-    }) as typeof original;
-    await f.run({ batchLimit: 50, maxBatches: 5, defaults: { deliveryTtlDays: null } });
-    expect((f.sqlite.prepare('SELECT id FROM deliveries').all() as { id: string }[]).map(r => r.id)).toContain(raced);
-  });
-
   it('accepts a raised page ceiling so a large table can be traversed', async () => {
     const f = fixture(); const msg = f.message(1);
     f.sqlite.transaction(() => { for (let i = 0; i < 600; i++) f.delivery(msg, 'acked', seconds); })();

--- a/packages/engine/src/engine/__tests__/rowidRetention.test.ts
+++ b/packages/engine/src/engine/__tests__/rowidRetention.test.ts
@@ -28,12 +28,12 @@ function fixture() {
     handle.sqlite.prepare('INSERT INTO messages(id,workspace_id,channel_id,agent_id,body,thread_id) VALUES (?,?,?,?,?,?)').run(id, ws, ws, ws, 'body', thread);
     return id;
   };
-  const delivery = (msg: string, status = 'acked', created = old, ws = 'one') => {
+  const delivery = (msg: string, status = 'acked', created = old, ws = 'one', expires: number | null = null) => {
     const id = `delivery-${++sequence}`;
     // A distinct agent is needed for each message/agent delivery uniqueness.
     const agent = `agent-${sequence}`;
     handle.sqlite.prepare('INSERT INTO agents(id,workspace_id,name,token_hash) VALUES (?,?,?,?)').run(agent, ws, agent, agent);
-    handle.sqlite.prepare('INSERT INTO deliveries(id,workspace_id,message_id,agent_id,seq,status,created_at) VALUES (?,?,?,?,?,?,?)').run(id, ws, msg, agent, sequence, status, created);
+    handle.sqlite.prepare('INSERT INTO deliveries(id,workspace_id,message_id,agent_id,seq,status,created_at,expires_at) VALUES (?,?,?,?,?,?,?,?)').run(id, ws, msg, agent, sequence, status, created, expires);
     return id;
   };
   let state: RowidRetentionState | undefined;
@@ -194,4 +194,75 @@ describe('schema-free retention candidate pages', () => {
       expect(f.sqlite.prepare('SELECT count(*) n FROM deliveries').get()).toEqual({ n: 1 });
     },
   );
+
+  // Regression for the 2026-09-09 capacity incident: `queued` / `delivered`
+  // deliveries past `expires_at` are covered by no `delivery_ttl_days` value,
+  // so before this they were unreclaimable at any TTL. 4,409,692 of 4,409,767
+  // queued rows on production were already expired.
+  it('reaps queued and delivered rows long past expires_at', async () => {
+    const f = fixture(); const msg = f.message(1);
+    const staleQueued = f.delivery(msg, 'queued', seconds, 'one', seconds - 30 * 86400);
+    const staleDelivered = f.delivery(msg, 'delivered', seconds, 'one', seconds - 30 * 86400);
+    expect((await f.run({ batchLimit: 50, maxBatches: 5 })).deliveries).toBe(2);
+    const left = f.sqlite.prepare('SELECT id FROM deliveries').all() as { id: string }[];
+    expect(left.map(r => r.id)).not.toContain(staleQueued);
+    expect(left.map(r => r.id)).not.toContain(staleDelivered);
+  });
+
+  it('keeps an active delivery inside its expiry grace window', async () => {
+    const f = fixture(); const msg = f.message(1);
+    const recent = f.delivery(msg, 'queued', seconds, 'one', seconds - 2 * 86400);
+    expect((await f.run({ batchLimit: 50, maxBatches: 5, expiredDeliveryGraceDays: 7 })).deliveries).toBe(0);
+    expect((f.sqlite.prepare('SELECT id FROM deliveries').all() as { id: string }[]).map(r => r.id)).toContain(recent);
+  });
+
+  it('never reaps an active delivery with no expires_at, however old', async () => {
+    const f = fixture(); const msg = f.message(1);
+    const immortal = f.delivery(msg, 'queued', old, 'one', null);
+    expect((await f.run({ batchLimit: 50, maxBatches: 5 })).deliveries).toBe(0);
+    expect((f.sqlite.prepare('SELECT id FROM deliveries').all() as { id: string }[]).map(r => r.id)).toContain(immortal);
+  });
+
+  it('honours the grace window boundary rather than any workspace TTL', async () => {
+    const f = fixture(); const msg = f.message(1);
+    // delivery_ttl_days disabled: only the expiry rule can authorize this.
+    const stale = f.delivery(msg, 'queued', seconds, 'one', seconds - 10 * 86400);
+    expect((await f.run({
+      batchLimit: 50, maxBatches: 5, expiredDeliveryGraceDays: 30,
+      defaults: { deliveryTtlDays: null },
+    })).deliveries).toBe(0);
+    expect((await f.run({
+      batchLimit: 50, maxBatches: 5, expiredDeliveryGraceDays: 7,
+      defaults: { deliveryTtlDays: null },
+    })).deliveries).toBe(1);
+    expect((f.sqlite.prepare('SELECT id FROM deliveries').all() as { id: string }[]).map(r => r.id)).not.toContain(stale);
+  });
+
+  it('does not delete an expired queued row that was acked after the candidate read', async () => {
+    const f = fixture(); const msg = f.message(1);
+    const raced = f.delivery(msg, 'queued', seconds, 'one', seconds - 30 * 86400);
+    const original = f.sqlite.prepare.bind(f.sqlite);
+    // Flip the row to `acked` between the page read and the DELETE. The widened
+    // guard still matches it (acked is settled), so without a status guard it
+    // would be deleted under the expiry rule with its own TTL never checked.
+    let flipped = false;
+    (f.sqlite as unknown as { prepare: typeof original }).prepare = ((query: string) => {
+      if (!flipped && /^DELETE FROM deliveries/i.test(query)) {
+        flipped = true;
+        original("UPDATE deliveries SET status = 'acked' WHERE id = ?").run(raced);
+      }
+      return original(query);
+    }) as typeof original;
+    await f.run({ batchLimit: 50, maxBatches: 5, defaults: { deliveryTtlDays: null } });
+    expect((f.sqlite.prepare('SELECT id FROM deliveries').all() as { id: string }[]).map(r => r.id)).toContain(raced);
+  });
+
+  it('accepts a raised page ceiling so a large table can be traversed', async () => {
+    const f = fixture(); const msg = f.message(1);
+    f.sqlite.transaction(() => { for (let i = 0; i < 600; i++) f.delivery(msg, 'acked', seconds); })();
+    await f.run({ batchLimit: 500, maxBatches: 1 });
+    const reads = f.queries.filter(q => q.sql.includes('FROM deliveries NOT INDEXED') && q.sql.includes('WITH page'));
+    // Previously clamped to 200; the host may now ask for more.
+    expect(reads.some(q => q.params.at(-1) === 500)).toBe(true);
+  });
 });

--- a/packages/engine/src/engine/__tests__/rowidRetention.test.ts
+++ b/packages/engine/src/engine/__tests__/rowidRetention.test.ts
@@ -299,6 +299,28 @@ describe('schema-free retention candidate pages', () => {
     expect(flipped).toBe(true);
   });
 
+  it('opt-in active expiry recovery skips status-transition races by rechecking queued/delivered at DELETE time', async () => {
+    const f = fixture(); const msg = f.message(1);
+    const toFlip = f.delivery(msg, 'queued', seconds, 'one', seconds - 20 * 86400);
+    const executeAll = f.db.all.bind(f.db);
+    let flipped = false;
+    const spy = vi.spyOn(f.db, 'all').mockImplementation((query: unknown) => {
+      const text = f.db.dialect.sqlToQuery(query as never).sql;
+      if (!flipped && text.toLowerCase().includes('idx_deliveries_active_expiry')) {
+        flipped = true;
+        // Leave the active set by transitioning to a settled status right
+        // before the indexed-candidate subquery is mutated by the outer DELETE.
+        f.sqlite.prepare(`UPDATE deliveries SET status = 'acked' WHERE id = ?`).run(toFlip);
+      }
+      return executeAll(query as never);
+    });
+
+    await f.run({ activeExpiryRecovery: true, expiredDeliveryGraceDays: 7, maxBatches: 4, batchLimit: 200 });
+    spy.mockRestore();
+    expect(f.sqlite.prepare('SELECT id FROM deliveries WHERE id=?').get(toFlip)).toBeTruthy();
+    expect(flipped).toBe(true);
+  });
+
   it('opt-in active expiry recovery has hard worst-case DELETE statement count < 1000', async () => {
     const f = fixture(); const msg = f.message(1);
     for (let i = 0; i < 9000; i++) f.delivery(msg, 'delivered', seconds, 'one', seconds - 20 * 86400);

--- a/packages/engine/src/engine/__tests__/rowidRetention.test.ts
+++ b/packages/engine/src/engine/__tests__/rowidRetention.test.ts
@@ -203,7 +203,7 @@ describe('schema-free retention candidate pages', () => {
     const f = fixture(); const msg = f.message(1);
     const staleQueued = f.delivery(msg, 'queued', seconds, 'one', seconds - 30 * 86400);
     const staleDelivered = f.delivery(msg, 'delivered', seconds, 'one', seconds - 30 * 86400);
-    expect((await f.run({ batchLimit: 50, maxBatches: 5 })).deliveries).toBe(2);
+    expect((await f.run({ batchLimit: 50, maxBatches: 5, activeExpiryRecovery: true })).deliveries).toBe(2);
     const left = f.sqlite.prepare('SELECT id FROM deliveries').all() as { id: string }[];
     expect(left.map(r => r.id)).not.toContain(staleQueued);
     expect(left.map(r => r.id)).not.toContain(staleDelivered);
@@ -228,11 +228,11 @@ describe('schema-free retention candidate pages', () => {
     // delivery_ttl_days disabled: only the expiry rule can authorize this.
     const stale = f.delivery(msg, 'queued', seconds, 'one', seconds - 10 * 86400);
     expect((await f.run({
-      batchLimit: 50, maxBatches: 5, expiredDeliveryGraceDays: 30,
+      batchLimit: 50, maxBatches: 5, expiredDeliveryGraceDays: 30, activeExpiryRecovery: true,
       defaults: { deliveryTtlDays: null },
     })).deliveries).toBe(0);
     expect((await f.run({
-      batchLimit: 50, maxBatches: 5, expiredDeliveryGraceDays: 7,
+      batchLimit: 50, maxBatches: 5, expiredDeliveryGraceDays: 7, activeExpiryRecovery: true,
       defaults: { deliveryTtlDays: null },
     })).deliveries).toBe(1);
     expect((f.sqlite.prepare('SELECT id FROM deliveries').all() as { id: string }[]).map(r => r.id)).not.toContain(stale);
@@ -333,7 +333,7 @@ describe('schema-free retention candidate pages', () => {
     f.sqlite.transaction(() => { for (let i = 0; i < 600; i++) f.delivery(msg, 'acked', seconds); })();
     await f.run({ batchLimit: 500, maxBatches: 1 });
     const reads = f.queries.filter(q => q.sql.includes('FROM deliveries NOT INDEXED') && q.sql.includes('WITH page'));
-    // Previously clamped to 200; the host may now ask for more.
-    expect(reads.some(q => q.params.at(-1) === 500)).toBe(true);
+    // Rowid mode ceilings remain fixed at 200 rows/page.
+    expect(reads.some(q => q.params.at(-1) === 200)).toBe(true);
   });
 });

--- a/packages/engine/src/engine/__tests__/rowidRetention.test.ts
+++ b/packages/engine/src/engine/__tests__/rowidRetention.test.ts
@@ -238,6 +238,77 @@ describe('schema-free retention candidate pages', () => {
     expect((f.sqlite.prepare('SELECT id FROM deliveries').all() as { id: string }[]).map(r => r.id)).not.toContain(stale);
   });
 
+  it('opt-in active expiry recovery uses idx_deliveries_active_expiry and caps DELETE rows per call', async () => {
+    const f = fixture(); const msg = f.message(1);
+    // 5,000 expired queued deliveries; recovery caps at 4,000 rows per call.
+    for (let i = 0; i < 5000; i++) f.delivery(msg, 'queued', seconds, 'one', seconds - 10 * 86400);
+    const result = await f.run({ activeExpiryRecovery: true, expiredDeliveryGraceDays: 7, maxBatches: 4, batchLimit: 200 });
+    expect(result.deliveries).toBeLessThanOrEqual(4000);
+    expect(f.sqlite.prepare('SELECT count(*) n FROM deliveries').get()).toEqual({ n: 5000 - result.deliveries });
+
+    const hasIndexMarker = f.queries.some((q) => q.sql.toLowerCase().includes('idx_deliveries_active_expiry'));
+    expect(hasIndexMarker).toBe(true);
+
+    const recoveryDeletes = f.queries.filter((q) => /^DELETE/i.test(q.sql) && q.sql.toLowerCase().includes('from deliveries'));
+    expect(recoveryDeletes.length).toBeLessThanOrEqual(4);
+
+    // Ensure the planner uses the index (not a scan).
+    const idxQuery = f.queries.find((q) => q.sql.toLowerCase().includes('idx_deliveries_active_expiry'));
+    expect(idxQuery).toBeTruthy();
+    const explain = f.sqlite.prepare('EXPLAIN QUERY PLAN ' + idxQuery!.sql).all(...idxQuery!.params) as Array<{ detail: string }>;
+    expect(explain.some((row) => /USING INDEX idx_deliveries_active_expiry/.test(row.detail))).toBe(true);
+  });
+
+  it('opt-in active expiry recovery preserves NULL expires_at, live active rows, and settled deliveries', async () => {
+    const f = fixture(); const msg = f.message(1);
+    const nullExpires = f.delivery(msg, 'queued', seconds, 'one', null);
+    const inGrace = f.delivery(msg, 'queued', seconds, 'one', seconds - 3 * 86400); // within 7-day grace
+    // Settled deliveries are pruned by delivery TTL, independent of grace.
+    // Pick an unexpired acked row so we can verify the grace recovery
+    // doesn't delete it.
+    const settledAcked = f.delivery(msg, 'acked', seconds - 10 * 86400, 'one', seconds - 10 * 86400);
+    const expiredQueued = f.delivery(msg, 'queued', seconds, 'one', seconds - 20 * 86400);
+
+    await f.run({ activeExpiryRecovery: true, expiredDeliveryGraceDays: 7, maxBatches: 4 });
+
+    const remaining = f.sqlite.prepare('SELECT id,status,expires_at FROM deliveries').all() as Array<{ id: string; status: string; expires_at: number | null }>;
+    const cutoffSeconds = Math.floor((seconds * 1000 - 7 * 86400_000) / 1000);
+    expect(remaining.some(r => r.id === nullExpires)).toBe(true);
+    expect(remaining.some(r => r.id === inGrace && r.expires_at !== null && r.expires_at > cutoffSeconds && r.status === 'queued')).toBe(true);
+    expect(remaining.some(r => r.id === settledAcked)).toBe(true);
+    expect(remaining.some(r => r.id === expiredQueued)).toBe(false);
+  });
+
+  it('opt-in active expiry recovery skips expiry-extension races by rechecking expires_at at DELETE time', async () => {
+    const f = fixture(); const msg = f.message(1);
+    const toFlip = f.delivery(msg, 'queued', seconds, 'one', seconds - 20 * 86400);
+    const executeAll = f.db.all.bind(f.db);
+    let flipped = false;
+    const spy = vi.spyOn(f.db, 'all').mockImplementation((query: unknown) => {
+      const text = f.db.dialect.sqlToQuery(query as never).sql;
+      if (!flipped && text.toLowerCase().includes('idx_deliveries_active_expiry')) {
+        flipped = true;
+        f.sqlite.prepare(`UPDATE deliveries SET expires_at = ${seconds + 30} WHERE id = ?`).run(toFlip);
+      }
+      return executeAll(query as never);
+    });
+
+    await f.run({ activeExpiryRecovery: true, expiredDeliveryGraceDays: 7, maxBatches: 4, batchLimit: 200 });
+    spy.mockRestore();
+    expect(f.sqlite.prepare('SELECT id FROM deliveries WHERE id=?').get(toFlip)).toBeTruthy();
+    expect(flipped).toBe(true);
+  });
+
+  it('opt-in active expiry recovery has hard worst-case DELETE statement count < 1000', async () => {
+    const f = fixture(); const msg = f.message(1);
+    for (let i = 0; i < 9000; i++) f.delivery(msg, 'delivered', seconds, 'one', seconds - 20 * 86400);
+    await f.run({ activeExpiryRecovery: true, expiredDeliveryGraceDays: 7, maxBatches: 4, batchLimit: 200 });
+    const statements = f.queries.filter(q => /^DELETE FROM deliveries/i.test(q.sql));
+    // Rowid scan for active is disabled in this mode, so only the set-based recovery deletes should happen.
+    expect(statements.length).toBeLessThan(1000);
+    expect(statements.length).toBeLessThanOrEqual(4);
+  });
+
   it('does not delete an expired queued row that was acked after the candidate read', async () => {
     const f = fixture(); const msg = f.message(1);
     const raced = f.delivery(msg, 'queued', seconds, 'one', seconds - 30 * 86400);

--- a/packages/engine/src/engine/__tests__/rowidRetention.test.ts
+++ b/packages/engine/src/engine/__tests__/rowidRetention.test.ts
@@ -4,7 +4,11 @@ import { getSqliteDb, runMigrations, type SqliteDbHandle } from '../../adapters/
 import * as schema from '../../db/schema.js';
 import type { EngineDb } from '../../ports/database.js';
 import { pruneExpired, type PruneOptions } from '../retention.js';
-import type { RetentionCursorStore, RowidRetentionState } from '../rowidRetention.js';
+import {
+  ROWID_RETENTION_D1_QUERY_CEILING,
+  type RetentionCursorStore,
+  type RowidRetentionState,
+} from '../rowidRetention.js';
 import { snowflakeIdLowerBound } from '../snowflake.js';
 
 const now = new Date('2026-09-09T14:00:00Z');
@@ -212,14 +216,16 @@ describe('schema-free retention candidate pages', () => {
   it('keeps an active delivery inside its expiry grace window', async () => {
     const f = fixture(); const msg = f.message(1);
     const recent = f.delivery(msg, 'queued', seconds, 'one', seconds - 2 * 86400);
-    expect((await f.run({ batchLimit: 50, maxBatches: 5, expiredDeliveryGraceDays: 7 })).deliveries).toBe(0);
+    expect((await f.run({
+      batchLimit: 50, maxBatches: 5, expiredDeliveryGraceDays: 7, activeExpiryRecovery: true,
+    })).deliveries).toBe(0);
     expect((f.sqlite.prepare('SELECT id FROM deliveries').all() as { id: string }[]).map(r => r.id)).toContain(recent);
   });
 
   it('never reaps an active delivery with no expires_at, however old', async () => {
     const f = fixture(); const msg = f.message(1);
     const immortal = f.delivery(msg, 'queued', old, 'one', null);
-    expect((await f.run({ batchLimit: 50, maxBatches: 5 })).deliveries).toBe(0);
+    expect((await f.run({ batchLimit: 50, maxBatches: 5, activeExpiryRecovery: true })).deliveries).toBe(0);
     expect((f.sqlite.prepare('SELECT id FROM deliveries').all() as { id: string }[]).map(r => r.id)).toContain(immortal);
   });
 
@@ -321,14 +327,20 @@ describe('schema-free retention candidate pages', () => {
     expect(flipped).toBe(true);
   });
 
-  it('opt-in active expiry recovery has hard worst-case DELETE statement count < 1000', async () => {
+  it('keeps the hard worst-case D1 statement ceiling below 1000 and counts every issued query', async () => {
     const f = fixture(); const msg = f.message(1);
-    for (let i = 0; i < 9000; i++) f.delivery(msg, 'delivered', seconds, 'one', seconds - 20 * 86400);
-    await f.run({ activeExpiryRecovery: true, expiredDeliveryGraceDays: 7, maxBatches: 4, batchLimit: 200 });
-    const statements = f.queries.filter(q => /^DELETE FROM deliveries/i.test(q.sql));
-    // Rowid scan for active is disabled in this mode, so only the set-based recovery deletes should happen.
-    expect(statements.length).toBeLessThan(1000);
-    expect(statements.length).toBeLessThanOrEqual(4);
+    // Four full indexed recovery batches, followed by five full cursor pages
+    // of settled deliveries. The exported ceiling additionally derives the
+    // same maximum independently for every one of the five retention tables.
+    for (let i = 0; i < 4000; i++) f.delivery(msg, 'delivered', seconds, 'one', seconds - 20 * 86400);
+    for (let i = 0; i < 1000; i++) f.delivery(msg, 'acked', old);
+    await f.run({ activeExpiryRecovery: true, expiredDeliveryGraceDays: 7, maxBatches: 5, batchLimit: 200 });
+    expect(ROWID_RETENTION_D1_QUERY_CEILING).toBe(534);
+    expect(ROWID_RETENTION_D1_QUERY_CEILING).toBeLessThan(1000);
+    expect(f.queries.length).toBeLessThanOrEqual(ROWID_RETENTION_D1_QUERY_CEILING);
+    expect(f.queries.filter(q => q.sql.includes('idx_deliveries_active_expiry'))).toHaveLength(4);
+    expect(f.queries.filter(q => q.sql.includes('FROM deliveries NOT INDEXED') && q.sql.includes('WITH page'))).toHaveLength(5);
+    expect(f.queries.filter(q => /^DELETE FROM deliveries NOT INDEXED/i.test(q.sql))).toHaveLength(100);
   });
 
   it('accepts a raised page ceiling so a large table can be traversed', async () => {

--- a/packages/engine/src/engine/retention.ts
+++ b/packages/engine/src/engine/retention.ts
@@ -77,6 +77,12 @@ export interface PruneOptions {
    * Opt-in cleanup after the grace window skips `delivery.failed` notices.
    */
   activeExpiryRecovery?: boolean;
+  /**
+   * Cursor mode only: max set-based recovery batches for active `queued`/
+   * `delivered` rows (capped at 4). Only used when `activeExpiryRecovery`
+   * is enabled.
+   */
+  activeExpiryRecoveryMaxBatches?: number;
   /** Clock override for tests. */
   now?: Date;
   /** Deployment-wide TTL fallbacks; see {@link RetentionDefaults}. */

--- a/packages/engine/src/engine/retention.ts
+++ b/packages/engine/src/engine/retention.ts
@@ -69,6 +69,14 @@ export interface PruneOptions {
    * Cursor mode only. Default 7 days.
    */
   expiredDeliveryGraceDays?: number;
+  /**
+   * Cursor mode only: after the grace window, switch active `queued`/
+   * `delivered` recovery from the widened rowid scan to a set-based DELETE
+   * using `idx_deliveries_active_expiry`.
+   *
+   * Opt-in cleanup after the grace window skips `delivery.failed` notices.
+   */
+  activeExpiryRecovery?: boolean;
   /** Clock override for tests. */
   now?: Date;
   /** Deployment-wide TTL fallbacks; see {@link RetentionDefaults}. */

--- a/packages/engine/src/engine/retention.ts
+++ b/packages/engine/src/engine/retention.ts
@@ -58,10 +58,17 @@ export interface PruneOptions {
   cursorStore?: RetentionCursorStore;
   /** Admission budget for cursor mode; does not cancel in-flight SQL. Default 10s, capped at 30s. */
   maxDurationMs?: number;
-  /** Max rows deleted per table per batch (the SQL LIMIT). Default 200. */
+  /** Max rows deleted per table per batch (the SQL LIMIT). Default 200, capped at 1000 in cursor mode. */
   batchLimit?: number;
-  /** Max batches per table per call, bounding total work per run. Default 5. */
+  /** Max batches per table per call, bounding total work per run. Default 5, capped at 20 in cursor mode. */
   maxBatches?: number;
+  /**
+   * How long a `queued` / `delivered` delivery must have been past its
+   * `expires_at` before retention may reap it. Independent of
+   * `delivery_ttl_days`, which cannot express this class at any value.
+   * Cursor mode only. Default 7 days.
+   */
+  expiredDeliveryGraceDays?: number;
   /** Clock override for tests. */
   now?: Date;
   /** Deployment-wide TTL fallbacks; see {@link RetentionDefaults}. */

--- a/packages/engine/src/engine/retention.ts
+++ b/packages/engine/src/engine/retention.ts
@@ -58,9 +58,9 @@ export interface PruneOptions {
   cursorStore?: RetentionCursorStore;
   /** Admission budget for cursor mode; does not cancel in-flight SQL. Default 10s, capped at 30s. */
   maxDurationMs?: number;
-  /** Max rows deleted per table per batch (the SQL LIMIT). Default 200, capped at 1000 in cursor mode. */
+  /** Max rows deleted per table per batch (the SQL LIMIT). Default and hard cap 200 in cursor mode. */
   batchLimit?: number;
-  /** Max batches per table per call, bounding total work per run. Default 5, capped at 20 in cursor mode. */
+  /** Max batches per table per call, bounding total work per run. Default and hard cap 5 in cursor mode. */
   maxBatches?: number;
   /**
    * How long a `queued` / `delivered` delivery must have been past its
@@ -70,9 +70,10 @@ export interface PruneOptions {
    */
   expiredDeliveryGraceDays?: number;
   /**
-   * Cursor mode only: after the grace window, switch active `queued`/
-   * `delivered` recovery from the widened rowid scan to a set-based DELETE
-   * using `idx_deliveries_active_expiry`.
+   * Cursor mode only: after the grace window, recover active `queued`/
+   * `delivered` rows with a set-based DELETE using
+   * `idx_deliveries_active_expiry`. The default rowid scan remains
+   * settled-only.
    *
    * Opt-in cleanup after the grace window skips `delivery.failed` notices.
    */

--- a/packages/engine/src/engine/rowidRetention.ts
+++ b/packages/engine/src/engine/rowidRetention.ts
@@ -181,12 +181,12 @@ export async function pruneRowidPages(db: EngineDb, opts: PruneOptions & { curso
   // Opt-in active expiry recovery BEFORE the rowid crawl so a slow scan
   // cannot starve active cleanup.
   if (activeExpiryRecovery) {
-    const maxBatches = opts.activeExpiryRecoveryMaxBatches ?? MAX_ACTIVE_EXPIRY_RECOVERY_BATCHES;
+    const maxBatches = bounded(opts.activeExpiryRecoveryMaxBatches, MAX_ACTIVE_EXPIRY_RECOVERY_BATCHES, MAX_ACTIVE_EXPIRY_RECOVERY_BATCHES);
     result.deliveries += await recoverExpiredActiveDeliveriesSetBased(
       db,
       now,
       grace,
-      { maxBatches: Math.min(Math.max(Math.floor(maxBatches), 1), MAX_ACTIVE_EXPIRY_RECOVERY_BATCHES) },
+      { maxBatches },
     );
   }
   for (let step = 0; step < pages && Date.now() < deadline; step++) {

--- a/packages/engine/src/engine/rowidRetention.ts
+++ b/packages/engine/src/engine/rowidRetention.ts
@@ -238,11 +238,10 @@ export async function pruneRowidPages(db: EngineDb, opts: PruneOptions & { curso
         const policyGuard = table.setting ? sql`AND (SELECT w.retention FROM workspaces w
           WHERE w.id = ${row.workspace_id}) IS ${row.retention}` : sql``;
         const timeGuard = table.setting && !table.snowflake ? sql`AND created_at = ${row.created_at}` : sql``;
-        // The widened deliveries guard admits both settled and long-expired
-        // active rows, so it no longer implies which rule authorized the
-        // delete. Pin the exact status read: a queued row that gets acked
-        // between the page read and this DELETE must not be removed under the
-        // expiry rule without its own TTL ever being checked.
+        // The deliveries page is guarded as settled-only (default cursor mode),
+        // but the opt-in active recovery path re-checks status/expiry again.
+        // Always pin the exact status read so concurrent status changes
+        // cannot authorize a stale deletion.
         const statusGuard = table.result === 'deliveries' ? sql`AND status = ${row.status}` : sql``;
         return sql`(rowid = ${row._rowid} AND ${identity} ${policyGuard} ${timeGuard} ${statusGuard})`;
       });

--- a/packages/engine/src/engine/rowidRetention.ts
+++ b/packages/engine/src/engine/rowidRetention.ts
@@ -48,17 +48,15 @@ const settled = "deliveries.status IN ('acked', 'failed', 'dead_lettered')";
 // query joins it, so a bare column is ambiguous there. The page builder rewrites
 // `deliveries.` to `page.` for the SELECT and leaves it intact for the DELETE.
 const DEFAULT_EXPIRED_DELIVERY_GRACE_DAYS = 7;
-function buildTables(_opts: { activeExpiryRecovery: boolean }) : Table[] {
-  // Deliveries deletion in cursor mode is settled-only by default.
-  // Active queued/delivered cleanup (after grace) is opt-in and handled
-  // exclusively by the set-based recovery path.
-  const reapableDeliveries = settled;
-  return [
+// Deliveries deletion in cursor mode is settled-only by default. Active
+// queued/delivered cleanup is opt-in and handled exclusively by the indexed,
+// set-based recovery path below.
+const tables: Table[] = [
     { name: 'messages', result: 'messages', columns: 'id, workspace_id',
       setting: 'message_ttl_days', fallback: 'messageTtlDays', snowflake: true,
       guard: 'NOT EXISTS (SELECT 1 FROM messages replies WHERE replies.thread_id = messages.id)' },
     { name: 'deliveries', result: 'deliveries', columns: 'id, workspace_id, created_at, status, expires_at',
-      setting: 'delivery_ttl_days', fallback: 'deliveryTtlDays', guard: reapableDeliveries },
+      setting: 'delivery_ttl_days', fallback: 'deliveryTtlDays', guard: settled },
     { name: 'message_logs', result: 'messageLogs', columns: 'id, workspace_id',
       setting: 'message_log_ttl_days', fallback: 'messageLogTtlDays', snowflake: true, guard: '1' },
     { name: 'workspace_events', result: 'workspaceEvents', columns: 'workspace_id, seq, created_at',
@@ -66,11 +64,27 @@ function buildTables(_opts: { activeExpiryRecovery: boolean }) : Table[] {
       guard: 'EXISTS (SELECT 1 FROM workspace_events hw WHERE hw.workspace_id = workspace_events.workspace_id AND hw.seq > workspace_events.seq LIMIT 1)' },
     { name: 'read_receipts', result: 'readReceipts', columns: 'message_id, agent_id',
       guard: 'NOT EXISTS (SELECT 1 FROM messages m WHERE m.id = read_receipts.message_id)' },
-  ];
-}
+];
 
 const MAX_ACTIVE_EXPIRY_RECOVERY_BATCHES = 4;
 const ACTIVE_EXPIRY_RECOVERY_DELETE_LIMIT = 1000;
+const ROWID_PAGE_LIMIT = 200;
+const ROWID_MAX_BATCHES_PER_TABLE = 5;
+const ROWID_DELETE_CHUNK_SIZE = 10;
+
+/** Hard D1 statement ceiling for one cursor-mode retention invocation.
+ *
+ * Per table: one high-water SELECT, then at most five page SELECTs and twenty
+ * ten-row DELETEs per page. The opt-in active recovery adds at most four
+ * indexed set-based DELETEs. cursorStore persistence is host-owned, not D1.
+ */
+export const ROWID_RETENTION_D1_QUERY_CEILING =
+  tables.length * (
+    1
+    + ROWID_MAX_BATCHES_PER_TABLE
+    + ROWID_MAX_BATCHES_PER_TABLE * Math.ceil(ROWID_PAGE_LIMIT / ROWID_DELETE_CHUNK_SIZE)
+  )
+  + MAX_ACTIVE_EXPIRY_RECOVERY_BATCHES;
 
 async function recoverExpiredActiveDeliveriesSetBased(
   db: EngineDb,
@@ -118,17 +132,7 @@ function bounded(value: number | undefined, fallback: number, max: number): numb
 
 function expired(
   row: Candidate, table: Table, defaults: Required<RetentionDefaults>, now: number,
-  expiredDeliveryGraceDays: number,
 ): boolean {
-  // Active deliveries are judged on their own expiry, not on a workspace TTL:
-  // no `delivery_ttl_days` value can express "this queued row is dead". Checked
-  // before the `!table.setting` fallthrough below, which returns true
-  // unconditionally and would otherwise delete live, unexpired deliveries.
-  if (table.result === 'deliveries' && (row.status === 'queued' || row.status === 'delivered')) {
-    if (row.expires_at == null) return false;
-    const grace = Math.max(0, Math.floor(expiredDeliveryGraceDays * 86_400_000));
-    return row.expires_at * 1000 < now - grace;
-  }
   if (!table.setting || !table.fallback) return true;
   const settings = row.retention ? JSON.parse(row.retention) as WorkspaceRetentionSettings : {};
   const override = settings?.[table.setting];
@@ -159,10 +163,8 @@ export async function pruneRowidPages(db: EngineDb, opts: PruneOptions & { curso
   // Preserve existing cursor-mode ceilings exactly: 200 rows/page and 5
   // batches/table.
   const activeExpiryRecovery = opts.activeExpiryRecovery === true;
-  const tables = buildTables({ activeExpiryRecovery });
-
-  const limit = bounded(opts.batchLimit, 200, 200);
-  const pages = bounded(opts.maxBatches, 5, 5) * tables.length;
+  const limit = bounded(opts.batchLimit, ROWID_PAGE_LIMIT, ROWID_PAGE_LIMIT);
+  const pages = bounded(opts.maxBatches, ROWID_MAX_BATCHES_PER_TABLE, ROWID_MAX_BATCHES_PER_TABLE) * tables.length;
   const deadline = Date.now() + bounded(opts.maxDurationMs, 10_000, 30_000);
   const defaults: Required<RetentionDefaults> = {
     messageTtlDays: null, deliveryTtlDays: 90, messageLogTtlDays: 90, workspaceEventTtlDays: 30,
@@ -216,12 +218,12 @@ export async function pruneRowidPages(db: EngineDb, opts: PruneOptions & { curso
     for (const row of page) safeRowid.parse(row._rowid);
     // Keep exact row identities alongside rowid: SQLite may reuse a deleted
     // rowid between the candidate read and a later DELETE.
-      const removable = page.filter(row => row.eligible && expired(row, table, defaults, now, grace));
+    const removable = page.filter(row => row.eligible && expired(row, table, defaults, now));
     // At most seven bindings per row, kept below D1's 100-variable limit.
     // Small atomic chunks also avoid one subrequest per retained-history row.
-    for (let offset = 0; offset < removable.length; offset += 10) {
+    for (let offset = 0; offset < removable.length; offset += ROWID_DELETE_CHUNK_SIZE) {
       if (Date.now() >= deadline) { await save(); return result; }
-      const chunk = removable.slice(offset, offset + 10);
+      const chunk = removable.slice(offset, offset + ROWID_DELETE_CHUNK_SIZE);
       const guarded = chunk.map(row => {
         const identity = table.result === 'workspaceEvents'
           ? sql`workspace_id = ${row.workspace_id} AND seq = ${row.seq}`

--- a/packages/engine/src/engine/rowidRetention.ts
+++ b/packages/engine/src/engine/rowidRetention.ts
@@ -26,6 +26,7 @@ type Candidate = {
   id: string;
   workspace_id: string;
   created_at: number;
+  expires_at: number | null;
   seq: number;
   message_id: string;
   agent_id: string;
@@ -42,13 +43,29 @@ type Table = {
   snowflake?: boolean;
   guard: string;
 };
-const settled = "status IN ('acked', 'failed', 'dead_lettered')";
+const settled = "deliveries.status IN ('acked', 'failed', 'dead_lettered')";
+// Table-qualified: `workspaces` also has an `expires_at`, and the outer page
+// query joins it, so a bare column is ambiguous there. The page builder rewrites
+// `deliveries.` to `page.` for the SELECT and leaves it intact for the DELETE.
+const active = "deliveries.status IN ('queued', 'delivered')";
+// A `queued` or `delivered` delivery whose `expires_at` has long passed is
+// covered by no `delivery_ttl_days` policy at ANY value — the settled guard
+// cannot see it — so before this it was unreclaimable and simply accumulated.
+// On production 2026-09-09, 4,409,692 of 4,409,767 queued deliveries were
+// already past `expires_at`, in a 9.9GB database against D1's 10GB cap.
+//
+// Deliberately widens the EXISTING deliveries guard rather than adding a second
+// table entry: this scan is an unindexed rowid crawl, so a second entry would
+// double the crawl cost for the largest table in the database to reap rows the
+// same pass already walks past.
+const reapableDeliveries = `(${settled} OR (${active} AND deliveries.expires_at IS NOT NULL))`;
+const DEFAULT_EXPIRED_DELIVERY_GRACE_DAYS = 7;
 const tables: Table[] = [
   { name: 'messages', result: 'messages', columns: 'id, workspace_id',
     setting: 'message_ttl_days', fallback: 'messageTtlDays', snowflake: true,
     guard: 'NOT EXISTS (SELECT 1 FROM messages replies WHERE replies.thread_id = messages.id)' },
-  { name: 'deliveries', result: 'deliveries', columns: 'id, workspace_id, created_at, status',
-    setting: 'delivery_ttl_days', fallback: 'deliveryTtlDays', guard: settled },
+  { name: 'deliveries', result: 'deliveries', columns: 'id, workspace_id, created_at, status, expires_at',
+    setting: 'delivery_ttl_days', fallback: 'deliveryTtlDays', guard: reapableDeliveries },
   { name: 'message_logs', result: 'messageLogs', columns: 'id, workspace_id',
     setting: 'message_log_ttl_days', fallback: 'messageLogTtlDays', snowflake: true, guard: '1' },
   { name: 'workspace_events', result: 'workspaceEvents', columns: 'workspace_id, seq, created_at',
@@ -62,7 +79,19 @@ function bounded(value: number | undefined, fallback: number, max: number): numb
   return value !== undefined && Number.isFinite(value) ? Math.max(1, Math.min(max, Math.floor(value))) : fallback;
 }
 
-function expired(row: Candidate, table: Table, defaults: Required<RetentionDefaults>, now: number): boolean {
+function expired(
+  row: Candidate, table: Table, defaults: Required<RetentionDefaults>, now: number,
+  expiredDeliveryGraceDays: number,
+): boolean {
+  // Active deliveries are judged on their own expiry, not on a workspace TTL:
+  // no `delivery_ttl_days` value can express "this queued row is dead". Checked
+  // before the `!table.setting` fallthrough below, which returns true
+  // unconditionally and would otherwise delete live, unexpired deliveries.
+  if (table.result === 'deliveries' && (row.status === 'queued' || row.status === 'delivered')) {
+    if (row.expires_at == null) return false;
+    const grace = Math.max(0, Math.floor(expiredDeliveryGraceDays * 86_400_000));
+    return row.expires_at * 1000 < now - grace;
+  }
   if (!table.setting || !table.fallback) return true;
   const settings = row.retention ? JSON.parse(row.retention) as WorkspaceRetentionSettings : {};
   const override = settings?.[table.setting];
@@ -90,13 +119,19 @@ function expired(row: Candidate, table: Table, defaults: Required<RetentionDefau
 export async function pruneRowidPages(db: EngineDb, opts: PruneOptions & { cursorStore: RetentionCursorStore }): Promise<PruneResult> {
   const now = (opts.now ?? new Date()).getTime();
   if (!Number.isFinite(now)) throw new Error('Invalid retention clock');
-  const limit = bounded(opts.batchLimit, 200, 200);
-  const pages = bounded(opts.maxBatches, 5, 5) * tables.length;
+  // Ceilings, not defaults: the defaults stay 200/5 so no existing caller
+  // changes behaviour, but a host that has measured its own budget can now ask
+  // for more. At 200 rows/page this unindexed crawl needs ~43k pages for one
+  // traversal of an 8.65M-row deliveries table — about a month of 5-minute
+  // crons, far longer than the table takes to fill.
+  const limit = bounded(opts.batchLimit, 200, 1_000);
+  const pages = bounded(opts.maxBatches, 5, 20) * tables.length;
   const deadline = Date.now() + bounded(opts.maxDurationMs, 10_000, 30_000);
   const defaults: Required<RetentionDefaults> = {
     messageTtlDays: null, deliveryTtlDays: 90, messageLogTtlDays: 90, workspaceEventTtlDays: 30,
     ...Object.fromEntries(Object.entries(opts.defaults ?? {}).filter(([, value]) => value !== undefined)),
   };
+  const grace = opts.expiredDeliveryGraceDays ?? DEFAULT_EXPIRED_DELIVERY_GRACE_DAYS;
   const saved = await opts.cursorStore.load();
   // Corrupt state is an error, not permission to restart expensive work or
   // drop an unknown future cursor format during a rollback.
@@ -132,7 +167,7 @@ export async function pruneRowidPages(db: EngineDb, opts: PruneOptions & { curso
     for (const row of page) safeRowid.parse(row._rowid);
     // Keep exact row identities alongside rowid: SQLite may reuse a deleted
     // rowid between the candidate read and a later DELETE.
-    const removable = page.filter(row => row.eligible && expired(row, table, defaults, now));
+      const removable = page.filter(row => row.eligible && expired(row, table, defaults, now, grace));
     // At most seven bindings per row, kept below D1's 100-variable limit.
     // Small atomic chunks also avoid one subrequest per retained-history row.
     for (let offset = 0; offset < removable.length; offset += 10) {
@@ -154,7 +189,13 @@ export async function pruneRowidPages(db: EngineDb, opts: PruneOptions & { curso
         const policyGuard = table.setting ? sql`AND (SELECT w.retention FROM workspaces w
           WHERE w.id = ${row.workspace_id}) IS ${row.retention}` : sql``;
         const timeGuard = table.setting && !table.snowflake ? sql`AND created_at = ${row.created_at}` : sql``;
-        return sql`(rowid = ${row._rowid} AND ${identity} ${policyGuard} ${timeGuard})`;
+        // The widened deliveries guard admits both settled and long-expired
+        // active rows, so it no longer implies which rule authorized the
+        // delete. Pin the exact status read: a queued row that gets acked
+        // between the page read and this DELETE must not be removed under the
+        // expiry rule without its own TTL ever being checked.
+        const statusGuard = table.result === 'deliveries' ? sql`AND status = ${row.status}` : sql``;
+        return sql`(rowid = ${row._rowid} AND ${identity} ${policyGuard} ${timeGuard} ${statusGuard})`;
       });
       const deleted = await db.all(sql`DELETE FROM ${sql.raw(table.name)} NOT INDEXED
         WHERE (${sql.join(guarded, sql` OR `)}) AND ${sql.raw(table.guard)} RETURNING 1`);

--- a/packages/engine/src/engine/rowidRetention.ts
+++ b/packages/engine/src/engine/rowidRetention.ts
@@ -58,22 +58,71 @@ const active = "deliveries.status IN ('queued', 'delivered')";
 // table entry: this scan is an unindexed rowid crawl, so a second entry would
 // double the crawl cost for the largest table in the database to reap rows the
 // same pass already walks past.
-const reapableDeliveries = `(${settled} OR (${active} AND deliveries.expires_at IS NOT NULL))`;
 const DEFAULT_EXPIRED_DELIVERY_GRACE_DAYS = 7;
-const tables: Table[] = [
-  { name: 'messages', result: 'messages', columns: 'id, workspace_id',
-    setting: 'message_ttl_days', fallback: 'messageTtlDays', snowflake: true,
-    guard: 'NOT EXISTS (SELECT 1 FROM messages replies WHERE replies.thread_id = messages.id)' },
-  { name: 'deliveries', result: 'deliveries', columns: 'id, workspace_id, created_at, status, expires_at',
-    setting: 'delivery_ttl_days', fallback: 'deliveryTtlDays', guard: reapableDeliveries },
-  { name: 'message_logs', result: 'messageLogs', columns: 'id, workspace_id',
-    setting: 'message_log_ttl_days', fallback: 'messageLogTtlDays', snowflake: true, guard: '1' },
-  { name: 'workspace_events', result: 'workspaceEvents', columns: 'workspace_id, seq, created_at',
-    setting: 'workspace_event_ttl_days', fallback: 'workspaceEventTtlDays',
-    guard: 'EXISTS (SELECT 1 FROM workspace_events hw WHERE hw.workspace_id = workspace_events.workspace_id AND hw.seq > workspace_events.seq LIMIT 1)' },
-  { name: 'read_receipts', result: 'readReceipts', columns: 'message_id, agent_id',
-    guard: 'NOT EXISTS (SELECT 1 FROM messages m WHERE m.id = read_receipts.message_id)' },
-];
+function buildTables(opts: { activeExpiryRecovery: boolean }) : Table[] {
+  // Rowid scan is intentionally optimized to avoid unindexed full-table reads
+  // when callers opt into set-based active expiry recovery.
+  const reapableDeliveries = opts.activeExpiryRecovery
+    ? settled
+    : `(${settled} OR (${active} AND deliveries.expires_at IS NOT NULL))`;
+  return [
+    { name: 'messages', result: 'messages', columns: 'id, workspace_id',
+      setting: 'message_ttl_days', fallback: 'messageTtlDays', snowflake: true,
+      guard: 'NOT EXISTS (SELECT 1 FROM messages replies WHERE replies.thread_id = messages.id)' },
+    { name: 'deliveries', result: 'deliveries', columns: 'id, workspace_id, created_at, status, expires_at',
+      setting: 'delivery_ttl_days', fallback: 'deliveryTtlDays', guard: reapableDeliveries },
+    { name: 'message_logs', result: 'messageLogs', columns: 'id, workspace_id',
+      setting: 'message_log_ttl_days', fallback: 'messageLogTtlDays', snowflake: true, guard: '1' },
+    { name: 'workspace_events', result: 'workspaceEvents', columns: 'workspace_id, seq, created_at',
+      setting: 'workspace_event_ttl_days', fallback: 'workspaceEventTtlDays',
+      guard: 'EXISTS (SELECT 1 FROM workspace_events hw WHERE hw.workspace_id = workspace_events.workspace_id AND hw.seq > workspace_events.seq LIMIT 1)' },
+    { name: 'read_receipts', result: 'readReceipts', columns: 'message_id, agent_id',
+      guard: 'NOT EXISTS (SELECT 1 FROM messages m WHERE m.id = read_receipts.message_id)' },
+  ];
+}
+
+const MAX_ACTIVE_EXPIRY_RECOVERY_BATCHES = 4;
+const ACTIVE_EXPIRY_RECOVERY_DELETE_LIMIT = 1000;
+
+async function recoverExpiredActiveDeliveriesSetBased(
+  db: EngineDb,
+  nowMs: number,
+  graceDays: number,
+  opts: { maxBatches: number },
+): Promise<number> {
+  const graceMs = Math.max(0, Math.floor(graceDays * 86_400_000));
+  const cutoffMs = nowMs - graceMs;
+  const cutoffSeconds = Math.floor(cutoffMs / 1000);
+
+  // Use the existing index that already narrows to only active (queued/delivered).
+  // We still re-check queued/delivered + expires_at in the outer DELETE predicate
+  // to avoid expiry-extension races between selecting candidate ids and deleting.
+  const batches = Math.max(1, Math.min(Math.floor(opts.maxBatches), MAX_ACTIVE_EXPIRY_RECOVERY_BATCHES));
+  let deleted = 0;
+  for (let batch = 0; batch < batches; batch++) {
+    const changed = await db.all<{ _id: string }>(sql`
+      DELETE FROM deliveries
+      WHERE (
+        status IN ('queued', 'delivered')
+        AND expires_at IS NOT NULL
+        AND expires_at <= ${cutoffSeconds}
+      )
+      AND id IN (
+        SELECT id
+        FROM deliveries INDEXED BY idx_deliveries_active_expiry
+        WHERE status IN ('queued', 'delivered')
+          AND expires_at IS NOT NULL
+          AND expires_at <= ${cutoffSeconds}
+        ORDER BY expires_at, id
+        LIMIT ${ACTIVE_EXPIRY_RECOVERY_DELETE_LIMIT}
+      )
+      RETURNING id AS _id
+    `);
+    deleted += changed.length;
+    if (changed.length < ACTIVE_EXPIRY_RECOVERY_DELETE_LIMIT) break;
+  }
+  return deleted;
+}
 
 function bounded(value: number | undefined, fallback: number, max: number): number {
   return value !== undefined && Number.isFinite(value) ? Math.max(1, Math.min(max, Math.floor(value))) : fallback;
@@ -124,6 +173,9 @@ export async function pruneRowidPages(db: EngineDb, opts: PruneOptions & { curso
   // for more. At 200 rows/page this unindexed crawl needs ~43k pages for one
   // traversal of an 8.65M-row deliveries table — about a month of 5-minute
   // crons, far longer than the table takes to fill.
+  const activeExpiryRecovery = opts.activeExpiryRecovery === true;
+  const tables = buildTables({ activeExpiryRecovery });
+
   const limit = bounded(opts.batchLimit, 200, 1_000);
   const pages = bounded(opts.maxBatches, 5, 20) * tables.length;
   const deadline = Date.now() + bounded(opts.maxDurationMs, 10_000, 30_000);
@@ -206,6 +258,20 @@ export async function pruneRowidPages(db: EngineDb, opts: PruneOptions & { curso
     } else position.cursor = page.at(-1)!._rowid;
     await save();
     if (finished.size === tables.length) break;
+  }
+
+  // Opt-in set-based recovery for active deliveries that have passed the
+  // expiry grace window: this intentionally skips emitting `delivery.failed`
+  // notices (unlike the scheduled expiry sweep).
+  if (activeExpiryRecovery) {
+    const deleted = await recoverExpiredActiveDeliveriesSetBased(
+      db,
+      now,
+      grace,
+      { maxBatches: Math.min(bounded(opts.maxBatches, 5, 20), MAX_ACTIVE_EXPIRY_RECOVERY_BATCHES) },
+    );
+    // These deletes bypass the rowid scan's accounting; add them explicitly.
+    result.deliveries += deleted;
   }
   return result;
 }

--- a/packages/engine/src/engine/rowidRetention.ts
+++ b/packages/engine/src/engine/rowidRetention.ts
@@ -47,24 +47,12 @@ const settled = "deliveries.status IN ('acked', 'failed', 'dead_lettered')";
 // Table-qualified: `workspaces` also has an `expires_at`, and the outer page
 // query joins it, so a bare column is ambiguous there. The page builder rewrites
 // `deliveries.` to `page.` for the SELECT and leaves it intact for the DELETE.
-const active = "deliveries.status IN ('queued', 'delivered')";
-// A `queued` or `delivered` delivery whose `expires_at` has long passed is
-// covered by no `delivery_ttl_days` policy at ANY value — the settled guard
-// cannot see it — so before this it was unreclaimable and simply accumulated.
-// On production 2026-09-09, 4,409,692 of 4,409,767 queued deliveries were
-// already past `expires_at`, in a 9.9GB database against D1's 10GB cap.
-//
-// Deliberately widens the EXISTING deliveries guard rather than adding a second
-// table entry: this scan is an unindexed rowid crawl, so a second entry would
-// double the crawl cost for the largest table in the database to reap rows the
-// same pass already walks past.
 const DEFAULT_EXPIRED_DELIVERY_GRACE_DAYS = 7;
-function buildTables(opts: { activeExpiryRecovery: boolean }) : Table[] {
-  // Rowid scan is intentionally optimized to avoid unindexed full-table reads
-  // when callers opt into set-based active expiry recovery.
-  const reapableDeliveries = opts.activeExpiryRecovery
-    ? settled
-    : `(${settled} OR (${active} AND deliveries.expires_at IS NOT NULL))`;
+function buildTables(_opts: { activeExpiryRecovery: boolean }) : Table[] {
+  // Deliveries deletion in cursor mode is settled-only by default.
+  // Active queued/delivered cleanup (after grace) is opt-in and handled
+  // exclusively by the set-based recovery path.
+  const reapableDeliveries = settled;
   return [
     { name: 'messages', result: 'messages', columns: 'id, workspace_id',
       setting: 'message_ttl_days', fallback: 'messageTtlDays', snowflake: true,
@@ -105,14 +93,14 @@ async function recoverExpiredActiveDeliveriesSetBased(
       WHERE (
         status IN ('queued', 'delivered')
         AND expires_at IS NOT NULL
-        AND expires_at <= ${cutoffSeconds}
+        AND expires_at < ${cutoffSeconds}
       )
       AND id IN (
         SELECT id
         FROM deliveries INDEXED BY idx_deliveries_active_expiry
         WHERE status IN ('queued', 'delivered')
           AND expires_at IS NOT NULL
-          AND expires_at <= ${cutoffSeconds}
+          AND expires_at < ${cutoffSeconds}
         ORDER BY expires_at, id
         LIMIT ${ACTIVE_EXPIRY_RECOVERY_DELETE_LIMIT}
       )
@@ -168,16 +156,13 @@ function expired(
 export async function pruneRowidPages(db: EngineDb, opts: PruneOptions & { cursorStore: RetentionCursorStore }): Promise<PruneResult> {
   const now = (opts.now ?? new Date()).getTime();
   if (!Number.isFinite(now)) throw new Error('Invalid retention clock');
-  // Ceilings, not defaults: the defaults stay 200/5 so no existing caller
-  // changes behaviour, but a host that has measured its own budget can now ask
-  // for more. At 200 rows/page this unindexed crawl needs ~43k pages for one
-  // traversal of an 8.65M-row deliveries table — about a month of 5-minute
-  // crons, far longer than the table takes to fill.
+  // Preserve existing cursor-mode ceilings exactly: 200 rows/page and 5
+  // batches/table.
   const activeExpiryRecovery = opts.activeExpiryRecovery === true;
   const tables = buildTables({ activeExpiryRecovery });
 
-  const limit = bounded(opts.batchLimit, 200, 1_000);
-  const pages = bounded(opts.maxBatches, 5, 20) * tables.length;
+  const limit = bounded(opts.batchLimit, 200, 200);
+  const pages = bounded(opts.maxBatches, 5, 5) * tables.length;
   const deadline = Date.now() + bounded(opts.maxDurationMs, 10_000, 30_000);
   const defaults: Required<RetentionDefaults> = {
     messageTtlDays: null, deliveryTtlDays: 90, messageLogTtlDays: 90, workspaceEventTtlDays: 30,
@@ -192,6 +177,18 @@ export async function pruneRowidPages(db: EngineDb, opts: PruneOptions & { curso
   const save = () => opts.cursorStore.save(structuredClone(state));
   const result: PruneResult = { messages: 0, deliveries: 0, messageLogs: 0, readReceipts: 0, workspaceEvents: 0 };
   const finished = new Set<number>();
+
+  // Opt-in active expiry recovery BEFORE the rowid crawl so a slow scan
+  // cannot starve active cleanup.
+  if (activeExpiryRecovery) {
+    const maxBatches = opts.activeExpiryRecoveryMaxBatches ?? MAX_ACTIVE_EXPIRY_RECOVERY_BATCHES;
+    result.deliveries += await recoverExpiredActiveDeliveriesSetBased(
+      db,
+      now,
+      grace,
+      { maxBatches: Math.min(Math.max(Math.floor(maxBatches), 1), MAX_ACTIVE_EXPIRY_RECOVERY_BATCHES) },
+    );
+  }
   for (let step = 0; step < pages && Date.now() < deadline; step++) {
     const index = state.next;
     state.next = (index + 1) % tables.length;
@@ -260,18 +257,5 @@ export async function pruneRowidPages(db: EngineDb, opts: PruneOptions & { curso
     if (finished.size === tables.length) break;
   }
 
-  // Opt-in set-based recovery for active deliveries that have passed the
-  // expiry grace window: this intentionally skips emitting `delivery.failed`
-  // notices (unlike the scheduled expiry sweep).
-  if (activeExpiryRecovery) {
-    const deleted = await recoverExpiredActiveDeliveriesSetBased(
-      db,
-      now,
-      grace,
-      { maxBatches: Math.min(bounded(opts.maxBatches, 5, 20), MAX_ACTIVE_EXPIRY_RECOVERY_BATCHES) },
-    );
-    // These deletes bypass the rowid scan's accounting; add them explicitly.
-    result.deliveries += deleted;
-  }
   return result;
 }

--- a/packages/engine/src/routes/deliveryRouting.ts
+++ b/packages/engine/src/routes/deliveryRouting.ts
@@ -554,7 +554,11 @@ export async function sweepDueNodeDeliveries(
   opts: { workspaceId?: string; now?: Date; limit?: number; wsBacklogLimit?: number } = {},
 ): Promise<number> {
   const now = opts.now ?? new Date();
-  const due = await deliveryEngine.fetchDueNodeDeliveryEvents(engine.db, { ...opts, now });
+  const due = await deliveryEngine.fetchDueNodeDeliveryEvents(engine.db, {
+    workspaceId: opts.workspaceId,
+    limit: opts.limit,
+    now,
+  });
 
   const httpPushEvents: typeof due = [];
   const wsAgents: { workspaceId: string; agentId: string }[] = [];

--- a/packages/engine/src/routes/deliveryRouting.ts
+++ b/packages/engine/src/routes/deliveryRouting.ts
@@ -509,8 +509,14 @@ async function redriveWsBacklogForAgent(
   ctx: RoutingContext,
   agentId: string,
   now: Date,
+  wsBacklogLimit: number | undefined,
 ): Promise<void> {
-  const backlog = await deliveryEngine.fetchQueuedWsBacklogEvents(ctx.db, ctx.workspaceId, agentId, { now });
+  const backlog = await deliveryEngine.fetchQueuedWsBacklogEvents(
+    ctx.db,
+    ctx.workspaceId,
+    agentId,
+    { now, limit: wsBacklogLimit },
+  );
   if (backlog.length === 0) return;
 
   const backlogDeliveries = backlog.map((event) => event.delivery);
@@ -545,7 +551,7 @@ async function redriveWsBacklogForAgent(
  */
 export async function sweepDueNodeDeliveries(
   engine: EngineDeps,
-  opts: { workspaceId?: string; now?: Date; limit?: number } = {},
+  opts: { workspaceId?: string; now?: Date; limit?: number; wsBacklogLimit?: number } = {},
 ): Promise<number> {
   const now = opts.now ?? new Date();
   const due = await deliveryEngine.fetchDueNodeDeliveryEvents(engine.db, { ...opts, now });
@@ -580,6 +586,7 @@ export async function sweepDueNodeDeliveries(
         { db: engine.db, workspaceId: agent.workspaceId, engine },
         agent.agentId,
         now,
+        opts.wsBacklogLimit,
       )
     )),
   ]);


### PR DESCRIPTION
## Why this targets `release/8.5.2`

Production runs `@relaycast/engine@8.5.2-hotfix.2`, whose host-owned cursor retention path lives in `rowidRetention.ts`. The equivalent mainline work in #404 cannot reach the currently deployed Relaycast Cloud package, so this maintenance-branch PR is the production incident fix while #404 remains the forward-port.

## Incident

The deployed cursor guard only visits settled deliveries. A `queued` or `delivered` row whose `expires_at` is long past is covered by no `delivery_ttl_days` value, so it was unreclaimable. On 2026-09-09 production had 4,409,692 already-expired queued rows plus 4,197,199 dead-lettered rows: 8.65M deliveries in a 9.9 GB D1 database against the 10 GB limit.

## Changes

- Keeps the default five-table rowid crawler settled-only and hard-clamped at 200 rows x 5 batches per table.
- Adds an opt-in, indexed active-expiry recovery pass before the rowid crawl. It uses `idx_deliveries_active_expiry`, rechecks exact status and `expires_at < cutoff` in both candidate selection and the outer DELETE, and is hard-capped at 4 x 1,000 rows per invocation.
- Preserves `cursorStore` v1 for rollback compatibility.
- Documents and tests the incident semantic: recovery after the seven-day grace does not emit historical `delivery.failed` notices, avoiding a multi-million-event failure storm. Normal expiry remains the notice-producing path.
- Adds optional `wsBacklogLimit` to `sweepDueNodeDeliveries`, bounding each selected agent's ordered WebSocket backlog page while leaving deferred rows queued for later sweeps.
- Derives and tests a hard worst-case D1 statement ceiling of 534 per retention invocation: five tables x (one high-water read + five page reads + five x twenty chunked deletes), plus four indexed recovery deletes. This stays below D1's 1,000-query invocation limit.

## Verification

- Focused retention/delivery tests: 78 passed.
- Full engine suite: 866 passed.
- Engine lint and build passed.
- Diff check and gitleaks passed; no secrets found.
- Independent exact-head review found no correctness or security blocker.

## Guarded rollout

1. Merge only after exact-head CI is green.
2. Publish only `@relaycast/engine@8.5.2-hotfix.3` from `release/8.5.2` under the `alpha` dist-tag and verify the exact npm artifact.
3. Pin that exact version in relaycast-cloud#133.
4. Enable active recovery with 4 batches and deploy WebSocket redrive breadth 4 x depth 25 (at most 100 rows attempted per cycle).
5. Observe deletion throughput, database size, overload rate, oldest expired age, and replay health. Disable the temporary active recovery switch after the incident backlog drains.
