### PR TITLE
fix(engine): make anonymous workspace replay hosted-safe

### DIFF
--- a/.agentworkforce/trajectories/completed/2026-09/traj_5v5uzkchh8nt/summary.md
+++ b/.agentworkforce/trajectories/completed/2026-09/traj_5v5uzkchh8nt/summary.md
@@ -1,0 +1,31 @@
+# Trajectory: Address Relaycast PR #408 exact-head review findings
+
+> **Status:** ✅ Completed
+> **Confidence:** 95%
+> **Started:** September 10, 2026 at 04:53 AM
+> **Completed:** September 10, 2026 at 04:54 AM
+
+---
+
+## Summary
+
+Redacted Rust bootstrap recovery capabilities from Debug output and documented the proof-required container setting with regression coverage.
+
+**Approach:** Standard approach
+
+---
+
+## Key Decisions
+
+### Redacted anonymous bootstrap idempotency keys in Rust Debug output
+- **Chose:** Redacted anonymous bootstrap idempotency keys in Rust Debug output
+- **Reasoning:** The key is a reveal-once recovery capability; diagnostic output must preserve safe context without exposing either recovery value.
+
+---
+
+## Chapters
+
+### 1. Work
+*Agent: default*
+
+- Redacted anonymous bootstrap idempotency keys in Rust Debug output: Redacted anonymous bootstrap idempotency keys in Rust Debug output

--- a/.agentworkforce/trajectories/completed/2026-09/traj_5v5uzkchh8nt/trajectory.json
+++ b/.agentworkforce/trajectories/completed/2026-09/traj_5v5uzkchh8nt/trajectory.json
@@ -1,0 +1,53 @@
+{
+  "id": "traj_5v5uzkchh8nt",
+  "version": 1,
+  "task": {
+    "title": "Address Relaycast PR #408 exact-head review findings"
+  },
+  "status": "completed",
+  "startedAt": "2026-09-10T02:53:52.276Z",
+  "completedAt": "2026-09-10T02:54:48.629Z",
+  "agents": [
+    {
+      "name": "default",
+      "role": "lead",
+      "joinedAt": "2026-09-10T02:53:52.709Z"
+    }
+  ],
+  "chapters": [
+    {
+      "id": "chap_edgcbdxwxu81",
+      "title": "Work",
+      "agentName": "default",
+      "startedAt": "2026-09-10T02:53:52.709Z",
+      "endedAt": "2026-09-10T02:54:48.629Z",
+      "events": [
+        {
+          "ts": 1789008832710,
+          "type": "decision",
+          "content": "Redacted anonymous bootstrap idempotency keys in Rust Debug output: Redacted anonymous bootstrap idempotency keys in Rust Debug output",
+          "raw": {
+            "question": "Redacted anonymous bootstrap idempotency keys in Rust Debug output",
+            "chosen": "Redacted anonymous bootstrap idempotency keys in Rust Debug output",
+            "alternatives": [],
+            "reasoning": "The key is a reveal-once recovery capability; diagnostic output must preserve safe context without exposing either recovery value."
+          },
+          "significance": "high"
+        }
+      ]
+    }
+  ],
+  "retrospective": {
+    "summary": "Redacted Rust bootstrap recovery capabilities from Debug output and documented the proof-required container setting with regression coverage.",
+    "approach": "Standard approach",
+    "confidence": 0.95
+  },
+  "commits": [],
+  "filesChanged": [],
+  "projectId": "AgentWorkforce/relaycast",
+  "tags": [],
+  "_trace": {
+    "startRef": "e58117cb2bdf04c5286a2b920222114485e0f2d4",
+    "endRef": "e58117cb2bdf04c5286a2b920222114485e0f2d4"
+  }
+}

--- a/.agentworkforce/trajectories/completed/2026-09/traj_j8xeqcgycgh5/summary.md
+++ b/.agentworkforce/trajectories/completed/2026-09/traj_j8xeqcgycgh5/summary.md
@@ -1,0 +1,32 @@
+# Trajectory: Add Rust self-host bootstrap proof parity for Relaycast #407
+
+> **Status:** ✅ Completed
+> **Task:** #407
+> **Confidence:** 94%
+> **Started:** September 10, 2026 at 04:34 AM
+> **Completed:** September 10, 2026 at 04:40 AM
+
+---
+
+## Summary
+
+Added Rust opt-in self-host bootstrap proof parity with hosted-safe omission, destination/redirect protections, redaction, docs, and wire-level tests.
+
+**Approach:** Standard approach
+
+---
+
+## Key Decisions
+
+### Rust bootstrap proof remains opt-in and destination-bound
+- **Chose:** Rust bootstrap proof remains opt-in and destination-bound
+- **Reasoning:** Hosted callers use only a high-entropy idempotency key; the proof is forwarded solely for keyed explicit self-host HTTPS or loopback HTTP, never hosted or redirects.
+
+---
+
+## Chapters
+
+### 1. Work
+*Agent: default*
+
+- Rust bootstrap proof remains opt-in and destination-bound: Rust bootstrap proof remains opt-in and destination-bound

--- a/.agentworkforce/trajectories/completed/2026-09/traj_j8xeqcgycgh5/trajectory.json
+++ b/.agentworkforce/trajectories/completed/2026-09/traj_j8xeqcgycgh5/trajectory.json
@@ -1,0 +1,57 @@
+{
+  "id": "traj_j8xeqcgycgh5",
+  "version": 1,
+  "task": {
+    "title": "Add Rust self-host bootstrap proof parity for Relaycast #407",
+    "source": {
+      "system": "plain",
+      "id": "#407"
+    }
+  },
+  "status": "completed",
+  "startedAt": "2026-09-10T02:34:08.684Z",
+  "completedAt": "2026-09-10T02:40:34.406Z",
+  "agents": [
+    {
+      "name": "default",
+      "role": "lead",
+      "joinedAt": "2026-09-10T02:40:01.609Z"
+    }
+  ],
+  "chapters": [
+    {
+      "id": "chap_0w8lpmtbldp0",
+      "title": "Work",
+      "agentName": "default",
+      "startedAt": "2026-09-10T02:40:01.609Z",
+      "endedAt": "2026-09-10T02:40:34.406Z",
+      "events": [
+        {
+          "ts": 1789008001610,
+          "type": "decision",
+          "content": "Rust bootstrap proof remains opt-in and destination-bound: Rust bootstrap proof remains opt-in and destination-bound",
+          "raw": {
+            "question": "Rust bootstrap proof remains opt-in and destination-bound",
+            "chosen": "Rust bootstrap proof remains opt-in and destination-bound",
+            "alternatives": [],
+            "reasoning": "Hosted callers use only a high-entropy idempotency key; the proof is forwarded solely for keyed explicit self-host HTTPS or loopback HTTP, never hosted or redirects."
+          },
+          "significance": "high"
+        }
+      ]
+    }
+  ],
+  "retrospective": {
+    "summary": "Added Rust opt-in self-host bootstrap proof parity with hosted-safe omission, destination/redirect protections, redaction, docs, and wire-level tests.",
+    "approach": "Standard approach",
+    "confidence": 0.94
+  },
+  "commits": [],
+  "filesChanged": [],
+  "projectId": "AgentWorkforce/relaycast",
+  "tags": [],
+  "_trace": {
+    "startRef": "606023c96a4cd6e30b1c2c016cfecf9b9d538c6b",
+    "endRef": "606023c96a4cd6e30b1c2c016cfecf9b9d538c6b"
+  }
+}

--- a/.agentworkforce/trajectories/completed/2026-09/traj_jlce0oeiitkw/summary.md
+++ b/.agentworkforce/trajectories/completed/2026-09/traj_jlce0oeiitkw/summary.md
@@ -1,0 +1,31 @@
+# Trajectory: Harden RelaycastSetup anonymous keyed workspace transport
+
+> **Status:** ✅ Completed
+> **Confidence:** 96%
+> **Started:** September 10, 2026 at 05:18 AM
+> **Completed:** September 10, 2026 at 05:21 AM
+
+---
+
+## Summary
+
+Hardened RelaycastSetup anonymous keyed workspace creation with the shared HTTPS-or-loopback destination rule, manual redirects, and non-retryable redirect rejection. Added deterministic remote HTTP, cross- and same-origin redirect, loopback, authenticated, and unkeyed-control tests; audited remaining workspace-create idempotency senders.
+
+**Approach:** Standard approach
+
+---
+
+## Key Decisions
+
+### Apply anonymous keyed transport controls to RelaycastSetup
+- **Chose:** Apply anonymous keyed transport controls to RelaycastSetup
+- **Reasoning:** Resolve optional API credentials before classifying requests; share RelayCast destination validation; use manual redirects and treat any 3xx/opaque redirect as non-retryable so the reveal-once idempotency recovery capability never reaches a remote HTTP endpoint or redirect target.
+
+---
+
+## Chapters
+
+### 1. Work
+*Agent: default*
+
+- Apply anonymous keyed transport controls to RelaycastSetup: Apply anonymous keyed transport controls to RelaycastSetup

--- a/.agentworkforce/trajectories/completed/2026-09/traj_jlce0oeiitkw/trajectory.json
+++ b/.agentworkforce/trajectories/completed/2026-09/traj_jlce0oeiitkw/trajectory.json
@@ -1,0 +1,53 @@
+{
+  "id": "traj_jlce0oeiitkw",
+  "version": 1,
+  "task": {
+    "title": "Harden RelaycastSetup anonymous keyed workspace transport"
+  },
+  "status": "completed",
+  "startedAt": "2026-09-10T03:18:56.500Z",
+  "completedAt": "2026-09-10T03:21:45.400Z",
+  "agents": [
+    {
+      "name": "default",
+      "role": "lead",
+      "joinedAt": "2026-09-10T03:21:20.096Z"
+    }
+  ],
+  "chapters": [
+    {
+      "id": "chap_r6gxpp4vfzcg",
+      "title": "Work",
+      "agentName": "default",
+      "startedAt": "2026-09-10T03:21:20.096Z",
+      "endedAt": "2026-09-10T03:21:45.400Z",
+      "events": [
+        {
+          "ts": 1789010480097,
+          "type": "decision",
+          "content": "Apply anonymous keyed transport controls to RelaycastSetup: Apply anonymous keyed transport controls to RelaycastSetup",
+          "raw": {
+            "question": "Apply anonymous keyed transport controls to RelaycastSetup",
+            "chosen": "Apply anonymous keyed transport controls to RelaycastSetup",
+            "alternatives": [],
+            "reasoning": "Resolve optional API credentials before classifying requests; share RelayCast destination validation; use manual redirects and treat any 3xx/opaque redirect as non-retryable so the reveal-once idempotency recovery capability never reaches a remote HTTP endpoint or redirect target."
+          },
+          "significance": "high"
+        }
+      ]
+    }
+  ],
+  "retrospective": {
+    "summary": "Hardened RelaycastSetup anonymous keyed workspace creation with the shared HTTPS-or-loopback destination rule, manual redirects, and non-retryable redirect rejection. Added deterministic remote HTTP, cross- and same-origin redirect, loopback, authenticated, and unkeyed-control tests; audited remaining workspace-create idempotency senders.",
+    "approach": "Standard approach",
+    "confidence": 0.96
+  },
+  "commits": [],
+  "filesChanged": [],
+  "projectId": "AgentWorkforce/relaycast",
+  "tags": [],
+  "_trace": {
+    "startRef": "46cc924a53bb572fcbe8837f708b417a20857e54",
+    "endRef": "46cc924a53bb572fcbe8837f708b417a20857e54"
+  }
+}

--- a/.agentworkforce/trajectories/completed/2026-09/traj_nz7b01xau3kd/summary.md
+++ b/.agentworkforce/trajectories/completed/2026-09/traj_nz7b01xau3kd/summary.md
@@ -1,0 +1,31 @@
+# Trajectory: Protect anonymous keyed workspace bootstrap transport in Rust and TypeScript
+
+> **Status:** ✅ Completed
+> **Confidence:** 96%
+> **Started:** September 10, 2026 at 05:03 AM
+> **Completed:** September 10, 2026 at 05:07 AM
+
+---
+
+## Summary
+
+Applied HTTPS-or-loopback validation and redirect blocking to all anonymous keyed workspace bootstrap requests in Rust and TypeScript, with cross-origin redirect and remote HTTP regressions.
+
+**Approach:** Standard approach
+
+---
+
+## Key Decisions
+
+### Applied transport safeguards to every anonymous keyed workspace bootstrap request
+- **Chose:** Applied transport safeguards to every anonymous keyed workspace bootstrap request
+- **Reasoning:** The anonymous idempotency key is a reveal-once recovery capability, so it must receive HTTPS-or-loopback validation and redirect blocking independently of optional proof forwarding.
+
+---
+
+## Chapters
+
+### 1. Work
+*Agent: default*
+
+- Applied transport safeguards to every anonymous keyed workspace bootstrap request: Applied transport safeguards to every anonymous keyed workspace bootstrap request

--- a/.agentworkforce/trajectories/completed/2026-09/traj_nz7b01xau3kd/trajectory.json
+++ b/.agentworkforce/trajectories/completed/2026-09/traj_nz7b01xau3kd/trajectory.json
@@ -1,0 +1,53 @@
+{
+  "id": "traj_nz7b01xau3kd",
+  "version": 1,
+  "task": {
+    "title": "Protect anonymous keyed workspace bootstrap transport in Rust and TypeScript"
+  },
+  "status": "completed",
+  "startedAt": "2026-09-10T03:03:55.656Z",
+  "completedAt": "2026-09-10T03:07:55.644Z",
+  "agents": [
+    {
+      "name": "default",
+      "role": "lead",
+      "joinedAt": "2026-09-10T03:06:58.034Z"
+    }
+  ],
+  "chapters": [
+    {
+      "id": "chap_h3aiftt3b2ry",
+      "title": "Work",
+      "agentName": "default",
+      "startedAt": "2026-09-10T03:06:58.034Z",
+      "endedAt": "2026-09-10T03:07:55.644Z",
+      "events": [
+        {
+          "ts": 1789009618035,
+          "type": "decision",
+          "content": "Applied transport safeguards to every anonymous keyed workspace bootstrap request: Applied transport safeguards to every anonymous keyed workspace bootstrap request",
+          "raw": {
+            "question": "Applied transport safeguards to every anonymous keyed workspace bootstrap request",
+            "chosen": "Applied transport safeguards to every anonymous keyed workspace bootstrap request",
+            "alternatives": [],
+            "reasoning": "The anonymous idempotency key is a reveal-once recovery capability, so it must receive HTTPS-or-loopback validation and redirect blocking independently of optional proof forwarding."
+          },
+          "significance": "high"
+        }
+      ]
+    }
+  ],
+  "retrospective": {
+    "summary": "Applied HTTPS-or-loopback validation and redirect blocking to all anonymous keyed workspace bootstrap requests in Rust and TypeScript, with cross-origin redirect and remote HTTP regressions.",
+    "approach": "Standard approach",
+    "confidence": 0.96
+  },
+  "commits": [],
+  "filesChanged": [],
+  "projectId": "AgentWorkforce/relaycast",
+  "tags": [],
+  "_trace": {
+    "startRef": "0df3f0a2b6db9fdf49aeeb3dc6b7e304a5b1e51e",
+    "endRef": "0df3f0a2b6db9fdf49aeeb3dc6b7e304a5b1e51e"
+  }
+}

--- a/.agentworkforce/trajectories/completed/2026-09/traj_qbc6obum4olc/summary.md
+++ b/.agentworkforce/trajectories/completed/2026-09/traj_qbc6obum4olc/summary.md
@@ -1,0 +1,32 @@
+# Trajectory: Implement hosted-safe anonymous workspace idempotency contract for issue #407
+
+> **Status:** ✅ Completed
+> **Task:** #407
+> **Confidence:** 94%
+> **Started:** September 10, 2026 at 04:26 AM
+> **Completed:** September 10, 2026 at 04:26 AM
+
+---
+
+## Summary
+
+Implemented hosted-safe anonymous workspace idempotency with opt-in self-host proof enforcement, SDK coverage, and Docker/replay/redaction verification.
+
+**Approach:** Standard approach
+
+---
+
+## Key Decisions
+
+### Use the high-entropy anonymous Idempotency-Key as the hosted recovery capability
+- **Chose:** Use the high-entropy anonymous Idempotency-Key as the hosted recovery capability
+- **Reasoning:** Hosted clients cannot safely hold a deployment-wide secret; the server still needs that secret only for deterministic child API-key derivation, while opt-in self-host proof preserves the stricter deployment model.
+
+---
+
+## Chapters
+
+### 1. Work
+*Agent: default*
+
+- Use the high-entropy anonymous Idempotency-Key as the hosted recovery capability: Use the high-entropy anonymous Idempotency-Key as the hosted recovery capability

--- a/.agentworkforce/trajectories/completed/2026-09/traj_qbc6obum4olc/trajectory.json
+++ b/.agentworkforce/trajectories/completed/2026-09/traj_qbc6obum4olc/trajectory.json
@@ -1,0 +1,57 @@
+{
+  "id": "traj_qbc6obum4olc",
+  "version": 1,
+  "task": {
+    "title": "Implement hosted-safe anonymous workspace idempotency contract for issue #407",
+    "source": {
+      "system": "plain",
+      "id": "#407"
+    }
+  },
+  "status": "completed",
+  "startedAt": "2026-09-10T02:26:31.596Z",
+  "completedAt": "2026-09-10T02:26:32.136Z",
+  "agents": [
+    {
+      "name": "default",
+      "role": "lead",
+      "joinedAt": "2026-09-10T02:26:31.876Z"
+    }
+  ],
+  "chapters": [
+    {
+      "id": "chap_gus28ulr9uqi",
+      "title": "Work",
+      "agentName": "default",
+      "startedAt": "2026-09-10T02:26:31.876Z",
+      "endedAt": "2026-09-10T02:26:32.136Z",
+      "events": [
+        {
+          "ts": 1789007191877,
+          "type": "decision",
+          "content": "Use the high-entropy anonymous Idempotency-Key as the hosted recovery capability: Use the high-entropy anonymous Idempotency-Key as the hosted recovery capability",
+          "raw": {
+            "question": "Use the high-entropy anonymous Idempotency-Key as the hosted recovery capability",
+            "chosen": "Use the high-entropy anonymous Idempotency-Key as the hosted recovery capability",
+            "alternatives": [],
+            "reasoning": "Hosted clients cannot safely hold a deployment-wide secret; the server still needs that secret only for deterministic child API-key derivation, while opt-in self-host proof preserves the stricter deployment model."
+          },
+          "significance": "high"
+        }
+      ]
+    }
+  ],
+  "retrospective": {
+    "summary": "Implemented hosted-safe anonymous workspace idempotency with opt-in self-host proof enforcement, SDK coverage, and Docker/replay/redaction verification.",
+    "approach": "Standard approach",
+    "confidence": 0.94
+  },
+  "commits": [],
+  "filesChanged": [],
+  "projectId": "AgentWorkforce/relaycast",
+  "tags": [],
+  "_trace": {
+    "startRef": "996ec342099968fef63bdc646f647e5820ba3d39",
+    "endRef": "996ec342099968fef63bdc646f647e5820ba3d39"
+  }
+}

--- a/.env.example
+++ b/.env.example
@@ -7,6 +7,9 @@ PORT=8080
 # and reuse it across restarts. If unset, anonymous keyed workspace creation
 # fails closed with 503 while unkeyed and authenticated creation still works.
 # RELAYCAST_WORKSPACE_BOOTSTRAP_SECRET=
+# Set to true only when every anonymous keyed caller is trusted with the
+# deployment secret. Hosted clients must leave this false/unset.
+# RELAYCAST_WORKSPACE_BOOTSTRAP_PROOF_REQUIRED=false
 
 # Database
 DATABASE_URL=postgresql://relay:relay@localhost:5433/relay

--- a/.github/workflows/container-integration.yml
+++ b/.github/workflows/container-integration.yml
@@ -4,7 +4,7 @@ name: Self-Host Container Integration
 # persistent volume, driving it entirely over HTTP -- the only place that
 # exercises the actual built image rather than the entrypoint script or the
 # engine in isolation. See test/container-image-integration.test.mjs for the
-# full scenario list (bootstrap-secret restart/replay, missing-secret 503,
+# full scenario list (idempotency-key restart/replay, missing-secret 503,
 # invalid-auth 401, digest-conflict 409, and log-redaction).
 on:
   schedule:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,15 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 Packages without a separate changelog are covered by the cross-package notes below.
 
-## [Unreleased]
+## [Unreleased - Minor]
+
+### Changed
+
+- Anonymous keyed workspace creation now treats a CSPRNG `Idempotency-Key` as the hosted-safe recovery capability; the deployment derivation secret remains server-only, while self-hosts can opt into shared-secret proof enforcement.
+
+### Added
+
+- Rust SDK `WorkspaceBootstrapOptions` and `RelayCast::create_workspace_with_options()` support crash-safe anonymous keyed workspace creation without a deployment secret.
 
 ## [8.7.0] - 2026-09-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,10 @@ Packages without a separate changelog are covered by the cross-package notes bel
 
 - Rust SDK `WorkspaceBootstrapOptions` supports crash-safe anonymous keyed workspace creation without a deployment secret and opt-in self-host bootstrap proof without exposing it to hosted Relaycast.
 
+### Fixed
+
+- Rust and TypeScript SDK anonymous keyed workspace bootstrap refuses remote HTTP and redirects, keeping its recovery capability on the intended origin.
+
 ## [8.7.0] - 2026-09-09
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ Packages without a separate changelog are covered by the cross-package notes bel
 
 ### Added
 
-- Rust SDK `WorkspaceBootstrapOptions` and `RelayCast::create_workspace_with_options()` support crash-safe anonymous keyed workspace creation without a deployment secret.
+- Rust SDK `WorkspaceBootstrapOptions` supports crash-safe anonymous keyed workspace creation without a deployment secret and opt-in self-host bootstrap proof without exposing it to hosted Relaycast.
 
 ## [8.7.0] - 2026-09-09
 

--- a/README.md
+++ b/README.md
@@ -111,21 +111,17 @@ const child = await RelayCast.createWorkspace('job-child', {
 });
 ```
 
-Fresh bootstrap callers can use the same contract without an API key, but must
-also present the deployment's bootstrap secret as proof — the idempotency key
-alone is a caller-chosen value, not a secret by itself, so it cannot authorize
-recovering another caller's workspace credentials. For the same reason, the
-key must be generated with a CSPRNG (for example, a v4 UUID or 16 random bytes
-hex-encoded — never a job id, timestamp, or counter), and persist it alongside
+Fresh bootstrap callers use the same contract without an API key. Their
+`Idempotency-Key` is a narrowly scoped, reveal-once recovery capability, so it
+must be generated with a CSPRNG (for example, a v4 UUID or 16 random bytes
+hex-encoded — never a job id, timestamp, or counter) and persisted alongside
 the work so a genuine retry reuses the exact same value. The server only
 enforces a 32-character structural minimum; it cannot verify randomness:
 
 ```ts
 const idempotencyKey = crypto.randomUUID(); // persist with the work; reuse it on retry
 const workspace = await RelayCast.createWorkspace('my-project', {
-  baseUrl: 'https://relay.example.com', // your self-hosted deployment
   idempotencyKey,
-  bootstrapSecret: process.env.RELAYCAST_WORKSPACE_BOOTSTRAP_SECRET,
 });
 ```
 
@@ -135,13 +131,15 @@ the workspace terminalizes its binding; replaying the key cannot accidentally
 create a replacement. Unauthenticated by-name lookup never returns workspace
 credentials.
 
-Keyed anonymous bootstrap requires a stable deployment secret. Self-hosted
-deployments must persist `RELAYCAST_WORKSPACE_BOOTSTRAP_SECRET` (or provide
-`workspaceBootstrapSecret` in the engine config); deployments without it return
-`503 workspace_create_idempotency_unavailable`. A caller that omits the secret
-or presents the wrong one gets `401 workspace_create_bootstrap_secret_invalid`
-before any lookup of the idempotency binding — the secret is the deployment's
-to configure and share only with callers it trusts to bootstrap a workspace.
+Keyed anonymous bootstrap requires a stable server-side derivation secret.
+Self-hosted deployments must persist `RELAYCAST_WORKSPACE_BOOTSTRAP_SECRET` (or
+provide `workspaceBootstrapSecret` in engine config); deployments without it
+return `503 workspace_create_idempotency_unavailable`. Never distribute that
+deployment-wide secret to hosted clients. Self-hosted operators that need the
+previous shared-secret proof can opt in with
+`RELAYCAST_WORKSPACE_BOOTSTRAP_PROOF_REQUIRED=true`; only then must callers
+also send `X-Workspace-Bootstrap-Secret`, and missing or invalid proof returns
+`401 workspace_create_bootstrap_secret_invalid` before a binding lookup.
 Unkeyed creates remain available and continue to generate a fresh API key.
 
 If workspace storage remains unavailable after its transient retries and the

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,7 @@ services:
       - ${RELAYCAST_BASE_URL:?Set RELAYCAST_BASE_URL to the public HTTPS origin, for example https://relay.ratifyprotocol.com}
     environment:
       RELAYCAST_WORKSPACE_BOOTSTRAP_SECRET: ${RELAYCAST_WORKSPACE_BOOTSTRAP_SECRET-}
+      RELAYCAST_WORKSPACE_BOOTSTRAP_PROOF_REQUIRED: ${RELAYCAST_WORKSPACE_BOOTSTRAP_PROOF_REQUIRED-false}
     init: true
     restart: unless-stopped
     read_only: true

--- a/docker/entrypoint-core.mjs
+++ b/docker/entrypoint-core.mjs
@@ -16,6 +16,7 @@ Options:
 
 Environment:
   RELAYCAST_WORKSPACE_BOOTSTRAP_SECRET  Stable secret for anonymous keyed workspace retries
+  RELAYCAST_WORKSPACE_BOOTSTRAP_PROOF_REQUIRED  Set true to require bootstrap-secret proof for anonymous keyed creates
 `;
 
 export class BaseUrlError extends Error {

--- a/docker/entrypoint-core.mjs
+++ b/docker/entrypoint-core.mjs
@@ -342,6 +342,9 @@ export function buildEngineConfig(env, mailbox = {}) {
     ...(env.RELAYCAST_WORKSPACE_BOOTSTRAP_SECRET
       ? { workspaceBootstrapSecret: env.RELAYCAST_WORKSPACE_BOOTSTRAP_SECRET }
       : {}),
+    ...(env.RELAYCAST_WORKSPACE_BOOTSTRAP_PROOF_REQUIRED === 'true'
+      ? { workspaceBootstrapProofRequired: true }
+      : {}),
     ...(Object.keys(mailbox).length > 0 ? { mailbox } : {}),
   };
 }

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -64,7 +64,8 @@ Flags take precedence over environment variables.
 | `--base-url <url>` | — | `http://localhost:<port>` | Public origin. **Set this in production** — it's embedded in signed file-upload/download URLs, so it must be the address clients actually reach. |
 | `--env <name>` | `RELAYCAST_ENV` | `production` | Environment label used in logs. |
 | — | `RELAYCAST_MESSAGE_TTL_DAYS` | unset (keep forever) | Opt in to pruning message history after this many days. Unset, `0`, or negative keeps messages forever. Per-workspace `retention` settings override this; operational tables (deliveries, message logs) prune at 90 days regardless. |
-| — | `RELAYCAST_WORKSPACE_BOOTSTRAP_SECRET` | unset (fail closed) | Stable deployment secret for anonymous keyed workspace retries. Generate once with `openssl rand -hex 32` and persist it across restarts. |
+| — | `RELAYCAST_WORKSPACE_BOOTSTRAP_SECRET` | unset (fail closed) | Stable server-only derivation secret for anonymous keyed workspace retries. Generate once with `openssl rand -hex 32` and persist it across restarts. |
+| — | `RELAYCAST_WORKSPACE_BOOTSTRAP_PROOF_REQUIRED` | `false` | Optional self-host policy requiring callers to prove the derivation secret. Leave unset for hosted-safe anonymous retries. |
 
 **Telemetry is off by default** — self-host ships a no-op telemetry sink, so
 nothing is sent anywhere. (There is no PostHog/analytics in self-host.)
@@ -88,14 +89,18 @@ it, put it in a Dockerfile, pass it as a command-line argument, or print it in
 logs. The server only passes it to the HMAC derivation path and never logs or
 stores it.
 
-**The caller must also present the secret.** `Idempotency-Key` is a
-caller-chosen, non-secret value, not proof of identity — every anonymous
-keyed create must send `X-Workspace-Bootstrap-Secret: <the same secret>` or it
-is rejected with `401 workspace_create_bootstrap_secret_invalid` before any
-lookup of the idempotency binding. Only give the secret to callers you trust
-to bootstrap a workspace on this deployment (your own setup script or
-container entrypoint, for example) — anyone who has it can create or recover
-any anonymous bootstrap workspace on this deployment:
+The caller does **not** receive this deployment-wide secret. Its high-entropy
+`Idempotency-Key` is the narrowly scoped recovery capability: use one CSPRNG
+key for each logical create/retry sequence and keep it unchanged when retrying.
+The server uses the secret only to derive the returned child key. This is the
+hosted-safe default and keeps the server secret out of SDKs, CLIs, and logs.
+
+If every anonymous keyed caller is trusted with the deployment secret, a
+self-host can opt into the former proof requirement with
+`RELAYCAST_WORKSPACE_BOOTSTRAP_PROOF_REQUIRED=true`. In that mode callers must
+send `X-Workspace-Bootstrap-Secret: <the same secret>`; missing or mismatched
+proof returns `401 workspace_create_bootstrap_secret_invalid` before binding
+lookup. Do not enable this mode for arbitrary hosted clients.
 
 Generate the replay key once per logical create/retry sequence with a CSPRNG;
 keep it unchanged when retrying (a v4 UUID or 16 random bytes encoded as hex
@@ -107,7 +112,6 @@ BOOTSTRAP_IDEMPOTENCY_KEY="$(openssl rand -hex 16)"
 curl -s -XPOST http://localhost:8787/v1/workspaces \
   -H 'content-type: application/json' \
   -H "Idempotency-Key: ${BOOTSTRAP_IDEMPOTENCY_KEY}" \
-  -H "X-Workspace-Bootstrap-Secret: $RELAYCAST_WORKSPACE_BOOTSTRAP_SECRET" \
   -d '{"name":"my-team"}'
 ```
 

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -181,7 +181,7 @@ components:
           description: Snowflake ID of the workspace
         api_key:
           type: string
-          description: Workspace API key (returned on first creation and on an authenticated idempotent replay or an anonymous bootstrap replay with a valid bootstrap-secret proof)
+          description: Workspace API key (returned on first creation and on authenticated or anonymous idempotent replay)
         created_at:
           type: string
           format: date-time
@@ -1503,11 +1503,10 @@ paths:
         provide an `Idempotency-Key`: authenticated requests bind the owner, key, and exact request
         digest, while anonymous bootstrap requests bind the key to the deployment. Replaying the
         same request returns the same workspace and usable API key with a `200` response, while
-        changing the request returns `409`. An anonymous (no `Authorization`) request that supplies
-        `Idempotency-Key` must also supply `X-Workspace-Bootstrap-Secret` matching the deployment's
-        configured bootstrap secret; the `Idempotency-Key` alone is a caller-chosen, non-secret
-        correlator, so proving the deployment secret is what authorizes looking up or recovering the
-        binding. If transient storage attempts are
+        changing the request returns `409`. For an anonymous (no `Authorization`) request, a
+        CSPRNG-generated `Idempotency-Key` is the narrowly scoped recovery capability; the configured
+        deployment secret remains server-only HMAC material for deterministic child-key derivation.
+        Self-hosts can optionally require `X-Workspace-Bootstrap-Secret` proof. If transient storage attempts are
         exhausted and the server cannot confirm the committed workspace/channel pair, it returns
         `503 workspace_storage_unavailable`; that outcome is indeterminate.
       tags:
@@ -1551,8 +1550,7 @@ paths:
             authorization it is scoped to anonymous bootstrap creation on this
             deployment. Reusing it with the same request replays the workspace;
             a different request is a 409. For an anonymous (bootstrap) create,
-            this key is part of what authorizes recovering the binding
-            alongside `X-Workspace-Bootstrap-Secret`. Callers must generate it
+            this key is the narrowly scoped recovery capability. Callers must generate it
             with a CSPRNG (a v4 UUID is suitable). The server enforces only a
             32-character structural minimum: only a shorter value returns
             `400 workspace_create_idempotency_key_too_weak`. This
@@ -1563,12 +1561,11 @@ paths:
           schema:
             type: string
           description: >-
-            Required alongside `Idempotency-Key` for an anonymous (no
-            `Authorization`) request. Must match the deployment's configured
-            bootstrap secret; a missing or mismatched value returns `401`
-            before any lookup of the idempotency binding. Not used, and not
-            required, for authenticated or unkeyed (no `Idempotency-Key`)
-            creates.
+            Optional self-host proof for anonymous keyed creates when the
+            deployment enables bootstrap proof enforcement. Hosted callers
+            must not send this deployment-wide secret. When enforcement is
+            enabled, a missing or mismatched value returns `401` before any
+            binding lookup. Not used for authenticated or unkeyed creates.
       responses:
         '200':
           description: Existing workspace returned (idempotent)
@@ -1613,8 +1610,9 @@ paths:
         '401':
           description: >-
             Invalid owner workspace key for authenticated keyed creation, or
-            `workspace_create_bootstrap_secret_invalid` — an anonymous keyed
-            create did not supply a matching `X-Workspace-Bootstrap-Secret`.
+            `workspace_create_bootstrap_secret_invalid` when a self-host has
+            enabled bootstrap-proof enforcement and an anonymous keyed create
+            did not supply a matching `X-Workspace-Bootstrap-Secret`.
           content:
             application/json:
               schema:

--- a/packages/engine/CHANGELOG.md
+++ b/packages/engine/CHANGELOG.md
@@ -7,7 +7,11 @@ See the [root changelog](../../CHANGELOG.md) for cross-package release highlight
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [Unreleased - Minor]
+
+### Changed
+
+- Anonymous keyed workspace creation now uses the validated CSPRNG `Idempotency-Key` as its hosted-safe recovery capability; bootstrap secrets remain server-only derivation material, and self-host proof enforcement is opt-in.
 
 ## [8.7.0] - 2026-09-09
 

--- a/packages/engine/src/__tests__/conformance/harness.ts
+++ b/packages/engine/src/__tests__/conformance/harness.ts
@@ -46,6 +46,7 @@ export function makeNodeStack(options?: {
   environment?: string;
   httpPushProxy?: EngineConfig['httpPushProxy'];
   workspaceBootstrapSecret?: string;
+  workspaceBootstrapProofRequired?: boolean;
   entitlements?: EntitlementsProvider;
 }): TestStack {
   const tasks = new BackgroundTasks();
@@ -67,6 +68,7 @@ export function makeNodeStack(options?: {
         mailbox: options?.mailbox,
         httpPushProxy: options?.httpPushProxy,
         workspaceBootstrapSecret: options?.workspaceBootstrapSecret ?? 'test-bootstrap-secret',
+        workspaceBootstrapProofRequired: options?.workspaceBootstrapProofRequired,
       },
       entitlements: options?.entitlements,
       // Disable the auto-sweep timer; tests drive presence.sweep() explicitly.

--- a/packages/engine/src/__tests__/conformance/workspaceLifecycle.test.ts
+++ b/packages/engine/src/__tests__/conformance/workspaceLifecycle.test.ts
@@ -193,13 +193,12 @@ describe('workspace lifecycle', () => {
     expect(await stack.runtime.handle.db.select().from(workspaces)).toHaveLength(0);
   });
 
-  it('keeps anonymous bootstrap available when Authorization is absent and the bootstrap secret is proven', async () => {
+  it('keeps hosted anonymous bootstrap available without exposing the deployment secret', async () => {
     const response = await stack.app.request('/v1/workspaces', {
       method: 'POST',
       headers: {
         'content-type': 'application/json',
-        'Idempotency-Key': anonKey('auth-absent-379'),
-        'X-Workspace-Bootstrap-Secret': 'test-bootstrap-secret',
+        'Idempotency-Key': anonKey('auth-absent-407'),
       },
       body: JSON.stringify({ name: 'anonymous-still-works' }),
     });
@@ -208,10 +207,12 @@ describe('workspace lifecycle', () => {
     expect((await response.json() as { data: { api_key: string } }).data.api_key).toMatch(/^rk_/);
   });
 
-  it('rejects an anonymous idempotency-keyed create that cannot prove the bootstrap secret', async () => {
+  it('retains bootstrap-secret proof enforcement as an explicit self-host option', async () => {
+    await stack.close();
+    stack = makeNodeStack({ workspaceBootstrapProofRequired: true });
     const missing = await stack.app.request('/v1/workspaces', {
       method: 'POST',
-      headers: { 'content-type': 'application/json', 'Idempotency-Key': anonKey('no-proof-379') },
+      headers: { 'content-type': 'application/json', 'Idempotency-Key': anonKey('no-proof-407') },
       body: JSON.stringify({ name: 'no-proof-workspace' }),
     });
     expect(missing.status).toBe(401);
@@ -222,7 +223,7 @@ describe('workspace lifecycle', () => {
       method: 'POST',
       headers: {
         'content-type': 'application/json',
-        'Idempotency-Key': anonKey('wrong-proof-379'),
+        'Idempotency-Key': anonKey('wrong-proof-407'),
         'X-Workspace-Bootstrap-Secret': 'not-the-configured-secret',
       },
       body: JSON.stringify({ name: 'wrong-proof-workspace' }),
@@ -263,42 +264,23 @@ describe('workspace lifecycle', () => {
     expect(ok.status).toBe(201);
   });
 
-  it('does not let an unproven caller retrieve a workspace another anonymous caller already bootstrapped', async () => {
-    const key = anonKey('squatting-attempt-e2e-379');
+  it('replays a hosted anonymous create using only its high-entropy recovery key', async () => {
+    const key = anonKey('hosted-replay-e2e-407');
     const body = JSON.stringify({ name: 'squatting-target-e2e' });
     const legitimate = await stack.app.request('/v1/workspaces', {
       method: 'POST',
       headers: {
         'content-type': 'application/json',
         'Idempotency-Key': key,
-        'X-Workspace-Bootstrap-Secret': 'test-bootstrap-secret',
       },
       body,
     });
     expect(legitimate.status).toBe(201);
     const legitimateData = (await legitimate.json() as { data: { workspace_id: string; api_key: string } }).data;
 
-    // A caller who only knows the (non-secret) Idempotency-Key and can
-    // recompute the (fully public) request digest, but does not know the
-    // deployment's bootstrap secret, must not be able to recover the same
-    // workspace or its API key.
-    const attacker = await stack.app.request('/v1/workspaces', {
-      method: 'POST',
-      headers: { 'content-type': 'application/json', 'Idempotency-Key': key },
-      body,
-    });
-    expect(attacker.status).toBe(401);
-    expect((await attacker.json() as { error: { code: string } }).error.code)
-      .toBe('workspace_create_bootstrap_secret_invalid');
-
-    // The legitimate caller can still replay with the correct proof.
     const replay = await stack.app.request('/v1/workspaces', {
       method: 'POST',
-      headers: {
-        'content-type': 'application/json',
-        'Idempotency-Key': key,
-        'X-Workspace-Bootstrap-Secret': 'test-bootstrap-secret',
-      },
+      headers: { 'content-type': 'application/json', 'Idempotency-Key': key },
       body,
     });
     expect(replay.status).toBe(200);
@@ -327,8 +309,7 @@ describe('workspace lifecycle', () => {
         method: 'POST',
         headers: {
           'content-type': 'application/json',
-          'Idempotency-Key': anonKey('restart-contract-379'),
-          'X-Workspace-Bootstrap-Secret': 'stable-test-secret',
+          'Idempotency-Key': anonKey('restart-contract-407'),
         },
         body: JSON.stringify({ name: 'restart-contract' }),
       });
@@ -345,26 +326,13 @@ describe('workspace lifecycle', () => {
         method: 'POST',
         headers: {
           'content-type': 'application/json',
-          'Idempotency-Key': anonKey('restart-contract-379'),
-          'X-Workspace-Bootstrap-Secret': 'stable-test-secret',
+          'Idempotency-Key': anonKey('restart-contract-407'),
         },
         body: JSON.stringify({ name: 'restart-contract' }),
       });
       expect(replay.status).toBe(200);
       expect((await replay.json() as { data: unknown }).data).toEqual(firstData);
 
-      // A caller who does not present the deployment's bootstrap secret
-      // cannot recover the same replay even after it has been restarted onto
-      // a fresh runtime -- only the secret, not the runtime process, is what
-      // stability across restarts depends on.
-      const unproven = await createEngine(restartedRuntime.deps).request('/v1/workspaces', {
-        method: 'POST',
-        headers: { 'content-type': 'application/json', 'Idempotency-Key': anonKey('restart-contract-379') },
-        body: JSON.stringify({ name: 'restart-contract' }),
-      });
-      expect(unproven.status).toBe(401);
-      expect((await unproven.json() as { error: { code: string } }).error.code)
-        .toBe('workspace_create_bootstrap_secret_invalid');
       restartedRuntime.close();
       restartedRuntime = undefined;
 
@@ -405,8 +373,7 @@ describe('workspace lifecycle', () => {
   it('replays anonymous bootstrap creates and terminalizes them on expiry', async () => {
     const headers = {
       'content-type': 'application/json',
-      'Idempotency-Key': anonKey('bootstrap-expiry-379'),
-      'X-Workspace-Bootstrap-Secret': 'test-bootstrap-secret',
+        'Idempotency-Key': anonKey('bootstrap-expiry-407'),
     };
     const body = JSON.stringify({ name: 'bootstrap-expiry', expires_in_seconds: 60 });
     const first = await stack.app.request('/v1/workspaces', { method: 'POST', headers, body });

--- a/packages/engine/src/bin/serve.ts
+++ b/packages/engine/src/bin/serve.ts
@@ -88,6 +88,9 @@ async function main(): Promise<void> {
       ...(process.env.RELAYCAST_WORKSPACE_BOOTSTRAP_SECRET
         ? { workspaceBootstrapSecret: process.env.RELAYCAST_WORKSPACE_BOOTSTRAP_SECRET }
         : {}),
+      ...(process.env.RELAYCAST_WORKSPACE_BOOTSTRAP_PROOF_REQUIRED === 'true'
+        ? { workspaceBootstrapProofRequired: true }
+        : {}),
       ...(Object.keys(mailbox).length > 0 ? { mailbox } : {}),
     },
     ...(eventQueue ? { eventQueue } : {}),

--- a/packages/engine/src/engine/__tests__/workspace.test.ts
+++ b/packages/engine/src/engine/__tests__/workspace.test.ts
@@ -245,7 +245,6 @@ describe('workspace write durability', () => {
     const requestDigest = await workspaceCreateRequestDigest({ name: 'bootstrap-child', expiresInSeconds: 3_600 });
     const created = await createWorkspace(db, 'bootstrap-child', {
       bootstrapSecret,
-      bootstrapSecretProof: bootstrapSecret,
       idempotencyKey,
       requestDigest,
       expiresAt: new Date(Date.now() + 3_600_000),
@@ -259,7 +258,6 @@ describe('workspace write durability', () => {
 
     const replay = await createWorkspace(db, 'bootstrap-child', {
       bootstrapSecret,
-      bootstrapSecretProof: bootstrapSecret,
       idempotencyKey,
       requestDigest,
     });
@@ -274,7 +272,7 @@ describe('workspace write durability', () => {
     const idempotencyKey = anonKey('same-key-379');
     const requestDigest = await workspaceCreateRequestDigest({ name: 'bootstrap-isolation' });
     const bootstrap = await createWorkspace(db, 'bootstrap-isolation', {
-      bootstrapSecret, bootstrapSecretProof: bootstrapSecret, idempotencyKey, requestDigest,
+      bootstrapSecret, idempotencyKey, requestDigest,
     });
     const owner = await createWorkspace(db, 'owner-isolation', {
       ownerApiKey: 'rk_live_owner_379', idempotencyKey, requestDigest,
@@ -284,7 +282,7 @@ describe('workspace write durability', () => {
 
     const changedDigest = await workspaceCreateRequestDigest({ name: 'bootstrap-changed' });
     await expect(createWorkspace(db, 'bootstrap-changed', {
-      bootstrapSecret, bootstrapSecretProof: bootstrapSecret, idempotencyKey, requestDigest: changedDigest,
+      bootstrapSecret, idempotencyKey, requestDigest: changedDigest,
     })).rejects.toMatchObject({ code: 'workspace_create_idempotency_conflict', status: 409 });
     expect(await db.select().from(workspaces)).toHaveLength(2);
   });
@@ -295,8 +293,8 @@ describe('workspace write durability', () => {
     const idempotencyKey = anonKey('bootstrap-concurrent-379');
     const requestDigest = await workspaceCreateRequestDigest({ name: 'bootstrap-concurrent' });
     const [first, second] = await Promise.all([
-      createWorkspace(db, 'bootstrap-concurrent', { bootstrapSecret, bootstrapSecretProof: bootstrapSecret, idempotencyKey, requestDigest }),
-      createWorkspace(db, 'bootstrap-concurrent', { bootstrapSecret, bootstrapSecretProof: bootstrapSecret, idempotencyKey, requestDigest }),
+      createWorkspace(db, 'bootstrap-concurrent', { bootstrapSecret, idempotencyKey, requestDigest }),
+      createWorkspace(db, 'bootstrap-concurrent', { bootstrapSecret, idempotencyKey, requestDigest }),
     ]);
     expect(first.workspace_id).toBe(second.workspace_id);
     expect(first.api_key).toBe(second.api_key);
@@ -305,50 +303,27 @@ describe('workspace write durability', () => {
     expect(await db.select().from(workspaceCreateIdempotency)).toHaveLength(1);
   });
 
-  it('rejects an anonymous bootstrap replay that cannot prove the deployment secret', async () => {
+  it('uses a high-entropy anonymous idempotency key as the hosted replay capability', async () => {
     attachD1Batch({});
     const bootstrapSecret = 'test-bootstrap-secret';
     const idempotencyKey = anonKey('squatting-attempt-379');
     const requestDigest = await workspaceCreateRequestDigest({ name: 'squatting-target' });
 
-    // The legitimate caller creates the workspace, proving the secret.
     const created = await createWorkspace(db, 'squatting-target', {
-      bootstrapSecret, bootstrapSecretProof: bootstrapSecret, idempotencyKey, requestDigest,
+      bootstrapSecret, idempotencyKey, requestDigest,
     });
     expect(created.created).toBe(true);
 
-    // An attacker who has only observed/guessed the same idempotency key and
-    // request digest -- both non-secret, attacker-computable values -- must
-    // not be able to retrieve the workspace or its API key without also
-    // proving the deployment's bootstrap secret.
-    await expect(createWorkspace(db, 'squatting-target', {
-      bootstrapSecret, idempotencyKey, requestDigest, // no bootstrapSecretProof
-    })).rejects.toMatchObject({ code: 'workspace_create_bootstrap_secret_invalid', status: 401 });
-
-    await expect(createWorkspace(db, 'squatting-target', {
-      bootstrapSecret, bootstrapSecretProof: 'wrong-secret', idempotencyKey, requestDigest,
-    })).rejects.toMatchObject({ code: 'workspace_create_bootstrap_secret_invalid', status: 401 });
-
-    // A first-time attacker create attempt under the same key must also fail
-    // closed rather than falling through to create its own workspace: an
-    // unproven caller must never influence bootstrap-scoped state at all.
-    await expect(createWorkspace(db, 'attacker-would-create', {
-      bootstrapSecret,
-      idempotencyKey: anonKey('never-created-379'),
-      requestDigest: await workspaceCreateRequestDigest({ name: 'attacker-would-create' }),
-    })).rejects.toMatchObject({ code: 'workspace_create_bootstrap_secret_invalid', status: 401 });
-    expect(await db.select().from(workspaces)).toHaveLength(1);
-
-    // The legitimate caller can still replay indefinitely -- e.g. across
-    // container restarts -- as long as it keeps presenting the same secret.
+    // The key is the hosted recovery capability. The deployment secret never
+    // crosses the API boundary, but still deterministically derives the key.
     const replay = await createWorkspace(db, 'squatting-target', {
-      bootstrapSecret, bootstrapSecretProof: bootstrapSecret, idempotencyKey, requestDigest,
+      bootstrapSecret, idempotencyKey, requestDigest,
     });
     expect(replay.created).toBe(false);
     expect(replay.api_key).toBe(created.api_key);
   });
 
-  it('rejects an anonymous bootstrap Idempotency-Key below the structural floor, even with the correct secret', async () => {
+  it('rejects an anonymous bootstrap Idempotency-Key below the structural floor', async () => {
     attachD1Batch({});
     const bootstrapSecret = 'test-bootstrap-secret';
     const requestDigest = await workspaceCreateRequestDigest({ name: 'weak-key-target' });
@@ -364,7 +339,7 @@ describe('workspace write durability', () => {
       'x'.repeat(MIN_BOOTSTRAP_IDEMPOTENCY_KEY_LENGTH - 1),
     ]) {
       await expect(createWorkspace(db, 'weak-key-target', {
-        bootstrapSecret, bootstrapSecretProof: bootstrapSecret, idempotencyKey: weakKey, requestDigest,
+        bootstrapSecret, idempotencyKey: weakKey, requestDigest,
       })).rejects.toMatchObject({
         code: 'workspace_create_idempotency_key_too_weak',
         status: 400,
@@ -373,36 +348,31 @@ describe('workspace write durability', () => {
     }
     expect(await db.select().from(workspaces)).toHaveLength(0);
 
-    // Control: a deterministic key of exactly the floor length, with the
-    // correct secret, succeeds. The server checks shape only; callers own
+    // Control: a deterministic key of exactly the floor length succeeds. The
+    // server checks shape only; callers own
     // randomness.
     const structuralKey = 'x'.repeat(MIN_BOOTSTRAP_IDEMPOTENCY_KEY_LENGTH);
     const created = await createWorkspace(db, 'weak-key-target', {
       bootstrapSecret,
-      bootstrapSecretProof: bootstrapSecret,
       idempotencyKey: structuralKey,
       requestDigest,
     });
     expect(created.created).toBe(true);
   });
 
-  it('does not weaken an attacker replay attempt just because the guessed key happens to be long enough', async () => {
-    // An attacker who can construct a long-enough (but still guessed) key
-    // still cannot pass the bootstrap-secret proof: the structural floor and
-    // the secret proof are independent, both-required checks, not
-    // alternatives to each other.
+  it('retains optional self-host bootstrap-secret proof enforcement', async () => {
     attachD1Batch({});
     const bootstrapSecret = 'test-bootstrap-secret';
     const idempotencyKey = anonKey('long-enough-guessed-key-379');
     const requestDigest = await workspaceCreateRequestDigest({ name: 'long-guess-target' });
 
     const created = await createWorkspace(db, 'long-guess-target', {
-      bootstrapSecret, bootstrapSecretProof: bootstrapSecret, idempotencyKey, requestDigest,
+      bootstrapSecret, bootstrapSecretProof: bootstrapSecret, bootstrapProofRequired: true, idempotencyKey, requestDigest,
     });
     expect(created.created).toBe(true);
 
     await expect(createWorkspace(db, 'long-guess-target', {
-      bootstrapSecret, idempotencyKey, requestDigest, // correct length, no proof
+      bootstrapSecret, bootstrapProofRequired: true, idempotencyKey, requestDigest,
     })).rejects.toMatchObject({ code: 'workspace_create_bootstrap_secret_invalid', status: 401 });
     expect(await db.select().from(workspaces)).toHaveLength(1);
   });

--- a/packages/engine/src/engine/workspace.ts
+++ b/packages/engine/src/engine/workspace.ts
@@ -30,14 +30,14 @@ type CreateWorkspaceOptions =
       /** Deployment-configured secret used to derive the anonymous bootstrap child key. */
       bootstrapSecret?: string;
       /**
-       * The bootstrap secret as presented by the caller. An anonymous,
-       * idempotency-keyed create must prove it, matching `bootstrapSecret`,
-       * before any binding lookup or credential is returned — otherwise the
-       * `Idempotency-Key` alone (a caller-chosen, non-secret value) would let
-       * any network peer who guesses or observes it retrieve a workspace's
-       * deterministic API key. See createWorkspace's bootstrap-proof check.
+       * The bootstrap secret as presented by the caller when a self-host opts
+       * into shared-secret proof enforcement. Hosted deployments keep the
+       * server derivation secret private and use the high-entropy
+       * Idempotency-Key as the narrowly scoped recovery capability.
        */
       bootstrapSecretProof?: string;
+      /** Enable the optional self-host bootstrap-secret proof requirement. */
+      bootstrapProofRequired?: boolean;
       /**
        * Crash-safe workspace-create replay key (relaycast#371/#379).
        *
@@ -47,9 +47,8 @@ type CreateWorkspaceOptions =
        * be unique per logical operation (e.g. a job id).
        *
        * Anonymous bootstrap (no owner key): the key is scoped to the
-       * deployment, not to a caller, and — together with
-       * `X-Workspace-Bootstrap-Secret` — is what recovers or replays the
-       * binding. Generate it with a CSPRNG, never a derived or guessable
+       * deployment, not to a caller, and is the reveal-once recovery
+       * capability for the binding. Generate it with a CSPRNG, never a derived or guessable
        * value such as a job id, timestamp, or counter. A v4 UUID, 16 random
        * bytes hex-encoded, or at least 24 random bytes base64url-encoded meet
        * the 32-character structural minimum. `createWorkspace` cannot verify
@@ -238,6 +237,7 @@ export async function createWorkspace(
   const providedOwnerApiKey = typeof options === 'string' ? options : options?.ownerApiKey;
   const bootstrapSecret = typeof options === 'string' ? undefined : options?.bootstrapSecret;
   const bootstrapSecretProof = typeof options === 'string' ? undefined : options?.bootstrapSecretProof;
+  const bootstrapProofRequired = typeof options === 'string' ? false : options?.bootstrapProofRequired === true;
   const expiresAt = typeof options === 'string' ? undefined : options?.expiresAt;
   const derivedOwnerApiKeyHash = providedOwnerApiKey ? await hashApiKey(providedOwnerApiKey) : undefined;
 
@@ -260,11 +260,10 @@ export async function createWorkspace(
     );
   }
 
-  // relaycast#379: an anonymous bootstrap Idempotency-Key stands in for a
-  // caller identity — together with X-Workspace-Bootstrap-Secret, it is
-  // part of what authorizes recovering a binding. Callers must generate it
-  // with a CSPRNG; this length-only structural floor is checked before any
-  // secret or database work and cannot prove the key was actually random.
+  // An anonymous bootstrap Idempotency-Key is a reveal-once recovery
+  // capability. Callers must generate it with a CSPRNG; this length-only
+  // structural floor is checked before any secret or database work and cannot
+  // prove the key was actually random.
   if (bootstrapIdempotency && idempotencyKey!.length < MIN_BOOTSTRAP_IDEMPOTENCY_KEY_LENGTH) {
     throw codedError(
       `Anonymous Idempotency-Key must be at least ${MIN_BOOTSTRAP_IDEMPOTENCY_KEY_LENGTH} characters. Generate it with a CSPRNG, such as a v4 UUID, 16 random bytes hex-encoded, or at least 24 random bytes base64url-encoded.`,
@@ -280,19 +279,12 @@ export async function createWorkspace(
       503,
     );
   }
-  // The Idempotency-Key is a caller-chosen, non-secret correlator, not proof
-  // of identity: without this check, any network peer who guesses or
-  // observes a low-entropy or leaked key (plus the fully public request
-  // digest) could replay another caller's anonymous bootstrap create and
-  // receive its deterministic child API key before — or instead of — the
-  // legitimate caller. Only a caller who also proves knowledge of the
-  // deployment's own bootstrap secret may look up or recover a bootstrap
-  // binding. The proof is checked with a constant-time comparison and before
-  // any binding lookup, so neither timing nor a binding's existence leaks to
-  // a caller who does not hold the secret. The container/self-host entrypoint
-  // and any other trusted caller hold the same configured secret, so replay
-  // across restarts stays fully stable for them.
-  if (bootstrapIdempotency && bootstrapSecret) {
+  // Hosted callers must never receive a deployment-wide secret. Their
+  // CSPRNG-generated Idempotency-Key is the narrow recovery capability, while
+  // bootstrapSecret remains server-only HMAC material for deterministic child
+  // key derivation. A self-host may retain the former shared-secret proof as
+  // an explicit hardening policy; check it before any binding lookup.
+  if (bootstrapIdempotency && bootstrapSecret && bootstrapProofRequired) {
     if (!bootstrapSecretProof || !(await constantTimeEqual(bootstrapSecretProof, bootstrapSecret))) {
       throw codedError(
         'A valid workspace bootstrap secret is required for anonymous idempotent workspace creation',

--- a/packages/engine/src/ports/index.ts
+++ b/packages/engine/src/ports/index.ts
@@ -116,6 +116,13 @@ export interface EngineConfig {
    */
   workspaceBootstrapSecret?: string;
   /**
+   * Require callers of anonymous keyed workspace creation to prove knowledge
+   * of `workspaceBootstrapSecret`. This optional self-host hardening mode is
+   * off for hosted deployments, where the high-entropy Idempotency-Key is the
+   * narrowly scoped recovery capability and the secret remains server-only.
+   */
+  workspaceBootstrapProofRequired?: boolean;
+  /**
    * Optional egress proxy for http_push node delivery. When set, nodes that
    * register with `delivery.use_proxy: true` have their webhook POST routed
    * through this forwarder instead of hitting the destination directly — the

--- a/packages/engine/src/routes/workspace.ts
+++ b/packages/engine/src/routes/workspace.ts
@@ -195,10 +195,9 @@ const publicWorkspaceLookupRateLimit = createMiddleware<AppEnv>(async (c, next) 
 });
 
 // POST /workspaces - create workspace (no auth required, workspace key optional).
-// An anonymous create carrying an Idempotency-Key additionally requires
-// X-Workspace-Bootstrap-Secret to match the deployment's configured
-// workspaceBootstrapSecret before any binding lookup or credential recovery
-// runs — see createWorkspace's bootstrap-proof check.
+// An anonymous create carrying a high-entropy Idempotency-Key uses that key as
+// its recovery capability. Self-hosts may additionally opt into requiring
+// X-Workspace-Bootstrap-Secret before any binding lookup or recovery runs.
 workspaceRoutes.post('/workspaces', async (c) => {
   try {
     const parsed = await parseJsonBody(c, createWorkspaceSchema, 'name is required');
@@ -245,6 +244,7 @@ workspaceRoutes.post('/workspaces', async (c) => {
           ? {
             bootstrapSecret: c.get('engine').config.workspaceBootstrapSecret,
             bootstrapSecretProof: c.req.header('X-Workspace-Bootstrap-Secret'),
+            bootstrapProofRequired: c.get('engine').config.workspaceBootstrapProofRequired,
           }
           : {}),
         ...(idempotencyKey ? { idempotencyKey } : {}),

--- a/packages/sdk-rust/CHANGELOG.md
+++ b/packages/sdk-rust/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
 
 ### Fixed
 
+- Anonymous keyed workspace bootstrap rejects remote HTTP and redirects, preventing its recovery capability from reaching another origin.
 - Retryable HTTP failures retain the final status, API error, request metadata, and attempt count after retries are exhausted.
 - Retried 5xx responses honor a bounded `Retry-After` delay.
 

--- a/packages/sdk-rust/CHANGELOG.md
+++ b/packages/sdk-rust/CHANGELOG.md
@@ -24,7 +24,7 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
 ### Added
 
 - `RelayCast::create_workspace` now requires explicit provenance, preventing CLI bootstrap workspaces from being mislabeled as SDK-created.
-- `WorkspaceBootstrapOptions` and `RelayCast::create_workspace_with_options()` support crash-safe anonymous keyed workspace creation without a deployment-wide secret.
+- `WorkspaceBootstrapOptions` and `RelayCast::create_workspace_with_options()` support crash-safe anonymous keyed workspace creation without a deployment-wide secret, plus opt-in self-host proof via `with_bootstrap_secret(...)`; the SDK never sends that proof to hosted Relaycast.
 - `RelayCast::release_agent_if_token_hash` performs generation-safe cleanup without changing the existing `ReleaseAgentRequest` struct.
 
 ## [4.2.0] - 2026-06-24

--- a/packages/sdk-rust/CHANGELOG.md
+++ b/packages/sdk-rust/CHANGELOG.md
@@ -24,6 +24,7 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
 ### Added
 
 - `RelayCast::create_workspace` now requires explicit provenance, preventing CLI bootstrap workspaces from being mislabeled as SDK-created.
+- `WorkspaceBootstrapOptions` and `RelayCast::create_workspace_with_options()` support crash-safe anonymous keyed workspace creation without a deployment-wide secret.
 - `RelayCast::release_agent_if_token_hash` performs generation-safe cleanup without changing the existing `ReleaseAgentRequest` struct.
 
 ## [4.2.0] - 2026-06-24

--- a/packages/sdk-rust/src/lib.rs
+++ b/packages/sdk-rust/src/lib.rs
@@ -199,6 +199,7 @@ pub use types::{
     CreateWebhookResponse,
     // Workspace
     CreateWorkspaceResponse,
+    WorkspaceBootstrapOptions,
     WorkspaceCreationSource,
     WorkspaceProvenance,
     WorkspaceUsageClassification,

--- a/packages/sdk-rust/src/relay.rs
+++ b/packages/sdk-rust/src/relay.rs
@@ -102,18 +102,52 @@ impl RelayCast {
         base_url: Option<&str>,
         provenance: WorkspaceProvenance,
     ) -> Result<CreateWorkspaceResponse> {
-        let url = format!("{}/v1/workspaces", base_url.unwrap_or(DEFAULT_BASE_URL));
+        let mut options = WorkspaceBootstrapOptions::new(provenance);
+        if let Some(base_url) = base_url {
+            options = options.with_base_url(base_url);
+        }
+        Self::create_workspace_with_options(name, options).await
+    }
+
+    /// Create a workspace with optional crash-safe anonymous idempotency.
+    ///
+    /// A hosted anonymous `idempotency_key` must be a CSPRNG-generated
+    /// reveal-once recovery capability. It is never combined with or used to
+    /// transmit a deployment-wide server secret.
+    pub async fn create_workspace_with_options(
+        name: &str,
+        options: WorkspaceBootstrapOptions,
+    ) -> Result<CreateWorkspaceResponse> {
+        if let Some(key) = options.idempotency_key.as_deref() {
+            if key.len() < 32 {
+                return Err(RelayError::InvalidResponse(
+                    "Anonymous Idempotency-Key must be at least 32 characters".to_string(),
+                ));
+            }
+            if key.len() > 255 || !key.bytes().all(|byte| (b'!'..=b'~').contains(&byte)) {
+                return Err(RelayError::InvalidResponse(
+                    "Idempotency-Key must contain 1-255 visible ASCII characters".to_string(),
+                ));
+            }
+        }
+
+        let url = format!(
+            "{}/v1/workspaces",
+            options.base_url.as_deref().unwrap_or(DEFAULT_BASE_URL)
+        );
 
         let client = reqwest::Client::new();
-        let response = client
+        let mut request = client
             .post(&url)
             .header("Content-Type", "application/json")
             .header("X-SDK-Version", SDK_VERSION)
             .header("X-Relaycast-Origin-Client", DEFAULT_ORIGIN_CLIENT)
             .header("X-Relaycast-Origin-Version", SDK_VERSION)
-            .json(&serde_json::json!({ "name": name, "provenance": provenance }))
-            .send()
-            .await?;
+            .json(&serde_json::json!({ "name": name, "provenance": options.provenance }));
+        if let Some(key) = options.idempotency_key {
+            request = request.header("Idempotency-Key", key);
+        }
+        let response = request.send().await?;
 
         let status = response.status().as_u16();
         let json: ApiResponse<CreateWorkspaceResponse> = response.json().await?;

--- a/packages/sdk-rust/src/relay.rs
+++ b/packages/sdk-rust/src/relay.rs
@@ -5,6 +5,7 @@ use crate::client::{ClientOptions, HttpClient};
 use crate::error::{RelayError, Result};
 use crate::types::*;
 use serde::Serialize;
+use url::Url;
 
 use crate::DEFAULT_BASE_URL;
 
@@ -13,6 +14,35 @@ const DEFAULT_ORIGIN_CLIENT: &str = "@relaycast/sdk-rust";
 
 fn strip_hash(channel: &str) -> &str {
     channel.strip_prefix('#').unwrap_or(channel)
+}
+
+fn validate_bootstrap_secret_destination(base_url: &str) -> Result<()> {
+    let parsed = Url::parse(base_url).map_err(|_| {
+        RelayError::InvalidResponse(
+            "Anonymous keyed workspace bootstrap requires a valid self-hosted baseUrl".to_string(),
+        )
+    })?;
+    let hostname = parsed
+        .host_str()
+        .unwrap_or_default()
+        .trim_end_matches('.')
+        .to_ascii_lowercase();
+    let loopback_http =
+        parsed.scheme() == "http" && matches!(hostname.as_str(), "localhost" | "127.0.0.1" | "::1");
+
+    if parsed.scheme() != "https" && !loopback_http {
+        return Err(RelayError::InvalidResponse(
+            "Anonymous keyed workspace bootstrap requires an HTTPS self-hosted baseUrl (or loopback HTTP for local development)".to_string(),
+        ));
+    }
+    if hostname == "cast.agentrelay.com" {
+        return Err(RelayError::InvalidResponse(
+            "Anonymous keyed workspace bootstrap cannot send a bootstrapSecret to the hosted gateway"
+                .to_string(),
+        ));
+    }
+
+    Ok(())
 }
 
 /// Options for creating a RelayCast client.
@@ -113,12 +143,21 @@ impl RelayCast {
     ///
     /// A hosted anonymous `idempotency_key` must be a CSPRNG-generated
     /// reveal-once recovery capability. It is never combined with or used to
-    /// transmit a deployment-wide server secret.
+    /// transmit a deployment-wide server secret. An optional
+    /// `bootstrap_secret` is sent only to an explicit safe self-hosted origin
+    /// for deployments that opt into proof enforcement.
     pub async fn create_workspace_with_options(
         name: &str,
         options: WorkspaceBootstrapOptions,
     ) -> Result<CreateWorkspaceResponse> {
-        if let Some(key) = options.idempotency_key.as_deref() {
+        let WorkspaceBootstrapOptions {
+            base_url,
+            provenance,
+            idempotency_key,
+            bootstrap_secret,
+        } = options;
+
+        if let Some(key) = idempotency_key.as_deref() {
             if key.len() < 32 {
                 return Err(RelayError::InvalidResponse(
                     "Anonymous Idempotency-Key must be at least 32 characters".to_string(),
@@ -131,21 +170,45 @@ impl RelayCast {
             }
         }
 
+        let sends_bootstrap_secret = idempotency_key.is_some() && bootstrap_secret.is_some();
+        if sends_bootstrap_secret {
+            let explicit_base_url = base_url.as_deref().ok_or_else(|| {
+                RelayError::InvalidResponse(
+                    "Anonymous keyed workspace bootstrap with a bootstrapSecret requires an explicit self-hosted baseUrl"
+                        .to_string(),
+                )
+            })?;
+            validate_bootstrap_secret_destination(explicit_base_url)?;
+        }
+
         let url = format!(
             "{}/v1/workspaces",
-            options.base_url.as_deref().unwrap_or(DEFAULT_BASE_URL)
+            base_url.as_deref().unwrap_or(DEFAULT_BASE_URL)
         );
 
-        let client = reqwest::Client::new();
+        // Never follow a redirect after attaching the self-host proof; a
+        // redirect could otherwise forward it to a different origin.
+        let client = if sends_bootstrap_secret {
+            reqwest::Client::builder()
+                .redirect(reqwest::redirect::Policy::none())
+                .build()?
+        } else {
+            reqwest::Client::new()
+        };
         let mut request = client
             .post(&url)
             .header("Content-Type", "application/json")
             .header("X-SDK-Version", SDK_VERSION)
             .header("X-Relaycast-Origin-Client", DEFAULT_ORIGIN_CLIENT)
             .header("X-Relaycast-Origin-Version", SDK_VERSION)
-            .json(&serde_json::json!({ "name": name, "provenance": options.provenance }));
-        if let Some(key) = options.idempotency_key {
+            .json(&serde_json::json!({ "name": name, "provenance": provenance }));
+        if let Some(key) = idempotency_key {
             request = request.header("Idempotency-Key", key);
+        }
+        if sends_bootstrap_secret {
+            if let Some(bootstrap_secret) = bootstrap_secret {
+                request = request.header("X-Workspace-Bootstrap-Secret", bootstrap_secret);
+            }
         }
         let response = request.send().await?;
 

--- a/packages/sdk-rust/src/relay.rs
+++ b/packages/sdk-rust/src/relay.rs
@@ -16,10 +16,10 @@ fn strip_hash(channel: &str) -> &str {
     channel.strip_prefix('#').unwrap_or(channel)
 }
 
-fn validate_bootstrap_secret_destination(base_url: &str) -> Result<()> {
+fn validate_anonymous_keyed_bootstrap_destination(base_url: &str) -> Result<Url> {
     let parsed = Url::parse(base_url).map_err(|_| {
         RelayError::InvalidResponse(
-            "Anonymous keyed workspace bootstrap requires a valid self-hosted baseUrl".to_string(),
+            "Anonymous keyed workspace bootstrap requires a valid baseUrl".to_string(),
         )
     })?;
     let hostname = parsed
@@ -35,6 +35,17 @@ fn validate_bootstrap_secret_destination(base_url: &str) -> Result<()> {
             "Anonymous keyed workspace bootstrap requires an HTTPS self-hosted baseUrl (or loopback HTTP for local development)".to_string(),
         ));
     }
+
+    Ok(parsed)
+}
+
+fn validate_bootstrap_secret_destination(base_url: &str) -> Result<()> {
+    let parsed = validate_anonymous_keyed_bootstrap_destination(base_url)?;
+    let hostname = parsed
+        .host_str()
+        .unwrap_or_default()
+        .trim_end_matches('.')
+        .to_ascii_lowercase();
     if hostname == "cast.agentrelay.com" {
         return Err(RelayError::InvalidResponse(
             "Anonymous keyed workspace bootstrap cannot send a bootstrapSecret to the hosted gateway"
@@ -170,7 +181,14 @@ impl RelayCast {
             }
         }
 
-        let sends_bootstrap_secret = idempotency_key.is_some() && bootstrap_secret.is_some();
+        let anonymous_keyed_request = idempotency_key.is_some();
+        if anonymous_keyed_request {
+            validate_anonymous_keyed_bootstrap_destination(
+                base_url.as_deref().unwrap_or(DEFAULT_BASE_URL),
+            )?;
+        }
+
+        let sends_bootstrap_secret = anonymous_keyed_request && bootstrap_secret.is_some();
         if sends_bootstrap_secret {
             let explicit_base_url = base_url.as_deref().ok_or_else(|| {
                 RelayError::InvalidResponse(
@@ -186,9 +204,9 @@ impl RelayCast {
             base_url.as_deref().unwrap_or(DEFAULT_BASE_URL)
         );
 
-        // Never follow a redirect after attaching the self-host proof; a
-        // redirect could otherwise forward it to a different origin.
-        let client = if sends_bootstrap_secret {
+        // An anonymous Idempotency-Key is a reveal-once recovery capability,
+        // so never follow a redirect that could forward it to another origin.
+        let client = if anonymous_keyed_request {
             reqwest::Client::builder()
                 .redirect(reqwest::redirect::Policy::none())
                 .build()?

--- a/packages/sdk-rust/src/types.rs
+++ b/packages/sdk-rust/src/types.rs
@@ -49,11 +49,33 @@ pub struct CreateWorkspaceResponse {
 /// `idempotency_key` is a reveal-once recovery capability for anonymous
 /// creation. Generate it with a CSPRNG and persist it for the logical create
 /// operation; it is sent to hosted Relaycast without any deployment secret.
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct WorkspaceBootstrapOptions {
     pub base_url: Option<String>,
     pub provenance: WorkspaceProvenance,
     pub idempotency_key: Option<String>,
+    /// Optional shared-secret proof for a self-host that explicitly requires
+    /// `X-Workspace-Bootstrap-Secret`.
+    ///
+    /// Leave this unset for hosted Relaycast. The SDK refuses to send it to
+    /// the hosted gateway, and only sends it with an idempotency key to an
+    /// explicit self-hosted origin.
+    pub bootstrap_secret: Option<String>,
+}
+
+impl std::fmt::Debug for WorkspaceBootstrapOptions {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("WorkspaceBootstrapOptions")
+            .field("base_url", &self.base_url)
+            .field("provenance", &self.provenance)
+            .field("idempotency_key", &self.idempotency_key)
+            .field(
+                "bootstrap_secret",
+                &self.bootstrap_secret.as_ref().map(|_| "<redacted>"),
+            )
+            .finish()
+    }
 }
 
 impl WorkspaceBootstrapOptions {
@@ -62,6 +84,7 @@ impl WorkspaceBootstrapOptions {
             base_url: None,
             provenance,
             idempotency_key: None,
+            bootstrap_secret: None,
         }
     }
 
@@ -72,6 +95,16 @@ impl WorkspaceBootstrapOptions {
 
     pub fn with_idempotency_key(mut self, idempotency_key: impl Into<String>) -> Self {
         self.idempotency_key = Some(idempotency_key.into());
+        self
+    }
+
+    /// Add a proof only for an opt-in self-hosted bootstrap deployment.
+    ///
+    /// This is intentionally optional: hosted anonymous bootstrap uses the
+    /// high-entropy idempotency key alone and must not receive a deployment
+    /// secret from the caller.
+    pub fn with_bootstrap_secret(mut self, bootstrap_secret: impl Into<String>) -> Self {
+        self.bootstrap_secret = Some(bootstrap_secret.into());
         self
     }
 }

--- a/packages/sdk-rust/src/types.rs
+++ b/packages/sdk-rust/src/types.rs
@@ -69,7 +69,10 @@ impl std::fmt::Debug for WorkspaceBootstrapOptions {
             .debug_struct("WorkspaceBootstrapOptions")
             .field("base_url", &self.base_url)
             .field("provenance", &self.provenance)
-            .field("idempotency_key", &self.idempotency_key)
+            .field(
+                "idempotency_key",
+                &self.idempotency_key.as_ref().map(|_| "<redacted>"),
+            )
             .field(
                 "bootstrap_secret",
                 &self.bootstrap_secret.as_ref().map(|_| "<redacted>"),

--- a/packages/sdk-rust/src/types.rs
+++ b/packages/sdk-rust/src/types.rs
@@ -44,6 +44,38 @@ pub struct CreateWorkspaceResponse {
     pub created_at: String,
 }
 
+/// Options for an unauthenticated workspace bootstrap request.
+///
+/// `idempotency_key` is a reveal-once recovery capability for anonymous
+/// creation. Generate it with a CSPRNG and persist it for the logical create
+/// operation; it is sent to hosted Relaycast without any deployment secret.
+#[derive(Debug, Clone)]
+pub struct WorkspaceBootstrapOptions {
+    pub base_url: Option<String>,
+    pub provenance: WorkspaceProvenance,
+    pub idempotency_key: Option<String>,
+}
+
+impl WorkspaceBootstrapOptions {
+    pub fn new(provenance: WorkspaceProvenance) -> Self {
+        Self {
+            base_url: None,
+            provenance,
+            idempotency_key: None,
+        }
+    }
+
+    pub fn with_base_url(mut self, base_url: impl Into<String>) -> Self {
+        self.base_url = Some(base_url.into());
+        self
+    }
+
+    pub fn with_idempotency_key(mut self, idempotency_key: impl Into<String>) -> Self {
+        self.idempotency_key = Some(idempotency_key.into());
+        self
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum WorkspaceCreationSource {

--- a/packages/sdk-rust/tests/parity.rs
+++ b/packages/sdk-rust/tests/parity.rs
@@ -7,10 +7,10 @@ use relaycast::{
     ListDeliveriesOptions, ListSessionEventsQuery, MessageInjectionMode, MessageListQuery,
     MonitorCertificationRequest, NodeDeliveryAuth, NodeDeliveryConfig, NodeListQuery,
     ObserverScope, ObserverTokenFilters, RateDirectoryAgentRequest, RegisterA2aOptions,
-    RegisterActionRequest, RelayCast, RelayCastOptions, ReleaseAgentRequest, RouteFeedbackRequest,
-    SearchDirectoryQuery, SpawnAgentRequest, SubmitCertificationRequest,
+    RegisterActionRequest, RelayCast, RelayCastOptions, RelayError, ReleaseAgentRequest,
+    RouteFeedbackRequest, SearchDirectoryQuery, SpawnAgentRequest, SubmitCertificationRequest,
     UpdateObserverTokenRequest, UpdateRoutingConfigRequest, WebhookTriggerRequest,
-    WorkspaceProvenance, WsClient, WsClientOptions, WsEvent,
+    WorkspaceBootstrapOptions, WorkspaceProvenance, WsClient, WsClientOptions, WsEvent,
 };
 use serde_json::json;
 use std::net::TcpListener;
@@ -448,6 +448,52 @@ async fn create_workspace_sends_origin_headers() {
     .expect("create_workspace failed");
 
     assert_eq!(created.workspace_id, "ws_123");
+}
+
+#[tokio::test]
+async fn create_workspace_with_options_sends_hosted_idempotency_key_without_a_secret() {
+    let server = MockServer::start().await;
+    let key = "hosted-run-407-9f3a7c1e5b8d2f4a6c0e8b2d4f6a8c0e";
+
+    Mock::given(method("POST"))
+        .and(path("/v1/workspaces"))
+        .and(header("idempotency-key", key))
+        .and(body_json(json!({
+            "name": "Hosted Retry",
+            "provenance": { "source": "sdk" }
+        })))
+        .respond_with(ok(json!({
+            "workspace_id": "ws_hosted",
+            "api_key": "rk_live_hosted",
+            "created_at": "2026-09-10T00:00:00.000Z"
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let created = RelayCast::create_workspace_with_options(
+        "Hosted Retry",
+        WorkspaceBootstrapOptions::new(WorkspaceProvenance::sdk())
+            .with_base_url(server.uri())
+            .with_idempotency_key(key),
+    )
+    .await
+    .expect("keyed hosted workspace create failed");
+
+    assert_eq!(created.workspace_id, "ws_hosted");
+}
+
+#[tokio::test]
+async fn create_workspace_with_options_rejects_a_weak_anonymous_key_before_request() {
+    let result = RelayCast::create_workspace_with_options(
+        "Weak Retry",
+        WorkspaceBootstrapOptions::new(WorkspaceProvenance::sdk()).with_idempotency_key("job-407"),
+    )
+    .await;
+
+    assert!(
+        matches!(result, Err(RelayError::InvalidResponse(message)) if message.contains("at least 32"))
+    );
 }
 
 #[tokio::test]

--- a/packages/sdk-rust/tests/parity.rs
+++ b/packages/sdk-rust/tests/parity.rs
@@ -481,6 +481,181 @@ async fn create_workspace_with_options_sends_hosted_idempotency_key_without_a_se
     .expect("keyed hosted workspace create failed");
 
     assert_eq!(created.workspace_id, "ws_hosted");
+    let requests = server
+        .received_requests()
+        .await
+        .expect("mock server should retain requests");
+    assert_eq!(requests.len(), 1);
+    assert!(requests[0]
+        .headers
+        .get("x-workspace-bootstrap-secret")
+        .is_none());
+}
+
+#[tokio::test]
+async fn create_workspace_with_options_forwards_an_opt_in_self_host_bootstrap_proof() {
+    let server = MockServer::start().await;
+    let key = "self-host-run-407-9f3a7c1e5b8d2f4a6c0e8b2d4f6a8c0e";
+
+    Mock::given(method("POST"))
+        .and(path("/v1/workspaces"))
+        .and(header("idempotency-key", key))
+        .and(header(
+            "x-workspace-bootstrap-secret",
+            "self-host-deployment-proof",
+        ))
+        .respond_with(ok(json!({
+            "workspace_id": "ws_self_hosted",
+            "api_key": "rk_live_self_hosted",
+            "created_at": "2026-09-10T00:00:00.000Z"
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let created = RelayCast::create_workspace_with_options(
+        "Self-host Retry",
+        WorkspaceBootstrapOptions::new(WorkspaceProvenance::sdk())
+            .with_base_url(server.uri())
+            .with_idempotency_key(key)
+            .with_bootstrap_secret("self-host-deployment-proof"),
+    )
+    .await
+    .expect("keyed self-host workspace create failed");
+
+    assert_eq!(created.workspace_id, "ws_self_hosted");
+}
+
+#[tokio::test]
+async fn bootstrap_secret_is_not_sent_without_an_idempotency_key() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path("/v1/workspaces"))
+        .respond_with(ok(json!({
+            "workspace_id": "ws_unkeyed",
+            "api_key": "rk_live_unkeyed",
+            "created_at": "2026-09-10T00:00:00.000Z"
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    RelayCast::create_workspace_with_options(
+        "Unkeyed Retry",
+        WorkspaceBootstrapOptions::new(WorkspaceProvenance::sdk())
+            .with_base_url(server.uri())
+            .with_bootstrap_secret("must-not-leave-the-process"),
+    )
+    .await
+    .expect("unkeyed workspace create failed");
+
+    let requests = server
+        .received_requests()
+        .await
+        .expect("mock server should retain requests");
+    assert_eq!(requests.len(), 1);
+    assert!(requests[0]
+        .headers
+        .get("x-workspace-bootstrap-secret")
+        .is_none());
+}
+
+#[tokio::test]
+async fn bootstrap_secret_is_rejected_for_the_hosted_gateway_without_disclosure() {
+    let secret = "self-host-deployment-secret";
+    let result = RelayCast::create_workspace_with_options(
+        "Hosted Retry",
+        WorkspaceBootstrapOptions::new(WorkspaceProvenance::sdk())
+            .with_base_url("https://CAST.AGENTRELAY.COM./")
+            .with_idempotency_key("hosted-run-407-9f3a7c1e5b8d2f4a6c0e8b2d4f6a8c0e")
+            .with_bootstrap_secret(secret),
+    )
+    .await;
+
+    assert!(matches!(
+        result,
+        Err(RelayError::InvalidResponse(message))
+            if message.contains("cannot send a bootstrapSecret") && !message.contains(secret)
+    ));
+}
+
+#[tokio::test]
+async fn bootstrap_secret_requires_an_explicit_secure_self_host_origin() {
+    let secret = "self-host-deployment-secret";
+    let key = "self-host-run-407-9f3a7c1e5b8d2f4a6c0e8b2d4f6a8c0e";
+
+    let missing_origin = RelayCast::create_workspace_with_options(
+        "Hosted Retry",
+        WorkspaceBootstrapOptions::new(WorkspaceProvenance::sdk())
+            .with_idempotency_key(key)
+            .with_bootstrap_secret(secret),
+    )
+    .await;
+    assert!(matches!(
+        missing_origin,
+        Err(RelayError::InvalidResponse(message))
+            if message.contains("requires an explicit self-hosted baseUrl") && !message.contains(secret)
+    ));
+
+    let insecure_origin = RelayCast::create_workspace_with_options(
+        "Hosted Retry",
+        WorkspaceBootstrapOptions::new(WorkspaceProvenance::sdk())
+            .with_base_url("http://self-host.example")
+            .with_idempotency_key(key)
+            .with_bootstrap_secret(secret),
+    )
+    .await;
+    assert!(matches!(
+        insecure_origin,
+        Err(RelayError::InvalidResponse(message))
+            if message.contains("requires an HTTPS self-hosted baseUrl") && !message.contains(secret)
+    ));
+}
+
+#[tokio::test]
+async fn bootstrap_secret_is_not_forwarded_across_a_redirect() {
+    let origin = MockServer::start().await;
+    let redirected = MockServer::start().await;
+    let key = "self-host-run-407-9f3a7c1e5b8d2f4a6c0e8b2d4f6a8c0e";
+
+    Mock::given(method("POST"))
+        .and(path("/v1/workspaces"))
+        .respond_with(ResponseTemplate::new(307).insert_header("Location", redirected.uri()))
+        .expect(1)
+        .mount(&origin)
+        .await;
+
+    let result = RelayCast::create_workspace_with_options(
+        "Redirected Retry",
+        WorkspaceBootstrapOptions::new(WorkspaceProvenance::sdk())
+            .with_base_url(origin.uri())
+            .with_idempotency_key(key)
+            .with_bootstrap_secret("do-not-forward"),
+    )
+    .await;
+    assert!(result.is_err());
+
+    assert!(
+        redirected
+            .received_requests()
+            .await
+            .unwrap_or_default()
+            .is_empty(),
+        "the proof must not be forwarded to a redirect target"
+    );
+}
+
+#[test]
+fn workspace_bootstrap_options_redacts_the_self_host_proof_from_debug_output() {
+    let secret = "self-host-deployment-secret";
+    let options = WorkspaceBootstrapOptions::new(WorkspaceProvenance::sdk())
+        .with_idempotency_key("hosted-run-407-9f3a7c1e5b8d2f4a6c0e8b2d4f6a8c0e")
+        .with_bootstrap_secret(secret);
+    let debug = format!("{options:?}");
+
+    assert!(debug.contains("<redacted>"));
+    assert!(!debug.contains(secret));
 }
 
 #[tokio::test]

--- a/packages/sdk-rust/tests/parity.rs
+++ b/packages/sdk-rust/tests/parity.rs
@@ -646,6 +646,54 @@ async fn bootstrap_secret_is_not_forwarded_across_a_redirect() {
     );
 }
 
+#[tokio::test]
+async fn anonymous_keyed_workspace_is_not_followed_across_a_redirect() {
+    let origin = MockServer::start().await;
+    let redirected = MockServer::start().await;
+    let key = "hosted-run-408-9f3a7c1e5b8d2f4a6c0e8b2d4f6a8c0e";
+
+    Mock::given(method("POST"))
+        .and(path("/v1/workspaces"))
+        .respond_with(ResponseTemplate::new(307).insert_header("Location", redirected.uri()))
+        .expect(1)
+        .mount(&origin)
+        .await;
+
+    let result = RelayCast::create_workspace_with_options(
+        "Redirected Keyed Retry",
+        WorkspaceBootstrapOptions::new(WorkspaceProvenance::sdk())
+            .with_base_url(origin.uri())
+            .with_idempotency_key(key),
+    )
+    .await;
+    assert!(result.is_err());
+
+    assert!(
+        redirected
+            .received_requests()
+            .await
+            .unwrap_or_default()
+            .is_empty(),
+        "the recovery capability must not be forwarded to a redirect target"
+    );
+}
+
+#[tokio::test]
+async fn anonymous_keyed_workspace_rejects_remote_plaintext_http() {
+    let result = RelayCast::create_workspace_with_options(
+        "Remote Plaintext Retry",
+        WorkspaceBootstrapOptions::new(WorkspaceProvenance::sdk())
+            .with_base_url("http://self-host.example")
+            .with_idempotency_key("hosted-run-408-9f3a7c1e5b8d2f4a6c0e8b2d4f6a8c0e"),
+    )
+    .await;
+
+    assert!(matches!(
+        result,
+        Err(RelayError::InvalidResponse(message)) if message.contains("requires an HTTPS")
+    ));
+}
+
 #[test]
 fn workspace_bootstrap_options_redacts_recovery_capabilities_from_debug_output() {
     let idempotency_key = "hosted-run-407-9f3a7c1e5b8d2f4a6c0e8b2d4f6a8c0e";

--- a/packages/sdk-rust/tests/parity.rs
+++ b/packages/sdk-rust/tests/parity.rs
@@ -647,15 +647,21 @@ async fn bootstrap_secret_is_not_forwarded_across_a_redirect() {
 }
 
 #[test]
-fn workspace_bootstrap_options_redacts_the_self_host_proof_from_debug_output() {
+fn workspace_bootstrap_options_redacts_recovery_capabilities_from_debug_output() {
+    let idempotency_key = "hosted-run-407-9f3a7c1e5b8d2f4a6c0e8b2d4f6a8c0e";
     let secret = "self-host-deployment-secret";
     let options = WorkspaceBootstrapOptions::new(WorkspaceProvenance::sdk())
-        .with_idempotency_key("hosted-run-407-9f3a7c1e5b8d2f4a6c0e8b2d4f6a8c0e")
-        .with_bootstrap_secret(secret);
+    .with_base_url("https://self-host.example.test")
+    .with_idempotency_key(idempotency_key)
+    .with_bootstrap_secret(secret);
     let debug = format!("{options:?}");
 
-    assert!(debug.contains("<redacted>"));
+    assert!(debug.contains("idempotency_key: Some(\"<redacted>\")"));
+    assert!(debug.contains("bootstrap_secret: Some(\"<redacted>\")"));
+    assert!(!debug.contains(idempotency_key));
     assert!(!debug.contains(secret));
+    assert!(debug.contains("https://self-host.example.test"));
+    assert!(debug.contains("source: Sdk"));
 }
 
 #[tokio::test]

--- a/packages/sdk-typescript/CHANGELOG.md
+++ b/packages/sdk-typescript/CHANGELOG.md
@@ -7,7 +7,11 @@ See the [root changelog](../../CHANGELOG.md) for cross-package release highlight
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [Unreleased - Minor]
+
+### Changed
+
+- `RelayCast.createWorkspace()` can replay anonymous hosted creation with a CSPRNG `idempotencyKey` without accepting or transmitting a deployment-wide secret.
 
 ## [8.6.0] - 2026-09-09
 

--- a/packages/sdk-typescript/CHANGELOG.md
+++ b/packages/sdk-typescript/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 - `RelayCast.createWorkspace()` can replay anonymous hosted creation with a CSPRNG `idempotencyKey` without accepting or transmitting a deployment-wide secret.
 
+### Fixed
+
+- Anonymous keyed workspace bootstrap rejects remote HTTP and redirects, preventing its recovery capability from reaching another origin.
+
 ## [8.6.0] - 2026-09-09
 
 ### Changed

--- a/packages/sdk-typescript/src/__tests__/relay.test.ts
+++ b/packages/sdk-typescript/src/__tests__/relay.test.ts
@@ -1277,6 +1277,29 @@ describe('RelayCast', () => {
       expect(init.headers['X-Workspace-Bootstrap-Secret']).toBe('deployment-secret');
     });
 
+    it('uses a high-entropy key at the hosted gateway without sending a deployment secret', async () => {
+      const { RelayCast } = await import('../relay.js');
+      mockFetch.mockImplementation(() =>
+        Promise.resolve({
+          ok: true,
+          status: 201,
+          json: () => Promise.resolve({
+            ok: true,
+            data: { workspace_id: 'ws_hosted', api_key: 'rk_live_hosted', created_at: '2024-01-01' },
+          }),
+        }),
+      );
+
+      await RelayCast.createWorkspace('hosted-child', {
+        idempotencyKey: 'hosted-run-407-9f3a7c1e5b8d2f4a6c0e8b2d4f6a8c0e',
+      });
+
+      const [url, init] = mockFetch.mock.calls[0]!;
+      expect(url).toBe('https://cast.agentrelay.com/v1/workspaces');
+      expect(init.headers['Idempotency-Key']).toBe('hosted-run-407-9f3a7c1e5b8d2f4a6c0e8b2d4f6a8c0e');
+      expect(init.headers['X-Workspace-Bootstrap-Secret']).toBeUndefined();
+    });
+
     it('rejects a short anonymous key before making a request', async () => {
       const { RelayCast } = await import('../relay.js');
 

--- a/packages/sdk-typescript/src/__tests__/relay.test.ts
+++ b/packages/sdk-typescript/src/__tests__/relay.test.ts
@@ -1250,6 +1250,7 @@ describe('RelayCast', () => {
       const [, init] = mockFetch.mock.calls[0]!;
       expect(init.headers.Authorization).toBe('Bearer rk_live_parent');
       expect(init.headers['Idempotency-Key']).toBe('cloud-job-371');
+      expect(init.redirect).toBeUndefined();
     });
 
     it('forwards the bootstrap secret proof for anonymous keyed creates', async () => {
@@ -1298,6 +1299,44 @@ describe('RelayCast', () => {
       expect(url).toBe('https://cast.agentrelay.com/v1/workspaces');
       expect(init.headers['Idempotency-Key']).toBe('hosted-run-407-9f3a7c1e5b8d2f4a6c0e8b2d4f6a8c0e');
       expect(init.headers['X-Workspace-Bootstrap-Secret']).toBeUndefined();
+      expect(init.redirect).toBe('manual');
+    });
+
+    it('does not follow a key-only anonymous bootstrap redirect to another origin', async () => {
+      const { RelayCast } = await import('../relay.js');
+      mockFetch.mockImplementation(() =>
+        Promise.resolve({
+          ok: false,
+          status: 307,
+          type: 'opaqueredirect',
+          headers: new Headers({ Location: 'https://redirected.example/v1/workspaces' }),
+          json: () => Promise.resolve({}),
+        }),
+      );
+
+      await expect(RelayCast.createWorkspace('hosted-child', {
+        idempotencyKey: 'hosted-run-408-9f3a7c1e5b8d2f4a6c0e8b2d4f6a8c0e',
+      })).rejects.toMatchObject({
+        code: 'transport_error',
+        statusCode: 307,
+      });
+
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+      const [, init] = mockFetch.mock.calls[0]!;
+      expect(init.redirect).toBe('manual');
+    });
+
+    it('rejects a key-only anonymous bootstrap over remote plaintext HTTP', async () => {
+      const { RelayCast } = await import('../relay.js');
+
+      await expect(RelayCast.createWorkspace('hosted-child', {
+        idempotencyKey: 'hosted-run-408-9f3a7c1e5b8d2f4a6c0e8b2d4f6a8c0e',
+        baseUrl: 'http://self-host.example',
+      })).rejects.toMatchObject({
+        rawCode: 'workspace_create_bootstrap_base_url_required',
+        statusCode: 400,
+      });
+      expect(mockFetch).not.toHaveBeenCalled();
     });
 
     it('rejects a short anonymous key before making a request', async () => {

--- a/packages/sdk-typescript/src/__tests__/setup.test.ts
+++ b/packages/sdk-typescript/src/__tests__/setup.test.ts
@@ -74,6 +74,7 @@ describe('RelaycastSetup', () => {
     expect(init.headers['X-Relaycast-Origin-Client']).toBe('@relaycast/sdk');
     expect(init.headers['X-Relaycast-Origin-Version']).toBeDefined();
     expect(init.headers.Authorization).toBeUndefined();
+    expect(init.redirect).toBeUndefined();
     expect(JSON.parse(init.body)).toEqual({ name: 'Acme Ops', provenance: { source: 'sdk' } });
   });
 
@@ -114,6 +115,72 @@ describe('RelaycastSetup', () => {
     const [, init] = mockFetch.mock.calls[0]!;
     expect(init.headers.Authorization).toBe('Bearer rk_live_parent');
     expect(init.headers['Idempotency-Key']).toBe('cloud-job-371');
+    expect(init.redirect).toBeUndefined();
+  });
+
+  it.each([
+    ['cross-origin', 'https://attacker.invalid/v1/workspaces'],
+    ['same-origin', 'https://cast.agentrelay.com/v1/workspaces'],
+  ])('createWorkspace() rejects a %s anonymous keyed redirect', async (_kind, location) => {
+    const { RelaycastSetup } = await import('../setup.js');
+    mockFetch.mockImplementation(() =>
+      Promise.resolve({
+        ok: false,
+        status: 307,
+        type: 'opaqueredirect',
+        headers: new Headers({ Location: location }),
+        text: () => Promise.resolve(''),
+      } as Response),
+    );
+
+    await expect(new RelaycastSetup().createWorkspace({
+      name: 'redirected',
+      idempotencyKey: 'setup-run-408-9f3a7c1e5b8d2f4a6c0e8b2d4f6a8c0e',
+    })).rejects.toMatchObject({
+      code: 'transport_error',
+      statusCode: 307,
+    });
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    const [, init] = mockFetch.mock.calls[0]!;
+    expect(init.redirect).toBe('manual');
+  });
+
+  it('createWorkspace() rejects anonymous keyed remote plaintext HTTP before dispatch', async () => {
+    const { RelaycastSetup } = await import('../setup.js');
+
+    await expect(new RelaycastSetup({
+      baseUrl: 'http://self-host.example',
+    }).createWorkspace({
+      name: 'insecure',
+      idempotencyKey: 'setup-run-408-9f3a7c1e5b8d2f4a6c0e8b2d4f6a8c0e',
+    })).rejects.toMatchObject({
+      code: 'transport_error',
+      statusCode: 400,
+    });
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it('createWorkspace() permits anonymous keyed loopback HTTP with manual redirects', async () => {
+    const { RelaycastSetup } = await import('../setup.js');
+    mockFetch.mockImplementation(() =>
+      jsonResponse({
+        ok: true,
+        data: { workspace_id: 'ws_local', api_key: 'rk_live_local', created_at: '2026-09-10' },
+      }, 201),
+    );
+
+    await new RelaycastSetup({
+      baseUrl: 'http://127.0.0.1:8787',
+    }).createWorkspace({
+      name: 'local',
+      idempotencyKey: 'setup-run-408-9f3a7c1e5b8d2f4a6c0e8b2d4f6a8c0e',
+    });
+
+    const [url, init] = mockFetch.mock.calls[0]!;
+    expect(url).toBe('http://127.0.0.1:8787/v1/workspaces');
+    expect(init.headers['Idempotency-Key']).toBe('setup-run-408-9f3a7c1e5b8d2f4a6c0e8b2d4f6a8c0e');
+    expect(init.redirect).toBe('manual');
   });
 
   it('does not silently downgrade an explicitly empty idempotency key', async () => {

--- a/packages/sdk-typescript/src/relay.ts
+++ b/packages/sdk-typescript/src/relay.ts
@@ -269,6 +269,40 @@ export const MIN_BOOTSTRAP_IDEMPOTENCY_KEY_LENGTH = 32;
 const HOSTED_GATEWAY_HOSTNAME = 'cast.agentrelay.com';
 const LOOPBACK_HOSTNAMES = new Set(['localhost', '127.0.0.1', '::1']);
 
+function validateAnonymousKeyedBootstrapDestination(value: string): URL {
+  let baseUrl: URL;
+  try {
+    baseUrl = new URL(value);
+  } catch {
+    throw new RelayError(
+      'transport_error',
+      'Anonymous keyed workspace bootstrap requires a valid baseUrl',
+      {
+        statusCode: 400,
+        retryable: false,
+        rawCode: 'workspace_create_bootstrap_base_url_required',
+      },
+    );
+  }
+
+  const hostname = baseUrl.hostname.replace(/^\[|\]$/g, '').replace(/\.$/, '').toLowerCase();
+  const isLoopbackHttp =
+    baseUrl.protocol === 'http:' && LOOPBACK_HOSTNAMES.has(hostname);
+  if (baseUrl.protocol !== 'https:' && !isLoopbackHttp) {
+    throw new RelayError(
+      'transport_error',
+      'Anonymous keyed workspace bootstrap requires an HTTPS self-hosted baseUrl (or loopback HTTP for local development)',
+      {
+        statusCode: 400,
+        retryable: false,
+        rawCode: 'workspace_create_bootstrap_base_url_required',
+      },
+    );
+  }
+
+  return baseUrl;
+}
+
 function validateWorkspaceBootstrapOptions(options: WorkspaceBootstrapOptions): void {
   // Owner-scoped keys are bounded by the authenticated API key and may remain
   // short. Anonymous keys are part of the recovery proof and must satisfy the
@@ -289,11 +323,14 @@ function validateWorkspaceBootstrapOptions(options: WorkspaceBootstrapOptions): 
     );
   }
 
-  if (
-    !options.apiKey &&
-    options.idempotencyKey !== undefined &&
-    options.bootstrapSecret !== undefined
-  ) {
+  const anonymousKeyedBootstrap = !options.apiKey && options.idempotencyKey !== undefined;
+  if (anonymousKeyedBootstrap) {
+    validateAnonymousKeyedBootstrapDestination(
+      options.baseUrl ?? 'https://cast.agentrelay.com',
+    );
+  }
+
+  if (anonymousKeyedBootstrap && options.bootstrapSecret !== undefined) {
     if (!options.baseUrl) {
       throw new RelayError(
         'transport_error',
@@ -306,34 +343,7 @@ function validateWorkspaceBootstrapOptions(options: WorkspaceBootstrapOptions): 
       );
     }
 
-    let baseUrl: URL;
-    try {
-      baseUrl = new URL(options.baseUrl);
-    } catch {
-      throw new RelayError(
-        'transport_error',
-        'Anonymous keyed workspace bootstrap requires a valid self-hosted baseUrl',
-        {
-          statusCode: 400,
-          retryable: false,
-          rawCode: 'workspace_create_bootstrap_base_url_required',
-        },
-      );
-    }
-    const isLoopbackHttp =
-      baseUrl.protocol === 'http:' &&
-      LOOPBACK_HOSTNAMES.has(baseUrl.hostname.replace(/^\[|\]$/g, '').replace(/\.$/, '').toLowerCase());
-    if (baseUrl.protocol !== 'https:' && !isLoopbackHttp) {
-      throw new RelayError(
-        'transport_error',
-        'Anonymous keyed workspace bootstrap requires an HTTPS self-hosted baseUrl (or loopback HTTP for local development)',
-        {
-          statusCode: 400,
-          retryable: false,
-          rawCode: 'workspace_create_bootstrap_base_url_required',
-        },
-      );
-    }
+    const baseUrl = validateAnonymousKeyedBootstrapDestination(options.baseUrl);
     const hostname = baseUrl.hostname.replace(/\.$/, '').toLowerCase();
     if (hostname === HOSTED_GATEWAY_HOSTNAME) {
       throw new RelayError(
@@ -446,13 +456,14 @@ export class RelayCast {
     const { apiKey, baseUrl } = resolved;
     const requestBaseUrl = baseUrl ?? 'https://cast.agentrelay.com';
     const identity = resolveAgentRelayIdentity(resolved);
+    const anonymousKeyedBootstrap = !apiKey && resolved.idempotencyKey !== undefined;
     const sendsBootstrapSecret =
-      !apiKey && resolved.idempotencyKey !== undefined && resolved.bootstrapSecret !== undefined;
+      anonymousKeyedBootstrap && resolved.bootstrapSecret !== undefined;
 
     const url = new URL('/v1/workspaces', requestBaseUrl);
     const res = await fetch(url.toString(), {
       method: 'POST',
-      ...(sendsBootstrapSecret ? { redirect: 'manual' as const } : {}),
+      ...(anonymousKeyedBootstrap ? { redirect: 'manual' as const } : {}),
       headers: {
         'Content-Type': 'application/json',
         ...(apiKey ? { Authorization: `Bearer ${apiKey}` } : {}),
@@ -477,7 +488,7 @@ export class RelayCast {
     });
 
     if (
-      sendsBootstrapSecret &&
+      anonymousKeyedBootstrap &&
       (res.type === 'opaqueredirect' || (res.status >= 300 && res.status < 400))
     ) {
       throw new RelayError(

--- a/packages/sdk-typescript/src/relay.ts
+++ b/packages/sdk-typescript/src/relay.ts
@@ -269,7 +269,7 @@ export const MIN_BOOTSTRAP_IDEMPOTENCY_KEY_LENGTH = 32;
 const HOSTED_GATEWAY_HOSTNAME = 'cast.agentrelay.com';
 const LOOPBACK_HOSTNAMES = new Set(['localhost', '127.0.0.1', '::1']);
 
-function validateAnonymousKeyedBootstrapDestination(value: string): URL {
+export function validateAnonymousKeyedBootstrapDestination(value: string): URL {
   let baseUrl: URL;
   try {
     baseUrl = new URL(value);

--- a/packages/sdk-typescript/src/relay.ts
+++ b/packages/sdk-typescript/src/relay.ts
@@ -209,20 +209,20 @@ export interface WorkspaceBootstrapOptions extends WorkspaceIdentityOptions {
    * authorization boundary, so this only needs to be unique per operation
    * (e.g. a job id).
    *
-   * Without `apiKey` (anonymous bootstrap): this key, together with
-   * `bootstrapSecret`, is what authorizes recovering the binding, so it
-   * MUST be generated with a CSPRNG. Never derive it from a job id, timestamp,
-   * or counter. The server enforces only a 32-character structural minimum
-   * and cannot verify true randomness. `crypto.randomUUID()` is a good default.
+   * Without `apiKey` (anonymous bootstrap): this is the reveal-once recovery
+   * capability, so it MUST be generated with a CSPRNG. Never derive it from a
+   * job id, timestamp, or counter. The server enforces only a 32-character
+   * structural minimum and cannot verify true randomness.
+   * `crypto.randomUUID()` is a good default.
    */
   idempotencyKey?: string;
   /**
-   * Deployment bootstrap secret, required alongside `idempotencyKey` for an
-   * anonymous (no `apiKey`) create. Proves the caller is authorized to
-   * recover an anonymous bootstrap binding — the idempotency key alone is
-   * not secret. Anonymous keyed callers must set `baseUrl` to their explicit
-   * self-hosted origin; this SDK refuses the hosted gateway to avoid sending a
-   * self-host deployment secret there. Ignored when `apiKey` is set.
+   * Optional self-host proof for deployments configured with
+   * `workspaceBootstrapProofRequired`. Hosted callers must omit this: the
+   * deployment secret stays server-only and the CSPRNG `idempotencyKey` is the
+   * recovery capability. When supplied, callers must set `baseUrl` to an
+   * explicit self-hosted origin; this SDK refuses the hosted gateway. Ignored
+   * when `apiKey` is set.
    */
   bootstrapSecret?: string;
 }

--- a/packages/sdk-typescript/src/setup.ts
+++ b/packages/sdk-typescript/src/setup.ts
@@ -8,8 +8,9 @@ import { camelizeKeys } from './casing.js';
 import { AgentClient } from './agent.js';
 import { HttpClient, type RetryPolicyInput } from './client.js';
 import { Relay } from './communicate/relay.js';
+import { RelayError } from './errors.js';
 import { SDK_ORIGIN } from './origin.js';
-import { RelayCast } from './relay.js';
+import { RelayCast, validateAnonymousKeyedBootstrapDestination } from './relay.js';
 import {
   AgentNotRegisteredError,
   MalformedApiResponseError,
@@ -341,6 +342,11 @@ export class RelaycastSetup {
   ): Promise<Response> {
     const url = new URL(path, this.config.baseUrl);
     const apiKey = await this.resolveApiKey();
+    const anonymousKeyedBootstrap =
+      !apiKey && extraHeaders?.['Idempotency-Key'] !== undefined;
+    if (anonymousKeyedBootstrap) {
+      validateAnonymousKeyedBootstrapDestination(this.config.baseUrl);
+    }
     const headers: Record<string, string> = {
       Accept: 'application/json',
       'X-SDK-Version': SDK_ORIGIN.version,
@@ -363,10 +369,22 @@ export class RelaycastSetup {
       try {
         const response = await fetch(url.toString(), {
           method,
+          ...(anonymousKeyedBootstrap ? { redirect: 'manual' as const } : {}),
           headers,
           body: method === 'POST' ? JSON.stringify(body ?? {}) : undefined,
           signal: AbortSignal.timeout(this.config.requestTimeoutMs),
         });
+
+        if (
+          anonymousKeyedBootstrap &&
+          (response.type === 'opaqueredirect' || (response.status >= 300 && response.status < 400))
+        ) {
+          throw new RelayError(
+            'transport_error',
+            'Refusing to follow an anonymous bootstrap redirect',
+            { statusCode: response.status, retryable: false },
+          );
+        }
 
         if (RETRY_STATUS_CODES.has(response.status) && attempt < this.config.retryPolicy.maxRetries) {
           const waitMs = response.status === 429
@@ -379,6 +397,9 @@ export class RelaycastSetup {
 
         return response;
       } catch (error) {
+        if (error instanceof RelayError) {
+          throw error;
+        }
         if (attempt >= this.config.retryPolicy.maxRetries) {
           throw error;
         }

--- a/test/container-entrypoint.test.mjs
+++ b/test/container-entrypoint.test.mjs
@@ -207,6 +207,25 @@ test('forwards the bootstrap secret without exposing it in container output', ()
   });
 });
 
+test('makes bootstrap-secret proof enforcement an explicit opt-in', () => {
+  assert.deepEqual(buildEngineConfig({
+    RELAYCAST_ENV: 'production',
+    RELAYCAST_WORKSPACE_BOOTSTRAP_SECRET: 'stable-container-secret-407',
+  }), {
+    environment: 'production',
+    workspaceBootstrapSecret: 'stable-container-secret-407',
+  });
+  assert.deepEqual(buildEngineConfig({
+    RELAYCAST_ENV: 'production',
+    RELAYCAST_WORKSPACE_BOOTSTRAP_SECRET: 'stable-container-secret-407',
+    RELAYCAST_WORKSPACE_BOOTSTRAP_PROOF_REQUIRED: 'true',
+  }), {
+    environment: 'production',
+    workspaceBootstrapSecret: 'stable-container-secret-407',
+    workspaceBootstrapProofRequired: true,
+  });
+});
+
 test('never writes the bootstrap secret to stdout or stderr on the real entrypoint path', async () => {
   // A shallow assertion on buildEngineConfig's return value (above) proves
   // the secret reaches the engine config object, but not that it is kept

--- a/test/container-entrypoint.test.mjs
+++ b/test/container-entrypoint.test.mjs
@@ -185,6 +185,10 @@ test('shows help without requiring a deployment authority', () => {
   const result = run(['--help']);
   assert.equal(result.status, 0, result.stderr);
   assert.match(result.stdout, /Required public HTTPS origin/);
+  assert.match(
+    result.stdout,
+    /RELAYCAST_WORKSPACE_BOOTSTRAP_PROOF_REQUIRED\s+Set true to require bootstrap-secret proof for anonymous keyed creates/,
+  );
   assertRefused([], /--base-url is required/); // Control: an actual start still refuses it.
 });
 

--- a/test/container-image-integration.test.mjs
+++ b/test/container-image-integration.test.mjs
@@ -4,7 +4,7 @@
 // against a persistent Docker-managed volume, and drives it entirely over HTTP,
 // the same way an operator would. It is the only place that proves:
 //   - a workspace bootstrapped before a container restart is still recoverable
-//     after the restart, using the same persisted volume and bootstrap secret
+//     after the restart, using the same persisted volume and idempotency key
 //     (relaycast#371/#379's crash-idempotency contract, exercised for real);
 //   - a deployment with no bootstrap secret configured fails closed (503)
 //     instead of accidentally falling back to something insecure;
@@ -252,7 +252,6 @@ describe(
       const { status, body } = await createWorkspace(secondaryPort, {
         name: "no-secret-workspace",
         idempotencyKey: key,
-        secret: BOOTSTRAP_SECRET, // caller presents a secret; the deployment has none configured
       });
       assert.equal(status, 503);
       assert.equal(
@@ -277,14 +276,12 @@ describe(
       const first = await createWorkspace(primaryPort, {
         name: "digest-conflict-original",
         idempotencyKey: key,
-        secret: BOOTSTRAP_SECRET,
       });
       assert.equal(first.status, 201);
 
       const conflict = await createWorkspace(primaryPort, {
         name: "digest-conflict-different-name",
         idempotencyKey: key,
-        secret: BOOTSTRAP_SECRET,
       });
       assert.equal(conflict.status, 409);
       assert.equal(
@@ -298,7 +295,6 @@ describe(
       const before = await createWorkspace(primaryPort, {
         name: "restart-replay-workspace",
         idempotencyKey: key,
-        secret: BOOTSTRAP_SECRET,
       });
       assert.equal(before.status, 201);
       assert.match(before.body?.data?.api_key ?? "", /^rk_live_/);
@@ -310,18 +306,9 @@ describe(
       const after = await createWorkspace(primaryPort, {
         name: "restart-replay-workspace",
         idempotencyKey: key,
-        secret: BOOTSTRAP_SECRET,
       });
       assert.equal(after.status, 200);
       assert.deepEqual(after.body?.data, before.body?.data);
-
-      // Control: without the secret, even the same key can no longer recover
-      // it after the restart -- the container did not silently widen access.
-      const unproven = await createWorkspace(primaryPort, {
-        name: "restart-replay-workspace",
-        idempotencyKey: key,
-      });
-      assert.equal(unproven.status, 401);
     });
 
     test("the bootstrap secret never appears in captured container logs", () => {


### PR DESCRIPTION
## Summary

- make a validated CSPRNG anonymous Idempotency-Key the hosted-safe, narrowly scoped replay capability; keep the deployment secret server-only for deterministic child-key derivation
- retain deployment-secret proof as explicit self-host opt-in, fail closed without server derivation material, and preserve owner isolation, atomic binding, conflicts, and terminalization
- add TypeScript and Rust SDK contracts plus engine, conformance, restart, Docker, and redaction coverage

## Verification

-  (all workspace suites; engine 945 tests)
- focused engine idempotency/conformance: 54 tests
- TypeScript SDK: 95 tests
- Rust parity keyed-create tests: 3 tests
- real Docker image integration: 5 tests
- , Prettier check, 
- Veto diff review: PASS (code 95, no critical/high security findings, secrets clean)

Fixes #407.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/AgentWorkforce/relaycast/pull/408?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes authentication semantics for anonymous workspace bootstrap and credential recovery across engine, SDKs, and self-host deployments; misconfiguration could widen replay or break existing bootstrap callers.
> 
> **Overview**
> Redefines **anonymous keyed workspace creation** so a CSPRNG **`Idempotency-Key`** is the hosted-safe, reveal-once recovery capability, while **`RELAYCAST_WORKSPACE_BOOTSTRAP_SECRET`** stays **server-only** for deterministic child-key derivation. **`X-Workspace-Bootstrap-Secret`** is no longer required by default; self-hosts can restore the old model with **`RELAYCAST_WORKSPACE_BOOTSTRAP_PROOF_REQUIRED=true`** (wired through Docker/entrypoint, engine config, routes, OpenAPI, and docs).
> 
> **TypeScript and Rust SDKs** gain matching bootstrap APIs and guards: anonymous keyed creates require **HTTPS or loopback HTTP**, use **manual redirects** and fail on 3xx/opaque redirect, and **never send bootstrap proof to the hosted gateway**. Rust adds **`WorkspaceBootstrapOptions`** / **`create_workspace_with_options`** and redacts recovery values in **`Debug`**.
> 
> Tests and container integration are updated for idempotency-key replay without caller-held deployment secrets, optional proof enforcement, and transport hardening on **`RelayCast`** and **`RelaycastSetup`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ac24de3be523166d7655910c0751f38d5feb3a56. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->