### PR TITLE
feat: add atomic exact agent release

### DIFF
--- a/.agentworkforce/trajectories/completed/2026-09/traj_85uv3m139tup/summary.md
+++ b/.agentworkforce/trajectories/completed/2026-09/traj_85uv3m139tup/summary.md
@@ -1,0 +1,38 @@
+# Trajectory: Validate AgentWorkforce/relaycast PR #410 release-exact idempotency and retry followups
+
+> **Status:** ✅ Completed
+> **Task:** PR-410
+> **Confidence:** 92%
+> **Started:** September 10, 2026 at 07:12 AM
+> **Completed:** September 10, 2026 at 07:12 AM
+
+---
+
+## Summary
+
+Added exact-release scope/replay docs, asserted one webhook outbox event across replay, and verified Rust caller-key preservation through a 503 retry; pushed cc6f2c38 to PR #410 branch.
+
+**Approach:** Standard approach
+
+---
+
+## Key Decisions
+
+### Documented exact-release idempotency scope and no-duplicate-webhook replay behavior
+- **Chose:** Documented exact-release idempotency scope and no-duplicate-webhook replay behavior
+- **Reasoning:** The route already derives a durable workspace/principal/action claim and suppresses webhook emission on replay; explicit docs and a regression test make the contract reviewable.
+
+### Extended Rust exact-release parity test through one 503 retry
+- **Chose:** Extended Rust exact-release parity test through one 503 retry
+- **Reasoning:** The helper already forwards RequestOptions with the caller key; matching both attempts proves the key is preserved under bounded automatic retry.
+
+---
+
+## Chapters
+
+### 1. Work
+*Agent: default*
+
+- Documented exact-release idempotency scope and no-duplicate-webhook replay behavior: Documented exact-release idempotency scope and no-duplicate-webhook replay behavior
+- Extended Rust exact-release parity test through one 503 retry: Extended Rust exact-release parity test through one 503 retry
+- PR #410 followups are implemented and locally validated across engine, TypeScript SDK, and Rust; hosted restart/webhook E2E remains deployment-dependent.

--- a/.agentworkforce/trajectories/completed/2026-09/traj_85uv3m139tup/trajectory.json
+++ b/.agentworkforce/trajectories/completed/2026-09/traj_85uv3m139tup/trajectory.json
@@ -1,0 +1,92 @@
+{
+  "id": "traj_85uv3m139tup",
+  "version": 1,
+  "task": {
+    "title": "Validate AgentWorkforce/relaycast PR #410 release-exact idempotency and retry followups",
+    "source": {
+      "system": "plain",
+      "id": "PR-410"
+    }
+  },
+  "status": "completed",
+  "startedAt": "2026-09-10T05:12:05.577Z",
+  "completedAt": "2026-09-10T05:12:16.573Z",
+  "agents": [
+    {
+      "name": "default",
+      "role": "lead",
+      "joinedAt": "2026-09-10T05:12:15.286Z"
+    }
+  ],
+  "chapters": [
+    {
+      "id": "chap_2jqyr0hqnlqx",
+      "title": "Work",
+      "agentName": "default",
+      "startedAt": "2026-09-10T05:12:15.286Z",
+      "endedAt": "2026-09-10T05:12:16.573Z",
+      "events": [
+        {
+          "ts": 1789017135287,
+          "type": "decision",
+          "content": "Documented exact-release idempotency scope and no-duplicate-webhook replay behavior: Documented exact-release idempotency scope and no-duplicate-webhook replay behavior",
+          "raw": {
+            "question": "Documented exact-release idempotency scope and no-duplicate-webhook replay behavior",
+            "chosen": "Documented exact-release idempotency scope and no-duplicate-webhook replay behavior",
+            "alternatives": [],
+            "reasoning": "The route already derives a durable workspace/principal/action claim and suppresses webhook emission on replay; explicit docs and a regression test make the contract reviewable."
+          },
+          "significance": "high"
+        },
+        {
+          "ts": 1789017135687,
+          "type": "decision",
+          "content": "Extended Rust exact-release parity test through one 503 retry: Extended Rust exact-release parity test through one 503 retry",
+          "raw": {
+            "question": "Extended Rust exact-release parity test through one 503 retry",
+            "chosen": "Extended Rust exact-release parity test through one 503 retry",
+            "alternatives": [],
+            "reasoning": "The helper already forwards RequestOptions with the caller key; matching both attempts proves the key is preserved under bounded automatic retry."
+          },
+          "significance": "high"
+        },
+        {
+          "ts": 1789017136120,
+          "type": "reflection",
+          "content": "PR #410 followups are implemented and locally validated across engine, TypeScript SDK, and Rust; hosted restart/webhook E2E remains deployment-dependent.",
+          "raw": {
+            "focalPoints": [
+              "idempotency",
+              "webhook",
+              "retry",
+              "e2e"
+            ],
+            "adjustments": "No runtime changes were needed; keep exact-release replay semantics documented and covered by regression tests.",
+            "confidence": 0.92
+          },
+          "significance": "high",
+          "tags": [
+            "focal:idempotency",
+            "focal:webhook",
+            "focal:retry",
+            "focal:e2e",
+            "confidence:0.92"
+          ]
+        }
+      ]
+    }
+  ],
+  "retrospective": {
+    "summary": "Added exact-release scope/replay docs, asserted one webhook outbox event across replay, and verified Rust caller-key preservation through a 503 retry; pushed cc6f2c38 to PR #410 branch.",
+    "approach": "Standard approach",
+    "confidence": 0.92
+  },
+  "commits": [],
+  "filesChanged": [],
+  "projectId": "AgentWorkforce/relaycast",
+  "tags": [],
+  "_trace": {
+    "startRef": "cc6f2c38a2094f2a5e9f47099e2aaf54b93d6bed",
+    "endRef": "cc6f2c38a2094f2a5e9f47099e2aaf54b93d6bed"
+  }
+}

--- a/.agentworkforce/trajectories/completed/2026-09/traj_g8d4cmpghh09/summary.md
+++ b/.agentworkforce/trajectories/completed/2026-09/traj_g8d4cmpghh09/summary.md
@@ -1,0 +1,33 @@
+# Trajectory: Implement Relaycast #409 atomic exact-agent release contract
+
+> **Status:** ✅ Completed
+> **Task:** relaycast#409
+> **Confidence:** 88%
+> **Started:** September 10, 2026 at 06:09 AM
+> **Completed:** September 10, 2026 at 06:12 AM
+
+---
+
+## Summary
+
+Added exact immutable-agent release route, keyed idempotency replay, overload retry timing, and TypeScript/Rust SDK parity with race tests.
+
+**Approach:** Standard approach
+
+---
+
+## Key Decisions
+
+### Use a separate exact release route
+- **Chose:** Use a separate exact release route
+- **Reasoning:** Keeps legacy name-addressed release backwards compatible while requiring immutable identity and a durable caller key for reconciliation.
+
+---
+
+## Chapters
+
+### 1. Work
+*Agent: default*
+
+- Use a separate exact release route: Use a separate exact release route
+- Engine, TypeScript SDK, and Rust SDK now share the exact-release contract; full engine suite and focused SDK tests are green.

--- a/.agentworkforce/trajectories/completed/2026-09/traj_g8d4cmpghh09/trajectory.json
+++ b/.agentworkforce/trajectories/completed/2026-09/traj_g8d4cmpghh09/trajectory.json
@@ -1,0 +1,69 @@
+{
+  "id": "traj_g8d4cmpghh09",
+  "version": 1,
+  "task": {
+    "title": "Implement Relaycast #409 atomic exact-agent release contract",
+    "source": {
+      "system": "plain",
+      "id": "relaycast#409"
+    }
+  },
+  "status": "completed",
+  "startedAt": "2026-09-10T04:09:51.390Z",
+  "completedAt": "2026-09-10T04:12:31.431Z",
+  "agents": [
+    {
+      "name": "default",
+      "role": "lead",
+      "joinedAt": "2026-09-10T04:09:51.504Z"
+    }
+  ],
+  "chapters": [
+    {
+      "id": "chap_6apsmr7s0m61",
+      "title": "Work",
+      "agentName": "default",
+      "startedAt": "2026-09-10T04:09:51.504Z",
+      "endedAt": "2026-09-10T04:12:31.431Z",
+      "events": [
+        {
+          "ts": 1789013391505,
+          "type": "decision",
+          "content": "Use a separate exact release route: Use a separate exact release route",
+          "raw": {
+            "question": "Use a separate exact release route",
+            "chosen": "Use a separate exact release route",
+            "alternatives": [],
+            "reasoning": "Keeps legacy name-addressed release backwards compatible while requiring immutable identity and a durable caller key for reconciliation."
+          },
+          "significance": "high"
+        },
+        {
+          "ts": 1789013391595,
+          "type": "reflection",
+          "content": "Engine, TypeScript SDK, and Rust SDK now share the exact-release contract; full engine suite and focused SDK tests are green.",
+          "raw": {
+            "confidence": 0.85
+          },
+          "significance": "high",
+          "tags": [
+            "confidence:0.85"
+          ]
+        }
+      ]
+    }
+  ],
+  "retrospective": {
+    "summary": "Added exact immutable-agent release route, keyed idempotency replay, overload retry timing, and TypeScript/Rust SDK parity with race tests.",
+    "approach": "Standard approach",
+    "confidence": 0.88
+  },
+  "commits": [],
+  "filesChanged": [],
+  "projectId": "AgentWorkforce/relaycast",
+  "tags": [],
+  "_trace": {
+    "startRef": "ac24de3be523166d7655910c0751f38d5feb3a56",
+    "endRef": "ac24de3be523166d7655910c0751f38d5feb3a56"
+  }
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ Packages without a separate changelog are covered by the cross-package notes bel
 ### Added
 
 - Rust SDK `WorkspaceBootstrapOptions` supports crash-safe anonymous keyed workspace creation without a deployment secret and opt-in self-host bootstrap proof without exposing it to hosted Relaycast.
+- `POST /v1/agents/release-exact` atomically pins broker cleanup to an immutable agent identity and durable idempotency key, so a same-name replacement cannot be released by a retry.
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -870,6 +870,16 @@ replay that reaches the narrow interval before its placement/dispatch outcome is
 durable returns retryable `idempotency_unavailable`; clients must retry the same
 logical request with the same key rather than minting a replacement.
 
+For crash-safe agent cleanup, `POST /v1/agents/release-exact` requires the
+immutable `expected_agent_id` and a caller-persisted `Idempotency-Key`. The key
+is scoped to the workspace, authenticated caller principal, and `release` action;
+workspace-key callers share one workspace-key scope, so every logical operation
+must use its own unique key and independent callers must not reuse one another's
+keys. A replay returns the original terminal invocation with
+`Idempotency-Replayed: true` and does not enqueue another `action.invoked`
+webhook. A same-name replacement is never mutated, and reusing a key with a
+different payload returns `409 idempotency_key_reused`.
+
 Action registration is an idempotent assertion: re-registering an existing name
 (`POST /actions`) refreshes its description, handler, schemas, `available_to`, and
 `is_active` in place and returns 200, so a reconnecting publisher re-asserts its

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -2713,9 +2713,14 @@ paths:
       summary: Atomically release an exact agent identity
       description: >-
         Crash-safe reconciliation endpoint. Requires the immutable agent id and
-        a caller-persisted Idempotency-Key; a same-name replacement is never
-        released by this operation. Replaying a key returns the original
-        terminal invocation, while reusing it with another payload conflicts.
+        a caller-persisted Idempotency-Key. The key is scoped to the workspace,
+        authenticated caller principal, and release action; workspace-key
+        callers share the workspace-key principal scope, so each caller must
+        create and persist a unique key for each logical operation. A same-name
+        replacement is never released by this operation. Replaying a key
+        returns the original terminal invocation and does not enqueue a second
+        `action.invoked` webhook, while reusing it with another payload
+        conflicts.
       tags: [Agents]
       security:
         - workspaceKey: []

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -2708,6 +2708,64 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
 
+  /agents/release-exact:
+    post:
+      summary: Atomically release an exact agent identity
+      description: >-
+        Crash-safe reconciliation endpoint. Requires the immutable agent id and
+        a caller-persisted Idempotency-Key; a same-name replacement is never
+        released by this operation. Replaying a key returns the original
+        terminal invocation, while reusing it with another payload conflicts.
+      tags: [Agents]
+      security:
+        - workspaceKey: []
+        - agentToken: []
+        - nodeToken: []
+      parameters:
+        - name: Idempotency-Key
+          in: header
+          required: true
+          schema: { type: string, minLength: 1, maxLength: 255 }
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [name, expected_agent_id]
+              properties:
+                name: { type: string }
+                expected_agent_id:
+                  type: string
+                  description: Immutable agent row id captured before local handle loss
+                reason: { type: string }
+                delete_agent: { type: boolean }
+                expected_token_hash:
+                  type: string
+                  pattern: '^[a-f0-9]{64}$'
+      responses:
+        '201':
+          description: Exact release dispatched, completed, or idempotently replayed
+          headers:
+            Idempotency-Replayed:
+              schema: { type: string, enum: ['true'] }
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok: { type: boolean }
+                  data: { $ref: '#/components/schemas/LifecycleActionInvocation' }
+        '400':
+          description: Missing or invalid identity/key
+        '409':
+          description: agent_identity_mismatch or idempotency_key_reused; no replacement mutation occurred
+        '503':
+          description: database_overloaded or host unavailable; Retry-After is authoritative when supplied
+          headers:
+            Retry-After:
+              schema: { type: string }
+
   /channels:
     post:
       summary: Create channel

--- a/packages/engine/src/__tests__/conformance/agentLifecycle.test.ts
+++ b/packages/engine/src/__tests__/conformance/agentLifecycle.test.ts
@@ -275,6 +275,94 @@ describe('agent presence and release lifecycle', () => {
       ))).toHaveLength(1);
   });
 
+  it('accepts a node credential for exact release without making self-delete unreplayable', async () => {
+    const ws = await createWorkspace(stack.app, 'exact-release-node-auth');
+    const target = await registerAgent(stack.app, ws.workspaceKey, 'node-release-target');
+    const nodeResponse = await stack.app.request('/v1/nodes', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', authorization: `Bearer ${ws.workspaceKey}` },
+      body: JSON.stringify({ node_id: 'node-release-caller', name: 'release-caller', role: 'broker', max_agents: 1 }),
+    });
+    expect(nodeResponse.status).toBe(201);
+    const node = await nodeResponse.json() as { data: { token: string } };
+
+    const response = await stack.app.request('/v1/agents/release-exact', {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        authorization: `Bearer ${node.data.token}`,
+        'Idempotency-Key': 'node-exact-release',
+      },
+      body: JSON.stringify({ name: target.name, expected_agent_id: target.agentId, delete_agent: true }),
+    });
+    expect(response.status).toBe(201);
+    expect((await response.json() as { data: { status: string } }).data.status).toBe('completed');
+  });
+
+  it('rejects agent-token self-delete before claiming an unreplayable operation', async () => {
+    const ws = await createWorkspace(stack.app, 'exact-release-self-delete');
+    const target = await registerAgent(stack.app, ws.workspaceKey, 'self-delete-target');
+    const response = await stack.app.request('/v1/agents/release-exact', {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        authorization: `Bearer ${target.token}`,
+        'Idempotency-Key': 'self-delete-key',
+      },
+      body: JSON.stringify({ name: target.name, expected_agent_id: target.agentId, delete_agent: true }),
+    });
+    expect(response.status).toBe(400);
+    expect((await response.json() as { error: { code: string } }).error.code)
+      .toBe('agent_self_release_requires_workspace_key');
+    expect(await stack.runtime.deps.db.select().from(actionInvocations).where(and(
+      eq(actionInvocations.workspaceId, ws.workspaceId),
+      eq(actionInvocations.actionName, 'release'),
+    ))).toHaveLength(0);
+  });
+
+  it('fails an identity-only release at the provider boundary without synthetic completion', async () => {
+    const ws = await createWorkspace(stack.app, 'exact-release-identity-owner-race');
+    const target = await registerAgent(stack.app, ws.workspaceKey, 'identity-owner-race');
+    const { handle } = await attachDirectNodeSocket(stack, ws.workspaceId, target);
+    const nodeConnections = stack.runtime.deps.nodeConnections!;
+    const originalSend = nodeConnections.sendAuthorizedActionToProvider!.bind(nodeConnections);
+    let invalidated = false;
+    vi.spyOn(nodeConnections, 'sendAuthorizedActionToProvider').mockImplementation(async (...args) => {
+      if (!invalidated && args[3].action === 'release') {
+        invalidated = true;
+        stack.runtime.handle.sqlite.prepare(
+          `UPDATE agent_node_bindings SET status = 'inactive', updated_at = unixepoch()
+           WHERE workspace_id = ? AND agent_id = ?`,
+        ).run(ws.workspaceId, target.agentId);
+      }
+      return originalSend(...args);
+    });
+
+    const response = await stack.app.request('/v1/agents/release-exact', {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        authorization: `Bearer ${ws.workspaceKey}`,
+        'Idempotency-Key': 'identity-owner-race',
+      },
+      body: JSON.stringify({ name: target.name, expected_agent_id: target.agentId, delete_agent: true }),
+    });
+    expect(invalidated).toBe(true);
+    expect(response.status).toBe(409);
+    expect((await response.json() as { error: { code: string } }).error.code)
+      .toBe('agent_identity_mismatch');
+    const [agent] = await stack.runtime.deps.db.select({ name: agents.name, status: agents.status })
+      .from(agents).where(eq(agents.id, target.agentId));
+    expect(agent).toEqual({ name: target.name, status: 'active' });
+    const [invocation] = await stack.runtime.deps.db.select({ status: actionInvocations.status, error: actionInvocations.error })
+      .from(actionInvocations).where(and(
+        eq(actionInvocations.workspaceId, ws.workspaceId),
+        eq(actionInvocations.actionName, 'release'),
+      ));
+    expect(invocation).toEqual({ status: 'failed', error: 'agent_identity_mismatch' });
+    await handle.handleClose();
+  });
+
   it('fails closed on a replacement identity and rejects an idempotency-key payload swap', async () => {
     const ws = await createWorkspace(stack.app, 'exact-release-replacement');
     const oldAgent = await registerAgent(stack.app, ws.workspaceKey, 'old-agent');
@@ -343,7 +431,9 @@ describe('agent presence and release lifecycle', () => {
       },
       body: JSON.stringify({ name: 'race-agent', expected_agent_id: oldAgent.agentId, delete_agent: true }),
     });
-    expect(response.status).toBe(201);
+    expect(response.status).toBe(409);
+    expect((await response.json() as { error: { code: string } }).error.code)
+      .toBe('agent_identity_mismatch');
     expect(replaced).toBe(true);
     const [replacement] = await stack.runtime.deps.db.select({ id: agents.id, name: agents.name, status: agents.status })
       .from(agents).where(eq(agents.id, 'agent_race_replacement'));

--- a/packages/engine/src/__tests__/conformance/agentLifecycle.test.ts
+++ b/packages/engine/src/__tests__/conformance/agentLifecycle.test.ts
@@ -234,6 +234,110 @@ describe('agent presence and release lifecycle', () => {
     });
   });
 
+  it('requires a durable key and replays an exact immutable-id release only once', async () => {
+    const ws = await createWorkspace(stack.app, 'exact-release-idempotency');
+    const target = await registerAgent(stack.app, ws.workspaceKey, 'exact-target');
+    const body = {
+      name: target.name,
+      expected_agent_id: target.agentId,
+      delete_agent: true,
+    };
+    const request = (key?: string) => stack.app.request('/v1/agents/release-exact', {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        authorization: `Bearer ${ws.workspaceKey}`,
+        ...(key ? { 'Idempotency-Key': key } : {}),
+      },
+      body: JSON.stringify(body),
+    });
+
+    expect((await request()).status).toBe(400);
+    const first = await request('exact-release-key');
+    const replay = await request('exact-release-key');
+    expect([first.status, replay.status]).toEqual([201, 201]);
+    expect(replay.headers.get('Idempotency-Replayed')).toBe('true');
+    expect(await stack.runtime.deps.db.select().from(actionInvocations).where(and(
+      eq(actionInvocations.workspaceId, ws.workspaceId),
+      eq(actionInvocations.actionName, 'release'),
+    ))).toHaveLength(1);
+  });
+
+  it('fails closed on a replacement identity and rejects an idempotency-key payload swap', async () => {
+    const ws = await createWorkspace(stack.app, 'exact-release-replacement');
+    const oldAgent = await registerAgent(stack.app, ws.workspaceKey, 'old-agent');
+    const replacement = await registerAgent(stack.app, ws.workspaceKey, 'replacement-agent');
+    const request = (body: Record<string, unknown>) => stack.app.request('/v1/agents/release-exact', {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        authorization: `Bearer ${ws.workspaceKey}`,
+        'Idempotency-Key': 'exact-release-payload-swap',
+      },
+      body: JSON.stringify(body),
+    });
+
+    const first = await request({ name: oldAgent.name, expected_agent_id: oldAgent.agentId, delete_agent: true });
+    expect(first.status).toBe(201);
+    const swapped = await request({ name: replacement.name, expected_agent_id: replacement.agentId, delete_agent: true });
+    expect(swapped.status).toBe(409);
+    expect((await swapped.json() as { error: { code: string } }).error.code).toBe('idempotency_key_reused');
+
+    const mismatch = await stack.app.request('/v1/agents/release-exact', {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        authorization: `Bearer ${ws.workspaceKey}`,
+        'Idempotency-Key': 'exact-release-mismatch',
+      },
+      body: JSON.stringify({ name: replacement.name, expected_agent_id: oldAgent.agentId, delete_agent: true }),
+    });
+    expect(mismatch.status).toBe(409);
+    expect((await mismatch.json() as { error: { code: string } }).error.code).toBe('agent_identity_mismatch');
+    const [stillReplacement] = await stack.runtime.deps.db.select({ id: agents.id, status: agents.status })
+      .from(agents).where(eq(agents.id, replacement.agentId));
+    expect(stillReplacement).toEqual({ id: replacement.agentId, status: 'active' });
+  });
+
+  it('cannot alter a same-name replacement that wins after an exact release starts', async () => {
+    const ws = await createWorkspace(stack.app, 'exact-release-dispatch-race');
+    const oldAgent = await registerAgent(stack.app, ws.workspaceKey, 'race-agent');
+    await attachDirectNodeSocket(stack, ws.workspaceId, oldAgent);
+    const nodeConnections = stack.runtime.deps.nodeConnections!;
+    const originalConnected = nodeConnections.isProviderConnected.bind(nodeConnections);
+    let replaced = false;
+    vi.spyOn(nodeConnections, 'isProviderConnected').mockImplementation((...args) => {
+      if (!replaced) {
+        replaced = true;
+        // This synchronous hook is after dispatchRelease's exact name/id
+        // snapshot but before its provider-send guard. It models a new agent
+        // taking the released name while the old operation is in flight.
+        stack.runtime.handle.sqlite.prepare('UPDATE agents SET name = ? WHERE id = ?')
+          .run('race-agent#old', oldAgent.agentId);
+        stack.runtime.handle.sqlite.prepare(
+          `INSERT INTO agents (id, workspace_id, name, type, token_hash, status, location_type, provider_name, metadata, created_at, last_seen)
+           VALUES (?, ?, ?, 'agent', ?, 'active', 'self_connected', 'default', '{}', unixepoch(), unixepoch())`,
+        ).run('agent_race_replacement', ws.workspaceId, 'race-agent', 'f'.repeat(64));
+      }
+      return originalConnected(...args);
+    });
+
+    const response = await stack.app.request('/v1/agents/release-exact', {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        authorization: `Bearer ${ws.workspaceKey}`,
+        'Idempotency-Key': 'exact-release-dispatch-race',
+      },
+      body: JSON.stringify({ name: 'race-agent', expected_agent_id: oldAgent.agentId, delete_agent: true }),
+    });
+    expect(response.status).toBe(201);
+    expect(replaced).toBe(true);
+    const [replacement] = await stack.runtime.deps.db.select({ id: agents.id, name: agents.name, status: agents.status })
+      .from(agents).where(eq(agents.id, 'agent_race_replacement'));
+    expect(replacement).toEqual({ id: 'agent_race_replacement', name: 'race-agent', status: 'active' });
+  });
+
   it('settles a guarded no-host fallback as a generation conflict after takeover', async () => {
     const ws = await createWorkspace(stack.app, 'hostless-release-generation-race');
     const caller = await registerAgent(stack.app, ws.workspaceKey, 'hostless-release-caller');

--- a/packages/engine/src/__tests__/conformance/agentLifecycle.test.ts
+++ b/packages/engine/src/__tests__/conformance/agentLifecycle.test.ts
@@ -1319,6 +1319,63 @@ describe('agent presence and release lifecycle', () => {
     expect(oldNode.sock.ofType('action.invoke')).toHaveLength(0);
   });
 
+  it('requires every supplied release proof to match the persisted invocation', async () => {
+    const ws = await createWorkspace(stack.app, 'release-generation-dual-proof');
+    const target = await registerAgent(stack.app, ws.workspaceKey, 'dual-proof-target');
+    const targetNode = await attachDirectNodeSocket(stack, ws.workspaceId, target);
+    const expectedTokenHash = await sha256Hex(target.token);
+    const invocationId = 'inv_release_dual_proof';
+    await stack.runtime.deps.db.insert(actionInvocations).values({
+      id: invocationId,
+      workspaceId: ws.workspaceId,
+      actionName: 'release',
+      invocationOrigin: 'builtin',
+      input: {
+        name: target.name,
+        expected_token_hash: expectedTokenHash,
+        expected_agent_id: 'agent_persisted_different',
+      },
+      status: 'dispatched',
+      handlerNodeId: targetNode.nodeId,
+      dispatchedNodeId: targetNode.nodeId,
+      dispatchedProvider: 'default',
+      dispatchAttempts: 1,
+    });
+
+    const sent = await stack.runtime.realtime.sendAuthorizedActionToProvider(
+      ws.workspaceId,
+      targetNode.nodeId,
+      'default',
+      {
+        v: 1,
+        type: 'action.invoke',
+        invocation_id: invocationId,
+        action: 'release',
+        input: {
+          name: target.name,
+          expected_token_hash: expectedTokenHash,
+          expected_agent_id: target.agentId,
+        },
+      },
+      {
+        kind: 'release-generation-v1',
+        invocationId,
+        agentName: target.name,
+        expectedTokenHash,
+        expectedAgentId: target.agentId,
+      },
+    );
+
+    expect(sent).toBe(false);
+    expect(targetNode.sock.ofType('action.invoke')).toHaveLength(0);
+    const [invocation] = await stack.runtime.deps.db
+      .select({ status: actionInvocations.status, error: actionInvocations.error })
+      .from(actionInvocations)
+      .where(eq(actionInvocations.id, invocationId));
+    expect(invocation).toEqual({ status: 'failed', error: 'agent_identity_mismatch' });
+    await targetNode.handle.handleClose();
+  });
+
   it('does not accept a release-generation proof for a registered action', async () => {
     const ws = await createWorkspace(stack.app, 'release-generation-origin-boundary');
     const target = await registerAgent(stack.app, ws.workspaceKey, 'release-origin-target');

--- a/packages/engine/src/__tests__/conformance/agentLifecycle.test.ts
+++ b/packages/engine/src/__tests__/conformance/agentLifecycle.test.ts
@@ -1,7 +1,7 @@
 import { invokeWithConcurrentReplay } from './invocationReplay.js';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { and, eq } from 'drizzle-orm';
-import { actionInvocations, agentNodeBindings, agents, channelMembers, nodes, workspaceEvents } from '../../db/schema.js';
+import { actionInvocations, agentNodeBindings, agents, channelMembers, nodes, pendingEvents, workspaceEvents } from '../../db/schema.js';
 import { AGENT_LIVENESS_TTL_MS, sweepStaleAgents } from '../../engine/agent.js';
 import {
   attachDirectNodeSocket,
@@ -237,6 +237,12 @@ describe('agent presence and release lifecycle', () => {
   it('requires a durable key and replays an exact immutable-id release only once', async () => {
     const ws = await createWorkspace(stack.app, 'exact-release-idempotency');
     const target = await registerAgent(stack.app, ws.workspaceKey, 'exact-target');
+    const subscription = await stack.app.request('/v1/subscriptions', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', authorization: `Bearer ${ws.workspaceKey}` },
+      body: JSON.stringify({ events: ['action.invoked'], url: 'http://127.0.0.1:1/hook' }),
+    });
+    expect(subscription.status).toBe(201);
     const body = {
       name: target.name,
       expected_agent_id: target.agentId,
@@ -261,6 +267,12 @@ describe('agent presence and release lifecycle', () => {
       eq(actionInvocations.workspaceId, ws.workspaceId),
       eq(actionInvocations.actionName, 'release'),
     ))).toHaveLength(1);
+    expect(await stack.runtime.deps.db.select({ eventType: pendingEvents.eventType })
+      .from(pendingEvents)
+      .where(and(
+        eq(pendingEvents.workspaceId, ws.workspaceId),
+        eq(pendingEvents.eventType, 'action.invoked'),
+      ))).toHaveLength(1);
   });
 
   it('fails closed on a replacement identity and rejects an idempotency-key payload swap', async () => {

--- a/packages/engine/src/__tests__/conformance/agentLifecycle.test.ts
+++ b/packages/engine/src/__tests__/conformance/agentLifecycle.test.ts
@@ -363,6 +363,55 @@ describe('agent presence and release lifecycle', () => {
     await handle.handleClose();
   });
 
+  it('persists and replays an identity-only local CAS conflict', async () => {
+    const ws = await createWorkspace(stack.app, 'exact-release-identity-cas-replay');
+    const target = await registerAgent(stack.app, ws.workspaceKey, 'identity-cas-replay');
+    const { handle } = await attachDirectNodeSocket(stack, ws.workspaceId, target);
+    const nodeConnections = stack.runtime.deps.nodeConnections!;
+    const originalConnected = nodeConnections.isProviderConnected.bind(nodeConnections);
+    let invalidated = false;
+    vi.spyOn(nodeConnections, 'isProviderConnected').mockImplementation((...args) => {
+      if (!invalidated) {
+        invalidated = true;
+        stack.runtime.handle.sqlite.pragma('foreign_keys = OFF');
+        stack.runtime.handle.sqlite.prepare('UPDATE agents SET id = ? WHERE id = ?')
+          .run('identity-cas-replaced', target.agentId);
+        stack.runtime.handle.sqlite.prepare('UPDATE agent_node_bindings SET agent_id = ? WHERE agent_id = ?')
+          .run('identity-cas-replaced', target.agentId);
+        stack.runtime.handle.sqlite.prepare('UPDATE channel_members SET agent_id = ? WHERE agent_id = ?')
+          .run('identity-cas-replaced', target.agentId);
+        stack.runtime.handle.sqlite.pragma('foreign_keys = ON');
+      }
+      return originalConnected(...args) && false;
+    });
+
+    const invoke = () => stack.app.request('/v1/agents/release-exact', {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        authorization: `Bearer ${ws.workspaceKey}`,
+        'Idempotency-Key': 'identity-cas-replay',
+      },
+      body: JSON.stringify({ name: target.name, expected_agent_id: target.agentId, delete_agent: true }),
+    });
+    const first = await invoke();
+    expect(invalidated).toBe(true);
+    expect(first.status).toBe(409);
+    expect((await first.json() as { error: { code: string } }).error.code)
+      .toBe('agent_identity_mismatch');
+    const replay = await invoke();
+    expect(replay.status).toBe(409);
+    expect((await replay.json() as { error: { code: string } }).error.code)
+      .toBe('agent_identity_mismatch');
+    const [invocation] = await stack.runtime.deps.db.select({ status: actionInvocations.status, error: actionInvocations.error })
+      .from(actionInvocations).where(and(
+        eq(actionInvocations.workspaceId, ws.workspaceId),
+        eq(actionInvocations.actionName, 'release'),
+      ));
+    expect(invocation).toEqual({ status: 'failed', error: 'agent_identity_mismatch' });
+    await handle.handleClose();
+  });
+
   it('fails closed on a replacement identity and rejects an idempotency-key payload swap', async () => {
     const ws = await createWorkspace(stack.app, 'exact-release-replacement');
     const oldAgent = await registerAgent(stack.app, ws.workspaceKey, 'old-agent');

--- a/packages/engine/src/__tests__/conformance/nodeCompletedRelease.test.ts
+++ b/packages/engine/src/__tests__/conformance/nodeCompletedRelease.test.ts
@@ -257,6 +257,61 @@ describe('node-completed release preserves attributed history', () => {
     expect(binding.status).toBe('active');
   });
 
+  it('persists immutable identity mismatch when node completion loses the target row', async () => {
+    const ws = await createWorkspace(stack.app, 'node-release-identity-mismatch');
+    const target = await registerAgent(stack.app, ws.workspaceKey, 'node-identity-mismatch');
+    const { handle } = await attachDirectNodeSocket(stack, ws.workspaceId, target);
+
+    const first = await stack.app.request('/v1/agents/release-exact', {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        authorization: `Bearer ${ws.workspaceKey}`,
+        'Idempotency-Key': 'node-identity-mismatch',
+      },
+      body: JSON.stringify({ name: target.name, expected_agent_id: target.agentId, delete_agent: true }),
+    });
+    expect(first.status).toBe(201);
+    const firstBody = await first.json() as { data: { invocation_id: string; status: string } };
+    expect(firstBody.data.status).toBe('dispatched');
+
+    stack.runtime.handle.sqlite.pragma('foreign_keys = OFF');
+    stack.runtime.handle.sqlite.prepare('UPDATE agents SET id = ? WHERE id = ?')
+      .run('node-identity-replaced', target.agentId);
+    stack.runtime.handle.sqlite.prepare('UPDATE agent_node_bindings SET agent_id = ? WHERE agent_id = ?')
+      .run('node-identity-replaced', target.agentId);
+    stack.runtime.handle.sqlite.prepare('UPDATE channel_members SET agent_id = ? WHERE agent_id = ?')
+      .run('node-identity-replaced', target.agentId);
+    stack.runtime.handle.sqlite.pragma('foreign_keys = ON');
+
+    await handle.handleMessage(JSON.stringify({
+      v: 1,
+      type: 'action.result',
+      invocation_id: firstBody.data.invocation_id,
+      output: { released: true },
+    }));
+
+    const [invocation] = await stack.runtime.deps.db
+      .select({ status: actionInvocations.status, error: actionInvocations.error })
+      .from(actionInvocations)
+      .where(eq(actionInvocations.id, firstBody.data.invocation_id));
+    expect(invocation).toEqual({ status: 'failed', error: 'agent_identity_mismatch' });
+
+    const replay = await stack.app.request('/v1/agents/release-exact', {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        authorization: `Bearer ${ws.workspaceKey}`,
+        'Idempotency-Key': 'node-identity-mismatch',
+      },
+      body: JSON.stringify({ name: target.name, expected_agent_id: target.agentId, delete_agent: true }),
+    });
+    expect(replay.status).toBe(409);
+    expect((await replay.json() as { error: { code: string } }).error.code)
+      .toBe('agent_identity_mismatch');
+    await handle.handleClose();
+  });
+
   it('settles a malformed persisted release generation as a durable conflict', async () => {
     const ws = await createWorkspace(stack.app, 'node-release-corrupt-generation');
     const target = await registerAgent(stack.app, ws.workspaceKey, 'corrupt-release-target');

--- a/packages/engine/src/adapters/node/realtime.ts
+++ b/packages/engine/src/adapters/node/realtime.ts
@@ -308,9 +308,12 @@ export class InProcessRealtime implements RealtimeBus, ConnectionRegistry, NodeC
               eq(actionInvocations.dispatchedProvider, providerName),
             ),
           ),
-          authorization.expectedTokenHash
-            ? sql`json_extract(${actionInvocations.input}, '$.expected_token_hash') = ${authorization.expectedTokenHash}`
-            : sql`json_extract(${actionInvocations.input}, '$.expected_agent_id') = ${authorization.expectedAgentId}`,
+          ...(authorization.expectedTokenHash !== undefined
+            ? [sql`json_extract(${actionInvocations.input}, '$.expected_token_hash') = ${authorization.expectedTokenHash}`]
+            : []),
+          ...(authorization.expectedAgentId !== undefined
+            ? [sql`json_extract(${actionInvocations.input}, '$.expected_agent_id') = ${authorization.expectedAgentId}`]
+            : []),
         ));
       if (!authorized) {
         await this.db

--- a/packages/engine/src/adapters/node/realtime.ts
+++ b/packages/engine/src/adapters/node/realtime.ts
@@ -265,7 +265,10 @@ export class InProcessRealtime implements RealtimeBus, ConnectionRegistry, NodeC
         && typeof releaseInput === 'object'
         && !Array.isArray(releaseInput)
         && releaseInput.name === authorization.agentName
-        && releaseInput.expected_token_hash === authorization.expectedTokenHash;
+        && (authorization.expectedTokenHash === undefined
+          || releaseInput.expected_token_hash === authorization.expectedTokenHash)
+        && (authorization.expectedAgentId === undefined
+          || releaseInput.expected_agent_id === authorization.expectedAgentId);
       if (
         message.invocation_id !== authorization.invocationId
         || message.action !== 'release'
@@ -279,7 +282,8 @@ export class InProcessRealtime implements RealtimeBus, ConnectionRegistry, NodeC
         .innerJoin(agents, and(
           eq(agents.workspaceId, workspaceId),
           eq(agents.name, authorization.agentName),
-          eq(agents.tokenHash, authorization.expectedTokenHash),
+          ...(authorization.expectedTokenHash ? [eq(agents.tokenHash, authorization.expectedTokenHash)] : []),
+          ...(authorization.expectedAgentId ? [eq(agents.id, authorization.expectedAgentId)] : []),
           eq(agents.providerName, providerName),
         ))
         .innerJoin(agentNodeBindings, and(
@@ -304,14 +308,18 @@ export class InProcessRealtime implements RealtimeBus, ConnectionRegistry, NodeC
               eq(actionInvocations.dispatchedProvider, providerName),
             ),
           ),
-          sql`json_extract(${actionInvocations.input}, '$.expected_token_hash') = ${authorization.expectedTokenHash}`,
+          authorization.expectedTokenHash
+            ? sql`json_extract(${actionInvocations.input}, '$.expected_token_hash') = ${authorization.expectedTokenHash}`
+            : sql`json_extract(${actionInvocations.input}, '$.expected_agent_id') = ${authorization.expectedAgentId}`,
         ));
       if (!authorized) {
         await this.db
           .update(actionInvocations)
           .set({
             status: 'failed',
-            error: 'agent_release_generation_conflict',
+            error: authorization.expectedAgentId
+              ? 'agent_identity_mismatch'
+              : 'agent_release_generation_conflict',
             completedAt: new Date(),
           })
           .where(and(

--- a/packages/engine/src/engine/action.ts
+++ b/packages/engine/src/engine/action.ts
@@ -2226,7 +2226,7 @@ async function completeGuardedReleaseNodeInvocation(
       .update(actionInvocations)
       .set({
         status: 'failed',
-        error: RELEASE_GENERATION_CONFLICT_CODE,
+        error: expectedAgentId ? RELEASE_IDENTITY_MISMATCH_CODE : RELEASE_GENERATION_CONFLICT_CODE,
         completedAt: new Date(),
         spawnReservedAt: null,
       })
@@ -2254,7 +2254,7 @@ async function completeGuardedReleaseNodeInvocation(
       .update(actionInvocations)
       .set({
         status: 'failed',
-        error: RELEASE_GENERATION_CONFLICT_CODE,
+        error: expectedAgentId ? RELEASE_IDENTITY_MISMATCH_CODE : RELEASE_GENERATION_CONFLICT_CODE,
         completedAt: new Date(),
         spawnReservedAt: null,
       })
@@ -2315,7 +2315,7 @@ async function completeGuardedReleaseNodeInvocation(
       .update(actionInvocations)
       .set({
         status: 'failed',
-        error: RELEASE_GENERATION_CONFLICT_CODE,
+        error: expectedAgentId ? RELEASE_IDENTITY_MISMATCH_CODE : RELEASE_GENERATION_CONFLICT_CODE,
         completedAt,
         spawnReservedAt: null,
       })
@@ -3099,8 +3099,11 @@ async function dispatchNodeInvocation(args: {
             kind: 'release-generation-v1',
             invocationId: args.invocationId,
             agentName: typeof args.input.name === 'string' ? args.input.name : '',
-            ...(guardedReleaseHash ? { expectedTokenHash: guardedReleaseHash } : {}),
-            ...(guardedReleaseAgentId ? { expectedAgentId: guardedReleaseAgentId } : {}),
+            ...(guardedReleaseHash && guardedReleaseAgentId
+              ? { expectedTokenHash: guardedReleaseHash, expectedAgentId: guardedReleaseAgentId }
+              : guardedReleaseHash
+                ? { expectedTokenHash: guardedReleaseHash }
+                : { expectedAgentId: guardedReleaseAgentId! }),
           },
         ) ?? false)
     : await args.registry.sendToProvider(

--- a/packages/engine/src/engine/action.ts
+++ b/packages/engine/src/engine/action.ts
@@ -122,6 +122,7 @@ function isAcceptedDeletedRegisteredActionInvocation(
 }
 
 const RELEASE_GENERATION_CONFLICT_CODE = 'agent_release_generation_conflict';
+const RELEASE_IDENTITY_MISMATCH_CODE = 'agent_identity_mismatch';
 
 function releaseExpectedTokenHash(input: Record<string, unknown>): string | null {
   const value = input.expected_token_hash;
@@ -136,15 +137,30 @@ function releaseExpectedTokenHash(input: Record<string, unknown>): string | null
   return value;
 }
 
+function releaseExpectedAgentId(input: Record<string, unknown>): string | null {
+  const value = input.expected_agent_id;
+  if (value === undefined) return null;
+  if (typeof value !== 'string' || value.trim().length === 0) {
+    throw codedError(
+      'release action input.expected_agent_id must be a non-empty immutable agent id',
+      'invalid_release_request',
+      400,
+    );
+  }
+  return value;
+}
+
 function releaseGenerationStillCurrent(
   workspaceId: string,
   agentId: string,
   expectedTokenHash: string | null,
+  expectedAgentId: string | null = null,
 ) {
   return sql`EXISTS (
     SELECT 1 FROM ${agents}
     WHERE ${agents.workspaceId} = ${workspaceId}
       AND ${agents.id} = ${agentId}
+      ${expectedAgentId ? sql`AND ${agents.id} = ${expectedAgentId}` : sql``}
       ${expectedTokenHash ? sql`AND ${agents.tokenHash} = ${expectedTokenHash}` : sql``}
   )`;
 }
@@ -669,11 +685,13 @@ async function waitForInvocationReplayOutcome(
     if (
       isBuiltinReleaseInvocation(current)
       && current.status === 'failed'
-      && current.error === RELEASE_GENERATION_CONFLICT_CODE
+      && (current.error === RELEASE_GENERATION_CONFLICT_CODE || current.error === RELEASE_IDENTITY_MISMATCH_CODE)
     ) {
       throw codedError(
-        'Action invocation failed because the release generation changed',
-        RELEASE_GENERATION_CONFLICT_CODE,
+        current.error === RELEASE_IDENTITY_MISMATCH_CODE
+          ? 'Action invocation failed because the immutable agent identity changed'
+          : 'Action invocation failed because the release generation changed',
+        current.error,
         409,
       );
     }
@@ -1064,6 +1082,8 @@ async function dispatchRelease(args: {
   completionDeps?: InvocationCompletionDeps;
   workspaceId: string;
   invocationId?: string;
+  idempotencyKey?: string;
+  idempotencyActorId?: string;
   data: {
     input?: Record<string, unknown>;
     caller_id?: string;
@@ -1076,6 +1096,25 @@ async function dispatchRelease(args: {
     throw codedError('release action input.name is required', 'invalid_release_request', 400);
   }
   const expectedTokenHash = releaseExpectedTokenHash(input);
+  const expectedAgentId = releaseExpectedAgentId(input);
+
+  // Claim the operation before resolving the mutable name. A completed exact
+  // release tombstones/renames the row, so a lost-response replay must find
+  // this immutable invocation before it looks up the name again.
+  const exactClaim = expectedAgentId ? await createInvocation(args.db, args.workspaceId, null, {
+    input,
+    caller_id: args.data.caller_id,
+    caller_name: args.data.caller_name,
+    action_name: 'release',
+    invocation_id: args.invocationId ?? (args.idempotencyKey && (args.idempotencyActorId ?? args.data.caller_id)
+      ? await idempotentInvocationId(args.workspaceId, args.idempotencyActorId ?? args.data.caller_id!, 'release', args.idempotencyKey)
+      : undefined),
+  }) : null;
+  if (exactClaim?.replayed) {
+    const { invocation } = exactClaim;
+    const settled = await waitForInvocationReplayOutcome(args.db, args.workspaceId, invocation);
+    return markInvocationReplay(invocationAck(settled, { actionName: 'release' }));
+  }
 
   const [agent] = await args.db
     .select()
@@ -1083,9 +1122,36 @@ async function dispatchRelease(args: {
     .where(and(
       eq(agents.workspaceId, args.workspaceId),
       eq(agents.name, name),
+      ...(expectedAgentId ? [eq(agents.id, expectedAgentId)] : []),
       ...(expectedTokenHash ? [eq(agents.tokenHash, expectedTokenHash)] : []),
     ));
   if (!agent) {
+    if (expectedAgentId) {
+      await args.db
+        .update(actionInvocations)
+        .set({ status: 'failed', error: RELEASE_IDENTITY_MISMATCH_CODE, completedAt: new Date() })
+        .where(and(
+          eq(actionInvocations.workspaceId, args.workspaceId),
+          eq(actionInvocations.id, exactClaim!.invocation.id),
+          inArray(actionInvocations.status, OPEN_INVOCATION_STATUSES),
+        ));
+      const [sameName] = await args.db
+        .select({ id: agents.id })
+        .from(agents)
+        .where(and(eq(agents.workspaceId, args.workspaceId), eq(agents.name, name)));
+      if (sameName) {
+        throw codedError(
+          `Agent "${name}" no longer matches the expected immutable identity`,
+          RELEASE_IDENTITY_MISMATCH_CODE,
+          409,
+        );
+      }
+      throw codedError(
+        `Agent "${name}" with expected identity is absent`,
+        RELEASE_IDENTITY_MISMATCH_CODE,
+        409,
+      );
+    }
     if (expectedTokenHash) {
       const [sameName] = await args.db
         .select({ id: agents.id })
@@ -1101,12 +1167,17 @@ async function dispatchRelease(args: {
     }
     throw codedError(`Agent "${name}" not found`, 'agent_not_found', 404);
   }
-  const { invocation, replayed } = await createInvocation(args.db, args.workspaceId, null, {
+  // Legacy requests retain their prior behavior: invalid names/generation
+  // guards fail before creating an invocation. Exact requests have already
+  // claimed so their post-release replay survives the tombstone rename.
+  const { invocation, replayed } = exactClaim ?? await createInvocation(args.db, args.workspaceId, null, {
     input,
     caller_id: args.data.caller_id,
     caller_name: args.data.caller_name,
     action_name: 'release',
-    invocation_id: args.invocationId,
+    invocation_id: args.invocationId ?? (args.idempotencyKey && (args.idempotencyActorId ?? args.data.caller_id)
+      ? await idempotentInvocationId(args.workspaceId, args.idempotencyActorId ?? args.data.caller_id!, 'release', args.idempotencyKey)
+      : undefined),
   });
   if (replayed) {
     const settled = await waitForInvocationReplayOutcome(args.db, args.workspaceId, invocation);
@@ -1132,6 +1203,7 @@ async function dispatchRelease(args: {
       args.workspaceId,
       agent.id,
       expectedTokenHash,
+      expectedAgentId,
     );
     const atomicExitNodeId = sql<string | null>`COALESCE(
       (
@@ -1340,6 +1412,7 @@ async function dispatchRelease(args: {
         args.workspaceId,
         agent.id,
         expectedTokenHash,
+        expectedAgentId,
       );
       const results = await runAtomicWrites(args.db, (writeDb) => [
         writeDb
@@ -1508,6 +1581,10 @@ export async function dispatchAgentRelease(
   options: {
     nodeConnections?: NodeConnectionRegistry;
     completionDeps?: InvocationCompletionDeps;
+    /** Required by the exact route; derives a durable action-invocation claim. */
+    idempotencyKey?: string;
+    /** Stable idempotency scope; may be a workspace-key principal, not an agent FK. */
+    idempotencyActorId?: string;
   } = {},
 ) {
   return dispatchRelease({
@@ -1516,6 +1593,8 @@ export async function dispatchAgentRelease(
     completionDeps: options.completionDeps,
     workspaceId,
     data,
+    idempotencyKey: options.idempotencyKey,
+    idempotencyActorId: options.idempotencyActorId,
   });
 }
 
@@ -2135,7 +2214,8 @@ async function completeGuardedReleaseNodeInvocation(
     && AGENT_TOKEN_HASH_PATTERN.test(persistedTokenHash)
     ? persistedTokenHash
     : null;
-  if (!name || !expectedTokenHash) {
+  const expectedAgentId = releaseExpectedAgentId(input);
+  if (!name || (!expectedTokenHash && !expectedAgentId)) {
     const [failed] = await db
       .update(actionInvocations)
       .set({
@@ -2158,7 +2238,11 @@ async function completeGuardedReleaseNodeInvocation(
   const [agent] = await db
     .select()
     .from(agents)
-    .where(and(eq(agents.workspaceId, workspaceId), eq(agents.name, name)));
+    .where(and(
+      eq(agents.workspaceId, workspaceId),
+      eq(agents.name, name),
+      ...(expectedAgentId ? [eq(agents.id, expectedAgentId)] : []),
+    ));
   if (!agent) {
     const [failed] = await db
       .update(actionInvocations)
@@ -2184,6 +2268,7 @@ async function completeGuardedReleaseNodeInvocation(
     workspaceId,
     agent.id,
     expectedTokenHash,
+    expectedAgentId,
   );
   const activeBindingStillCurrent = sql`EXISTS (
     SELECT 1 FROM ${agentNodeBindings}
@@ -2304,7 +2389,7 @@ async function completeGuardedReleaseNodeInvocation(
       eq(agents.workspaceId, workspaceId),
       eq(agents.id, agent.id),
       eq(agents.name, name),
-      eq(agents.tokenHash, expectedTokenHash),
+      ...(expectedTokenHash ? [eq(agents.tokenHash, expectedTokenHash)] : []),
       invocationCompleted,
     );
     if (input.delete_agent === true) {
@@ -2862,7 +2947,10 @@ async function dispatchNodeInvocation(args: {
   const guardedReleaseHash = args.invocationOrigin === 'builtin' && isReleaseInvocation(args.action)
     ? releaseExpectedTokenHash(args.input)
     : null;
-  if (guardedReleaseHash) {
+  const guardedReleaseAgentId = args.invocationOrigin === 'builtin' && isReleaseInvocation(args.action)
+    ? releaseExpectedAgentId(args.input)
+    : null;
+  if (guardedReleaseHash || guardedReleaseAgentId) {
     const name = typeof args.input.name === 'string' ? args.input.name : '';
     const [current] = await args.db
       .select({ id: agents.id })
@@ -2870,7 +2958,8 @@ async function dispatchNodeInvocation(args: {
       .where(and(
         eq(agents.workspaceId, args.workspaceId),
         eq(agents.name, name),
-        eq(agents.tokenHash, guardedReleaseHash),
+        ...(guardedReleaseHash ? [eq(agents.tokenHash, guardedReleaseHash)] : []),
+        ...(guardedReleaseAgentId ? [eq(agents.id, guardedReleaseAgentId)] : []),
         sql`EXISTS (
             SELECT 1 FROM ${agentNodeBindings}
             WHERE ${agentNodeBindings.workspaceId} = ${args.workspaceId}
@@ -3677,7 +3766,7 @@ export async function completeNodeInvocation(
   if (
     !data.error
     && isBuiltinReleaseInvocation(existing)
-    && existingInput.expected_token_hash !== undefined
+    && (existingInput.expected_token_hash !== undefined || existingInput.expected_agent_id !== undefined)
   ) {
     return completeGuardedReleaseNodeInvocation(
       db,

--- a/packages/engine/src/engine/action.ts
+++ b/packages/engine/src/engine/action.ts
@@ -1370,15 +1370,17 @@ async function dispatchRelease(args: {
         )));
 
       return writes;
-    }, expectedTokenHash ? { requireAtomic: true } : undefined);
+    }, expectedTokenHash || expectedAgentId ? { requireAtomic: true } : undefined);
     const generationConflict = results[0] as Array<{ id: string }>;
     const completed = results[1] as Array<{ id: string; handlerNodeId: string | null }>;
     const completedExitNodeId = completed[0]?.handlerNodeId ?? null;
 
-    if (expectedTokenHash && (generationConflict.length > 0 || completed.length === 0)) {
+    if ((expectedTokenHash || expectedAgentId) && (generationConflict.length > 0 || completed.length === 0)) {
       throw codedError(
-        `Agent "${name}" no longer matches the expected token generation`,
-        RELEASE_GENERATION_CONFLICT_CODE,
+        expectedAgentId
+          ? `Agent "${name}" no longer matches the expected immutable identity`
+          : `Agent "${name}" no longer matches the expected token generation`,
+        expectedAgentId ? RELEASE_IDENTITY_MISMATCH_CODE : RELEASE_GENERATION_CONFLICT_CODE,
         409,
       );
     }
@@ -1407,7 +1409,7 @@ async function dispatchRelease(args: {
   };
   const failClosed = async (): Promise<never> => {
     const completedAt = new Date();
-    if (expectedTokenHash) {
+    if (expectedTokenHash || expectedAgentId) {
       const generationStillCurrent = releaseGenerationStillCurrent(
         args.workspaceId,
         agent.id,
@@ -1443,8 +1445,10 @@ async function dispatchRelease(args: {
       const generationConflict = results[0] as Array<{ id: string }>;
       if (generationConflict.length > 0) {
         throw codedError(
-          `Agent "${name}" no longer matches the expected token generation`,
-          RELEASE_GENERATION_CONFLICT_CODE,
+          expectedAgentId
+            ? `Agent "${name}" no longer matches the expected immutable identity`
+            : `Agent "${name}" no longer matches the expected token generation`,
+          expectedAgentId ? RELEASE_IDENTITY_MISMATCH_CODE : RELEASE_GENERATION_CONFLICT_CODE,
           409,
         );
       }
@@ -1517,7 +1521,7 @@ async function dispatchRelease(args: {
       throw codedError(
         'Release invocation failed after provider dispatch',
         errorCode,
-        errorCode === RELEASE_GENERATION_CONFLICT_CODE ? 409 : 503,
+        errorCode === RELEASE_GENERATION_CONFLICT_CODE || errorCode === RELEASE_IDENTITY_MISMATCH_CODE ? 409 : 503,
       );
     }
     return invocationAck(dispatched.settled, { actionName: 'release' });
@@ -1526,7 +1530,7 @@ async function dispatchRelease(args: {
   // The provider can disconnect between the liveness check and send. Complete
   // the DB lifecycle locally instead of creating an ownerless pending request.
   if (!dispatched.accepted) {
-    if (expectedTokenHash) {
+    if (expectedTokenHash || expectedAgentId) {
       const [settled] = await args.db
         .select({ error: actionInvocations.error })
         .from(actionInvocations)
@@ -1534,10 +1538,12 @@ async function dispatchRelease(args: {
           eq(actionInvocations.workspaceId, args.workspaceId),
           eq(actionInvocations.id, invocation.id),
         ));
-      if (settled?.error === RELEASE_GENERATION_CONFLICT_CODE) {
+      if (settled?.error === RELEASE_GENERATION_CONFLICT_CODE || settled?.error === RELEASE_IDENTITY_MISMATCH_CODE) {
         throw codedError(
-          `Agent "${name}" no longer matches the expected token generation`,
-          RELEASE_GENERATION_CONFLICT_CODE,
+          expectedAgentId
+            ? `Agent "${name}" no longer matches the expected immutable identity`
+            : `Agent "${name}" no longer matches the expected token generation`,
+          expectedAgentId ? RELEASE_IDENTITY_MISMATCH_CODE : RELEASE_GENERATION_CONFLICT_CODE,
           409,
         );
       }
@@ -2950,6 +2956,9 @@ async function dispatchNodeInvocation(args: {
   const guardedReleaseAgentId = args.invocationOrigin === 'builtin' && isReleaseInvocation(args.action)
     ? releaseExpectedAgentId(args.input)
     : null;
+  const releaseConflictCode = guardedReleaseAgentId
+    ? RELEASE_IDENTITY_MISMATCH_CODE
+    : RELEASE_GENERATION_CONFLICT_CODE;
   if (guardedReleaseHash || guardedReleaseAgentId) {
     const name = typeof args.input.name === 'string' ? args.input.name : '';
     const [current] = await args.db
@@ -2973,7 +2982,7 @@ async function dispatchNodeInvocation(args: {
         .update(actionInvocations)
         .set({
           status: 'failed',
-          error: RELEASE_GENERATION_CONFLICT_CODE,
+          error: releaseConflictCode,
           completedAt: new Date(),
         })
         .where(and(
@@ -3080,7 +3089,7 @@ async function dispatchNodeInvocation(args: {
             actionName: args.action,
           },
         ) ?? false)
-    : guardedReleaseHash
+    : guardedReleaseHash || guardedReleaseAgentId
       ? await (args.registry.sendAuthorizedActionToProvider?.(
           args.workspaceId,
           args.nodeId,
@@ -3090,7 +3099,8 @@ async function dispatchNodeInvocation(args: {
             kind: 'release-generation-v1',
             invocationId: args.invocationId,
             agentName: typeof args.input.name === 'string' ? args.input.name : '',
-            expectedTokenHash: guardedReleaseHash,
+            ...(guardedReleaseHash ? { expectedTokenHash: guardedReleaseHash } : {}),
+            ...(guardedReleaseAgentId ? { expectedAgentId: guardedReleaseAgentId } : {}),
           },
         ) ?? false)
     : await args.registry.sendToProvider(
@@ -3100,7 +3110,7 @@ async function dispatchNodeInvocation(args: {
         frame,
       );
 
-  if (!sent && guardedReleaseHash) {
+  if (!sent && (guardedReleaseHash || guardedReleaseAgentId)) {
     // An adapter compiled against the older owner-authorization contract may
     // expose the method but reject the new proof kind. Settle any still-open
     // row before the caller considers local fallback, so a guarded delete can
@@ -3172,7 +3182,7 @@ async function dispatchNodeInvocation(args: {
     );
     return { accepted: false, pending: false, sent: true, settled };
   }
-  if (!accepted && guardedReleaseHash) {
+  if (!accepted && (guardedReleaseHash || guardedReleaseAgentId)) {
     const [settled] = await args.db
       .select()
       .from(actionInvocations)

--- a/packages/engine/src/engine/action.ts
+++ b/packages/engine/src/engine/action.ts
@@ -1246,14 +1246,14 @@ async function dispatchRelease(args: {
         .update(actionInvocations)
         .set({
           status: 'failed',
-          error: RELEASE_GENERATION_CONFLICT_CODE,
+          error: expectedAgentId ? RELEASE_IDENTITY_MISMATCH_CODE : RELEASE_GENERATION_CONFLICT_CODE,
           completedAt,
         })
         .where(and(
           eq(actionInvocations.workspaceId, args.workspaceId),
           eq(actionInvocations.id, invocation.id),
           inArray(actionInvocations.status, OPEN_INVOCATION_STATUSES),
-          expectedTokenHash ? sql`NOT (${generationStillCurrent})` : sql`0`,
+          expectedTokenHash || expectedAgentId ? sql`NOT (${generationStillCurrent})` : sql`0`,
         ))
         .returning({ id: actionInvocations.id }));
 
@@ -1421,7 +1421,7 @@ async function dispatchRelease(args: {
           .update(actionInvocations)
           .set({
             status: 'failed',
-            error: RELEASE_GENERATION_CONFLICT_CODE,
+            error: expectedAgentId ? RELEASE_IDENTITY_MISMATCH_CODE : RELEASE_GENERATION_CONFLICT_CODE,
             completedAt,
           })
           .where(and(

--- a/packages/engine/src/ports/realtime.ts
+++ b/packages/engine/src/ports/realtime.ts
@@ -82,7 +82,9 @@ export interface ReleaseActionProviderAuthorization {
   kind: 'release-generation-v1';
   invocationId: string;
   agentName: string;
-  expectedTokenHash: string;
+  /** One or both immutable generation proofs may be supplied. */
+  expectedTokenHash?: string;
+  expectedAgentId?: string;
 }
 
 /** Legacy registered action proof, retained only so current owners fail it closed. */

--- a/packages/engine/src/ports/realtime.ts
+++ b/packages/engine/src/ports/realtime.ts
@@ -78,14 +78,14 @@ export interface AgentActionProviderAuthorization {
 }
 
 /** Exact token-generation proof for a release accepted by the socket owner. */
-export interface ReleaseActionProviderAuthorization {
+export type ReleaseActionProviderAuthorization = {
   kind: 'release-generation-v1';
   invocationId: string;
   agentName: string;
-  /** One or both immutable generation proofs may be supplied. */
-  expectedTokenHash?: string;
-  expectedAgentId?: string;
-}
+} & (
+  | { expectedTokenHash: string; expectedAgentId?: string }
+  | { expectedTokenHash?: string; expectedAgentId: string }
+);
 
 /** Legacy registered action proof, retained only so current owners fail it closed. */
 export interface LegacyRegisteredNodeActionProviderAuthorization {

--- a/packages/engine/src/routes/agent.ts
+++ b/packages/engine/src/routes/agent.ts
@@ -20,7 +20,9 @@ import { fanoutPresence, fanoutToAgents, fanoutToWorkspace } from './fanout.js';
 import { runInBackground } from './background.js';
 import { sendWebhookEvent } from './webhookOutbox.js';
 import { emitServerEvent } from '../lib/serverTelemetry.js';
+import { jsonIdempotentOk, parseIdempotencyKey } from '../middleware/idempotency.js';
 import { errorResponse } from '../lib/httpError.js';
+import { D1WriteRetryExhaustedError } from '../lib/d1Retry.js';
 import {
   jsonCreated,
   jsonError,
@@ -123,6 +125,10 @@ const releaseAgentSchema = z.object({
   reason: z.string().nullable().optional(),
   delete_agent: z.boolean().optional(),
   expected_token_hash: z.string().regex(AGENT_TOKEN_HASH_PATTERN).optional(),
+});
+
+const exactReleaseAgentSchema = releaseAgentSchema.extend({
+  expected_agent_id: z.string().min(1),
 });
 
 const listSessionEventsQuerySchema = z.object({
@@ -993,6 +999,78 @@ agentRoutes.post(
 
       return jsonCreated(c, result);
     } catch (err: unknown) {
+      return errorResponse(c, err);
+    }
+  },
+);
+
+// POST /v1/agents/release-exact - durable, immutable-identity release reconciliation.
+//
+// This intentionally does not alter the legacy name-only route. A broker that
+// has lost its local process handle must opt into the stricter contract and
+// persist this idempotency key before it starts retrying.
+agentRoutes.post(
+  '/agents/release-exact',
+  requireAuth,
+  rateLimit,
+  async (c) => {
+    try {
+      const db = c.get('db');
+      const workspace = c.get('workspace');
+      const callerAgent = c.get('agent');
+      const callerNode = c.get('node');
+      const parsed = await parseJsonBody(c, exactReleaseAgentSchema, 'name and expected_agent_id are required');
+      if (!parsed.ok) return parsed.response;
+
+      const { key: idempotencyKey, error: idempotencyError } = parseIdempotencyKey(c.req.header('Idempotency-Key'));
+      if (idempotencyError) return jsonError(c, 'invalid_idempotency_key', idempotencyError, 400);
+      if (!idempotencyKey) return jsonError(c, 'idempotency_key_required', 'Idempotency-Key is required for exact agent release', 400);
+
+      const result = await actionEngine.dispatchAgentRelease(
+        db,
+        workspace.id,
+        {
+          input: {
+            name: parsed.data.name,
+            reason: parsed.data.reason ?? null,
+            delete_agent: parsed.data.delete_agent === true,
+            expected_agent_id: parsed.data.expected_agent_id,
+            ...(parsed.data.expected_token_hash ? { expected_token_hash: parsed.data.expected_token_hash } : {}),
+          },
+          // A workspace key has no agent FK. Keep the audit caller null while
+          // the separate durable scope below owns its idempotency namespace.
+          caller_id: callerAgent?.id ?? callerNode?.id,
+          caller_name: callerAgent?.name ?? callerNode?.name ?? 'workspace',
+        },
+        {
+          nodeConnections: c.get('engine').nodeConnections,
+          completionDeps: c.get('engine'),
+          idempotencyKey,
+          idempotencyActorId: callerAgent?.id ?? callerNode?.id ?? 'workspace-key',
+        },
+      );
+      const replayed = actionEngine.wasInvocationReplayed(result);
+      if (!replayed) {
+        await sendWebhookEvent(c, {
+          type: 'action.invoked',
+          workspaceId: workspace.id,
+          data: {
+            invocation_id: result.invocation_id,
+            action_name: result.action_name,
+            caller_name: callerAgent?.name ?? callerNode?.name ?? 'workspace',
+            handler_agent_id: result.handler_agent_id,
+            handler_node_id: result.handler_node_id,
+          },
+        });
+      }
+      return jsonIdempotentOk(c, { status: 201, data: result, replayed });
+    } catch (err: unknown) {
+      if (err instanceof D1WriteRetryExhaustedError) {
+        // The storage layer has already spent its bounded retry budget. An
+        // exact keyed operation is safe to retry only after this delay.
+        c.header('Retry-After', '1');
+        return jsonError(c, 'database_overloaded', 'Release database is temporarily overloaded', 503);
+      }
       return errorResponse(c, err);
     }
   },

--- a/packages/engine/src/routes/agent.ts
+++ b/packages/engine/src/routes/agent.ts
@@ -3,7 +3,7 @@ import { z } from 'zod';
 import { and, eq } from 'drizzle-orm';
 import { AGENT_TOKEN_HASH_PATTERN, AgentTypeSchema, CliTypeSchema } from '@relaycast/types';
 import type { AppEnv } from '../env.js';
-import { requireWorkspaceKey, requireAuth, requireAgentToken, requireWorkspaceRead } from '../middleware/auth.js';
+import { requireWorkspaceKey, requireAuth, requireAgentToken, requireSender, requireWorkspaceRead } from '../middleware/auth.js';
 import { rateLimit } from '../middleware/rateLimit.js';
 import * as agentEngine from '../engine/agent.js';
 import * as agentIdentityEngine from '../engine/agentIdentity.js';
@@ -1011,7 +1011,7 @@ agentRoutes.post(
 // persist this idempotency key before it starts retrying.
 agentRoutes.post(
   '/agents/release-exact',
-  requireAuth,
+  requireSender,
   rateLimit,
   async (c) => {
     try {
@@ -1025,6 +1025,9 @@ agentRoutes.post(
       const { key: idempotencyKey, error: idempotencyError } = parseIdempotencyKey(c.req.header('Idempotency-Key'));
       if (idempotencyError) return jsonError(c, 'invalid_idempotency_key', idempotencyError, 400);
       if (!idempotencyKey) return jsonError(c, 'idempotency_key_required', 'Idempotency-Key is required for exact agent release', 400);
+      if (callerAgent?.id === parsed.data.expected_agent_id && parsed.data.delete_agent === true) {
+        return jsonError(c, 'agent_self_release_requires_workspace_key', 'Self-release with delete_agent requires a workspace or node credential', 400);
+      }
 
       const result = await actionEngine.dispatchAgentRelease(
         db,
@@ -1039,7 +1042,7 @@ agentRoutes.post(
           },
           // A workspace key has no agent FK. Keep the audit caller null while
           // the separate durable scope below owns its idempotency namespace.
-          caller_id: callerAgent?.id ?? callerNode?.id,
+          caller_id: callerAgent?.id,
           caller_name: callerAgent?.name ?? callerNode?.name ?? 'workspace',
         },
         {

--- a/packages/sdk-rust/CHANGELOG.md
+++ b/packages/sdk-rust/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
 ### Fixed
 
 - Anonymous keyed workspace bootstrap rejects remote HTTP and redirects, preventing its recovery capability from reaching another origin.
+- `RelayError::retry_after_ms()` exposes the authoritative server delay for exact-release overload handling.
 - Retryable HTTP failures retain the final status, API error, request metadata, and attempt count after retries are exhausted.
 - Retried 5xx responses honor a bounded `Retry-After` delay.
 
@@ -27,6 +28,7 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
 - `RelayCast::create_workspace` now requires explicit provenance, preventing CLI bootstrap workspaces from being mislabeled as SDK-created.
 - `WorkspaceBootstrapOptions` and `RelayCast::create_workspace_with_options()` support crash-safe anonymous keyed workspace creation without a deployment-wide secret, plus opt-in self-host proof via `with_bootstrap_secret(...)`; the SDK never sends that proof to hosted Relaycast.
 - `RelayCast::release_agent_if_token_hash` performs generation-safe cleanup without changing the existing `ReleaseAgentRequest` struct.
+- `RelayCast::release_agent_exact()` performs immutable-id, idempotent agent-release reconciliation.
 
 ## [4.2.0] - 2026-06-24
 

--- a/packages/sdk-rust/src/client.rs
+++ b/packages/sdk-rust/src/client.rs
@@ -18,24 +18,26 @@ const DEFAULT_ORIGIN_CLIENT: &str = "@relaycast/sdk-rust";
 // One entry per attempt. The delay for the final attempt is never used —
 // there is nothing left to wait for once retries are exhausted.
 const RETRY_BACKOFFS_MS: [u64; 3] = [200, 400, 800];
-// Upper bound on a server-provided `Retry-After` delay so a misconfigured or
-// hostile response can't stall a caller far past the client's own backoff.
+// Upper bound on an *automatic* server-provided retry delay so a misconfigured
+// response cannot stall a caller. The typed terminal error still exposes the
+// unmodified authoritative value for durable exact-release reconciliation.
 const MAX_RETRY_AFTER_MS: u64 = 5_000;
 const MAX_ERROR_BODY_SUMMARY_CHARS: usize = 512;
 const MAX_REQUEST_ID_CHARS: usize = 256;
 const REQUEST_ID_HEADER_CANDIDATES: [&str; 2] = ["x-request-id", "x-correlation-id"];
 
-/// Parse a bounded retry delay (in milliseconds) from a response's
-/// `Retry-After` header. Only the delay-seconds form is supported; malformed
-/// or missing headers fall back to the caller's default backoff.
+/// Parse the authoritative retry delay (in milliseconds) from a response's
+/// `Retry-After` header. Only the delay-seconds form is supported.
 fn parse_retry_after_ms(headers: &HeaderMap) -> Option<u64> {
     let value = headers.get(reqwest::header::RETRY_AFTER)?.to_str().ok()?;
     let seconds: u64 = value.trim().parse().ok()?;
-    Some(seconds.saturating_mul(1000).min(MAX_RETRY_AFTER_MS))
+    Some(seconds.saturating_mul(1000))
 }
 
 fn retry_delay_ms(headers: &HeaderMap, fallback_ms: u64) -> u64 {
-    parse_retry_after_ms(headers).unwrap_or(fallback_ms)
+    parse_retry_after_ms(headers)
+        .map(|delay| delay.min(MAX_RETRY_AFTER_MS))
+        .unwrap_or(fallback_ms)
 }
 
 fn request_is_retryable(method: &Method, options: &RequestOptions) -> bool {
@@ -303,6 +305,7 @@ impl HttpClient {
             }
 
             let request_id = extract_request_id(response.headers());
+            let retry_after_ms = parse_retry_after_ms(response.headers());
 
             // Handle 204 No Content
             if status == 204 {
@@ -328,6 +331,7 @@ impl HttpClient {
                             status,
                             request_id,
                             attempts,
+                            retry_after_ms,
                         });
                     }
                     return Err(err.into());
@@ -345,6 +349,7 @@ impl HttpClient {
                     status,
                     request_id,
                     attempts,
+                    retry_after_ms,
                 });
             }
 
@@ -443,10 +448,11 @@ mod tests {
     use reqwest::Method;
 
     #[test]
-    fn retry_after_is_bounded_without_a_wall_clock_wait() {
+    fn retry_after_preserves_authoritative_value_while_auto_wait_is_bounded() {
         let mut headers = HeaderMap::new();
         headers.insert("retry-after", HeaderValue::from_static("3600"));
-        assert_eq!(parse_retry_after_ms(&headers), Some(MAX_RETRY_AFTER_MS));
+        assert_eq!(parse_retry_after_ms(&headers), Some(3_600_000));
+        assert_eq!(retry_delay_ms(&headers, 200), MAX_RETRY_AFTER_MS);
 
         headers.insert("retry-after", HeaderValue::from_static("0"));
         assert_eq!(retry_delay_ms(&headers, 200), 0);

--- a/packages/sdk-rust/src/credentials.rs
+++ b/packages/sdk-rust/src/credentials.rs
@@ -230,6 +230,7 @@ pub async fn bootstrap_session(
                         code: "agent_token_required".to_string(),
                         request_id: None,
                         attempts: 1,
+                        retry_after_ms: None,
                     }),
                 } {
                     Ok(result) => {
@@ -334,6 +335,7 @@ pub async fn bootstrap_session(
                         code: "agent_already_exists".to_string(),
                         request_id: None,
                         attempts: 1,
+                        retry_after_ms: None,
                     })?;
                 let rotate_result = relay
                     .rotate_agent_token(&name, existing_agent_token)

--- a/packages/sdk-rust/src/error.rs
+++ b/packages/sdk-rust/src/error.rs
@@ -19,6 +19,8 @@ pub enum RelayError {
         /// Number of HTTP attempts made (including the one that produced this
         /// error) before it was returned to the caller.
         attempts: u32,
+        /// Server-authoritative retry delay, when supplied in Retry-After.
+        retry_after_ms: Option<u64>,
     },
 
     /// An HTTP request error.
@@ -55,6 +57,7 @@ impl RelayError {
             status,
             request_id: None,
             attempts: 1,
+            retry_after_ms: None,
         }
     }
 
@@ -123,6 +126,14 @@ impl RelayError {
     pub fn attempts(&self) -> Option<u32> {
         match self {
             Self::Api { attempts, .. } => Some(*attempts),
+            _ => None,
+        }
+    }
+
+    /// Get the server-authoritative retry delay, when present.
+    pub fn retry_after_ms(&self) -> Option<u64> {
+        match self {
+            Self::Api { retry_after_ms, .. } => *retry_after_ms,
             _ => None,
         }
     }

--- a/packages/sdk-rust/src/lib.rs
+++ b/packages/sdk-rust/src/lib.rs
@@ -255,6 +255,7 @@ pub use types::{
     ReaderInfo,
     RegisterActionRequest,
     ReleaseAgentRequest,
+    ExactReleaseAgentRequest,
     ReleaseAgentResponse,
     // Search
     SearchOptions,

--- a/packages/sdk-rust/src/registration.rs
+++ b/packages/sdk-rust/src/registration.rs
@@ -272,6 +272,7 @@ impl AgentRegistrationClient {
                 code,
                 request_id,
                 attempts,
+                ..
             }) => {
                 let retry_after_secs = DEFAULT_REGISTRATION_COOLDOWN_SECS;
                 let blocked_until = Instant::now() + Duration::from_secs(retry_after_secs);
@@ -289,6 +290,7 @@ impl AgentRegistrationClient {
                 code,
                 request_id,
                 attempts,
+                ..
             }) => Err(AgentRegistrationError::Api {
                 agent_name: trimmed_name.to_string(),
                 status,

--- a/packages/sdk-rust/src/relay.rs
+++ b/packages/sdk-rust/src/relay.rs
@@ -1,7 +1,7 @@
 //! Main RelayCast client for workspace-level operations.
 
 use crate::agent::AgentClient;
-use crate::client::{ClientOptions, HttpClient};
+use crate::client::{ClientOptions, HttpClient, RequestOptions};
 use crate::error::{RelayError, Result};
 use crate::types::*;
 use serde::Serialize;
@@ -656,6 +656,22 @@ impl RelayCast {
     ) -> Result<ReleaseAgentResponse> {
         self.client
             .post("/v1/agents/release", Some(request), None)
+            .await
+    }
+
+    /// Release only the exact immutable agent identity using a durable caller
+    /// idempotency key. Reuse the same key after an overload or lost response.
+    pub async fn release_agent_exact(
+        &self,
+        request: ExactReleaseAgentRequest,
+        idempotency_key: impl Into<String>,
+    ) -> Result<ReleaseAgentResponse> {
+        self.client
+            .post(
+                "/v1/agents/release-exact",
+                Some(request),
+                Some(RequestOptions::with_idempotency_key(idempotency_key)),
+            )
             .await
     }
 

--- a/packages/sdk-rust/src/types.rs
+++ b/packages/sdk-rust/src/types.rs
@@ -488,6 +488,20 @@ pub struct ReleaseAgentRequest {
     pub delete_agent: Option<bool>,
 }
 
+/// Immutable-identity release reconciliation request. The operation is only
+/// accepted by `/v1/agents/release-exact` with a caller-held Idempotency-Key.
+#[derive(Debug, Clone, Serialize)]
+pub struct ExactReleaseAgentRequest {
+    pub name: String,
+    pub expected_agent_id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reason: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub delete_agent: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub expected_token_hash: Option<String>,
+}
+
 pub type ReleaseAgentResponse = InvokeActionResult;
 
 #[derive(Debug, Clone, Default)]

--- a/packages/sdk-rust/tests/parity.rs
+++ b/packages/sdk-rust/tests/parity.rs
@@ -7,7 +7,7 @@ use relaycast::{
     ListDeliveriesOptions, ListSessionEventsQuery, MessageInjectionMode, MessageListQuery,
     MonitorCertificationRequest, NodeDeliveryAuth, NodeDeliveryConfig, NodeListQuery,
     ObserverScope, ObserverTokenFilters, RateDirectoryAgentRequest, RegisterA2aOptions,
-    RegisterActionRequest, RelayCast, RelayCastOptions, RelayError, ReleaseAgentRequest,
+    ExactReleaseAgentRequest, RegisterActionRequest, RelayCast, RelayCastOptions, RelayError, ReleaseAgentRequest,
     RouteFeedbackRequest, SearchDirectoryQuery, SpawnAgentRequest, SubmitCertificationRequest,
     UpdateObserverTokenRequest, UpdateRoutingConfigRequest, WebhookTriggerRequest,
     WorkspaceBootstrapOptions, WorkspaceProvenance, WsClient, WsClientOptions, WsEvent,
@@ -303,6 +303,39 @@ async fn spawn_and_release_methods_use_expected_endpoints() {
         .expect("release_agent failed");
     assert_eq!(released.invocation_id, "inv_release_1");
     assert_eq!(released.action_name, "release");
+}
+
+#[tokio::test]
+async fn exact_release_uses_immutable_id_and_caller_idempotency_key() {
+    let server = MockServer::start().await;
+    let relay = RelayCast::new(RelayCastOptions::new("rk_live_test").with_base_url(server.uri()))
+        .expect("failed to create relay client");
+    Mock::given(method("POST"))
+        .and(path("/v1/agents/release-exact"))
+        .and(header("Idempotency-Key", "exact-release-key"))
+        .and(body_json(json!({
+            "name": "WorkerOne",
+            "expected_agent_id": "agent_exact_1",
+            "delete_agent": true
+        })))
+        .respond_with(ok(json!({
+            "invocation_id": "inv_exact_1", "action_name": "release",
+            "handler_agent_id": null, "handler_node_id": null,
+            "dispatched_node_id": null, "input": {}, "status": "completed",
+            "created_at": "2026-01-01T00:00:01.000Z"
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let released = relay.release_agent_exact(ExactReleaseAgentRequest {
+        name: "WorkerOne".to_string(),
+        expected_agent_id: "agent_exact_1".to_string(),
+        reason: None,
+        delete_agent: Some(true),
+        expected_token_hash: None,
+    }, "exact-release-key").await.expect("exact release succeeds");
+    assert_eq!(released.invocation_id, "inv_exact_1");
 }
 
 #[tokio::test]

--- a/packages/sdk-rust/tests/parity.rs
+++ b/packages/sdk-rust/tests/parity.rs
@@ -318,6 +318,20 @@ async fn exact_release_uses_immutable_id_and_caller_idempotency_key() {
             "expected_agent_id": "agent_exact_1",
             "delete_agent": true
         })))
+        .respond_with(api_error(503, "database_overloaded", "retry exact release")
+            .insert_header("Retry-After", "0"))
+        .up_to_n_times(1)
+        .expect(1)
+        .mount(&server)
+        .await;
+    Mock::given(method("POST"))
+        .and(path("/v1/agents/release-exact"))
+        .and(header("Idempotency-Key", "exact-release-key"))
+        .and(body_json(json!({
+            "name": "WorkerOne",
+            "expected_agent_id": "agent_exact_1",
+            "delete_agent": true
+        })))
         .respond_with(ok(json!({
             "invocation_id": "inv_exact_1", "action_name": "release",
             "handler_agent_id": null, "handler_node_id": null,

--- a/packages/sdk-typescript/CHANGELOG.md
+++ b/packages/sdk-typescript/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 ### Fixed
 
 - Anonymous keyed workspace bootstrap rejects remote HTTP and redirects, preventing its recovery capability from reaching another origin.
+- `agents.releaseExact()` preserves its caller-held idempotency key across retries, exposes server `Retry-After`, and legacy unkeyed release is no longer replayed automatically.
 
 ## [8.6.0] - 2026-09-09
 

--- a/packages/sdk-typescript/src/__tests__/relay.test.ts
+++ b/packages/sdk-typescript/src/__tests__/relay.test.ts
@@ -2039,13 +2039,13 @@ describe('RelayCast', () => {
       const { RelayCast } = await import('../relay.js');
       const relay = new RelayCast({
         apiKey: 'rk_live_test123',
-        retryPolicy: { maxRetries: 1, backoffMs: 0, jitter: false },
+        retryPolicy: { maxRetries: 1, backoffMs: 300, jitter: false },
       });
       mockFetch
         .mockImplementationOnce(() => Promise.resolve({
           ok: false,
           status: 503,
-          headers: new Headers({ 'Retry-After': '0' }),
+          headers: new Headers({ 'Retry-After': '0.001' }),
           json: () => Promise.resolve({ ok: false, error: { code: 'database_overloaded', message: 'busy' } }),
         }))
         .mockImplementationOnce(() => mockResponse({
@@ -2053,7 +2053,13 @@ describe('RelayCast', () => {
           handler_node_id: null, dispatched_node_id: null, input: {}, status: 'completed', created_at: '2026-01-01T00:00:00.000Z',
         }, true, 201));
 
-      await relay.agents.releaseExact({ name: 'worker', expectedAgentId: 'agent_exact_1', deleteAgent: true }, { idempotencyKey: 'release-exact-key' });
+      vi.useFakeTimers();
+      const release = relay.agents.releaseExact(
+        { name: 'worker', expectedAgentId: 'agent_exact_1', deleteAgent: true },
+        { idempotencyKey: 'release-exact-key' },
+      );
+      await vi.advanceTimersByTimeAsync(1);
+      await release;
       expect(mockFetch).toHaveBeenCalledTimes(2);
       for (const [, init] of mockFetch.mock.calls) {
         expect(init.headers['Idempotency-Key']).toBe('release-exact-key');

--- a/packages/sdk-typescript/src/__tests__/relay.test.ts
+++ b/packages/sdk-typescript/src/__tests__/relay.test.ts
@@ -2033,4 +2033,44 @@ describe('RelayCast', () => {
       expect(init.headers.Authorization).toBe('Bearer at_live_agent123');
     });
   });
+
+  describe('exact agent release', () => {
+    it('preserves the caller key across an overload retry and exposes Retry-After', async () => {
+      const { RelayCast } = await import('../relay.js');
+      const relay = new RelayCast({
+        apiKey: 'rk_live_test123',
+        retryPolicy: { maxRetries: 1, backoffMs: 0, jitter: false },
+      });
+      mockFetch
+        .mockImplementationOnce(() => Promise.resolve({
+          ok: false,
+          status: 503,
+          headers: new Headers({ 'Retry-After': '0' }),
+          json: () => Promise.resolve({ ok: false, error: { code: 'database_overloaded', message: 'busy' } }),
+        }))
+        .mockImplementationOnce(() => mockResponse({
+          invocation_id: 'inv_exact_1', action_name: 'release', handler_agent_id: null,
+          handler_node_id: null, dispatched_node_id: null, input: {}, status: 'completed', created_at: '2026-01-01T00:00:00.000Z',
+        }, true, 201));
+
+      await relay.agents.releaseExact({ name: 'worker', expectedAgentId: 'agent_exact_1', deleteAgent: true }, { idempotencyKey: 'release-exact-key' });
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+      for (const [, init] of mockFetch.mock.calls) {
+        expect(init.headers['Idempotency-Key']).toBe('release-exact-key');
+      }
+    });
+
+    it('does not replay the legacy unkeyed release after an ambiguous 503', async () => {
+      const { RelayCast } = await import('../relay.js');
+      const relay = new RelayCast({ apiKey: 'rk_live_test123', retryPolicy: { maxRetries: 2, backoffMs: 0, jitter: false } });
+      mockFetch.mockImplementation(() => Promise.resolve({
+        ok: false,
+        status: 503,
+        headers: new Headers({ 'Retry-After': '1' }),
+        json: () => Promise.resolve({ ok: false, error: { code: 'database_overloaded', message: 'busy' } }),
+      }));
+      await expect(relay.agents.release({ name: 'worker' })).rejects.toMatchObject({ retryAfterMs: 1000, status: 503 });
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+    });
+  });
 });

--- a/packages/sdk-typescript/src/__tests__/relay.test.ts
+++ b/packages/sdk-typescript/src/__tests__/relay.test.ts
@@ -1011,6 +1011,31 @@ describe('RelayCast', () => {
       expect(mockFetch).toHaveBeenCalledTimes(2);
     });
 
+    it('bounds an excessive Retry-After delay before an automatic retry', async () => {
+      vi.useFakeTimers();
+      const { RelayCast } = await import('../relay.js');
+      const relay = new RelayCast({
+        apiKey: 'rk_live_test123',
+        retryPolicy: { maxRetries: 1, backoffMs: 0, jitter: false, retryOn: [503] },
+      });
+
+      mockFetch
+        .mockImplementationOnce(() => Promise.resolve({
+          ok: false,
+          status: 503,
+          headers: new Headers({ 'Retry-After': '86400' }),
+          json: () => Promise.resolve({ ok: false, error: { code: 'database_overloaded', message: 'busy' } }),
+        }))
+        .mockImplementationOnce(() => mockResponse({ id: 'ws_1' }, true, 200));
+
+      const promise = relay.workspace.info();
+      await vi.advanceTimersByTimeAsync(59_999);
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+      await vi.advanceTimersByTimeAsync(1);
+      await expect(promise).resolves.toEqual({ id: 'ws_1' });
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+    });
+
     it('accepts retry policy overrides via RelayCast constructor options', async () => {
       vi.useFakeTimers();
       const { RelayCast } = await import('../relay.js');

--- a/packages/sdk-typescript/src/client.ts
+++ b/packages/sdk-typescript/src/client.ts
@@ -314,9 +314,7 @@ export class HttpClient {
       }
 
       if (this._retryPolicy.retryOn.includes(res.status) && attempt < maxRetries) {
-        const waitMs = res.status === 429
-          ? parseRetryAfterMs(res) ?? computeBackoffMs(this._retryPolicy, attempt)
-          : computeBackoffMs(this._retryPolicy, attempt);
+        const waitMs = parseRetryAfterMs(res) ?? computeBackoffMs(this._retryPolicy, attempt);
         attempt += 1;
         await sleep(waitMs);
         continue;

--- a/packages/sdk-typescript/src/client.ts
+++ b/packages/sdk-typescript/src/client.ts
@@ -111,6 +111,8 @@ const DEFAULT_RETRY_POLICY: RetryPolicy = {
   retryOn: [429, 500, 502, 503, 504],
 };
 
+const MAX_AUTOMATIC_RETRY_DELAY_MS = 60_000;
+
 function normalizeRetryPolicy(input?: RetryPolicyInput): RetryPolicy {
   return {
     maxRetries: Number.isFinite(input?.maxRetries) ? Math.max(0, Math.floor(input!.maxRetries!)) : DEFAULT_RETRY_POLICY.maxRetries,
@@ -314,7 +316,10 @@ export class HttpClient {
       }
 
       if (this._retryPolicy.retryOn.includes(res.status) && attempt < maxRetries) {
-        const waitMs = parseRetryAfterMs(res) ?? computeBackoffMs(this._retryPolicy, attempt);
+        const waitMs = Math.min(
+          parseRetryAfterMs(res) ?? computeBackoffMs(this._retryPolicy, attempt),
+          MAX_AUTOMATIC_RETRY_DELAY_MS,
+        );
         attempt += 1;
         await sleep(waitMs);
         continue;

--- a/packages/sdk-typescript/src/client.ts
+++ b/packages/sdk-typescript/src/client.ts
@@ -133,7 +133,9 @@ function computeBackoffMs(policy: RetryPolicy, retryAttempt: number): number {
 }
 
 function parseRetryAfterMs(res: Response): number | null {
-  const header = res.headers.get('Retry-After');
+  // Lightweight SDK test doubles and Fetch-compatible shims can omit
+  // `headers`; treat that exactly as an absent Retry-After value.
+  const header = res.headers?.get('Retry-After');
   if (!header) return null;
 
   const asSeconds = Number(header);
@@ -280,7 +282,12 @@ export class HttpClient {
     const hasBody = body !== undefined && method.toUpperCase() !== 'GET';
     if (hasBody) headers['Content-Type'] = 'application/json';
     const wireBody = hasBody ? decamelizeKeys(body) : undefined;
-    const maxRetries = options?.retry === false ? 0 : this._retryPolicy.maxRetries;
+    // A POST/PATCH without a caller-provided idempotency key is not safe to
+    // replay after a lost response. Exact lifecycle operations opt in by
+    // carrying their durable key in the request headers.
+    const idempotencyKey = Object.entries(headers).find(([name]) => name.toLowerCase() === 'idempotency-key')?.[1];
+    const isUnsafeMutation = ['POST', 'PATCH'].includes(method.toUpperCase()) && !idempotencyKey;
+    const maxRetries = options?.retry === false || isUnsafeMutation ? 0 : this._retryPolicy.maxRetries;
 
     let attempt = 0;
 
@@ -343,7 +350,7 @@ export class HttpClient {
         const errParsed = ApiErrorSchema.safeParse(json);
         const code = errParsed.success ? errParsed.data.error.code : 'unknown_error';
         const message = errParsed.success ? errParsed.data.error.message : 'Unknown error';
-        throw relayErrorFromApi(code, message, res.status);
+        throw relayErrorFromApi(code, message, res.status, parseRetryAfterMs(res) ?? undefined);
       }
 
       const data = envelope.data.data;

--- a/packages/sdk-typescript/src/errors.ts
+++ b/packages/sdk-typescript/src/errors.ts
@@ -13,6 +13,8 @@ export interface RelayErrorOptions {
   retryable?: boolean;
   rawCode?: string;
   cause?: unknown;
+  /** Authoritative delay supplied by the server, when present. */
+  retryAfterMs?: number;
 }
 
 const RAW_CODE_MAP: Record<string, RelayErrorCode> = {
@@ -77,6 +79,7 @@ export class RelayError extends Error {
   readonly statusCode?: number;
   readonly rawCode?: string;
   readonly status: number;
+  readonly retryAfterMs?: number;
 
   constructor(code: RelayErrorCode, message: string, options: RelayErrorOptions = {}) {
     super(message);
@@ -86,6 +89,7 @@ export class RelayError extends Error {
     this.rawCode = options.rawCode;
     this.retryable = options.retryable ?? relayErrorRetryable(code, options.statusCode);
     this.status = options.statusCode ?? 0;
+    this.retryAfterMs = options.retryAfterMs;
     if (options.cause !== undefined) {
       (this as { cause?: unknown }).cause = options.cause;
     }
@@ -96,7 +100,8 @@ export function relayErrorFromApi(
   rawCode: string | undefined,
   message: string,
   statusCode?: number,
+  retryAfterMs?: number,
 ): RelayError {
   const code = normalizeRelayErrorCode(rawCode, statusCode);
-  return new RelayError(code, message, { statusCode, rawCode });
+  return new RelayError(code, message, { statusCode, rawCode, retryAfterMs });
 }

--- a/packages/sdk-typescript/src/relay.ts
+++ b/packages/sdk-typescript/src/relay.ts
@@ -42,6 +42,7 @@ import type {
   SpawnAgentRequest,
   SpawnAgentResponse,
   ReleaseAgentRequest,
+  ExactReleaseAgentRequest,
   ReleaseAgentResponse,
   RegisterA2aOptions,
   RegisterA2aResponse,
@@ -892,6 +893,20 @@ export class RelayCast {
       this.client.post('/v1/agents/spawn', data),
     release: (data: ReleaseAgentRequest): Promise<ReleaseAgentResponse> =>
       this.client.post('/v1/agents/release', data),
+    /**
+     * Atomically release only the exact immutable agent identity. The key is
+     * deliberately mandatory: callers persist and reuse it across restarts.
+     */
+    releaseExact: (
+      data: ExactReleaseAgentRequest,
+      options: { idempotencyKey: string },
+    ): Promise<ReleaseAgentResponse> => {
+      const idempotencyKey = options.idempotencyKey.trim();
+      if (!idempotencyKey) throw new Error('idempotencyKey is required for exact agent release');
+      return this.client.post('/v1/agents/release-exact', data, {
+        headers: { 'Idempotency-Key': idempotencyKey },
+      });
+    },
     events: {
       emit: (name: string, data: EmitSessionEventRequest): Promise<SessionEvent> =>
         this.client.post(`/v1/agents/${encodeURIComponent(name)}/events`, data),

--- a/packages/sdk-typescript/src/types.ts
+++ b/packages/sdk-typescript/src/types.ts
@@ -647,6 +647,7 @@ export type ReadReceipt = Camelize<Raw.ReadReceipt>;
 export type ReaderInfo = Camelize<Raw.ReaderInfo>;
 export type RelaycastMessageEvent = Camelize<Raw.RelaycastMessageEvent>;
 export type ReleaseAgentRequest = Camelize<Raw.ReleaseAgentRequest>;
+export type ExactReleaseAgentRequest = Camelize<Raw.ExactReleaseAgentRequest>;
 export type ReleaseAgentResponse = Camelize<Raw.ReleaseAgentResponse>;
 export type SendDmRequest = Camelize<Raw.SendDmRequest>;
 export type SetSystemPromptRequest = Camelize<Raw.SetSystemPromptRequest>;

--- a/packages/types/src/agent.ts
+++ b/packages/types/src/agent.ts
@@ -116,5 +116,14 @@ export const ReleaseAgentRequestSchema = z.object({
 });
 export type ReleaseAgentRequest = z.infer<typeof ReleaseAgentRequestSchema>;
 
+/**
+ * Server-authorized release reconciliation. Unlike the legacy name-addressed
+ * request this pins the mutation to the immutable agent row id.
+ */
+export const ExactReleaseAgentRequestSchema = ReleaseAgentRequestSchema.extend({
+  expected_agent_id: z.string().min(1),
+});
+export type ExactReleaseAgentRequest = z.infer<typeof ExactReleaseAgentRequestSchema>;
+
 export const ReleaseAgentResponseSchema = LifecycleActionInvocationResponseSchema;
 export type ReleaseAgentResponse = z.infer<typeof ReleaseAgentResponseSchema>;


### PR DESCRIPTION
## Summary

Implements #409's safe release-reconciliation contract without changing legacy `POST /v1/agents/release` behavior.

- Adds `POST /v1/agents/release-exact`, requiring `expected_agent_id` and `Idempotency-Key`.
- Uses a durable action-invocation claim before mutable-name lookup, so lost-response replay returns the original terminal invocation even after a tombstone rename.
- Enforces immutable identity at initial lookup, dispatch authorization, local completion, and node completion; same-name replacements are never mutated.
- Rejects key/payload swaps, exposes `Idempotency-Replayed`, and converts exhausted D1 retries to `database_overloaded` with `Retry-After`.
- Adds TypeScript `agents.releaseExact()` and Rust `release_agent_exact()`, both preserving caller keys; typed SDK errors expose Retry-After and unkeyed legacy POSTs are not automatically replayed.

## Evidence

- Engine lifecycle 36/36, node providers 47/47, TypeScript SDK 96/96 passed in clean Daytona snapshot.
- Full prior validation and SDK/Rust suites are recorded in the preceding evidence comment.
- New identity-only zero-row CAS regression durably records `agent_identity_mismatch`; first request and same-key replay return the same 409, including after process restart.
- Source-bound HTTP proof used a destroyed response and persistent SQLite across restart. Sanitized evidence SHA256: `fa777b2a2ed8f7cf3ea5fa3218753298324af07f4cc77d1db0e7594e871fc266`.
- Veto diff review: PASS, code score 92, zero findings.

## Follow-up gates

Independent review, hosted deployment, and source-bound broker restart proof are complete for this branch. No credentials or observer URLs are included in the evidence.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/AgentWorkforce/relaycast/pull/410?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes agent lifecycle teardown, idempotency, and webhook emission on a reconciliation path; mistakes could release the wrong identity or double-invoke side effects, though legacy release is untouched and tests are extensive.
> 
> **Overview**
> Adds **`POST /v1/agents/release-exact`** as a crash-safe alternative to legacy name-only release: callers must supply **`expected_agent_id`** and a persisted **`Idempotency-Key`**, scoped to workspace, principal, and the `release` action. The engine **claims the invocation before name lookup** so replays survive tombstone renames, return **`Idempotency-Replayed`**, and **do not enqueue a second `action.invoked` webhook**; payload/key mismatches yield **`409 idempotency_key_reused`**, and identity races yield **`agent_identity_mismatch`** through dispatch, local completion, and node completion (same-name replacements are not touched). Legacy **`POST /v1/agents/release`** behavior is unchanged; release-generation authorization can now prove **token hash, agent id, or both**.
> 
> **TypeScript** adds **`agents.releaseExact()`** (mandatory key, key preserved on retry, **`retryAfterMs` on errors**); **unkeyed POST/PATCH mutations no longer auto-retry** after ambiguous failures. **Rust** adds **`release_agent_exact()`** and **`RelayError::retry_after_ms()`** with bounded automatic waits vs authoritative server delay. OpenAPI, README, and changelogs document the contract; conformance tests cover idempotency, webhooks, races, and overload **`503` + `Retry-After`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 52ae4a7c98204ab3fe05ddeb5d77aa9173e2f1f8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

