### PR TITLE
fix(release): reconcile npm tags and Docker locks safely

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -219,7 +219,12 @@ jobs:
 
             const dockerLockPath = path.join('docker', 'package-lock.json');
             const dockerLock = JSON.parse(fs.readFileSync(dockerLockPath, 'utf8'));
-            if (dockerLock.packages?.['']) dockerLock.packages[''].version = version;
+            if (dockerLock.packages?.['']) {
+              dockerLock.packages[''].version = version;
+              if (dockerLock.packages[''].dependencies?.['@relaycast/engine']) {
+                dockerLock.packages[''].dependencies['@relaycast/engine'] = version;
+              }
+            }
             if (dockerLock.packages?.['node_modules/@relaycast/engine']) {
               dockerLock.packages['node_modules/@relaycast/engine'].version = version;
             }

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -55,6 +55,12 @@ permissions:
 
 env:
   NPM_CONFIG_FUND: false
+  # npm can take several minutes to propagate a publish to dist-tags. Keep
+  # one shared, bounded reconciliation budget for all packages.
+  NPM_TAG_VERIFY_ATTEMPTS: 30
+  NPM_TAG_VERIFY_DELAY_MS: 10000
+  NPM_PACKAGE_VERIFY_ATTEMPTS: 12
+  NPM_PACKAGE_VERIFY_DELAY_SECONDS: 10
 
 jobs:
   # Build all packages, version them, run tests
@@ -413,18 +419,12 @@ jobs:
           else
             npm publish "$GITHUB_WORKSPACE/$TARBALL" --access public --provenance --tag ${{ needs.build.outputs.effective_tag }} --ignore-scripts
           fi
-          # Publishing and package identity are not enough: npm dist-tags are
-          # independently mutable. Poll the tag set atomically by npm publish
-          # until the registry reports its exact version. OIDC trusted
-          # publishing does not authorize npm dist-tag rewrites, so a resumed
-          # run fails closed if that mapping was moved or removed. For
-          # next/beta/alpha, this command never addresses or moves latest.
-          node "$GITHUB_WORKSPACE/scripts/npm-dist-tag.mjs" verify \
-            --package "$PACKAGE_NAME" \
-            --version "$NEW_VERSION" \
-            --tag "${{ needs.build.outputs.effective_tag }}" \
-            --attempts 5 \
-            --delay-ms 5000
+          # Dist-tags propagate independently of the immutable package
+          # artifact. Do not fail this matrix job on a stale read: the
+          # authoritative verify-publish job checks every package in one
+          # shared bounded window. This keeps a successful signed publish
+          # resumable without ever rewriting a tag or republishing a
+          # mismatched artifact.
 
   # Independently reconciles the npm registry against what this release
   # attempted to publish, rather than trusting the matrix job's own status
@@ -486,37 +486,25 @@ jobs:
             echo "| Package | Published |"
             echo "|---------|-----------|"
           } >> "$GITHUB_STEP_SUMMARY"
-          # A handful of short retries absorb ordinary npm registry read
-          # propagation delay immediately after publish, so this reconciler
-          # does not raise a false "missing" alarm for a package that in fact
-          # published successfully moments earlier.
+          # A bounded package-visibility retry absorbs npm processing delay
+          # before checking immutable provenance. Dist-tags are reconciled
+          # separately below in rounds so a slow package cannot starve peers.
           missing=()
           for pkg in "${PACKAGES[@]}"; do
             found=false
-            for check_attempt in 1 2 3 4 5; do
+            for check_attempt in $(seq 1 "$NPM_PACKAGE_VERIFY_ATTEMPTS"); do
               if npm view "${pkg}@${NEW_VERSION}" version >/dev/null 2>&1; then
                 actual_integrity="$(npm view "${pkg}@${NEW_VERSION}" dist.integrity 2>/dev/null || true)"
                 if node scripts/release-provenance.mjs published --manifest release-provenance.json --package "$pkg" --integrity "$actual_integrity" --version "$NEW_VERSION"; then
-                  # Independent verification is read-only: the publish matrix
-                  # must already have reconciled the requested mutable tag.
-                  # Missing, stale, unavailable, or ambiguous responses fail
-                  # closed after a bounded propagation window.
-                  if node scripts/npm-dist-tag.mjs verify \
-                    --package "$pkg" \
-                    --version "$NEW_VERSION" \
-                    --tag "$DIST_TAG" \
-                    --attempts 5 \
-                    --delay-ms 5000; then
-                    found=true
-                    break
-                  fi
-                  echo "${pkg}@${NEW_VERSION} has no verified ${DIST_TAG} dist-tag mapping" >&2
-                  break
+                found=true
+                break
                 fi
                 echo "${pkg}@${NEW_VERSION} exists with a non-matching artifact; refusing to reconcile it" >&2
                 break
               fi
-              sleep $(( check_attempt * 5 ))
+              if [ "$check_attempt" -lt "$NPM_PACKAGE_VERIFY_ATTEMPTS" ]; then
+                sleep "$NPM_PACKAGE_VERIFY_DELAY_SECONDS"
+              fi
             done
             if [ "$found" = "true" ]; then
               echo "| ${pkg} | done |" >> "$GITHUB_STEP_SUMMARY"
@@ -535,8 +523,23 @@ jobs:
             echo "::error::${#missing[@]} package(s) missing at v${NEW_VERSION}: ${missing[*]}"
             exit 1
           fi
+
+          # npm dist-tags are mutable registry state, but trusted publishing
+          # does not authorize `npm dist-tag`. Verify the exact mapping only;
+          # never rewrite it and never use a stale tag as a reason to publish
+          # again. All packages share this bounded round-robin window.
+          TAG_VERIFY_ARGS=(
+            --version "$NEW_VERSION"
+            --tag "$DIST_TAG"
+            --attempts "$NPM_TAG_VERIFY_ATTEMPTS"
+            --delay-ms "$NPM_TAG_VERIFY_DELAY_MS"
+          )
+          for pkg in "${PACKAGES[@]}"; do
+            TAG_VERIFY_ARGS+=(--package "$pkg")
+          done
+          node scripts/npm-dist-tag.mjs verify-many "${TAG_VERIFY_ARGS[@]}"
           echo "" >> "$GITHUB_STEP_SUMMARY"
-          echo "All ${#PACKAGES[@]} packages confirmed published at v${NEW_VERSION}." >> "$GITHUB_STEP_SUMMARY"
+          echo "All ${#PACKAGES[@]} packages confirmed published at v${NEW_VERSION} with ${DIST_TAG} dist-tags." >> "$GITHUB_STEP_SUMMARY"
 
   # Create git tag and release
   create-release:
@@ -633,13 +636,13 @@ jobs:
           if [ "${REUSE_EXISTING_RELEASE_TAG:-false}" = "true" ]; then
             echo "existing release tag restored; leaving its lockfile tree unchanged"
           else
-            # The build artifact deliberately gives the engine lock entry the
-            # target version before that registry artifact exists. A generic
-            # install trusts that placeholder version and can retain the old
-            # resolved tarball/integrity. Updating the exact dependency forces
-            # npm to resolve the newly published immutable artifact while
-            # preserving docker/package.json's exact version pin.
-            npm update --package-lock-only --ignore-scripts @relaycast/engine
+            # Do not run npm update here: it can refresh unrelated semver
+            # ranges (for example zod), producing a release tree that fails
+            # exact validation despite correct package artifacts. Project the
+            # immutable provenance entries into the lockfile instead.
+            node "$GITHUB_WORKSPACE/scripts/refresh-docker-lock.mjs" \
+              --manifest "$GITHUB_WORKSPACE/release-provenance.json" \
+              --version "${{ needs.build.outputs.new_version }}"
           fi
 
       - name: Re-validate release contract with the refreshed lockfile

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -167,7 +167,7 @@ jobs:
                 pkg.version = version;
 
                 // Update @relaycast/* dependencies to exact version
-                for (const depType of ['dependencies', 'devDependencies', 'peerDependencies']) {
+                for (const depType of ['dependencies', 'devDependencies', 'optionalDependencies', 'peerDependencies']) {
                   for (const dep of Object.keys(pkg[depType] || {})) {
                     if (dep.startsWith('@relaycast/')) {
                       pkg[depType][dep] = version;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@ Packages without a separate changelog are covered by the cross-package notes bel
 
 ### Fixed
 
+- NPM release reconciliation now waits for all package dist-tags within one bounded propagation window and preserves unrelated Docker lockfile resolutions.
+
 - Rust and TypeScript SDK anonymous keyed workspace bootstrap refuses remote HTTP and redirects, keeping its recovery capability on the intended origin.
 
 ## [8.7.0] - 2026-09-09

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "build": "turbo build",
     "test": "turbo test",
-    "test:release": "node --test scripts/check-published-engine-migrations.test.mjs scripts/npm-dist-tag.test.mjs scripts/release-contract.test.mjs scripts/release-workflow-contract.test.mjs",
+    "test:release": "node --test scripts/check-published-engine-migrations.test.mjs scripts/npm-dist-tag.test.mjs scripts/refresh-docker-lock.test.mjs scripts/release-contract.test.mjs scripts/release-workflow-contract.test.mjs",
     "test:container": "node --test test/container-entrypoint.test.mjs",
     "test:container-image": "node --test test/container-image-integration.test.mjs",
     "lint": "turbo lint",

--- a/scripts/npm-dist-tag.mjs
+++ b/scripts/npm-dist-tag.mjs
@@ -4,6 +4,12 @@ import { spawnSync } from "node:child_process";
 import { resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
+// npm may take a few minutes to expose a newly published package and its
+// dist-tag through every registry read path. Keep retries bounded while
+// allowing that documented propagation window to elapse.
+export const DEFAULT_ATTEMPTS = 30;
+export const DEFAULT_DELAY_MS = 10_000;
+
 function requiredString(value, label) {
   if (
     typeof value !== "string" ||
@@ -110,48 +116,92 @@ export async function ensureNpmDistTag({
   packageName,
   version,
   distTag,
-  attempts = 5,
-  delayMs = 5_000,
+  attempts = DEFAULT_ATTEMPTS,
+  delayMs = DEFAULT_DELAY_MS,
   readTag = readNpmDistTag,
   sleep = (milliseconds) =>
     new Promise((resolveSleep) => setTimeout(resolveSleep, milliseconds)),
 }) {
-  requiredString(packageName, "packageName");
+  const result = await ensureNpmDistTags({
+    packageNames: [packageName],
+    version,
+    distTag,
+    attempts,
+    delayMs,
+    readTag,
+    sleep,
+  });
+  return { packageName, version, distTag, attempts: result.attempts };
+}
+
+/**
+ * Verify several dist-tags in rounds under one shared bounded window. A slow
+ * package therefore cannot consume a separate retry budget before the other
+ * packages are checked. This is read-only: stale tags fail closed and are
+ * never rewritten or used as a reason to republish a package.
+ */
+export async function ensureNpmDistTags({
+  packageNames,
+  version,
+  distTag,
+  attempts = DEFAULT_ATTEMPTS,
+  delayMs = DEFAULT_DELAY_MS,
+  readTag = readNpmDistTag,
+  sleep = (milliseconds) =>
+    new Promise((resolveSleep) => setTimeout(resolveSleep, milliseconds)),
+}) {
+  if (!Array.isArray(packageNames) || packageNames.length === 0) {
+    throw new Error("packageNames must contain at least one package");
+  }
+  const names = packageNames.map((packageName) =>
+    requiredString(packageName, "packageName"),
+  );
+  if (new Set(names).size !== names.length) {
+    throw new Error("packageNames must not contain duplicates");
+  }
   requiredString(version, "version");
   requiredString(distTag, "distTag");
   positiveInteger(attempts, "attempts");
   nonNegativeInteger(delayMs, "delayMs");
 
-  let last = { kind: "missing" };
+  const last = new Map();
   for (let attempt = 1; attempt <= attempts; attempt += 1) {
-    const observation = readTag(packageName, distTag);
-    last = observation;
-    if (observation?.kind === "value" && observation.value === version) {
-      return { packageName, version, distTag, attempts: attempt };
+    let pending = false;
+    for (const packageName of names) {
+      const observation = readTag(packageName, distTag);
+      last.set(packageName, observation);
+      if (observation?.kind === "value" && observation.value === version) {
+        continue;
+      }
+      if (
+        !observation ||
+        !["missing", "unavailable", "value"].includes(observation.kind)
+      ) {
+        throw new Error(
+          `npm returned an ambiguous ${packageName} dist-tag ${distTag} response`,
+        );
+      }
+      pending = true;
     }
-    if (
-      !observation ||
-      !["missing", "unavailable", "value"].includes(observation.kind)
-    ) {
-      throw new Error(
-        `npm returned an ambiguous ${packageName} dist-tag ${distTag} response`,
-      );
+    if (!pending) {
+      return { packageNames: names, version, distTag, attempts: attempt };
     }
     if (attempt < attempts) await sleep(delayMs);
   }
 
-  if (last.kind === "value") {
-    throw new Error(
-      `${packageName} dist-tag ${distTag} points to ${last.value}, expected ${version}`,
-    );
-  }
-  if (last.kind === "unavailable") {
-    throw new Error(
-      `npm could not verify ${packageName} dist-tag ${distTag} after ${attempts} attempts`,
-    );
-  }
+  const failures = names.map((packageName) => {
+    const observation = last.get(packageName);
+    if (observation?.kind === "value") {
+      return `${packageName} dist-tag ${distTag} points to ${observation.value}, expected ${version}`;
+    }
+    if (observation?.kind === "unavailable") {
+      return `npm could not verify ${packageName} dist-tag ${distTag} after ${attempts} attempts`;
+    }
+    return `${packageName} dist-tag ${distTag} is absent after ${attempts} attempts`;
+  });
+  if (failures.length === 1) throw new Error(failures[0]);
   throw new Error(
-    `${packageName} dist-tag ${distTag} is absent after ${attempts} attempts`,
+    `npm dist-tag ${distTag} reconciliation failed:\n${failures.join("\n")}`,
   );
 }
 
@@ -167,28 +217,51 @@ function argument(name, { optional = false, fallback } = {}) {
   return value;
 }
 
+function argumentsFor(name) {
+  const values = [];
+  for (let index = 0; index < process.argv.length; index += 1) {
+    if (process.argv[index] !== name) continue;
+    const value = process.argv[index + 1];
+    if (!value || value.startsWith("--")) {
+      throw new Error(`${name} requires a value`);
+    }
+    values.push(value);
+  }
+  return values;
+}
+
 if (
   process.argv[1] &&
   fileURLToPath(import.meta.url) === resolve(process.argv[1])
 ) {
   const command = process.argv[2];
-  if (command !== "verify") {
-    throw new Error("command must be verify");
+  if (command !== "verify" && command !== "verify-many") {
+    throw new Error("command must be verify or verify-many");
   }
-  const result = await ensureNpmDistTag({
-    packageName: argument("--package"),
+  const packageNames =
+    command === "verify-many" ? argumentsFor("--package") : [argument("--package")];
+  const result = await ensureNpmDistTags({
+    packageNames,
     version: argument("--version"),
     distTag: argument("--tag"),
     attempts: positiveInteger(
-      argument("--attempts", { optional: true, fallback: "5" }),
+      argument("--attempts", {
+        optional: true,
+        fallback: String(DEFAULT_ATTEMPTS),
+      }),
       "--attempts",
     ),
     delayMs: nonNegativeInteger(
-      argument("--delay-ms", { optional: true, fallback: "5000" }),
+      argument("--delay-ms", {
+        optional: true,
+        fallback: String(DEFAULT_DELAY_MS),
+      }),
       "--delay-ms",
     ),
   });
   process.stdout.write(
-    `${result.packageName} dist-tag ${result.distTag} verified at ${result.version}\n`,
+    command === "verify"
+      ? `${packageNames[0]} dist-tag ${result.distTag} verified at ${result.version}\n`
+      : `${packageNames.length} dist-tags ${result.distTag} verified at ${result.version}\n`,
   );
 }

--- a/scripts/npm-dist-tag.mjs
+++ b/scripts/npm-dist-tag.mjs
@@ -189,15 +189,17 @@ export async function ensureNpmDistTags({
     if (attempt < attempts) await sleep(delayMs);
   }
 
-  const failures = names.map((packageName) => {
+  const failures = names.flatMap((packageName) => {
     const observation = last.get(packageName);
     if (observation?.kind === "value") {
-      return `${packageName} dist-tag ${distTag} points to ${observation.value}, expected ${version}`;
+      return observation.value === version
+        ? []
+        : [`${packageName} dist-tag ${distTag} points to ${observation.value}, expected ${version}`];
     }
     if (observation?.kind === "unavailable") {
-      return `npm could not verify ${packageName} dist-tag ${distTag} after ${attempts} attempts`;
+      return [`npm could not verify ${packageName} dist-tag ${distTag} after ${attempts} attempts`];
     }
-    return `${packageName} dist-tag ${distTag} is absent after ${attempts} attempts`;
+    return [`${packageName} dist-tag ${distTag} is absent after ${attempts} attempts`];
   });
   if (failures.length === 1) throw new Error(failures[0]);
   throw new Error(

--- a/scripts/npm-dist-tag.test.mjs
+++ b/scripts/npm-dist-tag.test.mjs
@@ -1,13 +1,80 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 import {
+  DEFAULT_ATTEMPTS,
+  DEFAULT_DELAY_MS,
   ensureNpmDistTag,
+  ensureNpmDistTags,
   parseNpmDistTagOutput,
   parseNpmDistTagsOutput,
   readNpmDistTag,
 } from "./npm-dist-tag.mjs";
 
 describe("npm dist-tag reconciliation", () => {
+  it("uses a bounded multi-package window so slow packages do not starve peers", async () => {
+    const reads = new Map([
+      ["@relaycast/types", 0],
+      ["@relaycast/openclaw", 0],
+    ]);
+    const observations = [];
+    let sleeps = 0;
+    const result = await ensureNpmDistTags({
+      packageNames: ["@relaycast/types", "@relaycast/openclaw"],
+      version: "8.8.0",
+      distTag: "latest",
+      attempts: 3,
+      delayMs: 0,
+      readTag: (packageName) => {
+        const read = reads.get(packageName);
+        reads.set(packageName, read + 1);
+        observations.push(`${packageName}:${read + 1}`);
+        return read >= (packageName.endsWith("types") ? 1 : 2)
+          ? { kind: "value", value: "8.8.0" }
+          : { kind: "value", value: "8.7.0" };
+      },
+      sleep: async () => {
+        sleeps += 1;
+      },
+    });
+
+    assert.equal(result.attempts, 3);
+    assert.equal(sleeps, 2);
+    assert.deepEqual(observations, [
+      "@relaycast/types:1",
+      "@relaycast/openclaw:1",
+      "@relaycast/types:2",
+      "@relaycast/openclaw:2",
+      "@relaycast/types:3",
+      "@relaycast/openclaw:3",
+    ]);
+  });
+
+  it("keeps the default propagation budget bounded and materially longer than the old 25-second window", () => {
+    assert.equal(DEFAULT_ATTEMPTS, 30);
+    assert.equal(DEFAULT_DELAY_MS, 10_000);
+    assert.equal((DEFAULT_ATTEMPTS - 1) * DEFAULT_DELAY_MS, 290_000);
+  });
+
+  it("fails closed for a multi-package stale tag without attempting a rewrite", async () => {
+    let reads = 0;
+    await assert.rejects(
+      ensureNpmDistTags({
+        packageNames: ["@relaycast/types", "@relaycast/openclaw"],
+        version: "8.8.0",
+        distTag: "latest",
+        attempts: 2,
+        delayMs: 0,
+        readTag: () => {
+          reads += 1;
+          return { kind: "value", value: "8.7.0" };
+        },
+        sleep: async () => {},
+      }),
+      /@relaycast\/types dist-tag latest points to 8\.7\.0, expected 8\.8\.0/,
+    );
+    assert.equal(reads, 4);
+  });
+
   it("allows bounded missing/stale registry propagation to converge", async () => {
     const observations = [
       { kind: "missing" },

--- a/scripts/npm-dist-tag.test.mjs
+++ b/scripts/npm-dist-tag.test.mjs
@@ -75,6 +75,28 @@ describe("npm dist-tag reconciliation", () => {
     assert.equal(reads, 4);
   });
 
+  it("reports only stale packages when peers already match", async () => {
+    await assert.rejects(
+      ensureNpmDistTags({
+        packageNames: ["@relaycast/types", "@relaycast/engine"],
+        version: "8.8.0",
+        distTag: "latest",
+        attempts: 1,
+        delayMs: 0,
+        readTag: (packageName) =>
+          packageName === "@relaycast/types"
+            ? { kind: "value", value: "8.8.0" }
+            : { kind: "value", value: "8.7.0" },
+        sleep: async () => {},
+      }),
+      (error) => {
+        assert.match(String(error), /@relaycast\/engine dist-tag latest points to 8\.7\.0/);
+        assert.doesNotMatch(String(error), /@relaycast\/types/);
+        return true;
+      },
+    );
+  });
+
   it("allows bounded missing/stale registry propagation to converge", async () => {
     const observations = [
       { kind: "missing" },

--- a/scripts/refresh-docker-lock.mjs
+++ b/scripts/refresh-docker-lock.mjs
@@ -5,6 +5,8 @@ import { resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { packageProvenance, readReleaseProvenance } from "./release-provenance.mjs";
 
+const DOCKER_PACKAGE_KEY = /(?:^|\/)node_modules\/(@relaycast\/[^/]+)$/;
+
 /**
  * Update only the release-owned entries in the self-host lockfile. Running
  * npm update here can refresh unrelated semver ranges (for example zod) and
@@ -30,7 +32,7 @@ export function refreshDockerLock(lock, manifest, version) {
   }
 
   for (const [key, entry] of Object.entries(lock.packages)) {
-    const match = key.match(/(?:^|\/)node_modules\/(@relaycast\/[^/]+)$/);
+    const match = key.match(DOCKER_PACKAGE_KEY);
     if (!match) continue;
     const [, packageName] = match;
     const packageEntry = packageProvenance(manifest, packageName);

--- a/scripts/refresh-docker-lock.mjs
+++ b/scripts/refresh-docker-lock.mjs
@@ -1,0 +1,68 @@
+#!/usr/bin/env node
+
+import { readFileSync, writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { packageProvenance, readReleaseProvenance } from "./release-provenance.mjs";
+
+/**
+ * Update only the release-owned entries in the self-host lockfile. Running
+ * npm update here can refresh unrelated semver ranges (for example zod) and
+ * make an otherwise valid release fail exact-tree validation. The lockfile is
+ * deliberately treated as a projection of the immutable release manifest;
+ * no dependency is resolved or rewritten implicitly.
+ */
+export function refreshDockerLock(lock, manifest, version) {
+  if (!lock || typeof lock !== "object" || !lock.packages) {
+    throw new Error("Docker lockfile must contain a packages object");
+  }
+  if (manifest.version !== version) {
+    throw new Error("release provenance version does not match Docker lock version");
+  }
+  lock.version = version;
+  const root = lock.packages[""];
+  if (!root || typeof root !== "object") {
+    throw new Error("Docker lockfile is missing its root package entry");
+  }
+  root.version = version;
+  if (root.dependencies?.["@relaycast/engine"] !== undefined) {
+    root.dependencies["@relaycast/engine"] = version;
+  }
+
+  for (const [key, entry] of Object.entries(lock.packages)) {
+    if (!key.startsWith("node_modules/@relaycast/")) continue;
+    const packageName = key.slice("node_modules/".length);
+    const packageEntry = packageProvenance(manifest, packageName);
+    if (packageEntry.version !== version) {
+      throw new Error(`${packageName} provenance version does not match the release`);
+    }
+    entry.version = version;
+    entry.resolved = `https://registry.npmjs.org/${packageName}/-/${packageName.slice("@relaycast/".length)}-${version}.tgz`;
+    entry.integrity = packageEntry.integrity;
+    for (const dependencyType of ["dependencies", "devDependencies", "peerDependencies"]) {
+      for (const dependencyName of Object.keys(entry[dependencyType] ?? {})) {
+        if (dependencyName.startsWith("@relaycast/")) {
+          entry[dependencyType][dependencyName] = version;
+        }
+      }
+    }
+  }
+  return lock;
+}
+
+function argument(name) {
+  const index = process.argv.indexOf(name);
+  if (index === -1 || !process.argv[index + 1] || process.argv[index + 1].startsWith("--")) {
+    throw new Error(`${name} is required`);
+  }
+  return process.argv[index + 1];
+}
+
+if (process.argv[1] && fileURLToPath(import.meta.url) === resolve(process.argv[1])) {
+  const manifest = readReleaseProvenance(argument("--manifest"));
+  const version = argument("--version");
+  const lockPath = resolve(process.cwd(), "package-lock.json");
+  const lock = JSON.parse(readFileSync(lockPath, "utf8"));
+  writeFileSync(lockPath, `${JSON.stringify(refreshDockerLock(lock, manifest, version), null, 2)}\n`);
+  process.stdout.write(`Docker lockfile refreshed for ${version} without resolving unrelated dependencies\n`);
+}

--- a/scripts/refresh-docker-lock.mjs
+++ b/scripts/refresh-docker-lock.mjs
@@ -30,8 +30,9 @@ export function refreshDockerLock(lock, manifest, version) {
   }
 
   for (const [key, entry] of Object.entries(lock.packages)) {
-    if (!key.startsWith("node_modules/@relaycast/")) continue;
-    const packageName = key.slice("node_modules/".length);
+    const match = key.match(/(?:^|\/)node_modules\/(@relaycast\/[^/]+)$/);
+    if (!match) continue;
+    const [, packageName] = match;
     const packageEntry = packageProvenance(manifest, packageName);
     if (packageEntry.version !== version) {
       throw new Error(`${packageName} provenance version does not match the release`);

--- a/scripts/refresh-docker-lock.mjs
+++ b/scripts/refresh-docker-lock.mjs
@@ -40,7 +40,12 @@ export function refreshDockerLock(lock, manifest, version) {
     entry.version = version;
     entry.resolved = `https://registry.npmjs.org/${packageName}/-/${packageName.slice("@relaycast/".length)}-${version}.tgz`;
     entry.integrity = packageEntry.integrity;
-    for (const dependencyType of ["dependencies", "devDependencies", "peerDependencies"]) {
+    for (const dependencyType of [
+      "dependencies",
+      "devDependencies",
+      "optionalDependencies",
+      "peerDependencies",
+    ]) {
       for (const dependencyName of Object.keys(entry[dependencyType] ?? {})) {
         if (dependencyName.startsWith("@relaycast/")) {
           entry[dependencyType][dependencyName] = version;

--- a/scripts/refresh-docker-lock.test.mjs
+++ b/scripts/refresh-docker-lock.test.mjs
@@ -6,6 +6,11 @@ const manifest = {
   version: "8.8.0",
   packages: [
     {
+      name: "@relaycast/a2a",
+      version: "8.8.0",
+      integrity: "sha512-a2a=",
+    },
+    {
       name: "@relaycast/engine",
       version: "8.8.0",
       integrity: "sha512-engine=",
@@ -28,6 +33,12 @@ describe("Docker lock refresh", () => {
         "": {
           version: "8.7.0",
           dependencies: { "@relaycast/engine": "8.7.0" },
+        },
+        "node_modules/@relaycast/a2a": {
+          version: "8.7.0",
+          resolved: "https://registry.npmjs.org/@relaycast/a2a/-/a2a-8.7.0.tgz",
+          integrity: "sha512-old-a2a=",
+          optionalDependencies: { "@relaycast/types": "8.7.0" },
         },
         "node_modules/@relaycast/engine": {
           version: "8.7.0",
@@ -60,6 +71,9 @@ describe("Docker lock refresh", () => {
     assert.equal(lock.packages[""].version, "8.8.0");
     assert.equal(lock.packages[""].dependencies["@relaycast/engine"], "8.8.0");
     assert.equal(lock.packages["node_modules/@relaycast/engine"].version, "8.8.0");
+    assert.equal(lock.packages["node_modules/@relaycast/a2a"].version, "8.8.0");
+    assert.equal(lock.packages["node_modules/@relaycast/a2a"].integrity, "sha512-a2a=");
+    assert.equal(lock.packages["node_modules/@relaycast/a2a"].optionalDependencies["@relaycast/types"], "8.8.0");
     assert.equal(lock.packages["node_modules/@relaycast/engine"].dependencies["@relaycast/types"], "8.8.0");
     assert.equal(lock.packages["node_modules/@relaycast/engine"].integrity, "sha512-engine=");
     assert.equal(lock.packages["node_modules/@relaycast/engine/node_modules/zod"].version, "4.6.1");

--- a/scripts/refresh-docker-lock.test.mjs
+++ b/scripts/refresh-docker-lock.test.mjs
@@ -40,6 +40,11 @@ describe("Docker lock refresh", () => {
           resolved: "https://registry.npmjs.org/@relaycast/types/-/types-8.7.0.tgz",
           integrity: "sha512-old-types=",
         },
+        "node_modules/@relaycast/engine/node_modules/zod": {
+          version: "4.6.1",
+          resolved: "https://registry.npmjs.org/zod/-/zod-4.6.1.tgz",
+          integrity: "sha512-nested=",
+        },
         "node_modules/zod": {
           version: "4.6.1",
           resolved: "https://registry.npmjs.org/zod/-/zod-4.6.1.tgz",
@@ -57,6 +62,8 @@ describe("Docker lock refresh", () => {
     assert.equal(lock.packages["node_modules/@relaycast/engine"].version, "8.8.0");
     assert.equal(lock.packages["node_modules/@relaycast/engine"].dependencies["@relaycast/types"], "8.8.0");
     assert.equal(lock.packages["node_modules/@relaycast/engine"].integrity, "sha512-engine=");
+    assert.equal(lock.packages["node_modules/@relaycast/engine/node_modules/zod"].version, "4.6.1");
+    assert.equal(lock.packages["node_modules/@relaycast/engine/node_modules/zod"].integrity, "sha512-nested=");
     assert.deepEqual(lock.packages["node_modules/zod"], unrelated);
   });
 

--- a/scripts/refresh-docker-lock.test.mjs
+++ b/scripts/refresh-docker-lock.test.mjs
@@ -1,0 +1,76 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { refreshDockerLock } from "./refresh-docker-lock.mjs";
+
+const manifest = {
+  version: "8.8.0",
+  packages: [
+    {
+      name: "@relaycast/engine",
+      version: "8.8.0",
+      integrity: "sha512-engine=",
+    },
+    {
+      name: "@relaycast/types",
+      version: "8.8.0",
+      integrity: "sha512-types=",
+    },
+  ],
+};
+
+describe("Docker lock refresh", () => {
+  it("updates only release-owned packages and preserves unrelated resolution", () => {
+    const lock = {
+      name: "relaycast-self-host-image",
+      version: "8.7.0",
+      lockfileVersion: 3,
+      packages: {
+        "": {
+          version: "8.7.0",
+          dependencies: { "@relaycast/engine": "8.7.0" },
+        },
+        "node_modules/@relaycast/engine": {
+          version: "8.7.0",
+          resolved: "https://registry.npmjs.org/@relaycast/engine/-/engine-8.7.0.tgz",
+          integrity: "sha512-old-engine=",
+          dependencies: { "@relaycast/types": "8.7.0", zod: "^4.3.6" },
+        },
+        "node_modules/@relaycast/types": {
+          version: "8.7.0",
+          resolved: "https://registry.npmjs.org/@relaycast/types/-/types-8.7.0.tgz",
+          integrity: "sha512-old-types=",
+        },
+        "node_modules/zod": {
+          version: "4.6.1",
+          resolved: "https://registry.npmjs.org/zod/-/zod-4.6.1.tgz",
+          integrity: "sha512-unrelated=",
+        },
+      },
+    };
+    const unrelated = structuredClone(lock.packages["node_modules/zod"]);
+
+    refreshDockerLock(lock, manifest, "8.8.0");
+
+    assert.equal(lock.version, "8.8.0");
+    assert.equal(lock.packages[""].version, "8.8.0");
+    assert.equal(lock.packages[""].dependencies["@relaycast/engine"], "8.8.0");
+    assert.equal(lock.packages["node_modules/@relaycast/engine"].version, "8.8.0");
+    assert.equal(lock.packages["node_modules/@relaycast/engine"].dependencies["@relaycast/types"], "8.8.0");
+    assert.equal(lock.packages["node_modules/@relaycast/engine"].integrity, "sha512-engine=");
+    assert.deepEqual(lock.packages["node_modules/zod"], unrelated);
+  });
+
+  it("fails closed when a lockfile package has no matching release provenance", () => {
+    const lock = {
+      version: "8.7.0",
+      packages: {
+        "": { version: "8.7.0" },
+        "node_modules/@relaycast/unknown": { version: "8.7.0" },
+      },
+    };
+    assert.throws(
+      () => refreshDockerLock(lock, manifest, "8.8.0"),
+      /release provenance must contain exactly one @relaycast\/unknown/,
+    );
+  });
+});

--- a/scripts/release-contract.mjs
+++ b/scripts/release-contract.mjs
@@ -21,6 +21,7 @@ const DOCKER_DEPENDENCY_TYPES = [
   "optionalDependencies",
   "peerDependencies",
 ];
+const DOCKER_PACKAGE_KEY = /(?:^|\/)node_modules\/(@relaycast\/[^/]+)$/;
 
 export function parseVersion(value) {
   const match = value.match(SEMVER);
@@ -260,9 +261,9 @@ function assertDockerImageManifestVersion(
   }
   if (requireResolvedArtifact) {
     const expectedNames = dockerPackageNames(manifest, manifests);
-    for (const packageName of expectedNames) {
+    const validatedTopLevel = new Set();
+    const validatePackageEntry = (packageKey, packageName) => {
       const packageManifest = manifests.get(packageName);
-      const packageKey = `node_modules/${packageName}`;
       const lockedPackage = lock.packages?.[packageKey];
       if (!lockedPackage) {
         throw new Error(`${lockPath} is missing Docker package ${packageKey}`);
@@ -292,13 +293,24 @@ function assertDockerImageManifestVersion(
           );
         }
       }
-    }
+    };
     for (const key of Object.keys(lock.packages ?? {})) {
-      const match = key.match(/^node_modules\/(?:@relaycast\/[^/]+)$/);
+      const match = key.match(DOCKER_PACKAGE_KEY);
       if (!match) continue;
-      const packageName = key.slice("node_modules/".length);
+      const packageName = match[1];
       if (!expectedNames.has(packageName)) {
         throw new Error(`${lockPath} contains stale Docker package ${packageName}`);
+      }
+      validatePackageEntry(key, packageName);
+      if (key === `node_modules/${packageName}`) {
+        validatedTopLevel.add(packageName);
+      }
+    }
+    for (const packageName of expectedNames) {
+      if (!validatedTopLevel.has(packageName)) {
+        throw new Error(
+          `${lockPath} is missing Docker package node_modules/${packageName}`,
+        );
       }
     }
   }

--- a/scripts/release-contract.mjs
+++ b/scripts/release-contract.mjs
@@ -173,6 +173,9 @@ function assertDockerImageManifestVersion(
 ) {
   const manifestPath = path.join(root, "docker", "package.json");
   const manifest = readJson(manifestPath);
+  const engineManifest = readJson(
+    path.join(root, "packages", "engine", "package.json"),
+  );
   if (manifest.version !== expectedVersion) {
     throw new Error(
       `${manifestPath} is ${manifest.version}, expected ${expectedVersion}`,
@@ -210,6 +213,25 @@ function assertDockerImageManifestVersion(
       throw new Error(
         `${lockPath} node_modules/@relaycast/engine has no valid registry integrity`,
       );
+    }
+  }
+
+  if (requireResolvedArtifact) {
+    for (const dependencyType of [
+      "dependencies",
+      "optionalDependencies",
+      "peerDependencies",
+    ]) {
+      const expected = engineManifest[dependencyType] ?? {};
+      const actual = lockedEngine[dependencyType] ?? {};
+      if (
+        JSON.stringify(Object.entries(actual).sort()) !==
+          JSON.stringify(Object.entries(expected).sort())
+      ) {
+        throw new Error(
+          `${lockPath} engine ${dependencyType} topology does not match packages/engine/package.json`,
+        );
+      }
     }
   }
 }

--- a/scripts/release-contract.mjs
+++ b/scripts/release-contract.mjs
@@ -16,6 +16,11 @@ const LEVEL_RANK = { Patch: 0, Minor: 1, Major: 2 };
 const SEMVER = /^(\d+)\.(\d+)\.(\d+)(?:-([0-9A-Za-z.-]+))?$/;
 const UNRELEASED =
   /^## \[Unreleased(?: - (Patch|Minor|Major))?\][ \t]*\n([\s\S]*?)(?=^## \[|(?![\s\S]))/m;
+const DOCKER_DEPENDENCY_TYPES = [
+  "dependencies",
+  "optionalDependencies",
+  "peerDependencies",
+];
 
 export function parseVersion(value) {
   const match = value.match(SEMVER);
@@ -116,10 +121,56 @@ function readJson(file) {
   return JSON.parse(readFileSync(file, "utf8"));
 }
 
+function dockerPackageManifests(root) {
+  const manifests = new Map();
+  for (const dir of packageDirectories(root)) {
+    const manifest = readJson(path.join(root, "packages", dir, "package.json"));
+    if (manifest.name?.startsWith("@relaycast/")) {
+      manifests.set(manifest.name, manifest);
+    }
+  }
+  return manifests;
+}
+
+function dockerPackageNames(manifest, manifests) {
+  const names = new Set();
+  const pending = [];
+  for (const dependencyType of DOCKER_DEPENDENCY_TYPES) {
+    for (const dependencyName of Object.keys(manifest[dependencyType] ?? {})) {
+      if (!dependencyName.startsWith("@relaycast/")) continue;
+      names.add(dependencyName);
+      pending.push(dependencyName);
+    }
+  }
+  while (pending.length > 0) {
+    const name = pending.pop();
+    const manifest = manifests.get(name);
+    if (!manifest) {
+      throw new Error(`Docker dependency ${name} has no workspace package manifest`);
+    }
+    for (const dependencyType of DOCKER_DEPENDENCY_TYPES) {
+      for (const dependencyName of Object.keys(manifest[dependencyType] ?? {})) {
+        if (!dependencyName.startsWith("@relaycast/") || names.has(dependencyName)) continue;
+        names.add(dependencyName);
+        pending.push(dependencyName);
+      }
+    }
+  }
+  return names;
+}
+
+function sameDependencyMap(actual, expected) {
+  return (
+    JSON.stringify(Object.entries(actual ?? {}).sort()) ===
+    JSON.stringify(Object.entries(expected ?? {}).sort())
+  );
+}
+
 function assertInternalDependencies(owner, pkg, expectedVersion) {
   for (const dependencyType of [
     "dependencies",
     "devDependencies",
+    "optionalDependencies",
     "peerDependencies",
   ]) {
     for (const [name, version] of Object.entries(pkg[dependencyType] ?? {})) {
@@ -173,9 +224,7 @@ function assertDockerImageManifestVersion(
 ) {
   const manifestPath = path.join(root, "docker", "package.json");
   const manifest = readJson(manifestPath);
-  const engineManifest = readJson(
-    path.join(root, "packages", "engine", "package.json"),
-  );
+  const manifests = dockerPackageManifests(root);
   if (manifest.version !== expectedVersion) {
     throw new Error(
       `${manifestPath} is ${manifest.version}, expected ${expectedVersion}`,
@@ -196,6 +245,13 @@ function assertDockerImageManifestVersion(
       `${lockPath} root package version is ${lockRoot?.version}, expected ${expectedVersion}`,
     );
   }
+  for (const dependencyType of DOCKER_DEPENDENCY_TYPES) {
+    if (!sameDependencyMap(lockRoot?.[dependencyType], manifest[dependencyType])) {
+      throw new Error(
+        `${lockPath} root ${dependencyType} topology does not match docker/package.json`,
+      );
+    }
+  }
   const lockedEngine = lock.packages?.["node_modules/@relaycast/engine"];
   if (lockedEngine?.version !== expectedVersion) {
     throw new Error(
@@ -203,34 +259,46 @@ function assertDockerImageManifestVersion(
     );
   }
   if (requireResolvedArtifact) {
-    const expectedTarball = `https://registry.npmjs.org/@relaycast/engine/-/engine-${expectedVersion}.tgz`;
-    if (lockedEngine?.resolved !== expectedTarball) {
-      throw new Error(
-        `${lockPath} node_modules/@relaycast/engine resolves ${lockedEngine?.resolved}, expected ${expectedTarball}`,
-      );
-    }
-    if (!/^sha512-[A-Za-z0-9+/]+=*$/.test(lockedEngine?.integrity ?? "")) {
-      throw new Error(
-        `${lockPath} node_modules/@relaycast/engine has no valid registry integrity`,
-      );
-    }
-  }
-
-  if (requireResolvedArtifact) {
-    for (const dependencyType of [
-      "dependencies",
-      "optionalDependencies",
-      "peerDependencies",
-    ]) {
-      const expected = engineManifest[dependencyType] ?? {};
-      const actual = lockedEngine[dependencyType] ?? {};
-      if (
-        JSON.stringify(Object.entries(actual).sort()) !==
-          JSON.stringify(Object.entries(expected).sort())
-      ) {
+    const expectedNames = dockerPackageNames(manifest, manifests);
+    for (const packageName of expectedNames) {
+      const packageManifest = manifests.get(packageName);
+      const packageKey = `node_modules/${packageName}`;
+      const lockedPackage = lock.packages?.[packageKey];
+      if (!lockedPackage) {
+        throw new Error(`${lockPath} is missing Docker package ${packageKey}`);
+      }
+      if (lockedPackage.version !== expectedVersion) {
         throw new Error(
-          `${lockPath} engine ${dependencyType} topology does not match packages/engine/package.json`,
+          `${lockPath} ${packageKey} is ${lockedPackage.version}, expected ${expectedVersion}`,
         );
+      }
+      const shortName = packageName.slice("@relaycast/".length);
+      const expectedTarball =
+        `https://registry.npmjs.org/${packageName}/-/${shortName}-${expectedVersion}.tgz`;
+      if (lockedPackage.resolved !== expectedTarball) {
+        throw new Error(
+          `${lockPath} ${packageKey} resolves ${lockedPackage.resolved}, expected ${expectedTarball}`,
+        );
+      }
+      if (!/^sha512-[A-Za-z0-9+/]+=*$/.test(lockedPackage.integrity ?? "")) {
+        throw new Error(
+          `${lockPath} ${packageKey} has no valid registry integrity`,
+        );
+      }
+      for (const dependencyType of DOCKER_DEPENDENCY_TYPES) {
+        if (!sameDependencyMap(lockedPackage[dependencyType], packageManifest[dependencyType])) {
+          throw new Error(
+            `${lockPath} ${packageName} ${dependencyType} topology does not match packages/${packageName.slice("@relaycast/".length)}/package.json`,
+          );
+        }
+      }
+    }
+    for (const key of Object.keys(lock.packages ?? {})) {
+      const match = key.match(/^node_modules\/(?:@relaycast\/[^/]+)$/);
+      if (!match) continue;
+      const packageName = key.slice("node_modules/".length);
+      if (!expectedNames.has(packageName)) {
+        throw new Error(`${lockPath} contains stale Docker package ${packageName}`);
       }
     }
   }

--- a/scripts/release-contract.test.mjs
+++ b/scripts/release-contract.test.mjs
@@ -437,6 +437,22 @@ describe("release version parity", () => {
     );
   });
 
+  it("rejects a stale Docker root engine pin on the placeholder path", () => {
+    const root = repositoryFixture();
+    const lockPath = path.join(root, "docker", "package-lock.json");
+    const lock = JSON.parse(readFileSync(lockPath, "utf8"));
+    lock.packages[""].dependencies["@relaycast/engine"] = "8.5.3";
+    writeFileSync(lockPath, JSON.stringify(lock));
+
+    assert.throws(
+      () =>
+        assertRepositoryVersionParity(root, "8.6.0-beta.0", {
+          requireDockerResolvedArtifact: false,
+        }),
+      /root dependencies topology does not match docker\/package\.json/,
+    );
+  });
+
   it("rejects a RUNBOOK.md engine-version mention that was not bumped", () => {
     const root = repositoryFixture();
     const runbookPath = path.join(root, "RUNBOOK.md");

--- a/scripts/release-contract.test.mjs
+++ b/scripts/release-contract.test.mjs
@@ -342,6 +342,7 @@ describe("release version parity", () => {
       );
       const lockPath = path.join(root, "docker", "package-lock.json");
       const lock = JSON.parse(readFileSync(lockPath, "utf8"));
+      delete lock.packages["node_modules/@relaycast/a2a"];
       lock.packages["node_modules/@relaycast/engine"].dependencies =
         lockDependencies;
       writeFileSync(lockPath, JSON.stringify(lock));
@@ -421,6 +422,35 @@ describe("release version parity", () => {
         description,
       );
     }
+  });
+
+  it("validates terminal nested Docker Relaycast entries", () => {
+    const root = repositoryFixture();
+    const lockPath = path.join(root, "docker", "package-lock.json");
+    const lock = JSON.parse(readFileSync(lockPath, "utf8"));
+    const nestedKey =
+      "node_modules/@relaycast/engine/node_modules/@relaycast/types";
+    lock.packages[nestedKey] = {
+      version: "8.6.0-beta.0",
+      resolved:
+        "https://registry.npmjs.org/@relaycast/types/-/types-8.6.0-beta.0.tgz",
+      integrity:
+        "sha512-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==",
+    };
+    writeFileSync(lockPath, JSON.stringify(lock));
+
+    assert.doesNotThrow(() =>
+      assertRepositoryVersionParity(root, "8.6.0-beta.0"),
+    );
+
+    lock.packages[nestedKey].version = "8.5.3";
+    writeFileSync(lockPath, JSON.stringify(lock));
+    assert.throws(
+      () => assertRepositoryVersionParity(root, "8.6.0-beta.0"),
+      new RegExp(
+        nestedKey + " is 8\\.5\\.3, expected 8\\.6\\.0-beta\\.0",
+      ),
+    );
   });
 
   it("permits the intentional pre-publish lockfile placeholder only when requested", () => {

--- a/scripts/release-contract.test.mjs
+++ b/scripts/release-contract.test.mjs
@@ -40,7 +40,12 @@ function repositoryFixture(version = "8.6.0-beta.0") {
       name: dir === "cli" ? "relaycast" : `@relaycast/${dir}`,
       version,
       ...(dir === "engine"
-        ? { dependencies: { "@relaycast/types": version } }
+        ? {
+            dependencies: {
+              "@relaycast/a2a": version,
+              "@relaycast/types": version,
+            },
+          }
         : {}),
     };
     writeFileSync(
@@ -81,12 +86,28 @@ function repositoryFixture(version = "8.6.0-beta.0") {
     path.join(root, "docker", "package-lock.json"),
     `${JSON.stringify({
       packages: {
-        "": { version },
+        "": {
+          version,
+          dependencies: { "@relaycast/engine": version },
+        },
+        "node_modules/@relaycast/a2a": {
+          version,
+          resolved: `https://registry.npmjs.org/@relaycast/a2a/-/a2a-${version}.tgz`,
+          integrity: "sha512-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==",
+        },
         "node_modules/@relaycast/engine": {
           version,
           resolved: `https://registry.npmjs.org/@relaycast/engine/-/engine-${version}.tgz`,
           integrity: "sha512-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==",
-          dependencies: { "@relaycast/types": version },
+          dependencies: {
+            "@relaycast/a2a": version,
+            "@relaycast/types": version,
+          },
+        },
+        "node_modules/@relaycast/types": {
+          version,
+          resolved: `https://registry.npmjs.org/@relaycast/types/-/types-${version}.tgz`,
+          integrity: "sha512-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==",
         },
       },
     })}\n`,
@@ -327,6 +348,76 @@ describe("release version parity", () => {
       assert.throws(
         () => assertRepositoryVersionParity(root, "8.6.0-beta.0"),
         /engine dependencies topology does not match/,
+        description,
+      );
+    }
+  });
+
+  it("checks dependency topology for every Docker-installed Relaycast package", () => {
+    for (const [packageDir, dependencyType, manifestDependencies, lockDependencies] of [
+      ["a2a", "dependencies", { zod: "^4.3.6" }, {}],
+      ["types", "optionalDependencies", { "@scope/optional": "^1.0.0" }, {}],
+      ["types", "peerDependencies", { "@scope/peer": "^1.0.0" }, {}],
+      ["a2a", "dependencies", {}, { zod: "^4.3.6" }],
+      ["types", "optionalDependencies", {}, { "@scope/optional": "^1.0.0" }],
+      ["types", "peerDependencies", {}, { "@scope/peer": "^1.0.0" }],
+    ]) {
+      const root = repositoryFixture();
+      const manifestPath = path.join(
+        root,
+        "packages",
+        packageDir,
+        "package.json",
+      );
+      const packageManifest = JSON.parse(readFileSync(manifestPath, "utf8"));
+      packageManifest[dependencyType] = manifestDependencies;
+      writeFileSync(manifestPath, JSON.stringify(packageManifest));
+
+      const lockPath = path.join(root, "docker", "package-lock.json");
+      const lock = JSON.parse(readFileSync(lockPath, "utf8"));
+      lock.packages[`node_modules/@relaycast/${packageDir}`][dependencyType] =
+        lockDependencies;
+      writeFileSync(lockPath, JSON.stringify(lock));
+
+      assert.throws(
+        () => assertRepositoryVersionParity(root, "8.6.0-beta.0"),
+        new RegExp(
+          `@relaycast/${packageDir} ${dependencyType} topology does not match`,
+        ),
+        `${packageDir} ${dependencyType}`,
+      );
+    }
+  });
+
+  it("rejects missing and stale top-level Docker Relaycast packages", () => {
+    for (const [description, mutate, expectedError] of [
+      [
+        "missing package",
+        (lock) => delete lock.packages["node_modules/@relaycast/a2a"],
+        /is missing Docker package node_modules\/@relaycast\/a2a/,
+      ],
+      [
+        "stale package",
+        (lock) => {
+          lock.packages["node_modules/@relaycast/observer-dashboard"] = {
+            version: "8.6.0-beta.0",
+            resolved:
+              "https://registry.npmjs.org/@relaycast/observer-dashboard/-/observer-dashboard-8.6.0-beta.0.tgz",
+            integrity: "sha512-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==",
+          };
+        },
+        /contains stale Docker package @relaycast\/observer-dashboard/,
+      ],
+    ]) {
+      const root = repositoryFixture();
+      const lockPath = path.join(root, "docker", "package-lock.json");
+      const lock = JSON.parse(readFileSync(lockPath, "utf8"));
+      mutate(lock);
+      writeFileSync(lockPath, JSON.stringify(lock));
+
+      assert.throws(
+        () => assertRepositoryVersionParity(root, "8.6.0-beta.0"),
+        expectedError,
         description,
       );
     }

--- a/scripts/release-contract.test.mjs
+++ b/scripts/release-contract.test.mjs
@@ -86,6 +86,7 @@ function repositoryFixture(version = "8.6.0-beta.0") {
           version,
           resolved: `https://registry.npmjs.org/@relaycast/engine/-/engine-${version}.tgz`,
           integrity: "sha512-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==",
+          dependencies: { "@relaycast/types": version },
         },
       },
     })}\n`,
@@ -283,6 +284,52 @@ describe("release version parity", () => {
       () => assertRepositoryVersionParity(root, "8.6.0-beta.0"),
       /resolves .*engine-8\.5\.3\.tgz.*engine-8\.6\.0-beta\.0\.tgz/,
     );
+  });
+
+  it("rejects Docker lock dependency topology drift", () => {
+    for (const [description, manifestDependencies, lockDependencies] of [
+      [
+        "added dependency",
+        { "@relaycast/types": "8.6.0-beta.0", hono: "^4.11.9" },
+        { "@relaycast/types": "8.6.0-beta.0" },
+      ],
+      [
+        "removed dependency",
+        { "@relaycast/types": "8.6.0-beta.0" },
+        { "@relaycast/types": "8.6.0-beta.0", hono: "^4.11.9" },
+      ],
+      [
+        "changed non-@relaycast dependency",
+        { "@relaycast/types": "8.6.0-beta.0", hono: "^4.12.0" },
+        { "@relaycast/types": "8.6.0-beta.0", hono: "^4.11.9" },
+      ],
+    ]) {
+      const root = repositoryFixture();
+      const engineManifestPath = path.join(
+        root,
+        "packages",
+        "engine",
+        "package.json",
+      );
+      writeFileSync(
+        engineManifestPath,
+        JSON.stringify({
+          name: "@relaycast/engine",
+          version: "8.6.0-beta.0",
+          dependencies: manifestDependencies,
+        }),
+      );
+      const lockPath = path.join(root, "docker", "package-lock.json");
+      const lock = JSON.parse(readFileSync(lockPath, "utf8"));
+      lock.packages["node_modules/@relaycast/engine"].dependencies =
+        lockDependencies;
+      writeFileSync(lockPath, JSON.stringify(lock));
+      assert.throws(
+        () => assertRepositoryVersionParity(root, "8.6.0-beta.0"),
+        /engine dependencies topology does not match/,
+        description,
+      );
+    }
   });
 
   it("permits the intentional pre-publish lockfile placeholder only when requested", () => {

--- a/scripts/release-workflow-contract.test.mjs
+++ b/scripts/release-workflow-contract.test.mjs
@@ -468,7 +468,7 @@ describe("publish workflow safety contract", () => {
       assert.match(verify, new RegExp(`"${pkg.replace(/[/]/g, "\\/")}"`));
     }
     assert.match(verify, /npm view "\$\{pkg\}@\$\{NEW_VERSION\}" version/);
-    assert.match(verify, /npm-dist-tag\.mjs verify/);
+    assert.match(verify, /npm-dist-tag\.mjs verify-many/);
     assert.match(verify, /--tag "\$DIST_TAG"/);
     assert.match(verify, /exit 1/);
 
@@ -500,7 +500,7 @@ describe("publish workflow safety contract", () => {
     );
   });
 
-  it("resumes a partially published matrix instead of hard-failing on an already-published package", () => {
+  it("resumes a partially published matrix without making tag propagation a matrix failure", () => {
     const publishPackages = jobBlock("publish-packages");
     const publishStep = publishPackages.slice(
       publishPackages.indexOf("- name: Publish to NPM"),
@@ -508,12 +508,19 @@ describe("publish workflow safety contract", () => {
     assert.match(publishStep, /npm view "\$\{PACKAGE_NAME\}@\$\{NEW_VERSION\}" version/);
     assert.match(publishStep, /dist\.integrity/);
     assert.match(publishStep, /already matches this build; skipping/);
-    assert.match(publishStep, /npm-dist-tag\.mjs" verify/);
-    assert.match(
-      publishStep,
-      /--tag "\$\{\{ needs\.build\.outputs\.effective_tag \}\}"/,
-    );
+    assert.doesNotMatch(publishStep, /npm-dist-tag\.mjs/);
     assert.doesNotMatch(publishStep, /^\s*npm dist-tag/m);
+  });
+
+  it("reconciles every dist-tag in one longer bounded, read-only window", () => {
+    const verify = jobBlock("verify-publish");
+    assert.match(verify, /npm-dist-tag\.mjs verify-many/);
+    assert.match(verify, /NPM_TAG_VERIFY_ATTEMPTS/);
+    assert.match(verify, /NPM_TAG_VERIFY_DELAY_MS/);
+    assert.match(verify, /--package \"\$pkg\"/);
+    assert.doesNotMatch(verify, /^\s*npm dist-tag/m);
+    assert.match(workflow, /NPM_TAG_VERIFY_ATTEMPTS: 30/);
+    assert.match(workflow, /NPM_TAG_VERIFY_DELAY_MS: 10000/);
   });
 
   it("publishes and reconciles exact build tarballs, never a version-only registry match", () => {
@@ -537,11 +544,8 @@ describe("publish workflow safety contract", () => {
 
     const refresh = createRelease.slice(refreshStart, validateStart);
     assert.match(refresh, /working-directory: docker/);
-    assert.match(
-      refresh,
-      /npm update --package-lock-only --ignore-scripts @relaycast\/engine/,
-    );
-    assert.doesNotMatch(refresh, /npm install --package-lock-only/);
+    assert.match(refresh, /refresh-docker-lock\.mjs/);
+    assert.doesNotMatch(refresh, /npm (?:install|update) --package-lock-only/);
   });
 
   it("reuses a matching tagged tree on rerun and tags before reconciling main", () => {

--- a/scripts/release-workflow-contract.test.mjs
+++ b/scripts/release-workflow-contract.test.mjs
@@ -142,7 +142,7 @@ function bumpFixtureVersion(root, version, dockerIntegrities) {
     const manifestPath = path.join(root, file);
     const manifest = JSON.parse(readFileSync(manifestPath, "utf8"));
     manifest.version = version;
-    for (const type of ["dependencies", "devDependencies", "peerDependencies"]) {
+    for (const type of ["dependencies", "devDependencies", "optionalDependencies", "peerDependencies"]) {
       for (const name of Object.keys(manifest[type] ?? {})) {
         if (name.startsWith("@relaycast/")) manifest[type][name] = version;
       }
@@ -154,7 +154,7 @@ function bumpFixtureVersion(root, version, dockerIntegrities) {
   for (const [key, entry] of Object.entries(rootLock.packages ?? {})) {
     if (!/^packages\/[^/]+$/.test(key)) continue;
     entry.version = version;
-    for (const type of ["dependencies", "devDependencies", "peerDependencies"]) {
+    for (const type of ["dependencies", "devDependencies", "optionalDependencies", "peerDependencies"]) {
       for (const name of Object.keys(entry[type] ?? {})) {
         if (name.startsWith("@relaycast/")) entry[type][name] = version;
       }
@@ -188,7 +188,7 @@ function bumpFixtureVersion(root, version, dockerIntegrities) {
     entry.version = version;
     entry.resolved = `https://registry.npmjs.org/${name}/-/${shortName}-${version}.tgz`;
     entry.integrity = dockerIntegrities[name];
-    for (const type of ["dependencies", "devDependencies", "peerDependencies"]) {
+    for (const type of ["dependencies", "devDependencies", "optionalDependencies", "peerDependencies"]) {
       for (const dependency of Object.keys(entry[type] ?? {})) {
         if (dependency.startsWith("@relaycast/")) entry[type][dependency] = version;
       }

--- a/scripts/release-workflow-contract.test.mjs
+++ b/scripts/release-workflow-contract.test.mjs
@@ -426,6 +426,18 @@ describe("publish workflow safety contract", () => {
     }
   });
 
+  it("bumps the Docker lock root engine pin on the placeholder path", () => {
+    const build = jobBlock("build");
+    assert.match(
+      build,
+      /dockerLock\.packages\[''\]\.dependencies\?\.\['@relaycast\/engine'\]/,
+    );
+    assert.match(
+      build,
+      /dockerLock\.packages\[''\]\.dependencies\['@relaycast\/engine'\] = version/,
+    );
+  });
+
   it("publishes and releases only after the all-package matrix succeeds", () => {
     const matrixStart = workflow.indexOf("      matrix:\n        package:");
     const matrixEnd = workflow.indexOf("\n\n    steps:", matrixStart);

--- a/scripts/validate-release-tag.mjs
+++ b/scripts/validate-release-tag.mjs
@@ -72,7 +72,7 @@ function releaseDateFromTag(tagMessage, cwd, tagCommit) {
 function jsonText(value) { return `${JSON.stringify(value, null, 2)}\n`; }
 
 function setInternalDependencies(pkg, version) {
-  for (const dependencyType of ["dependencies", "devDependencies", "peerDependencies"]) {
+  for (const dependencyType of ["dependencies", "devDependencies", "optionalDependencies", "peerDependencies"]) {
     for (const name of Object.keys(pkg[dependencyType] ?? {})) {
       if (name.startsWith("@relaycast/")) pkg[dependencyType][name] = version;
     }
@@ -135,7 +135,7 @@ function assertLockDiffIsReleaseOnly(source, actual, version, { docker, packageI
     if (!key) return false;
     if (!docker && packageLockEntryIsWorkspace(key)) {
       if (parts.length === 3 && parts[2] === "version") return afterValue === version;
-      if (parts.length === 4 && ["dependencies", "devDependencies", "peerDependencies"].includes(parts[2]) && parts[3].startsWith("@relaycast/")) return afterValue === version;
+      if (parts.length === 4 && ["dependencies", "devDependencies", "optionalDependencies", "peerDependencies"].includes(parts[2]) && parts[3].startsWith("@relaycast/")) return afterValue === version;
       return false;
     }
     if (!key.startsWith("node_modules/@relaycast/")) return false;
@@ -148,7 +148,7 @@ function assertLockDiffIsReleaseOnly(source, actual, version, { docker, packageI
     if (parts.length === 3 && parts[2] === "integrity") {
       return afterValue === packageIntegrities.get(packageName);
     }
-    if (parts.length === 4 && parts[2] === "dependencies" && parts[3].startsWith("@relaycast/")) return afterValue === version;
+    if (parts.length === 4 && ["dependencies", "optionalDependencies", "peerDependencies"].includes(parts[2]) && parts[3].startsWith("@relaycast/")) return afterValue === version;
     return false;
   };
   const unexpected = differences.filter(({ parts, after }) => !allowed(parts, after));


### PR DESCRIPTION
## Summary

- Fixes the npm propagation false-red seen in run 34436226889 (tracked by #396): signed `@relaycast/types@8.8.0` and `@relaycast/openclaw@8.8.0` were accepted, but `latest` remained `8.7.0` beyond the old 5x5s checks before converging later.
- Defers mutable dist-tag verification out of the publish matrix and verifies all package tags in one shared, read-only 30-attempt/10s round-robin window.
- Fixes the resumable run 34436785435 false-red: `npm update --package-lock-only` refreshed unrelated `zod` entries in `docker/package-lock.json`; the new provenance projection updates only release-owned `@relaycast/*` entries and preserves unrelated resolutions.
- Keeps exact integrity/provenance validation and never invokes `npm dist-tag` or republishes a mismatched same-version artifact.

## Validation

- `npm run test:release` (86 passing; executed with Node 22.22.2 because the local Homebrew Node 26 runtime is missing `libada`)
- `actionlint .github/workflows/publish-npm.yml` (only existing SC2086 info on the unchanged conflict-recovery `xargs` line)
- `git diff --cached --check`

Refs #396


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/AgentWorkforce/relaycast/pull/411?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the authoritative npm publish gate and how release commits refresh `docker/package-lock.json`; mistakes could block releases or ship an inconsistent lock, but behavior stays read-only for dist-tags and provenance-locked for Relaycast packages.
> 
> **Overview**
> Addresses flaky npm release failures where packages published successfully but **`latest` (and other dist-tags) lagged** beyond the old per-package 5×5s checks, and where **resuming a workflow** could fail after `npm update` rewrote unrelated lock entries (e.g. `zod`) in `docker/package-lock.json`.
> 
> **Dist-tag reconciliation** is removed from each matrix publish job so a slow tag no longer fails an otherwise-good publish. The `verify-publish` job now confirms immutable artifacts first (with workflow-wide retry env), then runs a single **read-only** `npm-dist-tag.mjs verify-many` round-robin over all packages (~30×10s shared budget). `ensureNpmDistTags` implements that multi-package window so one slow package does not exhaust peers’ retries.
> 
> **Docker self-host lockfile refresh** replaces `npm update --package-lock-only @relaycast/engine` with `refresh-docker-lock.mjs`, which projects **release provenance** into only `@relaycast/*` lock entries and leaves other resolutions untouched. Release bump/validation paths now include **`optionalDependencies`** for internal pins, and **release-contract** checks the full Docker-installed Relaycast tree (topology, tarballs, stale entries).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ce609d565a860b861029fbb64bc51a96783decd1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->