### PR TITLE
fix(release): add allow-listed npm repair workflow

### DIFF
--- a/.github/workflows/repair-npm-release.yml
+++ b/.github/workflows/repair-npm-release.yml
@@ -1,0 +1,261 @@
+name: Repair NPM Release
+
+# This workflow is deliberately separate from the normal publish workflow.
+# It consumes one audited, immutable build artifact and only repairs the git
+# tag/release bookkeeping after the registry already contains every package.
+on:
+  workflow_dispatch:
+    inputs:
+      confirmation:
+        description: "Type the audited repair name"
+        required: true
+        type: choice
+        options:
+          - repair-8.8.0
+        default: repair-8.8.0
+      run_id:
+        description: "Failed build run containing the immutable build-output artifact"
+        required: true
+        type: string
+        default: "34436226889"
+      source_commit:
+        description: "Immutable commit that produced the published npm bytes"
+        required: true
+        type: string
+        default: "18981479c26ea0677585b4e79301dc23d94ed5c0"
+      source_tree:
+        description: "Immutable source tree recorded by the build artifact"
+        required: true
+        type: string
+        default: "3ea102dfb9622e3cc2819feb0cdf202cc029c8e6"
+      provenance_digest:
+        description: "SHA-256 of the immutable release-provenance.json artifact"
+        required: true
+        type: string
+        default: "a18b90273f6b93eb127040bc23f6e66688781e20f1d41c0adde510b287d97917"
+      release_date:
+        description: "UTC date used by the failed build's release-date output"
+        required: true
+        type: string
+        default: "2026-09-10"
+
+concurrency:
+  group: repair-npm-release-8.8.0
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  repair:
+    name: Repair v8.8.0 tag and release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      actions: read
+    env:
+      NPM_TAG_VERIFY_ATTEMPTS: 30
+      NPM_TAG_VERIFY_DELAY_MS: 10000
+
+    steps:
+      - name: Checkout repair workflow
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22.22.3"
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Download the audited build artifact
+        uses: actions/download-artifact@v4
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          repository: ${{ github.repository }}
+          run-id: ${{ inputs.run_id }}
+          name: build-output
+          path: ${{ runner.temp }}/relaycast-repair-input
+
+      - name: Validate immutable artifact and registry state
+        env:
+          REPAIR_RUN_ID: ${{ inputs.run_id }}
+          REPAIR_SOURCE_COMMIT: ${{ inputs.source_commit }}
+          REPAIR_SOURCE_TREE: ${{ inputs.source_tree }}
+          REPAIR_PROVENANCE_DIGEST: ${{ inputs.provenance_digest }}
+          REPAIR_RELEASE_DATE: ${{ inputs.release_date }}
+        run: |
+          set -euo pipefail
+          git fetch origin main --tags
+          CURRENT_MAIN="$(git rev-parse origin/main)"
+          INPUT_ROOT="$RUNNER_TEMP/relaycast-repair-input"
+          node scripts/release-repair.mjs validate \
+            --run-id "$REPAIR_RUN_ID" \
+            --source-commit "$REPAIR_SOURCE_COMMIT" \
+            --source-tree "$REPAIR_SOURCE_TREE" \
+            --provenance-digest "$REPAIR_PROVENANCE_DIGEST" \
+            --version 8.8.0 \
+            --dist-tag latest \
+            --release-date "$REPAIR_RELEASE_DATE" \
+            --current-main "$CURRENT_MAIN" \
+            --workspace "$GITHUB_WORKSPACE" \
+            --manifest "$INPUT_ROOT/release-provenance.json" \
+            --artifact-root "$INPUT_ROOT"
+
+          # Read-only checks are the only registry operation in a repair. An
+          # existing same-version artifact with a different integrity blocks
+          # the workflow; it is never republished or silently adopted.
+          while IFS= read -r package_name; do
+            actual_integrity="$(npm view "${package_name}@8.8.0" dist.integrity --prefer-online 2>/dev/null || true)"
+            node scripts/release-provenance.mjs published \
+              --manifest "$INPUT_ROOT/release-provenance.json" \
+              --package "$package_name" \
+              --integrity "$actual_integrity" \
+              --version 8.8.0
+          done < <(node -e 'for (const pkg of require(process.argv[1]).packages) console.log(pkg.name)' "$INPUT_ROOT/release-provenance.json")
+
+          TAG_ARGS=(
+            verify-many
+            --version 8.8.0
+            --tag latest
+            --attempts "$NPM_TAG_VERIFY_ATTEMPTS"
+            --delay-ms "$NPM_TAG_VERIFY_DELAY_MS"
+          )
+          while IFS= read -r package_name; do
+            TAG_ARGS+=(--package "$package_name")
+          done < <(node -e 'for (const pkg of require(process.argv[1]).packages) console.log(pkg.name)' "$INPUT_ROOT/release-provenance.json")
+          node scripts/npm-dist-tag.mjs "${TAG_ARGS[@]}"
+
+      - name: Build and validate the historical release tree
+        env:
+          REPAIR_SOURCE_COMMIT: ${{ inputs.source_commit }}
+          REPAIR_SOURCE_TREE: ${{ inputs.source_tree }}
+          REPAIR_PROVENANCE_DIGEST: ${{ inputs.provenance_digest }}
+          REPAIR_RELEASE_DATE: ${{ inputs.release_date }}
+        run: |
+          set -euo pipefail
+          INPUT_ROOT="$RUNNER_TEMP/relaycast-repair-input"
+          RELEASE_ROOT="$RUNNER_TEMP/relaycast-release-tree"
+          git worktree add --detach "$RELEASE_ROOT" "$REPAIR_SOURCE_COMMIT"
+          cp "$INPUT_ROOT/package.json" "$RELEASE_ROOT/package.json"
+          cp "$INPUT_ROOT/package-lock.json" "$RELEASE_ROOT/package-lock.json"
+          cp "$INPUT_ROOT/Dockerfile" "$RELEASE_ROOT/Dockerfile"
+          cp "$INPUT_ROOT/RUNBOOK.md" "$RELEASE_ROOT/RUNBOOK.md"
+          cp "$INPUT_ROOT/release-provenance.json" "$RELEASE_ROOT/release-provenance.json"
+          cp -R "$INPUT_ROOT/release-artifacts" "$RELEASE_ROOT/release-artifacts"
+          cp "$INPUT_ROOT/docker/package.json" "$RELEASE_ROOT/docker/package.json"
+          cp "$INPUT_ROOT/docker/package-lock.json" "$RELEASE_ROOT/docker/package-lock.json"
+          rsync -a "$INPUT_ROOT/packages/" "$RELEASE_ROOT/packages/"
+          # The historical source predates PR #411's release-lock helpers.
+          # Keep the helpers from this workflow checkout untracked in the
+          # temporary tree so every validation uses the hardened logic while
+          # the eventual tag still contains only release-owned paths.
+          for script in release-contract.mjs release-provenance.mjs validate-release-tag.mjs check-release-contract.mjs cut-changelog.mjs npm-dist-tag.mjs; do
+            cp "$GITHUB_WORKSPACE/scripts/$script" "$RELEASE_ROOT/scripts/$script"
+          done
+          cd "$RELEASE_ROOT"
+
+          node "$GITHUB_WORKSPACE/scripts/release-repair.mjs" validate \
+            --run-id "${{ inputs.run_id }}" \
+            --source-commit "$REPAIR_SOURCE_COMMIT" \
+            --source-tree "$REPAIR_SOURCE_TREE" \
+            --provenance-digest "$REPAIR_PROVENANCE_DIGEST" \
+            --version 8.8.0 \
+            --dist-tag latest \
+            --release-date "$REPAIR_RELEASE_DATE" \
+            --current-main "$(git rev-parse origin/main)" \
+            --workspace "$RELEASE_ROOT" \
+            --manifest "$RELEASE_ROOT/release-provenance.json" \
+            --artifact-root "$RELEASE_ROOT"
+
+          TAG=v8.8.0
+          git fetch origin main --tags
+          if git show-ref --verify --quiet "refs/tags/$TAG"; then
+            node scripts/validate-release-tag.mjs \
+              --tag "$TAG" \
+              --source-commit "$REPAIR_SOURCE_COMMIT" \
+              --source-tree "$REPAIR_SOURCE_TREE" \
+              --version 8.8.0 \
+              --dist-tag latest \
+              --provenance-digest "$REPAIR_PROVENANCE_DIGEST" \
+              --provenance-manifest "$RELEASE_ROOT/release-provenance.json"
+            git -C "$RELEASE_ROOT" reset --hard "$TAG^{commit}"
+          else
+            node scripts/cut-changelog.mjs \
+              --version 8.8.0 --date "$REPAIR_RELEASE_DATE"
+            (cd docker && node "$GITHUB_WORKSPACE/scripts/refresh-docker-lock.mjs" \
+              --manifest "$RELEASE_ROOT/release-provenance.json" --version 8.8.0)
+            node scripts/check-release-contract.mjs --version 8.8.0
+
+            git -C "$RELEASE_ROOT" config user.name "GitHub Actions"
+            git -C "$RELEASE_ROOT" config user.email "actions@github.com"
+            git -C "$RELEASE_ROOT" add package.json package-lock.json packages/*/package.json
+            git -C "$RELEASE_ROOT" add packages/sdk-typescript/src/version.ts packages/cli/src/version.ts
+            git -C "$RELEASE_ROOT" add Dockerfile docker/package.json docker/package-lock.json RUNBOOK.md CHANGELOG.md packages/*/CHANGELOG.md
+            git -C "$RELEASE_ROOT" commit -m "chore(release): v8.8.0"
+
+            cat > "$RUNNER_TEMP/relaycast-release-tag-message" <<EOF
+          Release v8.8.0
+
+          Relaycast-NPM-Dist-Tag: latest
+          Relaycast-Source-Commit: $REPAIR_SOURCE_COMMIT
+          Relaycast-Source-Tree: $REPAIR_SOURCE_TREE
+          Relaycast-Release-Date: $REPAIR_RELEASE_DATE
+          Relaycast-Package-Provenance-SHA256: $REPAIR_PROVENANCE_DIGEST
+          EOF
+            git -C "$RELEASE_ROOT" tag -a "$TAG" -F "$RUNNER_TEMP/relaycast-release-tag-message"
+          fi
+
+          node scripts/validate-release-tag.mjs \
+            --tag "$TAG" \
+            --source-commit "$REPAIR_SOURCE_COMMIT" \
+            --source-tree "$REPAIR_SOURCE_TREE" \
+            --version 8.8.0 \
+            --dist-tag latest \
+            --provenance-digest "$REPAIR_PROVENANCE_DIGEST" \
+            --provenance-manifest "$RELEASE_ROOT/release-provenance.json"
+          git -C "$RELEASE_ROOT" push origin "$TAG"
+
+          # Keep the tag's sole parent equal to the historical source. Land a
+          # separate merge commit on main, using PR #411's conflict policy;
+          # this merge commit makes no claim that main produced npm bytes.
+          for attempt in 1 2 3; do
+            git -C "$RELEASE_ROOT" fetch origin main
+            git -C "$RELEASE_ROOT" reset --hard "$TAG^{commit}"
+            if git -C "$RELEASE_ROOT" merge --no-edit origin/main; then
+              :
+            else
+              conflicted="$(git -C "$RELEASE_ROOT" diff --name-only --diff-filter=U)"
+              if [ -z "$conflicted" ] || echo "$conflicted" | grep -qvE '(^|/)CHANGELOG\.md$'; then
+                git -C "$RELEASE_ROOT" merge --abort
+                echo "::error::main merge has an unexpected conflict; tag is intact and main was not changed"
+                exit 1
+              fi
+              echo "$conflicted" | xargs git -C "$RELEASE_ROOT" checkout --theirs --
+              node scripts/cut-changelog.mjs \
+                --version 8.8.0 --date "$REPAIR_RELEASE_DATE"
+              git -C "$RELEASE_ROOT" add CHANGELOG.md packages/*/CHANGELOG.md
+              GIT_EDITOR=true git -C "$RELEASE_ROOT" commit --no-edit
+            fi
+            if git -C "$RELEASE_ROOT" push origin HEAD:main; then
+              break
+            fi
+            if [ "$attempt" -eq 3 ]; then
+              echo "::error::main moved during repair; tag is intact and main was not changed"
+              exit 1
+            fi
+          done
+
+          echo "REPAIR_TAG_COMMIT=$(git -C "$RELEASE_ROOT" rev-parse "$TAG^{commit}")" >> "$GITHUB_ENV"
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: v8.8.0
+          name: v8.8.0
+          prerelease: false
+          generate_release_notes: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/repair-npm-release.yml
+++ b/.github/workflows/repair-npm-release.yml
@@ -171,6 +171,11 @@ jobs:
             --artifact-root "$RELEASE_ROOT"
 
           TAG=v8.8.0
+          # A rerun may reuse an already-pushed tag and still need to create
+          # the separate main merge commit. Configure identity before either
+          # the new-tag branch or the existing-tag branch can mutate git.
+          git config user.name "GitHub Actions"
+          git config user.email "actions@github.com"
           git fetch origin main --tags
           if git show-ref --verify --quiet "refs/tags/$TAG"; then
             node scripts/validate-release-tag.mjs \
@@ -189,8 +194,6 @@ jobs:
               --manifest "$RELEASE_ROOT/release-provenance.json" --version 8.8.0)
             node scripts/check-release-contract.mjs --version 8.8.0
 
-            git -C "$RELEASE_ROOT" config user.name "GitHub Actions"
-            git -C "$RELEASE_ROOT" config user.email "actions@github.com"
             git -C "$RELEASE_ROOT" add package.json package-lock.json packages/*/package.json
             git -C "$RELEASE_ROOT" add packages/sdk-typescript/src/version.ts packages/cli/src/version.ts
             git -C "$RELEASE_ROOT" add Dockerfile docker/package.json docker/package-lock.json RUNBOOK.md CHANGELOG.md packages/*/CHANGELOG.md

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "build": "turbo build",
     "test": "turbo test",
-    "test:release": "node --test scripts/check-published-engine-migrations.test.mjs scripts/npm-dist-tag.test.mjs scripts/refresh-docker-lock.test.mjs scripts/release-contract.test.mjs scripts/release-workflow-contract.test.mjs",
+    "test:release": "node --test scripts/check-published-engine-migrations.test.mjs scripts/npm-dist-tag.test.mjs scripts/refresh-docker-lock.test.mjs scripts/release-contract.test.mjs scripts/release-repair.test.mjs scripts/release-repair-workflow.test.mjs scripts/release-workflow-contract.test.mjs",
     "test:container": "node --test test/container-entrypoint.test.mjs",
     "test:container-image": "node --test test/container-image-integration.test.mjs",
     "lint": "turbo lint",

--- a/scripts/release-repair-workflow.test.mjs
+++ b/scripts/release-repair-workflow.test.mjs
@@ -40,6 +40,15 @@ describe("NPM release repair workflow safety contract", () => {
     assert.match(workflow, /softprops\/action-gh-release@v2/);
   });
 
+  it("configures git identity before an existing-tag rerun can merge main", () => {
+    const identity = workflow.indexOf('git config user.name "GitHub Actions"');
+    const existingTagBranch = workflow.indexOf('if git show-ref --verify --quiet "refs/tags/$TAG"');
+    const mainMerge = workflow.indexOf('git -C "$RELEASE_ROOT" merge --no-edit origin/main');
+    assert.ok(identity >= 0 && identity < existingTagBranch);
+    assert.ok(mainMerge > existingTagBranch);
+    assert.match(workflow, /git config user.email "actions@github\.com"/);
+  });
+
   it("does not use the dispatch checkout SHA as release provenance", () => {
     assert.doesNotMatch(workflow, /GITHUB_SHA/);
     assert.match(workflow, /source_commit:/);

--- a/scripts/release-repair-workflow.test.mjs
+++ b/scripts/release-repair-workflow.test.mjs
@@ -1,0 +1,48 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { describe, it } from "node:test";
+
+const workflow = readFileSync(
+  new URL("../.github/workflows/repair-npm-release.yml", import.meta.url),
+  "utf8",
+);
+
+describe("NPM release repair workflow safety contract", () => {
+  it("downloads and validates one immutable audited artifact", () => {
+    assert.match(workflow, /actions\/download-artifact@v4/);
+    assert.match(workflow, /run-id: \$\{\{ inputs\.run_id \}\}/);
+    assert.match(workflow, /name: build-output/);
+    assert.match(workflow, /release-repair\.mjs validate/);
+    assert.match(workflow, /--source-commit "\$REPAIR_SOURCE_COMMIT"/);
+    assert.match(workflow, /--source-tree "\$REPAIR_SOURCE_TREE"/);
+    assert.match(workflow, /--provenance-digest "\$REPAIR_PROVENANCE_DIGEST"/);
+    assert.match(workflow, /--current-main "\$CURRENT_MAIN"/);
+    assert.match(workflow, /--artifact-root "\$INPUT_ROOT"/);
+  });
+
+  it("verifies exact registry bytes and all dist-tags without mutation", () => {
+    assert.match(workflow, /release-provenance\.mjs published/);
+    assert.match(workflow, /npm-dist-tag\.mjs "\$\{TAG_ARGS\[@\]\}"/);
+    assert.doesNotMatch(workflow, /npm publish/);
+    assert.doesNotMatch(workflow, /npm dist-tag\s/);
+    assert.match(workflow, /NPM_TAG_VERIFY_ATTEMPTS: 30/);
+    assert.match(workflow, /NPM_TAG_VERIFY_DELAY_MS: 10000/);
+  });
+
+  it("validates and pushes the historical tag before the separate main merge", () => {
+    const tagPush = workflow.indexOf('git -C "$RELEASE_ROOT" push origin "$TAG"');
+    const mainPush = workflow.indexOf('git -C "$RELEASE_ROOT" push origin HEAD:main');
+    assert.ok(tagPush >= 0 && mainPush > tagPush);
+    assert.match(workflow, /validate-release-tag\.mjs/);
+    assert.match(workflow, /git worktree add --detach "\$RELEASE_ROOT" "\$REPAIR_SOURCE_COMMIT"/);
+    assert.match(workflow, /git -C "\$RELEASE_ROOT" merge --no-edit origin\/main/);
+    assert.match(workflow, /contents: write/);
+    assert.match(workflow, /softprops\/action-gh-release@v2/);
+  });
+
+  it("does not use the dispatch checkout SHA as release provenance", () => {
+    assert.doesNotMatch(workflow, /GITHUB_SHA/);
+    assert.match(workflow, /source_commit:/);
+    assert.match(workflow, /provenance_digest:/);
+  });
+});

--- a/scripts/release-repair.mjs
+++ b/scripts/release-repair.mjs
@@ -1,0 +1,177 @@
+#!/usr/bin/env node
+
+import { createHash } from "node:crypto";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { execFileSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import {
+  assertReleaseMetadata,
+  assertSourceProvenance,
+  provenanceDigest,
+  readReleaseProvenance,
+} from "./release-provenance.mjs";
+
+/**
+ * The 8.8.0 repair is intentionally allow-listed.  A repair must consume the
+ * immutable build artifact from the failed run; it must never turn a later
+ * checkout into a claim about the source that produced already-published npm
+ * bytes.
+ */
+export const RELAYCAST_8_8_0_REPAIR = Object.freeze({
+  runId: "34436226889",
+  version: "8.8.0",
+  distTag: "latest",
+  sourceCommit: "18981479c26ea0677585b4e79301dc23d94ed5c0",
+  sourceTree: "3ea102dfb9622e3cc2819feb0cdf202cc029c8e6",
+  provenanceDigest: "a18b90273f6b93eb127040bc23f6e66688781e20f1d41c0adde510b287d97917",
+  releaseDate: "2026-09-10",
+});
+
+const COMMIT = /^[0-9a-f]{40}$/;
+const TREE = COMMIT;
+const DIGEST = /^[0-9a-f]{64}$/;
+const DATE = /^\d{4}-\d{2}-\d{2}$/;
+
+function equalExpected(actual, expected, label) {
+  if (actual !== expected) {
+    throw new Error(`${label} is not the allow-listed 8.8.0 repair value`);
+  }
+}
+
+/** Validate operator inputs against the one audited 8.8.0 repair fixture. */
+export function assertRepairInputs({
+  runId,
+  version,
+  distTag,
+  sourceCommit,
+  sourceTree,
+  packageProvenanceDigest,
+  releaseDate = RELAYCAST_8_8_0_REPAIR.releaseDate,
+  currentMainCommit,
+} = {}) {
+  const values = { runId, version, distTag, sourceCommit, sourceTree, packageProvenanceDigest, releaseDate };
+  for (const [label, value] of Object.entries(values)) {
+    if (typeof value !== "string" || value.length === 0 || /[\u0000-\u0020]/.test(value)) {
+      throw new Error(`${label} must be a non-empty value without whitespace`);
+    }
+  }
+  if (!COMMIT.test(sourceCommit)) throw new Error("sourceCommit must be a full commit SHA");
+  if (!TREE.test(sourceTree)) throw new Error("sourceTree must be a full tree SHA");
+  if (!DIGEST.test(packageProvenanceDigest)) throw new Error("packageProvenanceDigest must be a SHA-256 digest");
+  if (!DATE.test(releaseDate)) throw new Error("releaseDate must be an ISO date");
+
+  const fixture = RELAYCAST_8_8_0_REPAIR;
+  equalExpected(runId, fixture.runId, "runId");
+  equalExpected(version, fixture.version, "version");
+  equalExpected(distTag, fixture.distTag, "distTag");
+  equalExpected(sourceCommit, fixture.sourceCommit, "sourceCommit");
+  equalExpected(sourceTree, fixture.sourceTree, "sourceTree");
+  equalExpected(packageProvenanceDigest, fixture.provenanceDigest, "packageProvenanceDigest");
+  equalExpected(releaseDate, fixture.releaseDate, "releaseDate");
+  if (currentMainCommit !== undefined) {
+    if (!COMMIT.test(currentMainCommit)) throw new Error("currentMainCommit must be a full commit SHA");
+    if (currentMainCommit === sourceCommit) {
+      throw new Error("repair source must not be the current main commit");
+    }
+  }
+  return fixture;
+}
+
+/** Validate the downloaded manifest and its exact tarball bytes. */
+export function assertRepairProvenance({
+  manifest,
+  artifactRoot,
+  sourceCommit,
+  sourceTree,
+  version,
+  distTag,
+  packageProvenanceDigest,
+} = {}) {
+  const parsed = typeof manifest === "string" ? readReleaseProvenance(manifest) : manifest;
+  if (!parsed || typeof parsed !== "object") throw new Error("repair provenance must be an object");
+  assertSourceProvenance(parsed, sourceCommit, sourceTree);
+  assertReleaseMetadata(parsed, version, distTag);
+  if (provenanceDigest(parsed) !== packageProvenanceDigest) {
+    throw new Error("repair provenance digest does not match the allow-listed artifact");
+  }
+  if (resolve(artifactRoot) !== artifactRoot) {
+    throw new Error("artifactRoot must be an absolute path");
+  }
+  const seen = new Set();
+  for (const pkg of parsed.packages) {
+    if (seen.has(pkg.name)) throw new Error(`repair provenance contains duplicate ${pkg.name}`);
+    seen.add(pkg.name);
+    if (pkg.version !== version) throw new Error(`${pkg.name} provenance version does not match the repair`);
+    const tarball = resolve(artifactRoot, pkg.tarball);
+    if (tarball !== artifactRoot && !tarball.startsWith(`${artifactRoot}/`)) {
+      throw new Error(`${pkg.name} tarball escapes the repair artifact root`);
+    }
+    const bytes = readFileSync(tarball);
+    const integrity = `sha512-${createHash("sha512").update(bytes).digest("base64")}`;
+    const shasum = createHash("sha1").update(bytes).digest("hex");
+    if (integrity !== pkg.integrity || shasum !== pkg.shasum) {
+      throw new Error(`${pkg.name} tarball bytes do not match release provenance`);
+    }
+  }
+  return parsed;
+}
+
+function git(cwd, args) {
+  return execFileSync("git", args, { cwd, encoding: "utf8" }).trim();
+}
+
+/** Validate the source object in the checkout before any release mutation. */
+export function assertRepairSource({ workspace = process.cwd(), sourceCommit, sourceTree } = {}) {
+  if (git(workspace, ["rev-parse", "--verify", `${sourceCommit}^{commit}`]) !== sourceCommit) {
+    throw new Error("repair source commit is not available locally");
+  }
+  const actualTree = git(workspace, ["rev-parse", `${sourceCommit}^{tree}`]);
+  if (actualTree !== sourceTree) {
+    throw new Error("repair source tree does not match the audited source commit");
+  }
+  return { sourceCommit, sourceTree };
+}
+
+function argument(name, { optional = false, fallback } = {}) {
+  const index = process.argv.indexOf(name);
+  if (index === -1) {
+    if (optional) return fallback;
+    throw new Error(`${name} is required`);
+  }
+  const value = process.argv[index + 1];
+  if (!value || value.startsWith("--")) throw new Error(`${name} requires a value`);
+  return value;
+}
+
+if (process.argv[1] && fileURLToPath(import.meta.url) === resolve(process.argv[1])) {
+  if (process.argv[2] !== "validate") throw new Error("command must be validate");
+  const sourceCommit = argument("--source-commit");
+  const sourceTree = argument("--source-tree");
+  const packageProvenanceDigest = argument("--provenance-digest");
+  const version = argument("--version");
+  const distTag = argument("--dist-tag");
+  const fixture = assertRepairInputs({
+    runId: argument("--run-id"),
+    version,
+    distTag,
+    sourceCommit,
+    sourceTree,
+    packageProvenanceDigest,
+    releaseDate: argument("--release-date"),
+    currentMainCommit: argument("--current-main"),
+  });
+  const workspace = argument("--workspace");
+  assertRepairSource({ workspace, sourceCommit, sourceTree });
+  const manifest = argument("--manifest");
+  assertRepairProvenance({
+    manifest,
+    artifactRoot: argument("--artifact-root"),
+    sourceCommit,
+    sourceTree,
+    version,
+    distTag,
+    packageProvenanceDigest,
+  });
+  process.stdout.write(`validated ${fixture.version} repair artifact from ${fixture.sourceCommit}\n`);
+}

--- a/scripts/release-repair.mjs
+++ b/scripts/release-repair.mjs
@@ -122,11 +122,16 @@ function git(cwd, args) {
 }
 
 /** Validate the source object in the checkout before any release mutation. */
-export function assertRepairSource({ workspace = process.cwd(), sourceCommit, sourceTree } = {}) {
-  if (git(workspace, ["rev-parse", "--verify", `${sourceCommit}^{commit}`]) !== sourceCommit) {
+export function assertRepairSource({
+  workspace = process.cwd(),
+  sourceCommit,
+  sourceTree,
+  gitCommand = git,
+} = {}) {
+  if (gitCommand(workspace, ["rev-parse", "--verify", `${sourceCommit}^{commit}`]) !== sourceCommit) {
     throw new Error("repair source commit is not available locally");
   }
-  const actualTree = git(workspace, ["rev-parse", `${sourceCommit}^{tree}`]);
+  const actualTree = gitCommand(workspace, ["rev-parse", `${sourceCommit}^{tree}`]);
   if (actualTree !== sourceTree) {
     throw new Error("repair source tree does not match the audited source commit");
   }

--- a/scripts/release-repair.test.mjs
+++ b/scripts/release-repair.test.mjs
@@ -1,15 +1,26 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
-import { execFileSync } from "node:child_process";
 import {
   RELAYCAST_8_8_0_REPAIR,
   assertRepairInputs,
   assertRepairSource,
 } from "./release-repair.mjs";
 
-const repositoryRoot = execFileSync("git", ["rev-parse", "--show-toplevel"], {
-  encoding: "utf8",
-}).trim();
+const CURRENT_MAIN = "e79efa732b24b4de134b4cd6c2b1346862e88443";
+const CURRENT_MAIN_TREE = "0f04fb3d5337ecc84c00a85c83253090eb020c3b";
+
+function fixtureGit(_workspace, args) {
+  const revision = args.at(-1);
+  if (revision === `${RELAYCAST_8_8_0_REPAIR.sourceCommit}^{commit}`) {
+    return RELAYCAST_8_8_0_REPAIR.sourceCommit;
+  }
+  if (revision === `${RELAYCAST_8_8_0_REPAIR.sourceCommit}^{tree}`) {
+    return RELAYCAST_8_8_0_REPAIR.sourceTree;
+  }
+  if (revision === `${CURRENT_MAIN}^{commit}`) return CURRENT_MAIN;
+  if (revision === `${CURRENT_MAIN}^{tree}`) return CURRENT_MAIN_TREE;
+  throw new Error(`unexpected fixture revision: ${revision}`);
+}
 
 describe("8.8.0 release repair fixture", () => {
   it("accepts the immutable source that produced the published artifacts", () => {
@@ -23,9 +34,10 @@ describe("8.8.0 release repair fixture", () => {
     );
     assert.doesNotThrow(() =>
       assertRepairSource({
-        workspace: repositoryRoot,
+        workspace: "/fixture",
         sourceCommit: RELAYCAST_8_8_0_REPAIR.sourceCommit,
         sourceTree: RELAYCAST_8_8_0_REPAIR.sourceTree,
+        gitCommand: fixtureGit,
       }),
     );
   });
@@ -44,9 +56,10 @@ describe("8.8.0 release repair fixture", () => {
     assert.throws(
       () =>
         assertRepairSource({
-          workspace: repositoryRoot,
-          sourceCommit: "e79efa732b24b4de134b4cd6c2b1346862e88443",
+          workspace: "/fixture",
+          sourceCommit: CURRENT_MAIN,
           sourceTree: RELAYCAST_8_8_0_REPAIR.sourceTree,
+          gitCommand: fixtureGit,
         }),
       /repair source tree does not match/,
     );

--- a/scripts/release-repair.test.mjs
+++ b/scripts/release-repair.test.mjs
@@ -1,0 +1,71 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { execFileSync } from "node:child_process";
+import {
+  RELAYCAST_8_8_0_REPAIR,
+  assertRepairInputs,
+  assertRepairSource,
+} from "./release-repair.mjs";
+
+const repositoryRoot = execFileSync("git", ["rev-parse", "--show-toplevel"], {
+  encoding: "utf8",
+}).trim();
+
+describe("8.8.0 release repair fixture", () => {
+  it("accepts the immutable source that produced the published artifacts", () => {
+    assert.deepEqual(
+      assertRepairInputs({
+        ...RELAYCAST_8_8_0_REPAIR,
+        packageProvenanceDigest: RELAYCAST_8_8_0_REPAIR.provenanceDigest,
+        currentMainCommit: "e79efa732b24b4de134b4cd6c2b1346862e88443",
+      }),
+      RELAYCAST_8_8_0_REPAIR,
+    );
+    assert.doesNotThrow(() =>
+      assertRepairSource({
+        workspace: repositoryRoot,
+        sourceCommit: RELAYCAST_8_8_0_REPAIR.sourceCommit,
+        sourceTree: RELAYCAST_8_8_0_REPAIR.sourceTree,
+      }),
+    );
+  });
+
+  it("rejects current main as the source of the already-published artifacts", () => {
+    assert.throws(
+      () =>
+        assertRepairInputs({
+          ...RELAYCAST_8_8_0_REPAIR,
+          sourceCommit: "e79efa732b24b4de134b4cd6c2b1346862e88443",
+          currentMainCommit: "e79efa732b24b4de134b4cd6c2b1346862e88443",
+          packageProvenanceDigest: RELAYCAST_8_8_0_REPAIR.provenanceDigest,
+        }),
+      /sourceCommit is not the allow-listed 8\.8\.0 repair value/,
+    );
+    assert.throws(
+      () =>
+        assertRepairSource({
+          workspace: repositoryRoot,
+          sourceCommit: "e79efa732b24b4de134b4cd6c2b1346862e88443",
+          sourceTree: RELAYCAST_8_8_0_REPAIR.sourceTree,
+        }),
+      /repair source tree does not match/,
+    );
+  });
+
+  it("rejects a mismatched run or provenance digest", () => {
+    for (const [field, value] of [
+      ["runId", "34436785435"],
+      ["packageProvenanceDigest", "0".repeat(64)],
+    ]) {
+      assert.throws(
+        () =>
+          assertRepairInputs({
+            ...RELAYCAST_8_8_0_REPAIR,
+            packageProvenanceDigest: RELAYCAST_8_8_0_REPAIR.provenanceDigest,
+            [field]: value,
+          }),
+        new RegExp(`${field} is not the allow-listed`),
+      );
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- Adds a separate, manual repair workflow for the failed 8.8.0 publish run `34436226889`.
- Allow-lists the audited source commit/tree, release provenance digest, run ID, version, dist-tag, and release date; current `main` cannot be substituted.
- Downloads and hashes the original tarballs, verifies every published npm integrity and dist-tag read-only, and never republishes.
- Reconstructs a release tag whose sole parent is `18981479…`, validates it with the PR #411 release-lock logic, then lands a separate merge commit on `main` before creating the GitHub Release.
- Adds regression coverage accepting `18981479…` and rejecting `e79efa73…`, plus workflow safety contracts.

Related: #396

## Validation

- Focused Bun test run: 7 new tests passed.
- Existing release tests run individually under Bun: 25 release-contract, 7 migration, 19 npm-dist-tag, 2 Docker-lock tests passed.
- `actionlint .github/workflows/repair-npm-release.yml`
- Real downloaded `build-output` provenance/tarball validation passed.
- Local historical release reconstruction, Docker lock refresh, release contract, tag validation, and merge simulation passed.
- Veto diff review: PASS; code 92/100, security approved, secrets clean.

This PR does not publish packages, create the tag/release, merge `main`, or deploy anything.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> When dispatched, the workflow can push `v8.8.0` and merge to `main` with `contents: write`; safeguards are allow-listed inputs and read-only npm checks, but operator error or race on `main` still matters.
> 
> **Overview**
> Adds a **manual, allow-listed** GitHub Actions workflow (`repair-npm-release.yml`) to fix **v8.8.0** git tag/release bookkeeping after npm already published from failed run `34436226889`, without republishing packages.
> 
> The workflow downloads the audited `build-output` artifact, runs `release-repair.mjs validate` against fixed source commit/tree/provenance digest inputs (not `GITHUB_SHA`), read-only checks npm integrity and `latest` dist-tags, then rebuilds a detached worktree, creates or reuses `v8.8.0`, pushes the tag **before** merging `main`, and opens a GitHub Release.
> 
> New `scripts/release-repair.mjs` hard-codes `RELAYCAST_8_8_0_REPAIR` and validates inputs, tarball bytes, and git source tree; `test:release` gains `release-repair.test.mjs` and `release-repair-workflow.test.mjs` safety contracts (no `npm publish`, tag-before-main, etc.).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4c814f2b2ac17d497157c2348a8e51163e1f4e4b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/AgentWorkforce/relaycast/pull/412?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

