### PR TITLE
fix(release): canonicalize repair source tree SHA

### DIFF
--- a/.agentworkforce/trajectories/completed/2026-09/traj_jxynh3zsmnvn/summary.md
+++ b/.agentworkforce/trajectories/completed/2026-09/traj_jxynh3zsmnvn/summary.md
@@ -1,0 +1,33 @@
+# Trajectory: Repair NPM release workflow source-tree SHA regression
+
+> **Status:** ✅ Completed
+> **Task:** Fix truncated immutable source-tree SHA handling in repair workflow; canonical source tree is 3ea102dfb9622e3cc2819feb0cdf202cc029c8e6
+> **Confidence:** 93%
+> **Started:** September 10, 2026 at 10:34 AM
+> **Completed:** September 10, 2026 at 10:38 AM
+
+---
+
+## Summary
+
+Canonicalized the NPM repair workflow's source tree from the allow-listed source commit and added exact-SHA regression coverage for the workflow default and fixture.
+
+**Approach:** Standard approach
+
+---
+
+## Key Decisions
+
+### Resolve sourceTree from the allow-listed source commit before repair validation
+- **Chose:** Resolve sourceTree from the allow-listed source commit before repair validation
+- **Reasoning:** The failed run supplied a 39-character source-tree input even though the repository default and fixture were canonical; deriving the tree from the immutable source commit removes manual truncation risk while existing fixture and provenance checks remain authoritative.
+
+---
+
+## Chapters
+
+### 1. Work
+*Agent: default*
+
+- Resolve sourceTree from the allow-listed source commit before repair validation: Resolve sourceTree from the allow-listed source commit before repair validation
+- The repair workflow now canonicalizes source-tree identity before both validation stages, and release regression coverage pins the exact 40-character SHA across workflow and fixture.

--- a/.agentworkforce/trajectories/completed/2026-09/traj_jxynh3zsmnvn/trajectory.json
+++ b/.agentworkforce/trajectories/completed/2026-09/traj_jxynh3zsmnvn/trajectory.json
@@ -1,0 +1,77 @@
+{
+  "id": "traj_jxynh3zsmnvn",
+  "version": 1,
+  "task": {
+    "title": "Repair NPM release workflow source-tree SHA regression",
+    "source": {
+      "system": "plain",
+      "id": "Fix truncated immutable source-tree SHA handling in repair workflow; canonical source tree is 3ea102dfb9622e3cc2819feb0cdf202cc029c8e6"
+    }
+  },
+  "status": "completed",
+  "startedAt": "2026-09-10T08:34:49.713Z",
+  "completedAt": "2026-09-10T08:38:26.212Z",
+  "agents": [
+    {
+      "name": "default",
+      "role": "lead",
+      "joinedAt": "2026-09-10T08:38:02.893Z"
+    }
+  ],
+  "chapters": [
+    {
+      "id": "chap_cbg2igjmrgcd",
+      "title": "Work",
+      "agentName": "default",
+      "startedAt": "2026-09-10T08:38:02.893Z",
+      "endedAt": "2026-09-10T08:38:26.212Z",
+      "events": [
+        {
+          "ts": 1789029482894,
+          "type": "decision",
+          "content": "Resolve sourceTree from the allow-listed source commit before repair validation: Resolve sourceTree from the allow-listed source commit before repair validation",
+          "raw": {
+            "question": "Resolve sourceTree from the allow-listed source commit before repair validation",
+            "chosen": "Resolve sourceTree from the allow-listed source commit before repair validation",
+            "alternatives": [],
+            "reasoning": "The failed run supplied a 39-character source-tree input even though the repository default and fixture were canonical; deriving the tree from the immutable source commit removes manual truncation risk while existing fixture and provenance checks remain authoritative."
+          },
+          "significance": "high"
+        },
+        {
+          "ts": 1789029484368,
+          "type": "reflection",
+          "content": "The repair workflow now canonicalizes source-tree identity before both validation stages, and release regression coverage pins the exact 40-character SHA across workflow and fixture.",
+          "raw": {
+            "focalPoints": [
+              "source-tree provenance",
+              "workflow safety",
+              "regression coverage"
+            ],
+            "confidence": 0.92
+          },
+          "significance": "high",
+          "tags": [
+            "focal:source-tree provenance",
+            "focal:workflow safety",
+            "focal:regression coverage",
+            "confidence:0.92"
+          ]
+        }
+      ]
+    }
+  ],
+  "retrospective": {
+    "summary": "Canonicalized the NPM repair workflow's source tree from the allow-listed source commit and added exact-SHA regression coverage for the workflow default and fixture.",
+    "approach": "Standard approach",
+    "confidence": 0.93
+  },
+  "commits": [],
+  "filesChanged": [],
+  "projectId": "AgentWorkforce/relaycast",
+  "tags": [],
+  "_trace": {
+    "startRef": "231d63e44102424b2bff0f8f42aa838d728f10af",
+    "endRef": "231d63e44102424b2bff0f8f42aa838d728f10af"
+  }
+}

--- a/.github/workflows/repair-npm-release.yml
+++ b/.github/workflows/repair-npm-release.yml
@@ -79,11 +79,27 @@ jobs:
           name: build-output
           path: ${{ runner.temp }}/relaycast-repair-input
 
+      - name: Resolve the audited source tree
+        env:
+          REPAIR_SOURCE_COMMIT: ${{ inputs.source_commit }}
+          REQUESTED_SOURCE_TREE: ${{ inputs.source_tree }}
+        run: |
+          set -euo pipefail
+          git fetch origin main --tags
+          # The source commit is allow-listed by release-repair.mjs. Derive
+          # its tree here so a manually truncated dispatch input cannot change
+          # the immutable provenance identity or stop the repair before the
+          # artifact checks run.
+          CANONICAL_SOURCE_TREE="$(git rev-parse "${REPAIR_SOURCE_COMMIT}^{tree}")"
+          if [ "$REQUESTED_SOURCE_TREE" != "$CANONICAL_SOURCE_TREE" ]; then
+            echo "::warning::Ignoring the supplied source_tree input; using the source commit's canonical tree $CANONICAL_SOURCE_TREE"
+          fi
+          echo "REPAIR_SOURCE_TREE=$CANONICAL_SOURCE_TREE" >> "$GITHUB_ENV"
+
       - name: Validate immutable artifact and registry state
         env:
           REPAIR_RUN_ID: ${{ inputs.run_id }}
           REPAIR_SOURCE_COMMIT: ${{ inputs.source_commit }}
-          REPAIR_SOURCE_TREE: ${{ inputs.source_tree }}
           REPAIR_PROVENANCE_DIGEST: ${{ inputs.provenance_digest }}
           REPAIR_RELEASE_DATE: ${{ inputs.release_date }}
         run: |
@@ -131,7 +147,6 @@ jobs:
       - name: Build and validate the historical release tree
         env:
           REPAIR_SOURCE_COMMIT: ${{ inputs.source_commit }}
-          REPAIR_SOURCE_TREE: ${{ inputs.source_tree }}
           REPAIR_PROVENANCE_DIGEST: ${{ inputs.provenance_digest }}
           REPAIR_RELEASE_DATE: ${{ inputs.release_date }}
         run: |

--- a/scripts/release-repair-workflow.test.mjs
+++ b/scripts/release-repair-workflow.test.mjs
@@ -6,8 +6,22 @@ const workflow = readFileSync(
   new URL("../.github/workflows/repair-npm-release.yml", import.meta.url),
   "utf8",
 );
+const repairScript = readFileSync(new URL("./release-repair.mjs", import.meta.url), "utf8");
+const CANONICAL_SOURCE_TREE = "3ea102dfb9622e3cc2819feb0cdf202cc029c8e6";
 
 describe("NPM release repair workflow safety contract", () => {
+  it("pins the full canonical source tree in both dispatch defaults and the repair fixture", () => {
+    const sourceTreeDefault = workflow.match(
+      /source_tree:\s*\n\s+description:[\s\S]*?\n\s+required: true\n\s+type: string\n\s+default: "([0-9a-f]+)"/,
+    )?.[1];
+    assert.equal(sourceTreeDefault, CANONICAL_SOURCE_TREE);
+    assert.match(CANONICAL_SOURCE_TREE, /^[0-9a-f]{40}$/);
+    assert.match(repairScript, new RegExp(`sourceTree: "${CANONICAL_SOURCE_TREE}"`));
+    assert.match(workflow, /CANONICAL_SOURCE_TREE="\$\(git rev-parse "\$\{REPAIR_SOURCE_COMMIT\}\^\{tree\}"\)"/);
+    assert.match(workflow, /echo "REPAIR_SOURCE_TREE=\$CANONICAL_SOURCE_TREE" >> "\$GITHUB_ENV"/);
+    assert.doesNotMatch(workflow, /REPAIR_SOURCE_TREE: \$\{\{ inputs\.source_tree \}\}/);
+  });
+
   it("downloads and validates one immutable audited artifact", () => {
     assert.match(workflow, /actions\/download-artifact@v4/);
     assert.match(workflow, /run-id: \$\{\{ inputs\.run_id \}\}/);


### PR DESCRIPTION
## Summary\n\n- Resolve the repair workflow tree from the allow-listed source commit before artifact validation, so a manually truncated source_tree dispatch input cannot stop the audited repair.\n- Keep the canonical 40-character tree SHA (3ea102dfb9622e3cc2819feb0cdf202cc029c8e6) pinned in the dispatch default and repair fixture.\n- Add workflow-contract regression coverage for the exact SHA and canonical resolver.\n\nThe failed run was #34454211899 (sourceTree must be a full tree SHA); no v8.8.0 tag or release exists. This PR does not merge main, publish packages, create tags/releases, or rerun the repair workflow.\n\n## Validation\n\n- npm run test:release — 102 passed\n- node --test scripts/release-repair.test.mjs scripts/release-repair-workflow.test.mjs — 9 passed\n- actionlint .github/workflows/repair-npm-release.yml — passed\n- git diff --check — passed\n- Typecheck not applicable: workflow/script-contract change and no root typecheck task\n- Veto diff review — PASS (code 94/100, security 95/100, secrets clean, no decision drift)\n\nEvidence: original commit 18981479c26ea0677585b4e79301dc23d94ed5c0; canonical tree 3ea102dfb9622e3cc2819feb0cdf202cc029c8e6; merged repair workflow commit 231d63e44102424b2bff0f8f42aa838d728f10af.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit e61ccb4bac7ac84fc81123d9c1932f503e08c659. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/AgentWorkforce/relaycast/pull/413?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

