### PR TITLE
Backport subscription delivery onto the schema-free production engine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,9 +16,32 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 Packages without a separate changelog are covered by the cross-package notes below.
 
-## [Unreleased - Patch]
+## [Unreleased - Minor]
+
+### Added
+
+- Node credentials can read their own dispatched spawn results, allowing served fleet actions to confirm broker readiness with node-scoped authority.
+
+- Agent registration accepts `auto_join_general: false` on HTTP and node control for isolated workers; recovery preserves existing memberships.
+
+- Node-control `agent.deregister` acknowledges requests with an ID after teardown, allowing brokers to confirm cleanup before deleting owned identities.
+- `POST /v1/agents/{name}/subscription-channel` provisions an exact identity-bound delivery channel without rotating recipient credentials.
 
 ### Fixed
+
+- Thread replies resolve full hyphenated mentions; subscription setup rejects recipients released during membership creation.
+- Verified spawn checks the selected provider heartbeat, and inventory reconciliation honors only canonical `verify_ready` input. Empty explicit targets retain legacy spawn routing.
+
+- Relayfile messages expose provider payloads from Cloud sync envelopes, preserving titles, authors, and terminal PR state for subscribers.
+
+- Subscription routes reject conflicting legacy memberships; agent removal invalidates channels actually removed by the release transaction.
+
+- Agent deletion invalidates cached membership so subscription route checks reflect the released identity.
+- Relayfile ingress preserves authenticated provider event semantics and resource references.
+- Hyphenated mentions resolve the full handle without waking a prefix agent.
+- Raw inbound webhooks now create durable agent deliveries.
+- Relayfile ingress and raw inbound hooks reject full mailboxes atomically with retry guidance, preserving unique events without partial delivery.
+- Explicit spawn targets are honored when a legacy global node alias exists, preserving its caller allowlist.
 
 - Hosts can bound retention candidate scans with persisted rowid cursors without schema changes, preserving workspace TTLs and table fairness.
 - Node replay uses bounded, ordered database pages with existing indexes, reducing shared-database contention without requiring schema changes.

--- a/README.md
+++ b/README.md
@@ -1003,3 +1003,46 @@ Relaycast includes anonymous telemetry.
 ## License
 
 Apache-2.0
+
+
+### Agent subscription delivery
+
+Workspace owners can `POST /v1/agents/{name}/subscription-channel` to obtain an
+idempotent channel whose only permitted member is that exact agent identity.
+The response is a normal channel with its verified `members` list; setup returns 404 if the recipient is released before membership can be established. This operation
+does not rotate the agent token. The `agent-events-` channel prefix is reserved;
+routing metadata cannot be changed and other agents cannot join or be invited.
+An agent recreated under the same name gets a different channel, so old webhook
+subscriptions never transfer to its replacement. Removing the subscription deletes
+its webhook resources; a shared per-agent channel can remain for other resources.
+This is a delivery audience restriction, not a private-channel history API.
+
+Channel messages and thread replies resolve mention handles using ASCII letters, digits, underscores and hyphens. For example,
+`@build-reviewer_2` resolves the full handle, never `build`. Duplicate mentions
+produce one mention delivery. A backslash immediately before `@` escapes it;
+email addresses are not mentions. Mention delivery still requires membership in
+the channel and workspace authorization.
+
+Relayfile events and raw inbound hooks preserve distinct events in FIFO order for members present when
+accepted. Joining later does not backfill old delivery rows. A full recipient
+mailbox causes the entire inbound event to return **503 `mailbox_full`** with
+`Retry-After: 30`; neither a partial message nor partial deliveries are committed.
+The Relayfile producer must retry the same event ID and retain exhausted attempts in its
+DLQ. Raw hooks must retry rejected payloads; they do not claim Relayfile event-ID deduplication. No newest-only coalescing is applied. The normal mailbox TTL still applies:
+expired deliveries become inspectable dead letters, not acted-on receipts.
+Operators must drain/retry the DLQ before declaring an event matrix complete.
+
+Explicit `target_node` on built-in spawn honors fleet placement even when a
+legacy workspace-global node action named `spawn` exists; its caller allowlist
+continues to apply. A dispatch acknowledgement does not establish harness readiness.
+
+Verified spawn (`verify_ready: true`) fails with `spawn_target_unavailable` when the selected provider lacks a live handler heartbeat or connected socket. Unverified legacy requests retain queue behavior. Relayfile ingress preserves authenticated `providerEventType` and `resourceRef` as `provider_event_type` and `resource_ref` in message metadata, alongside the provider record. Generic file events do not imply PR, CI, or review semantics. Cloud sync envelopes are unwrapped to expose their provider payload in message metadata and formatting; this does not promote payload fields into authenticated event semantics.
+
+Readiness requests do not reroute registered global spawn handlers. Only a nonempty explicit `target_node` selects fleet placement around a legacy node alias; handlers that receive `verify_ready` must honor its completion contract. A deleted recipient leaves its old route memberless so a replacement cannot inherit delivery. Retire or replace the inventoried producer binding and webhook when deleting a subscriber; channel history remains for audit.
+
+Node-control `agent.deregister` requests with an `id` receive a correlated `reply`
+only after the binding has been removed and the agent moved offline. Requests
+without an `id` retain fire-and-forget behavior. Brokers performing owned identity
+cleanup must await that acknowledgement before requesting deletion.
+
+The signed Relayfile webhook request follows Relayfile's existing external event contract (`eventId`, `providerEventType`, `resourceRef`). These are verified vendor payload fields, not alternate spellings of Relaycast HTTP fields; Relaycast message metadata remains snake_case.

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1368,6 +1368,7 @@ components:
           type: string
 
     RelayfileInboundEventSnapshot:
+      description: Provider record snapshot. Cloud sync envelopes expose their inner provider payload in message metadata and formatting; provider event semantics still require authenticated top-level event metadata.
       type: object
       properties:
         path:
@@ -1398,6 +1399,12 @@ components:
           type: string
         provider:
           type: string
+        providerEventType:
+          type: string
+          description: Authenticated provider semantic type, for example pull_request.closed. Preserved without inferring semantics from file.updated.
+        resourceRef:
+          type: string
+          description: Authenticated provider resource reference preserved in message metadata.
         correlationId:
           type: string
         timestamp:
@@ -2273,6 +2280,58 @@ paths:
         '204':
           description: Agent deleted
 
+  /agents/{name}/subscription-channel:
+    post:
+      summary: Ensure an exact agent subscription delivery channel
+      description: |
+        Workspace-owner operation. Idempotently returns a channel bound to the
+        agent's immutable identity ID and joins that identity. Other agents
+        cannot join or be invited. Does not rotate the recipient token. A
+        replacement registered under the same name gets a different channel.
+        The agent-events- prefix and routing metadata are reserved. This limits
+        delivery membership; it does not introduce private history access. Returns
+        404 if the recipient is released before membership is established.
+      tags: [Agents]
+      security:
+        - workspaceKey: []
+      parameters:
+        - in: path
+          name: name
+          required: true
+          schema: { type: string }
+      responses:
+        '200':
+          description: Channel with verified recipient membership
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [ok, data]
+                properties:
+                  ok: { type: boolean, enum: [true] }
+                  data:
+                    type: object
+                    required: [id, name, members, member_count]
+                    properties:
+                      id: { type: string }
+                      name: { type: string }
+                      member_count: { type: integer, enum: [1] }
+                      members:
+                        type: array
+                        minItems: 1
+                        maxItems: 1
+                        items:
+                          type: object
+                          properties:
+                            agent_id: { type: string }
+                            agent_name: { type: string }
+        '401':
+          description: Workspace key required
+        '404':
+          description: Recipient identity not found
+        '409':
+          description: Subscription channel archived
+
   /agents/{name}/legacy-identity:
     patch:
       summary: Atomically claim a legacy agent identity
@@ -2887,7 +2946,7 @@ paths:
   /channels/{name}/mute:
     post:
       summary: Mute a channel
-      description: Mute a channel for the authenticated agent. Muted channels suppress ordinary message delivery rows and realtime pushes, but explicit @mentions still create mention deliveries. The agent remains a member and still receives system/control events (member joins, channel updates, mute confirmations). Agent identity is derived from the agent token — no request body needed.
+      description: Mute a channel for the authenticated agent. Mention handles include ASCII letters, digits, underscores and hyphens; escaped and email-address @ signs are not mentions. Muted channels suppress ordinary message delivery rows and realtime pushes, but explicit @mentions still create mention deliveries. The agent remains a member and still receives system/control events (member joins, channel updates, mute confirmations). Agent identity is derived from the agent token — no request body needed.
       tags:
         - Channels
       security:
@@ -5418,6 +5477,9 @@ paths:
         HMAC-authenticated callback used by relayfile to inject matching provider
         file events into a Relaycast channel. The HMAC input is
         `X-Relay-Timestamp + "." + raw request body`, signed with SHA-256.
+        A full recipient mailbox returns 503 mailbox_full with Retry-After: 30;
+        the producer must retry the same event ID. The message and all delivery
+        rows roll back together, so no recipient is silently skipped.
       tags:
         - Relayfile
       parameters:
@@ -5512,7 +5574,13 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
         '503':
-          description: Relayfile inbound bridge or idempotency storage is unavailable
+          description: A recipient mailbox is full (mailbox_full), or the inbound bridge/idempotency storage is unavailable
+          headers:
+            Retry-After:
+              description: For mailbox_full, retry the same event ID after 30 seconds
+              schema:
+                type: integer
+                example: 30
           content:
             application/json:
               schema:
@@ -5625,6 +5693,17 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/SuccessResponse'
+        '503':
+          description: A recipient mailbox is full; no partial message or deliveries were committed
+          headers:
+            Retry-After:
+              description: Retry the event after 30 seconds
+              schema:
+                type: string
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
 
   /ws:
     get:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -2098,6 +2098,10 @@ paths:
                   type: string
                 metadata:
                   type: object
+                auto_join_general:
+                  type: boolean
+                  default: true
+                  description: Automatically join the general channel; set false to isolate event-only recipients.
                 recovery_proof_hash:
                   type: string
                   pattern: '^[a-f0-9]{64}$'

--- a/package-lock.json
+++ b/package-lock.json
@@ -5798,6 +5798,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -5819,6 +5820,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -5840,6 +5842,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -5861,6 +5864,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -5882,6 +5886,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -5903,6 +5908,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -5924,6 +5930,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -5945,6 +5952,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -5966,6 +5974,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -5987,6 +5996,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -6008,6 +6018,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -10729,7 +10740,7 @@
       "dependencies": {
         "@hono/node-server": "^1.13.7",
         "@relaycast/a2a": "8.5.2",
-        "@relaycast/types": "8.5.2",
+        "@relaycast/types": "8.7.0",
         "better-sqlite3": "^11.10.0",
         "drizzle-orm": "^0.45.1",
         "hono": "^4.11.9",
@@ -10746,6 +10757,14 @@
         "@types/ws": "^8.5.13",
         "drizzle-kit": "^0.31.9",
         "vitest": "^4.0.18"
+      }
+    },
+    "packages/engine/node_modules/@relaycast/types": {
+      "version": "8.7.0",
+      "resolved": "https://registry.npmjs.org/@relaycast/types/-/types-8.7.0.tgz",
+      "integrity": "sha512-86d2d5OdXV6QIblNpuNLei0Cd5ZNlEHsT+Tjw5a5HebM9ee4HsTdzaLuYbBDvAAhm1rEf4PdVuheCkyeJ+K6OQ==",
+      "dependencies": {
+        "zod": "^4.3.6"
       }
     },
     "packages/engine/node_modules/@types/node": {

--- a/packages/engine/CHANGELOG.md
+++ b/packages/engine/CHANGELOG.md
@@ -7,9 +7,31 @@ See the [root changelog](../../CHANGELOG.md) for cross-package release highlight
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased - Patch]
+## [Unreleased - Minor]
+
+### Added
+
+- Node credentials can read status for spawn invocations dispatched to their own node, so served providers can await confirmed broker readiness without workspace credentials.
+
+- Agent registration accepts `auto_join_general: false` on HTTP and node control for isolated workers; recovery preserves existing memberships.
+
+- Node-control `agent.deregister` acknowledges requests with an ID after teardown, allowing brokers to confirm cleanup before deleting owned identities.
+- `POST /v1/agents/{name}/subscription-channel` provisions an exact identity-bound delivery channel without rotating recipient credentials.
 
 ### Fixed
+
+- Thread replies resolve full hyphenated mentions; subscription setup rejects recipients released during membership creation.
+- Verified spawn checks the selected provider heartbeat, and inventory reconciliation honors only canonical `verify_ready` input. Empty explicit targets retain legacy spawn routing.
+
+- Relayfile messages expose provider payloads from Cloud sync envelopes, preserving titles, authors, and terminal PR state for subscribers.
+
+- Reserved per-agent subscription channels reject legacy foreign memberships with HTTP 409 before adoption.
+- Agent deletion invalidates cached membership so subscription route checks reflect the released identity.
+- Relayfile ingress preserves authenticated provider event semantics and resource references.
+- Hyphenated mentions resolve the full handle without waking a prefix agent.
+- Raw inbound webhooks now create durable agent deliveries.
+- Relayfile ingress and raw inbound hooks reject full mailboxes atomically with retry guidance, preserving unique events without partial delivery.
+- Explicit spawn targets are honored when a legacy global node alias exists, preserving its caller allowlist.
 
 - `pruneExpired` accepts a host-owned `cursorStore` for schema-free bounded rowid candidate scans and a `maxDurationMs` admission budget. Serialize calls and persist state durably; TTL policies are unchanged. In-flight SQL and message cascades are not canceled or write-bounded.
 - Node replay uses bounded, ordered database pages with existing indexes, reducing shared-database contention without requiring schema changes.

--- a/packages/engine/package.json
+++ b/packages/engine/package.json
@@ -2,7 +2,7 @@
   "name": "@relaycast/engine",
   "version": "8.5.2",
   "type": "module",
-  "description": "Portable, platform-agnostic engine for Relaycast — channels, threads, DMs, presence, real-time events. Runs on Node + SQLite (self-host) or behind a Cloudflare Durable Object adapter (hosted).",
+  "description": "Portable, platform-agnostic engine for Relaycast \u2014 channels, threads, DMs, presence, real-time events. Runs on Node + SQLite (self-host) or behind a Cloudflare Durable Object adapter (hosted).",
   "bin": {
     "relaycast-engine": "dist/bin/serve.js"
   },
@@ -60,7 +60,7 @@
   "dependencies": {
     "@hono/node-server": "^1.13.7",
     "@relaycast/a2a": "8.5.2",
-    "@relaycast/types": "8.5.2",
+    "@relaycast/types": "8.7.0",
     "better-sqlite3": "^11.10.0",
     "drizzle-orm": "^0.45.1",
     "hono": "^4.11.9",

--- a/packages/engine/src/__tests__/conformance/agentLifecycle.test.ts
+++ b/packages/engine/src/__tests__/conformance/agentLifecycle.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { and, eq } from 'drizzle-orm';
-import { actionInvocations, agentNodeBindings, agents, nodes, workspaceEvents } from '../../db/schema.js';
+import { actionInvocations, agentNodeBindings, agents, channelMembers, nodes, workspaceEvents } from '../../db/schema.js';
 import { AGENT_LIVENESS_TTL_MS, sweepStaleAgents } from '../../engine/agent.js';
 import {
   attachDirectNodeSocket,
@@ -16,6 +16,29 @@ describe('agent presence and release lifecycle', () => {
 
   beforeEach(() => { stack = makeNodeStack(); });
   afterEach(() => stack.close());
+
+  it('suppresses implicit membership by explicit registration contract and invalidates default membership cache', async () => {
+    const ws = await createWorkspace(stack.app, 'registration-isolation');
+    const readGeneral = async () => {
+      const response = await stack.app.request('/v1/channels/general', {
+        headers: { authorization: `Bearer ${ws.workspaceKey}` },
+      });
+      expect(response.status).toBe(200);
+      return (await response.json()).data;
+    };
+    await readGeneral(); // Prime the cache before registration.
+    const response = await stack.app.request('/v1/agents', {
+      method: 'POST', headers: { 'content-type': 'application/json', authorization: `Bearer ${ws.workspaceKey}` },
+      body: JSON.stringify({ name: 'isolated', auto_join_general: false }),
+    });
+    expect(response.status).toBe(201);
+    const isolated = (await response.json()).data;
+    expect(await stack.runtime.deps.db.select().from(channelMembers)
+      .where(eq(channelMembers.agentId, isolated.id))).toEqual([]);
+    const ordinary = await registerAgent(stack.app, ws.workspaceKey, 'ordinary');
+    expect((await readGeneral()).members.map((member: { agent_id: string }) => member.agent_id))
+      .toContain(ordinary.agentId);
+  });
 
   it('derives stale presence without writing during a roster read', async () => {
     const ws = await createWorkspace(stack.app, 'agent-presence-expiry');

--- a/packages/engine/src/__tests__/conformance/delivery.test.ts
+++ b/packages/engine/src/__tests__/conformance/delivery.test.ts
@@ -1901,6 +1901,46 @@ describe('durable delivery api', () => {
     ]);
   });
 
+  it('preserves hyphenated mentions through node reconnect replay', async () => {
+    const ws = await createWorkspace(stack.app, 'mention-replay');
+    const alice = await registerAgent(stack.app, ws.workspaceKey, 'alice');
+    const node = await enrollAndAttachNode(ws);
+    const bob = await registerViaNode(node, 'build-reviewer_2');
+    const response = await stack.app.request('/v1/channels/general/messages', {
+      method: 'POST', headers: { 'content-type': 'application/json', authorization: `Bearer ${alice.token}` },
+      body: JSON.stringify({ text: '@build-reviewer_2 ping @build-reviewer_2 email@example.com \\@escaped' }),
+    });
+    expect(response.status).toBe(201);
+    await stack.settle();
+    const live = latestDeliverOfType(node.sock, 'message.created');
+    expect(live.payload).toMatchObject({ data: { mentions: ['build-reviewer_2'] } });
+    await node.handle.handleClose();
+    const reconnected = await enrollAndAttachNode(ws, { id: node.id, name: node.name });
+    await reconnected.handle.handleMessage(JSON.stringify({ v: 1, type: 'inventory.sync',
+      agents: [{ agent_id: bob.agentId, name: 'build-reviewer_2', session_ref: 'sess-build-reviewer_2' }] }));
+    await stack.settle();
+    expect(latestDeliverOfType(reconnected.sock, 'message.created').payload).toEqual(live.payload);
+  });
+
+  it('normalizes a live raw-hook delivery for node recipients', async () => {
+    const ws = await createWorkspace(stack.app, 'raw-hook-wire');
+    const node = await enrollAndAttachNode(ws);
+    await registerViaNode(node, 'hook-recipient');
+    const created = await stack.app.request('/v1/webhooks', { method: 'POST',
+      headers: { 'content-type': 'application/json', authorization: `Bearer ${ws.workspaceKey}` },
+      body: JSON.stringify({ channel: 'general' }) });
+    expect(created.status).toBe(201);
+    const { data: hook } = await created.json();
+    const response = await stack.app.request(`/v1/hooks/${hook.webhook_id}`, { method: 'POST',
+      headers: { 'content-type': 'application/json', authorization: `Bearer ${hook.token}` },
+      body: JSON.stringify({ text: 'provider event', author: 'GitHub' }) });
+    expect(response.status).toBe(201);
+    await stack.settle();
+    expect(latestDeliverOfType(node.sock, 'message.created').payload).toMatchObject({
+      type: 'message.created', data: { channel_name: 'general', from_name: 'GitHub', text: 'provider event' },
+    });
+  });
+
   it('redelivers a DM with the same deliver payload after broker death/reconnect', async () => {
     const ws = await createWorkspace(stack.app, 'mailbox-node-redeliver-dm');
     const alice = await registerAgent(stack.app, ws.workspaceKey, 'alice');

--- a/packages/engine/src/__tests__/conformance/delivery.test.ts
+++ b/packages/engine/src/__tests__/conformance/delivery.test.ts
@@ -1925,7 +1925,7 @@ describe('durable delivery api', () => {
   it('normalizes a live raw-hook delivery for node recipients', async () => {
     const ws = await createWorkspace(stack.app, 'raw-hook-wire');
     const node = await enrollAndAttachNode(ws);
-    await registerViaNode(node, 'hook-recipient');
+    const recipient = await registerViaNode(node, 'hook-recipient');
     const created = await stack.app.request('/v1/webhooks', { method: 'POST',
       headers: { 'content-type': 'application/json', authorization: `Bearer ${ws.workspaceKey}` },
       body: JSON.stringify({ channel: 'general' }) });
@@ -1939,6 +1939,15 @@ describe('durable delivery api', () => {
     expect(latestDeliverOfType(node.sock, 'message.created').payload).toMatchObject({
       type: 'message.created', data: { channel_name: 'general', from_name: 'GitHub', text: 'provider event' },
     });
+    await node.handle.handleClose();
+    const reconnected = await enrollAndAttachNode(ws, { id: node.id, name: node.name });
+    await reconnected.handle.handleMessage(JSON.stringify({ v: 1, type: 'inventory.sync',
+      agents: [{ agent_id: recipient.agentId, name: 'hook-recipient', session_ref: 'sess-hook-recipient' }] }));
+    await stack.settle();
+    expect(latestDeliverOfType(reconnected.sock, 'message.created').payload).toMatchObject({
+      type: 'message.created', data: { channel_name: 'general', from_name: 'GitHub', text: 'provider event' },
+    });
+
   });
 
   it('redelivers a DM with the same deliver payload after broker death/reconnect', async () => {

--- a/packages/engine/src/__tests__/conformance/hyphenatedMentions.test.ts
+++ b/packages/engine/src/__tests__/conformance/hyphenatedMentions.test.ts
@@ -1,0 +1,48 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { makeNodeStack, createWorkspace, registerAgent, type TestStack } from './harness.js';
+
+describe('exact mention delivery', () => {
+  let stack: TestStack;
+  beforeEach(() => { stack = makeNodeStack(); });
+  afterEach(async () => { await stack.close(); });
+
+  it.each(['channel', 'thread'])('wakes the full muted handle once on %s, never its prefix or a nonmember', async (kind) => {
+    const ws = await createWorkspace(stack.app, 'mention-scope');
+    const sender = await registerAgent(stack.app, ws.workspaceKey, 'sender');
+    const target = await registerAgent(stack.app, ws.workspaceKey, 'gh-proof_alpha-0908');
+    const prefix = await registerAgent(stack.app, ws.workspaceKey, 'gh');
+    const outside = await registerAgent(stack.app, ws.workspaceKey, 'gh-proof-outside');
+    const request = (path: string, token: string, body?: unknown) => stack.app.request(path, {
+      method: 'POST', headers: { authorization: `Bearer ${token}`, 'content-type': 'application/json' },
+      ...(body === undefined ? {} : { body: JSON.stringify(body) }),
+    });
+    expect((await request('/v1/channels', sender.token, { name: 'scoped' })).status).toBe(201);
+    for (const agent of [target, prefix]) {
+      expect((await request('/v1/channels/scoped/join', agent.token)).status).toBeLessThan(300);
+      expect((await request('/v1/channels/scoped/mute', agent.token)).status).toBeLessThan(300);
+    }
+    let endpoint = '/v1/channels/scoped/messages';
+    if (kind === 'thread') {
+      const parent = await request(endpoint, sender.token, { text: 'thread root' });
+      endpoint = '/v1/messages/' + (await parent.json()).data.id + '/replies';
+    }
+    const post = await request(endpoint, sender.token, {
+      text: '@gh-proof_alpha-0908 @gh-proof_alpha-0908 @gh-proof-outside \\@gh sender@gh',
+    });
+    expect(post.status).toBe(201);
+    const body = await post.json() as { data: { id: string; mentions: string[] } };
+    if (kind === 'channel') expect(body.data.mentions).toEqual(['gh-proof_alpha-0908', 'gh-proof-outside']);
+    for (const [agent, count] of [[target, 1], [prefix, 0], [outside, 0]] as const) {
+      const response = await stack.app.request('/v1/deliveries', { headers: { authorization: `Bearer ${agent.token}` } });
+      expect(response.status).toBe(200);
+      const data = await response.json() as { data: Array<{ message_id: string; reason: string }> };
+      const matching = data.data.filter(row => row.message_id === body.data.id);
+      expect(matching).toHaveLength(count);
+      if (count) expect(matching[0].reason).toBe('mention');
+    }
+    const foreignWorkspace = await createWorkspace(stack.app, 'foreign');
+    const foreign = await registerAgent(stack.app, foreignWorkspace.workspaceKey, 'foreign');
+    const unauthorized = await request('/v1/channels/scoped/messages', foreign.token, { text: '@gh-proof_alpha-0908' });
+    expect(unauthorized.status).toBe(404);
+  });
+});

--- a/packages/engine/src/__tests__/conformance/integrationBackpressure.test.ts
+++ b/packages/engine/src/__tests__/conformance/integrationBackpressure.test.ts
@@ -1,0 +1,92 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { eq } from 'drizzle-orm';
+import { makeNodeStack, createWorkspace, registerAgent, type TestStack } from './harness.js';
+import { triggerIntegrationMessage } from '../../engine/inboundWebhook.js';
+import { messages } from '../../db/schema.js';
+
+describe('integration delivery backpressure and join freshness', () => {
+  let stack: TestStack;
+  beforeEach(() => { stack = makeNodeStack(); });
+  afterEach(async () => { await stack.close(); });
+  it('rejects a full mailbox atomically, keeps unique events retryable, and never replays pre-join events', async () => {
+    const ws = await createWorkspace(stack.app, 'backpressure');
+    const busy = await registerAgent(stack.app, ws.workspaceKey, 'busy');
+    const post = (path: string, token: string, body?: unknown) => stack.app.request(path, {
+      method: 'POST', headers: { authorization: `Bearer ${token}`, 'content-type': 'application/json' },
+      ...(body ? { body: JSON.stringify(body) } : {}),
+    });
+    const response = await post('/v1/channels', busy.token, { name: 'events' });
+    const { data: channel } = await response.json();
+    const db = stack.runtime.handle.db;
+    const emit = (text: string) => triggerIntegrationMessage(db, ws.workspaceId, channel.id,
+      { text, source: 'github', author: 'GitHub' }, { mailbox: { ttlMs: 60_000, depthCap: 1 } });
+    const first = await emit('unique-first');
+    const late = await registerAgent(stack.app, ws.workspaceKey, 'late');
+    await post('/v1/channels/events/join', late.token);
+    await expect(emit('unique-second')).rejects.toMatchObject({ code: 'mailbox_full', status: 503 });
+    expect(await db.select().from(messages).where(eq(messages.channelId, channel.id))).toHaveLength(1);
+    const list = async (token: string) => (await (await stack.app.request('/v1/deliveries', { headers: { authorization: `Bearer ${token}` } })).json()).data;
+    expect(await list(late.token)).toHaveLength(0);
+    const queued = await list(busy.token);
+    expect(queued.map((d: { message_id: string }) => d.message_id)).toEqual([first.message_id]);
+    expect((await post(`/v1/deliveries/${queued[0].id}/ack`, busy.token)).status).toBe(200);
+    const retried = await emit('unique-second');
+    expect((await list(late.token)).map((d: { message_id: string }) => d.message_id)).toEqual([retried.message_id]);
+    expect((await list(busy.token)).map((d: { message_id: string }) => d.message_id)).toEqual([retried.message_id]);
+  });
+  it('bounds concurrent unique events and preserves every rejected event for retry', async () => {
+    const ws = await createWorkspace(stack.app, 'concurrent-backpressure');
+    const busy = await registerAgent(stack.app, ws.workspaceKey, 'busy-burst');
+    const headers = { authorization: `Bearer ${busy.token}`, 'content-type': 'application/json' };
+    const ch = await stack.app.request('/v1/channels', { method: 'POST', headers, body: JSON.stringify({ name: 'burst' }) });
+    const { data: channel } = await ch.json();
+    const db = stack.runtime.handle.db;
+    const emit = (text: string) => triggerIntegrationMessage(db, ws.workspaceId, channel.id,
+      { text, source: 'github', author: 'GitHub' }, { mailbox: { ttlMs: 60_000, depthCap: 2 } });
+    const events = Array.from({length: 8}, (_, i) => `unique-${i}`);
+    const burst = await Promise.allSettled(events.map(emit));
+    expect(burst.filter(r => r.status === 'fulfilled')).toHaveLength(2);
+    const rejected = burst.flatMap((r, i) => {
+      if (r.status === 'fulfilled') return [];
+      expect(r.reason).toMatchObject({ code: 'mailbox_full', status: 503 });
+      return [events[i]];
+    });
+    for (const text of rejected) {
+      const inbox = await stack.app.request('/v1/deliveries', { headers });
+      for (const delivery of (await inbox.json()).data) {
+        expect((await stack.app.request(`/v1/deliveries/${delivery.id}/ack`, { method: 'POST', headers })).status).toBe(200);
+      }
+      await emit(text);
+    }
+    const stored = await db.select().from(messages).where(eq(messages.channelId, channel.id));
+    expect(stored.map(m => m.body).sort()).toEqual(events.sort());
+  });
+
+  it('raw HTTP hooks reject overflow without storing a partial message and accept the retry', async () => {
+    await stack.close();
+    stack = makeNodeStack({ mailbox: { depthCap: 1 } });
+    const ws = await createWorkspace(stack.app, 'raw-backpressure');
+    const busy = await registerAgent(stack.app, ws.workspaceKey, 'raw-busy');
+    const post = (path: string, token: string, body?: unknown) => stack.app.request(path, {
+      method: 'POST', headers: { authorization: `Bearer ${token}`, 'content-type': 'application/json' },
+      ...(body ? { body: JSON.stringify(body) } : {}),
+    });
+    await post('/v1/channels', busy.token, { name: 'raw-events' });
+    const created = await post('/v1/webhooks', ws.workspaceKey, { channel: 'raw-events' });
+    expect(created.status).toBe(201);
+    const { data: hook } = await created.json();
+    const emit = (text: string) => post(`/v1/hooks/${hook.webhook_id}`, hook.token, { text });
+    expect((await emit('raw-first')).status).toBe(201);
+    const overflow = await emit('raw-second');
+    expect(overflow.status).toBe(503);
+    expect(overflow.headers.get('Retry-After')).toBe('30');
+    expect(await overflow.json()).toMatchObject({ error: { code: 'mailbox_full' } });
+    const stored = await stack.runtime.handle.db.select().from(messages).where(eq(messages.workspaceId, ws.workspaceId));
+    expect(stored.map(m => m.body)).toEqual(['raw-first']);
+    const inbox = await stack.app.request('/v1/deliveries', { headers: { authorization: `Bearer ${busy.token}` } });
+    const { data: deliveries } = await inbox.json();
+    expect((await post(`/v1/deliveries/${deliveries[0].id}/ack`, busy.token)).status).toBe(200);
+    expect((await emit('raw-second')).status).toBe(201);
+  });
+
+});

--- a/packages/engine/src/__tests__/conformance/node.test.ts
+++ b/packages/engine/src/__tests__/conformance/node.test.ts
@@ -510,6 +510,62 @@ describe('node adapter conformance', () => {
       return { sock, handle };
     }
 
+    it('an explicit spawn target is not shadowed by a legacy global node alias', async () => {
+      const ws = await createWorkspace(stack.app, 'explicit-spawn-target');
+      const caller = await registerAgent(stack.app, ws.workspaceKey, 'caller');
+      const alpha = await enrollAndAttachNode(ws, { id: 'node_alpha', name: 'alpha', capabilities: [capability('spawn:claude', 'spawn', { agent: 'claude' })], load: 0 });
+      const beta = await enrollAndAttachNode(ws, { id: 'node_beta', name: 'beta', capabilities: [capability('spawn:claude', 'spawn', { agent: 'claude' })], load: 0 });
+      await stack.runtime.handle.db.insert(actions).values({
+        id: 'legacy-spawn', workspaceId: ws.workspaceId, name: 'spawn', description: 'Legacy global broker alias',
+        handlerNodeId: 'node_alpha', isGlobal: true, availableTo: ['caller'],
+      });
+      const spawn = await stack.app.request('/v1/actions/spawn/invoke', {
+        method: 'POST', headers: { 'content-type': 'application/json', authorization: `Bearer ${caller.token}` },
+        body: JSON.stringify({ input: { cli: 'claude', name: 'fresh-worker', target_node: 'beta', verify_ready: true } }),
+      });
+      expect(spawn.status).toBe(201);
+      const { data } = await spawn.json();
+      expect(data.handler_node_id).toBe('node_beta');
+      await stack.settle();
+      expect(beta.sock.ofType('action.invoke')).toHaveLength(1);
+      expect(alpha.sock.ofType('action.invoke')).toHaveLength(0);
+      const handlerSpawn = await stack.app.request('/v1/actions/spawn/invoke', {
+        method: 'POST', headers: { 'content-type': 'application/json', authorization: `Bearer ${caller.token}` },
+        body: JSON.stringify({ input: { cli: 'claude', name: 'handler-worker', verify_ready: true } }),
+      });
+      expect(handlerSpawn.status).toBe(201);
+      expect((await handlerSpawn.json()).data.handler_node_id).toBe('node_alpha');
+      await stack.settle();
+      expect(alpha.sock.ofType('action.invoke')).toHaveLength(1);
+      for (const target_node of ['', '   ']) {
+        const legacy = await stack.app.request('/v1/actions/spawn/invoke', {
+          method: 'POST', headers: { 'content-type': 'application/json', authorization: `Bearer ${caller.token}` },
+          body: JSON.stringify({ input: { cli: 'claude', name: 'legacy-empty-' + target_node.length, target_node } }),
+        });
+        expect(legacy.status).toBe(201);
+        const invocation = (await legacy.json()).data;
+        expect(invocation.handler_node_id).toBe('node_alpha');
+        const [stored] = await stack.runtime.handle.db.select().from(actionInvocations).where(eq(actionInvocations.id, invocation.invocation_id));
+        expect(stored.actionId).toBe('legacy-spawn');
+      }
+      const outsider = await registerAgent(stack.app, ws.workspaceKey, 'outsider');
+      const denied = await stack.app.request('/v1/actions/spawn/invoke', {
+        method: 'POST', headers: { 'content-type': 'application/json', authorization: `Bearer ${outsider.token}` },
+        body: JSON.stringify({ input: { cli: 'claude', name: 'forbidden', target_node: 'beta' } }),
+      });
+      expect(denied.status).toBe(403);
+      await beta.handle.handleClose();
+      const unavailable = await stack.app.request('/v1/actions/spawn/invoke', {
+        method: 'POST', headers: { 'content-type': 'application/json', authorization: `Bearer ${caller.token}` },
+        body: JSON.stringify({ input: { cli: 'claude', name: 'offline-worker', target_node: 'beta', verify_ready: true } }),
+      });
+      expect(unavailable.status).toBe(503);
+      expect(await unavailable.json()).toMatchObject({ error: { code: 'spawn_target_unavailable' } });
+      const claims = await stack.runtime.handle.db.select().from(actionInvocations).where(eq(actionInvocations.workspaceId, ws.workspaceId));
+      expect(claims.find(row => (row.input as {name?: string})?.name === 'offline-worker')?.status).toBe('failed');
+
+    }, 20_000);
+
     it('reports placeholder load as unavailable until a finite node explicitly marks it measured', async () => {
       const ws = await createWorkspace(stack.app, 'fleet-unreported-load-ws');
       const unbounded = await enrollAndAttachNode(ws, {
@@ -812,6 +868,9 @@ describe('node adapter conformance', () => {
         id: 'control-agent-deregister',
         type: 'agent.deregister',
         agent_id: controlAgentId,
+      });
+      expect(brokerSock.ofType('reply').at(-1)).toMatchObject({
+        id: 'control-agent-deregister', ok: true, data: { deregistered: true },
       });
       const activeBindingsAfterDeregister = await db
         .select({ id: agentNodeBindings.id })

--- a/packages/engine/src/__tests__/conformance/nodeControlExports.test.ts
+++ b/packages/engine/src/__tests__/conformance/nodeControlExports.test.ts
@@ -1,8 +1,9 @@
+import { recoverAgentViaNode, registerAgentViaNode } from '../../engine/node.js';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { and, eq } from 'drizzle-orm';
 import { handleProviderDisconnect, markNodeOffline } from '../../node-control.js';
-import { makeNodeStack, createWorkspace, FakeSocket, type TestStack } from './harness.js';
-import { nodeProviders, nodes } from '../../db/schema.js';
+import { makeNodeStack, createWorkspace, registerAgent, FakeSocket, type TestStack } from './harness.js';
+import { actionInvocations, channelMembers, nodeProviders, nodes } from '../../db/schema.js';
 
 // The provider-disconnect lifecycle is exported from @relaycast/engine/node-control
 // so an out-of-process socket owner — the relaycast-cloud NodeDO — drives it on
@@ -35,6 +36,7 @@ describe('node-control provider-disconnect exports', () => {
     capability: string,
     activeAgents = 0,
     instanceId = `${providerName}-i1`,
+    kind: 'action' | 'capacity' = 'action',
   ) {
     const provider = { name: providerName, instance_id: instanceId };
     const sock = new FakeSocket();
@@ -46,7 +48,7 @@ describe('node-control provider-disconnect exports', () => {
       name: nodeName,
       node_id: nodeId,
       provider,
-      capabilities: [{ name: capability, kind: 'action' }],
+      capabilities: [{ name: capability, kind }],
       max_agents: 4,
       tags: ['test'],
       version: 'v1',
@@ -71,6 +73,93 @@ describe('node-control provider-disconnect exports', () => {
       handlers_live: true,
     }));
   }
+
+  it('node registration opts out of general and invalidates the cache for default joins', async () => {
+    const ws = await createWorkspace(stack.app, 'node-registration-isolation');
+    await enrollNode(ws, 'node-isolation', 'isolation');
+    await attachProvider(ws.workspaceId, 'node-isolation', 'isolation', 'broker', 'spawn');
+    const readGeneral = async () => {
+      const response = await stack.app.request('/v1/channels/general', {
+        headers: { authorization: `Bearer ${ws.workspaceKey}` },
+      });
+      expect(response.status).toBe(200);
+      return (await response.json()).data;
+    };
+    await readGeneral();
+    const isolated = await registerAgentViaNode(db(), ws.workspaceId, 'node-isolation', 'broker', {
+      v: 1, type: 'agent.register', name: 'isolated-node-agent', auto_join_general: false,
+    });
+    expect(await db().select().from(channelMembers).where(eq(channelMembers.agentId, isolated.agent_id))).toEqual([]);
+    await recoverAgentViaNode(db(), ws.workspaceId, 'node-isolation', 'broker', {
+      v: 1, type: 'agent.recover', name: isolated.name, expected_agent_id: isolated.agent_id,
+    });
+    expect(await db().select().from(channelMembers).where(eq(channelMembers.agentId, isolated.agent_id))).toEqual([]);
+    const ordinary = await registerAgentViaNode(db(), ws.workspaceId, 'node-isolation', 'broker', {
+      v: 1, type: 'agent.register', name: 'ordinary-node-agent',
+    });
+    expect((await readGeneral()).members.map((member: { agent_id: string }) => member.agent_id))
+      .toContain(ordinary.agent_id);
+  });
+
+  it.each([
+    [{ verify_ready: true }, true],
+    [{ verify_ready: false }, false],
+    [{ verifyReady: true }, false],
+    [{ agent: { verify_ready: true } }, false],
+    [{ harness_config: { metadata: { verify_ready: true } } }, false],
+  ])('inventory follows the canonical readiness input: %j', async (readinessInput, verified) => {
+    const ws = await createWorkspace(stack.app, `inventory-readiness-${verified}`);
+    const caller = await registerAgent(stack.app, ws.workspaceKey, 'caller');
+    await enrollNode(ws, 'node-ready', 'ready');
+    const provider = await attachProvider(ws.workspaceId, 'node-ready', 'ready', 'broker', 'spawn:claude');
+    const response = await stack.app.request('/v1/actions/spawn/invoke', {
+      method: 'POST', headers: { 'content-type': 'application/json', authorization: `Bearer ${caller.token}` },
+      body: JSON.stringify({ input: { name: 'worker', cli: 'claude', ...readinessInput } }),
+    });
+    expect(response.status).toBe(201);
+    const invocationId = (await response.json()).data.invocation_id;
+    const agent = await registerAgentViaNode(db(), ws.workspaceId, 'node-ready', 'broker', {
+      v: 1, type: 'agent.register', name: 'worker', invocation_id: invocationId, auto_join_general: false,
+    });
+    await provider.handle.handleMessage(JSON.stringify({
+      v: 1, id: 'inventory', type: 'inventory.sync',
+      agents: [{ agent_id: agent.agent_id, name: agent.name, invocation_id: invocationId, session_ref: 'not-readiness' }],
+    }));
+    expect(provider.sock.ofType('reply').find((frame) => frame.id === 'inventory')).toMatchObject({ ok: true });
+    const [invocation] = await db().select().from(actionInvocations).where(eq(actionInvocations.id, invocationId));
+    expect(invocation.status).toBe(verified ? 'dispatched' : 'completed');
+    if (verified) {
+      await provider.handle.handleMessage(JSON.stringify({ v: 1, id: 'empty-during-cleanup', type: 'inventory.sync', agents: [] }));
+      const [pending] = await db().select().from(actionInvocations).where(eq(actionInvocations.id, invocationId));
+      expect(pending.status).toBe('dispatched');
+      await provider.handle.handleMessage(JSON.stringify({ v: 1, type: 'action.result', invocation_id: invocationId,
+        output: { spawned: true, ready: true, name: agent.name } }));
+      const [finished] = await db().select().from(actionInvocations).where(eq(actionInvocations.id, invocationId));
+      expect(finished.status).toBe('completed');
+      expect(finished.output).toMatchObject({ spawned: true, ready: true });
+    }
+  });
+
+  it.each(['not-live', 'stale'])('verified native spawn checks its own provider: %s', async (state) => {
+    const ws = await createWorkspace(stack.app, 'provider-readiness-' + state);
+    const caller = await registerAgent(stack.app, ws.workspaceKey, 'caller');
+    await enrollNode(ws, 'multi-provider-node', 'multi');
+    const spawn = await attachProvider(ws.workspaceId, 'multi-provider-node', 'multi', 'broker', 'spawn:claude', 0, 'broker-i1', 'capacity');
+    await attachProvider(ws.workspaceId, 'multi-provider-node', 'multi', 'other', 'ping');
+    await db().update(nodeProviders).set(state === 'stale'
+      ? { lastHeartbeatAt: new Date(Date.now() - 300_000) }
+      : { handlersLive: false })
+      .where(and(eq(nodeProviders.nodeId, 'multi-provider-node'), eq(nodeProviders.name, 'broker')));
+    const [aggregate] = await db().select().from(nodes).where(eq(nodes.id, 'multi-provider-node'));
+    expect(aggregate.handlersLive).toBe(true);
+    const response = await stack.app.request('/v1/actions/spawn/invoke', {
+      method: 'POST', headers: { 'content-type': 'application/json', authorization: `Bearer ${caller.token}` },
+      body: JSON.stringify({ input: { name: 'worker', cli: 'claude', target_node: 'multi', verify_ready: true } }),
+    });
+    expect(response.status).toBe(503);
+    expect((await response.json()).error.code).toBe('spawn_target_unavailable');
+    expect(spawn.sock.ofType('action.invoke')).toHaveLength(0);
+  });
 
   function nodeActiveAgents(workspaceId: string, nodeId: string) {
     return db()

--- a/packages/engine/src/__tests__/conformance/nodeProviders.test.ts
+++ b/packages/engine/src/__tests__/conformance/nodeProviders.test.ts
@@ -38,7 +38,39 @@ describe('node providers', () => {
       body: JSON.stringify({ node_id: nodeId, name, role: 'broker', capabilities: [], max_agents: 4, tags: ['test'], version: 'v0' }),
     });
     expect(res.status).toBe(201);
+    return (await res.json() as { data: { token: string } }).data.token;
   }
+
+  it('allows node-owned spawn status reads without exposing other invocations or mutation authority', async () => {
+    const ws = await createWorkspace(stack.app, 'np-spawn-status');
+    const foreign = await createWorkspace(stack.app, 'np-spawn-status-foreign');
+    const token = await enrollNode(ws, 'node_a', 'alpha');
+    await enrollNode(ws, 'node_b', 'beta');
+    const caller = await registerAgent(stack.app, ws.workspaceKey, 'caller');
+    await stack.runtime.handle.db.insert(actionInvocations).values([
+      { id: 'own-spawn', workspaceId: ws.workspaceId, actionName: 'spawn', dispatchedNodeId: 'node_a', status: 'completed', output: { spawned: true, ready: true } },
+      { id: 'other-node', workspaceId: ws.workspaceId, actionName: 'spawn', dispatchedNodeId: 'node_b', status: 'failed', error: 'private failure' },
+      { id: 'other-action', workspaceId: ws.workspaceId, actionName: 'deploy', dispatchedNodeId: 'node_a', status: 'completed' },
+      { id: 'unassigned', workspaceId: ws.workspaceId, actionName: 'spawn', status: 'pending' },
+      { id: 'foreign', workspaceId: foreign.workspaceId, actionName: 'spawn', status: 'pending' },
+    ]);
+    const get = (name: string, id: string, credential = token) => stack.app.request(`/v1/actions/${name}/invocations/${id}`, {
+      headers: { authorization: `Bearer ${credential}` },
+    });
+    const own = await get('spawn', 'own-spawn');
+    expect(own.status).toBe(200);
+    expect(await own.json()).toMatchObject({ data: { status: 'completed', output: { spawned: true, ready: true } } });
+    for (const [name, id] of [['spawn', 'other-node'], ['deploy', 'other-action'], ['spawn', 'unassigned'], ['spawn', 'foreign']]) {
+      expect((await get(name, id)).status).toBe(404);
+    }
+    expect((await get('spawn', 'other-node', ws.workspaceKey)).status).toBe(200);
+    expect((await get('spawn', 'other-node', caller.token)).status).toBe(200);
+    const mutation = await stack.app.request('/v1/actions/spawn/invocations/own-spawn/complete', {
+      method: 'POST', headers: { authorization: `Bearer ${token}`, 'content-type': 'application/json' },
+      body: JSON.stringify({ output: { ready: false } }),
+    });
+    expect(mutation.status).toBe(401);
+  });
 
   function attachSocket(workspaceId: string, nodeId: string) {
     const sock = new FakeSocket();

--- a/packages/engine/src/__tests__/conformance/subscriptionChannel.test.ts
+++ b/packages/engine/src/__tests__/conformance/subscriptionChannel.test.ts
@@ -1,0 +1,143 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { channelMembers, channels } from '../../db/schema.js';
+import { generateId } from '../../engine/snowflake.js';
+import { deleteAgent } from '../../engine/agent.js';
+import { createChannel, getChannel, joinChannel, ensureAgentSubscriptionChannel } from '../../engine/channel.js';
+import type { EngineDb, TransactionCapability } from '../../ports/database.js';
+import { makeNodeStack, createWorkspace, registerAgent, type TestStack } from './harness.js';
+
+describe('agent subscription channels', () => {
+  let stack: TestStack;
+  beforeEach(() => { stack = makeNodeStack(); });
+  afterEach(async () => { await stack.close(); });
+  it('provisions an idempotent exact recipient route and rejects membership widening', async () => {
+    const ws = await createWorkspace(stack.app, 'targeting');
+    const target = await registerAgent(stack.app, ws.workspaceKey, 'target-hyphen');
+    const other = await registerAgent(stack.app, ws.workspaceKey, 'target');
+    const post = (path: string, token: string, body?: unknown) => stack.app.request(path, {
+      method: 'POST', headers: { authorization: `Bearer ${token}`, 'content-type': 'application/json' },
+      ...(body === undefined ? {} : { body: JSON.stringify(body) }),
+    });
+    const endpoint = '/v1/agents/target-hyphen/subscription-channel';
+    expect((await post(endpoint, other.token)).status).toBe(401);
+    const response = await post(endpoint, ws.workspaceKey);
+    expect(response.status).toBe(200);
+    const { data: route } = await response.json() as { data: { name: string; members: Array<{ agent_name: string }> } };
+    expect(route.members.map(m => m.agent_name)).toEqual(['target-hyphen']);
+    expect((await (await post(endpoint, ws.workspaceKey)).json()).data.name).toBe(route.name);
+    expect((await post(`/v1/channels/${route.name}/join`, other.token)).status).toBe(403);
+    expect((await post(`/v1/channels/${route.name}/invite`, target.token, { agent_name: 'target' })).status).toBe(403);
+    const hook = await post('/v1/webhooks', ws.workspaceKey, { channel: route.name });
+    expect(hook.status).toBe(201);
+    const { data: webhook } = await hook.json();
+    const sent = await post(`/v1/hooks/${webhook.webhook_id}`, webhook.token, { text: 'event-only-fixture' });
+    expect(sent.status).toBe(201);
+    const { data: message } = await sent.json();
+    for (const [agent, count] of [[target, 1], [other, 0]] as const) {
+      const deliveries = await stack.app.request('/v1/deliveries', { headers: { authorization: `Bearer ${agent.token}` } });
+      const { data } = await deliveries.json();
+      expect(data.filter((d: {message_id: string}) => d.message_id === message.message_id)).toHaveLength(count);
+    }
+    await post(`/v1/channels/${route.name}/leave`, target.token);
+    expect((await (await post(endpoint, ws.workspaceKey)).json()).data.members).toHaveLength(1);
+  });
+  it('fails setup when release wins before the conditional membership insert', async () => {
+    const ws = await createWorkspace(stack.app, 'release-during-ensure');
+    await registerAgent(stack.app, ws.workspaceKey, 'racing-recipient');
+    const db = stack.runtime.handle.db;
+    const original = db.run.bind(db);
+    const hook = vi.spyOn(db, 'run').mockImplementationOnce(async (query) => {
+      await deleteAgent(db, ws.workspaceId, 'racing-recipient');
+      return original(query);
+    });
+    try {
+      await expect(ensureAgentSubscriptionChannel(db, ws.workspaceId, 'racing-recipient')).rejects.toMatchObject({ code: 'agent_not_found' });
+    } finally { hook.mockRestore(); }
+  });
+
+  it('never transfers a deleted identity subscription to a recreated name', async () => {
+    const ws = await createWorkspace(stack.app, 'target-lifecycle');
+    await registerAgent(stack.app, ws.workspaceKey, 'recreated-worker');
+    const request = (path: string, method = 'POST', body?: unknown) => stack.app.request(path, {
+      method, headers: { authorization: `Bearer ${ws.workspaceKey}`, 'content-type': 'application/json' },
+      ...(body === undefined ? {} : { body: JSON.stringify(body) }),
+    });
+    const endpoint = '/v1/agents/recreated-worker/subscription-channel';
+    const old = (await (await request(endpoint)).json()).data;
+    expect((await request('/v1/agents/recreated-worker', 'DELETE')).status).toBe(204);
+    expect((await request(endpoint)).status).toBe(404);
+    await registerAgent(stack.app, ws.workspaceKey, 'recreated-worker');
+    const current = (await (await request(endpoint)).json()).data;
+    expect(current.name).not.toBe(old.name);
+    expect(current.members.map((m: { agent_name: string }) => m.agent_name)).toEqual(['recreated-worker']);
+    const oldChannel = (await (await request(`/v1/channels/${old.name}`, 'GET')).json()).data;
+    expect(oldChannel.members).toHaveLength(0);
+    expect((await request(`/v1/channels/${current.name}`, 'PATCH', { metadata: { subscription_agent_id: 'another' } })).status).toBe(403);
+  });
+
+  it('reads live membership after a lifecycle release without a host node', async () => {
+    const ws = await createWorkspace(stack.app, 'target-release');
+    await registerAgent(stack.app, ws.workspaceKey, 'released-worker');
+    const headers = { authorization: `Bearer ${ws.workspaceKey}`, 'content-type': 'application/json' };
+    const route = await stack.app.request('/v1/agents/released-worker/subscription-channel', { method: 'POST', headers });
+    const { data: channel } = await route.json();
+    expect(channel.members).toHaveLength(1);
+    const release = await stack.app.request('/v1/agents/release', { method: 'POST', headers,
+      body: JSON.stringify({ name: 'released-worker', delete_agent: true, reason: 'owned process stopped' }) });
+    expect(release.status).toBe(201);
+    const after = await stack.app.request(`/v1/channels/${channel.name}`, { headers });
+    expect((await after.json()).data.members).toHaveLength(0);
+  });
+
+  it('rejects a legacy reserved channel containing a non-recipient without adopting it', async () => {
+    const ws = await createWorkspace(stack.app, 'legacy-route');
+    const target = await registerAgent(stack.app, ws.workspaceKey, 'legacy-target');
+    const other = await registerAgent(stack.app, ws.workspaceKey, 'legacy-other');
+    const db = stack.runtime.deps.db;
+    const channelId = generateId();
+    await db.insert(channels).values({ id: channelId, workspaceId: ws.workspaceId,
+      name: `agent-events-${target.agentId}`, metadata: { subscription_agent_id: target.agentId } });
+    await db.insert(channelMembers).values({ channelId, agentId: other.agentId, role: 'member' });
+    const response = await stack.app.request('/v1/agents/legacy-target/subscription-channel', {
+      method: 'POST', headers: { authorization: `Bearer ${ws.workspaceKey}` },
+    });
+    expect(response.status).toBe(409);
+    expect((await getChannel(db, ws.workspaceId, `agent-events-${target.agentId}`)).members.map(m => m.agent_id)).toEqual([other.agentId]);
+  });
+
+  it.each([null, 'invalid', 7, [], {}, { subscription_agent_id: 7 },
+    { subscription_agent_id: '' }, { subscription_agent_id: 'another-agent' }])(
+    'rejects malformed or mismatched legacy subscription metadata: %j', async (metadata) => {
+      const ws = await createWorkspace(stack.app, 'invalid-route');
+      const target = await registerAgent(stack.app, ws.workspaceKey, 'metadata-target');
+      const db = stack.runtime.deps.db;
+      const channelId = generateId();
+      await db.insert(channels).values({ id: channelId, workspaceId: ws.workspaceId,
+        name: `agent-events-${target.agentId}`, metadata });
+      const response = await stack.app.request('/v1/agents/metadata-target/subscription-channel', {
+        method: 'POST', headers: { authorization: `Bearer ${ws.workspaceKey}` },
+      });
+      expect(response.status).toBe(403);
+      expect((await response.json()).error.code).toBe('subscription_recipient_only');
+      expect((await getChannel(db, ws.workspaceId, `agent-events-${target.agentId}`)).members).toHaveLength(0);
+    },
+  );
+
+  it('invalidates a membership cached after release preflight but before its transaction', async () => {
+    const ws = await createWorkspace(stack.app, 'release-late-join');
+    const target = await registerAgent(stack.app, ws.workspaceKey, 'late-target');
+    const db = stack.runtime.deps.db as EngineDb & TransactionCapability;
+    await createChannel(db, ws.workspaceId, { name: 'late-channel' });
+    const original = db.withTransaction.bind(db);
+    const hook = vi.spyOn(db, 'withTransaction').mockImplementationOnce(async (fn) => {
+      await joinChannel(db, ws.workspaceId, 'late-channel', target.agentId);
+      expect((await getChannel(db, ws.workspaceId, 'late-channel')).members.map(m => m.agent_id)).toContain(target.agentId);
+      return original(fn);
+    });
+    try {
+      expect(await deleteAgent(db, ws.workspaceId, 'late-target')).toBe(true);
+      expect((await getChannel(db, ws.workspaceId, 'late-channel')).members).toHaveLength(0);
+    } finally { hook.mockRestore(); }
+  });
+
+});

--- a/packages/engine/src/__tests__/conformance/subscriptionChannel.test.ts
+++ b/packages/engine/src/__tests__/conformance/subscriptionChannel.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { channelMembers, channels } from '../../db/schema.js';
 import { generateId } from '../../engine/snowflake.js';
 import { deleteAgent } from '../../engine/agent.js';
-import { createChannel, getChannel, joinChannel, ensureAgentSubscriptionChannel } from '../../engine/channel.js';
+import { createChannel, getChannel, joinChannel, leaveChannel, ensureAgentSubscriptionChannel } from '../../engine/channel.js';
 import type { EngineDb, TransactionCapability } from '../../ports/database.js';
 import { makeNodeStack, createWorkspace, registerAgent, type TestStack } from './harness.js';
 
@@ -52,6 +52,33 @@ describe('agent subscription channels', () => {
     });
     try {
       await expect(ensureAgentSubscriptionChannel(db, ws.workspaceId, 'racing-recipient')).rejects.toMatchObject({ code: 'agent_not_found' });
+    } finally { hook.mockRestore(); }
+  });
+
+  it('rejects a released recipient joining its old subscription channel', async () => {
+    const ws = await createWorkspace(stack.app, 'released-join');
+    const target = await registerAgent(stack.app, ws.workspaceKey, 'released-join-target');
+    const db = stack.runtime.deps.db;
+    const channel = await ensureAgentSubscriptionChannel(db, ws.workspaceId, 'released-join-target');
+    await deleteAgent(db, ws.workspaceId, 'released-join-target');
+    await expect(joinChannel(db, ws.workspaceId, channel.name, target.agentId)).rejects.toMatchObject({ code: 'agent_not_found' });
+    expect((await getChannel(db, ws.workspaceId, channel.name)).members).toHaveLength(0);
+  });
+
+  it('prevents release racing a subscription join from recreating membership', async () => {
+    const ws = await createWorkspace(stack.app, 'release-racing-join');
+    const target = await registerAgent(stack.app, ws.workspaceKey, 'racing-join-target');
+    const db = stack.runtime.deps.db;
+    const channel = await ensureAgentSubscriptionChannel(db, ws.workspaceId, 'racing-join-target');
+    await leaveChannel(db, ws.workspaceId, channel.name, target.agentId);
+    const original = db.run.bind(db);
+    const hook = vi.spyOn(db, 'run').mockImplementationOnce(async query => {
+      await deleteAgent(db, ws.workspaceId, 'racing-join-target');
+      return original(query);
+    });
+    try {
+      await expect(joinChannel(db, ws.workspaceId, channel.name, target.agentId)).rejects.toMatchObject({ code: 'agent_not_found' });
+      expect((await getChannel(db, ws.workspaceId, channel.name)).members).toHaveLength(0);
     } finally { hook.mockRestore(); }
   });
 

--- a/packages/engine/src/engine/action.ts
+++ b/packages/engine/src/engine/action.ts
@@ -1600,6 +1600,13 @@ async function dispatchSpawn(args: {
     throw error;
   }
   const nodeId = placement.node.id;
+  const shadow = args.bypassShadow ? null : await fetchNodeAction(args.db, args.workspaceId, nodeId, capability);
+  const capProvider = (await capacityProviderName(args.db, args.workspaceId, nodeId, capability)) ?? DEFAULT_PROVIDER_NAME;
+  if (input.verify_ready === true && (placement.queued || !await isNodeProviderLive(args.db, args.registry, args.workspaceId, nodeId, shadow?.handlerProvider ?? capProvider))) {
+    await failNeverDispatchedInvocation(args.db, args.workspaceId, invocation.id, 'spawn_target_unavailable');
+    if (!placement.queued) await releaseNodeCapacity(args.db, args.workspaceId, nodeId);
+    throw codedError('Verified spawn target is not connected and ready to accept work; retry when it is available', 'spawn_target_unavailable', 503);
+  }
   // Placement and the durable idempotency claim are separate writes on D1.
   // Publish the selected response target immediately; a concurrent replay in
   // this narrow interval waits for this snapshot instead of returning null.
@@ -1612,7 +1619,6 @@ async function dispatchSpawn(args: {
   // Capacity-direct delegation (ctx.spawnAgent) bypasses the shadow so a handler
   // that delegates cannot re-enter itself.
   if (!args.bypassShadow) {
-    const shadow = await fetchNodeAction(args.db, args.workspaceId, nodeId, capability);
     if (shadow && shadow.handlerProvider) {
       const bound = await bindInvocationToRegisteredNodeAction(args.db, {
         workspaceId: args.workspaceId,
@@ -1650,7 +1656,6 @@ async function dispatchSpawn(args: {
     }
   }
 
-  const capProvider = (await capacityProviderName(args.db, args.workspaceId, nodeId, capability)) ?? DEFAULT_PROVIDER_NAME;
   const dispatched = await dispatchNodeInvocation({
     db: args.db,
     registry: args.registry,
@@ -1815,7 +1820,18 @@ export async function invokeAction(
     }
   }
 
-  if (!action && actionName === 'spawn') {
+  // Check availableTo access control — deny if caller is absent OR not in the list
+  if (action?.availableTo && action.availableTo.length > 0) {
+    if (!data.caller_name || !action.availableTo.includes(data.caller_name)) {
+      const who = data.caller_name ? `Agent "${data.caller_name}"` : 'Caller';
+      throw codedError(`${who} is not authorized to invoke action "${actionName}"`, 'action_denied', 403);
+    }
+  }
+
+  // Legacy workspace-global broker aliases must not swallow an explicit
+  // target_node. Capacity placement validates that target and its live provider.
+  // Keep the alias ACL above this branch; explicit targeting is not an ACL bypass.
+  if (actionName === 'spawn' && (!action || (action.handlerNodeId && typeof data.input?.target_node === 'string' && data.input.target_node.trim().length > 0))) {
     return dispatchSpawn({
       db,
       registry: options.nodeConnections,
@@ -1838,14 +1854,6 @@ export async function invokeAction(
 
   if (!action) {
     throw codedError(`Action "${actionName}" not found`, 'action_not_found', 404);
-  }
-
-  // Check availableTo access control — deny if caller is absent OR not in the list
-  if (action.availableTo && action.availableTo.length > 0) {
-    if (!data.caller_name || !action.availableTo.includes(data.caller_name)) {
-      const who = data.caller_name ? `Agent "${data.caller_name}"` : 'Caller';
-      throw codedError(`${who} is not authorized to invoke action "${actionName}"`, 'action_denied', 403);
-    }
   }
 
   if (action.handlerNodeId) {

--- a/packages/engine/src/engine/agent.ts
+++ b/packages/engine/src/engine/agent.ts
@@ -1,8 +1,10 @@
-import { eq, and, gt, lt, ne, sql } from 'drizzle-orm';
+import { eq, and, gt, lt, ne, sql, inArray } from 'drizzle-orm';
 import type { getDb } from '../db/index.js';
 import { agents, agentNodeBindings, agentRecoveryCredentials, channels, channelMembers, dmParticipants, actions, deliveries, nodes } from '../db/schema.js';
 import { randomHex, sha256Hex } from '../lib/crypto.js';
 import { generateId } from './snowflake.js';
+import { invalidateChannelCache } from './cache.js';
+import { queryInChunks } from '../lib/queryChunks.js';
 import { codedError } from '../lib/httpError.js';
 import { directNodeIdForAgent } from './node.js';
 import { runAtomicWrites, type AtomicWrite } from '../ports/database.js';
@@ -165,6 +167,7 @@ export async function registerAgent(
     persona?: string;
     metadata?: Record<string, unknown>;
     capabilities?: Record<string, unknown>;
+    autoJoinGeneral?: boolean;
     recoveryProofHash?: string;
     workUnitId?: string;
   },
@@ -245,7 +248,7 @@ export async function registerAgent(
         })
         .returning()];
 
-      if (generalChannel) {
+      if (generalChannel && data.autoJoinGeneral !== false) {
         writes.push(writeDb.insert(channelMembers).values({
           channelId: generalChannel.id,
           agentId,
@@ -295,6 +298,10 @@ export async function registerAgent(
       throw codedError(`Agent "${data.name}" already exists in this workspace`, 'agent_already_exists', 409);
     }
     throw insertErr;
+  }
+
+  if (generalChannel && data.autoJoinGeneral !== false) {
+    await invalidateChannelCache(workspaceId, 'general');
   }
 
   return {
@@ -622,7 +629,7 @@ export async function deleteAgent(db: Db, workspaceId: string, name: string) {
   // One atomic unit: a partial apply would leave the agent renamed and
   // credential-rotated while still a channel member — reachable by delivery
   // under a name its owner no longer knows.
-  await runAtomicWrites(db, (writeDb) => {
+  const releaseResults = await runAtomicWrites(db, (writeDb) => {
     const writes: AtomicWrite[] = [];
     writes.push(writeDb
       .update(agents)
@@ -653,7 +660,7 @@ export async function deleteAgent(db: Db, workspaceId: string, name: string) {
       .where(eq(agents.id, agent.id)));
     // `channel_members` and `dm_participants` cascade on DELETE; an UPDATE does
     // not fire that cascade, so a released agent would stay a delivery target.
-    writes.push(writeDb.delete(channelMembers).where(eq(channelMembers.agentId, agent.id)));
+    writes.push(writeDb.delete(channelMembers).where(eq(channelMembers.agentId, agent.id)).returning({ channelId: channelMembers.channelId }));
     writes.push(writeDb.delete(dmParticipants).where(eq(dmParticipants.agentId, agent.id)));
     // Release the node binding so the host's active-agent count is not held by
     // a tombstone, matching the release paths.
@@ -661,6 +668,12 @@ export async function deleteAgent(db: Db, workspaceId: string, name: string) {
     writes.push(writeDb.delete(nodes).where(eq(nodes.id, directNodeIdForAgent(agent.id))));
     return writes;
   });
+  // Capture memberships at deletion, not a preflight read that can race joins.
+  const removed = releaseResults[1] as Array<{ channelId: string }>;
+  const joinedChannels = await queryInChunks(removed.map(row => row.channelId), ids => db
+    .select({ name: channels.name }).from(channels)
+    .where(and(eq(channels.workspaceId, workspaceId), inArray(channels.id, ids))));
+  await Promise.all(joinedChannels.map(channel => invalidateChannelCache(workspaceId, channel.name)));
   return true;
 }
 

--- a/packages/engine/src/engine/channel.ts
+++ b/packages/engine/src/engine/channel.ts
@@ -1,4 +1,5 @@
-import { eq, and, sql, inArray } from 'drizzle-orm';
+import { eq, and, sql, inArray, ne } from 'drizzle-orm';
+import { z } from 'zod';
 import type { getDb } from '../db/index.js';
 import { channels, channelMembers, agents } from '../db/schema.js';
 import { generateId } from './snowflake.js';
@@ -7,12 +8,58 @@ import { codedError } from '../lib/httpError.js';
 
 type Db = ReturnType<typeof getDb>;
 
+const SUBSCRIPTION_CHANNEL_PREFIX = 'agent-events-';
+const subscriptionChannelMetadataSchema = z.object({
+  subscription_agent_id: z.string().min(1),
+});
+
+function assertSubscriptionRecipient(channel: { name: string; metadata: unknown }, agentId: string) {
+  if (!channel.name.startsWith(SUBSCRIPTION_CHANNEL_PREFIX)) return;
+  const metadata = subscriptionChannelMetadataSchema.safeParse(channel.metadata);
+  if (!metadata.success || metadata.data.subscription_agent_id !== agentId) {
+    throw codedError('Only the subscription recipient may join this channel', 'subscription_recipient_only', 403);
+  }
+}
+
+/** Owner-managed delivery route. Identity IDs prevent a recreated name inheriting old subscriptions. */
+export async function ensureAgentSubscriptionChannel(db: Db, workspaceId: string, agentName: string) {
+  const [agent] = await db.select().from(agents).where(and(eq(agents.workspaceId, workspaceId), eq(agents.name, agentName)));
+  if (!agent || agent.status === 'released') throw codedError('Recipient agent not found', 'agent_not_found', 404);
+  const name = `${SUBSCRIPTION_CHANNEL_PREFIX}${agent.id}`;
+  await db.insert(channels).values({
+    id: generateId(), workspaceId, name,
+    metadata: { subscription_agent_id: agent.id },
+  }).onConflictDoNothing();
+  const [channel] = await db.select().from(channels).where(and(eq(channels.workspaceId, workspaceId), eq(channels.name, name)));
+  assertSubscriptionRecipient(channel, agent.id);
+  if (channel.isArchived) throw codedError('Subscription channel is archived', 'channel_archived', 409);
+  const [foreignMember] = await db.select({ agentId: channelMembers.agentId }).from(channelMembers)
+    .where(and(eq(channelMembers.channelId, channel.id), ne(channelMembers.agentId, agent.id))).limit(1);
+  if (foreignMember) throw codedError('Existing subscription channel has another recipient', 'subscription_channel_conflict', 409);
+
+  // Recheck the identity in the INSERT, serialized with tombstoning/removal.
+  // A release between the lookup and this write must never rejoin a tombstone.
+  await db.run(sql`INSERT INTO channel_members (channel_id, agent_id, role)
+    SELECT ${channel.id}, id, 'owner' FROM agents
+    WHERE id = ${agent.id} AND name = ${agentName} AND status != 'released'
+    ON CONFLICT DO NOTHING`);
+  const [recipient] = await db.select({ agentId: agents.id }).from(channelMembers)
+    .innerJoin(agents, eq(agents.id, channelMembers.agentId))
+    .where(and(eq(channelMembers.channelId, channel.id), eq(agents.id, agent.id), eq(agents.name, agentName), ne(agents.status, 'released'))).limit(1);
+  if (!recipient) throw codedError('Recipient agent was released during subscription setup', 'agent_not_found', 404);
+  await invalidateChannelCache(workspaceId, name);
+  return getChannel(db, workspaceId, name);
+}
+
 export async function createChannel(
   db: Db,
   workspaceId: string,
   data: { name: string; topic?: string; metadata?: Record<string, unknown> },
   creatorAgentId?: string,
 ) {
+  if (data.name.startsWith(SUBSCRIPTION_CHANNEL_PREFIX)) {
+    throw codedError('Channel prefix is reserved for agent subscriptions', 'reserved_channel_name', 400);
+  }
   // Validate channel name: lowercase alphanumeric + hyphens
   if (!/^[a-z0-9][a-z0-9-]*$/.test(data.name)) {
     throw codedError('Channel name must be lowercase alphanumeric and hyphens, starting with a letter or number', 'invalid_channel_name', 400);
@@ -116,8 +163,10 @@ export async function listChannels(
 }
 
 export async function getChannel(db: Db, workspaceId: string, name: string) {
-  // Check in-memory cache first
-  const cached = await getCachedChannel(workspaceId, name);
+  // Subscription membership is a launch/lifecycle proof. Read it live even when
+  // a node lifecycle release bypasses the normal channel mutation handlers.
+  const cacheable = !name.startsWith(SUBSCRIPTION_CHANNEL_PREFIX);
+  const cached = cacheable ? await getCachedChannel(workspaceId, name) : null;
   if (cached) return cached;
 
   const [channel] = await db
@@ -160,7 +209,7 @@ export async function getChannel(db: Db, workspaceId: string, name: string) {
   };
 
   // Populate cache
-  await setCachedChannel(workspaceId, name, result);
+  if (cacheable) await setCachedChannel(workspaceId, name, result);
 
   return result;
 }
@@ -184,6 +233,9 @@ export async function updateChannel(
     throw codedError('Cannot update an archived channel', 'channel_archived', 400);
   }
 
+  if (name.startsWith(SUBSCRIPTION_CHANNEL_PREFIX) && updates.metadata !== undefined) {
+    throw codedError('Subscription routing metadata is immutable', 'subscription_metadata_immutable', 403);
+  }
   const setClause: Record<string, unknown> = {};
   if (updates.topic !== undefined) setClause.topic = updates.topic;
   if (updates.metadata !== undefined) setClause.metadata = updates.metadata;
@@ -259,6 +311,8 @@ export async function joinChannel(
   if (channel.isArchived) {
     throw codedError('Cannot join an archived channel', 'channel_archived', 400);
   }
+
+  assertSubscriptionRecipient(channel, agentId);
 
   // Check if already a member
   const [existing] = await db
@@ -408,6 +462,8 @@ export async function inviteAgent(
   if (!invitee) {
     throw codedError(`Agent "${inviteeAgentName}" not found`, 'agent_not_found', 404);
   }
+
+  assertSubscriptionRecipient(channel, invitee.id);
 
   // Check if already a member
   const [existing] = await db

--- a/packages/engine/src/engine/channel.ts
+++ b/packages/engine/src/engine/channel.ts
@@ -329,11 +329,19 @@ export async function joinChannel(
     return { channel: channelName, agent_id: agentId, already_member: true };
   }
 
-  await db.insert(channelMembers).values({
-    channelId: channel.id,
-    agentId,
-    role: 'member',
-  });
+  if (channel.name.startsWith(SUBSCRIPTION_CHANNEL_PREFIX)) {
+    // Serialize the liveness check with release's membership removal.
+    await db.run(sql`INSERT INTO channel_members (channel_id, agent_id, role)
+      SELECT ${channel.id}, id, 'member' FROM agents
+      WHERE id = ${agentId} AND workspace_id = ${workspaceId} AND status != 'released'
+      ON CONFLICT DO NOTHING`);
+    const [recipient] = await db.select({ id: agents.id }).from(channelMembers)
+      .innerJoin(agents, eq(agents.id, channelMembers.agentId))
+      .where(and(eq(channelMembers.channelId, channel.id), eq(agents.id, agentId), ne(agents.status, 'released'))).limit(1);
+    if (!recipient) throw codedError('Subscription recipient was released', 'agent_not_found', 404);
+  } else {
+    await db.insert(channelMembers).values({ channelId: channel.id, agentId, role: 'member' });
+  }
 
   await invalidateChannelCache(workspaceId, channelName);
 

--- a/packages/engine/src/engine/delivery.ts
+++ b/packages/engine/src/engine/delivery.ts
@@ -7,7 +7,7 @@ import { runAtomic } from '../ports/database.js';
 import type { NodeConnectionRegistry } from '../ports/realtime.js';
 import { isProviderAgentDeliveryReady } from '../ports/realtime.js';
 import { buildDeliverFrame, buildDeliverPayload, buildMessageCreatedEventData, buildThreadReplyEventData, buildDmReceivedEventData, buildGroupDmReceivedEventData } from './deliveryWire.js';
-import { publicMessageMetadata } from './messageMetadata.js';
+import { displayAgentName, publicMessageMetadata } from './messageMetadata.js';
 import { toIso } from '../lib/serialize.js';
 import { fetchAttachmentsBatch, type AttachmentRow } from './attachments.js';
 import type { DeliveryFanoutRecord } from './deliveryWrites.js';
@@ -552,7 +552,7 @@ function buildRoutableDeliveryEvent(
   row: PendingDeliveryRow,
   attachments: AttachmentRow[],
 ): { eventType: string; eventData: Record<string, unknown> } {
-  const senderName = row.senderAgentName ?? 'unknown';
+  const senderName = displayAgentName(row.metadata as Record<string, unknown> | null, row.senderAgentName);
   const injectionMode = row.delivery.mode === 'next-tool-call' ? 'steer' : 'wait';
   // Thread replies route as `thread.reply` in the live path even inside a DM /
   // group DM (see routes/thread.ts fanout), so a missed thread reply must

--- a/packages/engine/src/engine/delivery.ts
+++ b/packages/engine/src/engine/delivery.ts
@@ -1,3 +1,4 @@
+import { parseMessageMentions } from './mentions.js';
 import { eq, and, not, asc, isNull, inArray, notInArray, lte, gt, sql, getTableColumns, type SQL } from 'drizzle-orm';
 import type { getDb } from '../db/index.js';
 import { deliveries, messages, agents, readReceipts, channelMembers, channels, dmConversations } from '../db/schema.js';
@@ -632,7 +633,7 @@ function buildRoutableDeliveryEvent(
     };
   }
 
-  const mentions = [...row.body.matchAll(/@(\w+)/g)].map((match) => match[1]);
+  const mentions = parseMessageMentions(row.body);
   return {
     eventType,
     eventData: buildMessageCreatedEventData({

--- a/packages/engine/src/engine/deliveryWrites.ts
+++ b/packages/engine/src/engine/deliveryWrites.ts
@@ -110,6 +110,8 @@ export function buildChannelDeliveryWrite(
     depthCap: number;
     reason?: ChannelDeliveryReason;
     mentionHandles?: readonly string[];
+    /** Abort the enclosing atomic write when ANY recipient has no capacity. */
+    rejectOnOverflow?: boolean;
   },
 ): AtomicWrite {
   const mentionHandles = input.mentionHandles ?? [];
@@ -120,7 +122,12 @@ export function buildChannelDeliveryWrite(
       asDeliveryInsertSelect(qb
         .select({
           id: deliveryId(input.messageId, channelMembers.agentId),
-          workspaceId: sql<string>`${input.workspaceId}`,
+          // A NOT NULL guard runs inside the same INSERT SELECT as capacity
+          // evaluation. Unlike a preflight count, it cannot race another send.
+          // The enclosing atomic write rolls back the message and every recipient.
+          workspaceId: input.rejectOnOverflow
+            ? sql<string>`CASE WHEN ${belowDepthCapSql(input.workspaceId, channelMembers.agentId, input.depthCap)} THEN ${input.workspaceId} ELSE NULL END`
+            : sql<string>`${input.workspaceId}`,
           messageId: sql<string>`${input.messageId}`,
           agentId: channelMembers.agentId,
           mode: sql<string>`${input.mode}`,
@@ -170,7 +177,7 @@ export function buildChannelDeliveryWrite(
             eq(channelMembers.channelId, input.channelId),
             channelMuteDeliveryFilter(mentionHandles),
             ne(channelMembers.agentId, input.senderAgentId),
-            belowDepthCapSql(input.workspaceId, channelMembers.agentId, input.depthCap),
+            input.rejectOnOverflow ? undefined : belowDepthCapSql(input.workspaceId, channelMembers.agentId, input.depthCap),
           ),
         )),
     )

--- a/packages/engine/src/engine/inboundWebhook.ts
+++ b/packages/engine/src/engine/inboundWebhook.ts
@@ -5,7 +5,7 @@ import { randomHex, sha256Hex } from '../lib/crypto.js';
 import { codedError } from '../lib/httpError.js';
 import { generateId } from './snowflake.js';
 import { inboundWebhookMessageMetadata, sanitizeUserMessageMetadata } from './messageMetadata.js';
-import { runAtomicWrites, type AtomicWrite } from '../ports/database.js';
+import { runAtomicWrites, databaseConstraintKind, type AtomicWrite } from '../ports/database.js';
 import { buildChannelDeliveryWrite, fetchChannelDeliveryOutcomes } from './deliveryWrites.js';
 import { DEFAULT_MAILBOX_DEPTH_CAP, DEFAULT_MAILBOX_TTL_MS, type MailboxConfig } from './mailboxConfig.js';
 import { buildMessageSessionWrite, requireSessionRefFromMetadata } from './sessionMessages.js';
@@ -153,11 +153,19 @@ export async function deleteWebhook(db: Db, workspaceId: string, webhookId: stri
   return result.length > 0;
 }
 
+function rethrowMailboxError(error: unknown): never {
+  if (databaseConstraintKind(error) === 'mailbox_capacity') {
+    throw codedError('A recipient mailbox is full; retry this event after capacity becomes available', 'mailbox_full', 503);
+  }
+  throw error;
+}
+
 export async function triggerWebhook(
   db: Db,
   webhookId: string,
   token: string | null,
   data: { text?: string; source?: string; author?: string; payload?: Record<string, unknown> },
+  options: { mailbox?: MailboxConfig | ((workspaceId: string) => MailboxConfig) } = {},
 ) {
   // Look up webhook
   const [webhook] = await db
@@ -206,6 +214,9 @@ export async function triggerWebhook(
   // replay-ledger row. Token-protected hooks may opt into replay correlation.
   const sessionRef = webhook.tokenHash ? requireSessionRefFromMetadata(metadata) : null;
   const createdAt = new Date();
+  const mailbox = typeof options.mailbox === 'function' ? options.mailbox(webhook.workspaceId) : options.mailbox ?? {
+    ttlMs: DEFAULT_MAILBOX_TTL_MS, depthCap: DEFAULT_MAILBOX_DEPTH_CAP,
+  };
   const results = await runAtomicWrites(db, (writeDb) => {
     const writes: AtomicWrite[] = [
       writeDb
@@ -229,8 +240,13 @@ export async function triggerWebhook(
       createdAt,
     );
     if (sessionWrite) writes.push(sessionWrite);
+    writes.push(buildChannelDeliveryWrite(writeDb, {
+      workspaceId: webhook.workspaceId, messageId, channelId: webhook.channelId,
+      senderAgentId: postingAgentId, mode: 'immediate',
+      ttlMs: mailbox.ttlMs, depthCap: mailbox.depthCap, rejectOnOverflow: true,
+    }));
     return writes;
-  });
+  }, { requireAtomic: true }).catch(rethrowMailboxError);
   const [message] = results[0] as (typeof messages.$inferSelect)[];
 
   // Get channel name
@@ -239,7 +255,12 @@ export async function triggerWebhook(
     .from(channels)
     .where(eq(channels.id, webhook.channelId));
 
+  const outcomes = await fetchChannelDeliveryOutcomes(db, {
+    messageId, channelId: webhook.channelId, senderAgentId: postingAgentId,
+  });
   return {
+    _deliveries: outcomes.deliveries,
+    _delivery_rejections: outcomes.rejections,
     message_id: message.id,
     agent_id: message.agentId,
     webhook_id: webhook.id,
@@ -328,11 +349,12 @@ export async function triggerIntegrationMessage(
         mode: data.mode === 'steer' ? 'next-tool-call' : 'immediate',
         ttlMs: mailbox.ttlMs,
         depthCap: mailbox.depthCap,
+        rejectOnOverflow: true,
       }),
     );
 
     return writes;
-  });
+  }, { requireAtomic: true }).catch(rethrowMailboxError);
   const [message] = results[0] as (typeof messages.$inferSelect)[];
 
   const [channel] = await db

--- a/packages/engine/src/engine/mentions.ts
+++ b/packages/engine/src/engine/mentions.ts
@@ -1,0 +1,4 @@
+/** Shared by live delivery and durable replay; emails and escaped handles are not mentions. */
+export function parseMessageMentions(text: string): string[] {
+  return [...new Set([...text.matchAll(/(?:^|\s)@([\w-]+)/g)].map(match => match[1]))];
+}

--- a/packages/engine/src/engine/message.ts
+++ b/packages/engine/src/engine/message.ts
@@ -35,7 +35,7 @@ export async function postMessage(
   const messageId = generateId();
 
   // Parse @mentions from text without treating email domains as handles.
-  const mentionPattern = /(?:^|\s)@(\w+)/g;
+  const mentionPattern = /(?:^|\s)@([\w-]+)/g;
   const mentionedHandles = new Set<string>();
   for (let match = mentionPattern.exec(data.text); match !== null; match = mentionPattern.exec(data.text)) {
     mentionedHandles.add(match[1]);

--- a/packages/engine/src/engine/message.ts
+++ b/packages/engine/src/engine/message.ts
@@ -1,3 +1,4 @@
+import { parseMessageMentions } from './mentions.js';
 import { eq, and, sql, isNull, lt, gt, inArray } from 'drizzle-orm';
 import type { getDb } from '../db/index.js';
 import { messages, agents, reactions, readReceipts, messageAttachments } from '../db/schema.js';
@@ -34,12 +35,7 @@ export async function postMessage(
   const startedAtMs = Date.now();
   const messageId = generateId();
 
-  // Parse @mentions from text without treating email domains as handles.
-  const mentionPattern = /(?:^|\s)@([\w-]+)/g;
-  const mentionedHandles = new Set<string>();
-  for (let match = mentionPattern.exec(data.text); match !== null; match = mentionPattern.exec(data.text)) {
-    mentionedHandles.add(match[1]);
-  }
+  const mentionedHandles = new Set(parseMessageMentions(data.text));
 
   const metadata = sanitizeUserMessageMetadata(data.data);
   const sessionRef = requireSessionRefFromMetadata(metadata);

--- a/packages/engine/src/engine/node.ts
+++ b/packages/engine/src/engine/node.ts
@@ -1,3 +1,5 @@
+import { z } from 'zod';
+import { invalidateChannelCache } from './cache.js';
 import { and, asc, eq, inArray, isNotNull, isNull, lt, lte, ne, or, sql } from 'drizzle-orm';
 import type {
   FleetAgentRecoverMessage,
@@ -1396,7 +1398,7 @@ export async function registerAgentViaNode(
   options: { deliveryCursorSupported?: boolean } = {},
 ): Promise<AgentRegisterReplyData> {
   assertRegistrableAgentName(message.name);
-  return runAtomic(db, async (tx) => {
+  const registered = await runAtomic(db, async (tx) => {
     await rejectMigrationCanceledSpawnRegistration(tx, workspaceId, {
       invocationId: message.invocation_id,
       nodeId,
@@ -1483,7 +1485,7 @@ export async function registerAgentViaNode(
       }
 
       createdAgent = true;
-      await autoJoinGeneral(tx, workspaceId, result.id);
+      if (message.auto_join_general !== false) await autoJoinGeneral(tx, workspaceId, result.id);
       await upsertAgentNodeBinding(tx, workspaceId, result, nodeId, {
         sessionRef: message.session_ref ?? null,
         deactivateExisting: true,
@@ -1509,6 +1511,8 @@ export async function registerAgentViaNode(
       throw err;
     }
   });
+  if (message.auto_join_general !== false) await invalidateChannelCache(workspaceId, 'general');
+  return registered;
 }
 
 /**
@@ -1613,7 +1617,7 @@ export async function recoverAgentViaNode(
         );
       }
 
-      await autoJoinGeneral(tx, workspaceId, result.id);
+      // Recovery preserves memberships, including an intentionally isolated identity.
       await upsertAgentNodeBinding(tx, workspaceId, result, nodeId, {
         sessionRef: message.session_ref ?? null,
         deactivateExisting: true,
@@ -1711,6 +1715,12 @@ export async function deregisterAgentViaNode(
     }
   }
   return updated ?? null;
+}
+
+/** Inventory proves identity/presence, never a harness's ready state. */
+const spawnReadinessSchema = z.object({ verify_ready: z.literal(true) }).passthrough();
+function requiresSpawnReadiness(input: unknown): boolean {
+  return spawnReadinessSchema.safeParse(input).success;
 }
 
 export async function reconcileInventory(
@@ -1850,7 +1860,9 @@ export async function reconcileInventory(
       eq(actionInvocations.dispatchedProvider, providerName),
       inArray(actionInvocations.status, ['pending', 'dispatched']),
     ));
-  const providerInvocationIds = new Set(openInvocations.map((invocation) => invocation.id));
+  const providerInvocationIds = new Set(openInvocations
+    .filter((invocation) => !requiresSpawnReadiness(invocation.input))
+    .map((invocation) => invocation.id));
 
   const reconciledAgentIds: string[] = [];
   const newlyRoutedAgentIds: string[] = [];
@@ -1947,7 +1959,10 @@ export async function reconcileInventory(
 
   let rescheduledInvocations = 0;
   for (const invocation of openInvocations) {
-    if (liveInvocationIds.has(invocation.id)) continue;
+    // A live broker owns the bounded readiness wait and cleanup. A transient
+    // empty inventory during launch/teardown must not redispatch this spawn.
+    // Actual provider disconnect and invocation expiry retain their own recovery.
+    if (liveInvocationIds.has(invocation.id) || requiresSpawnReadiness(invocation.input)) continue;
     try {
       if (await rescheduleNodeInvocation(db, registry, invocation)) {
         rescheduledInvocations++;
@@ -2346,6 +2361,11 @@ export async function handleNodeControlMessage(args: HandleNodeControlMessageArg
       }
       case 'agent.deregister':
         await deregisterAgentViaNode(args.db, args.workspaceId, args.nodeId, message, args.completionDeps);
+        // A caller deleting an owned identity must know the live binding is gone
+        // before invoking release. Older fire-and-forget callers omit the id.
+        if (message.id) {
+          sendControl(args.socket, { v: 1, id: message.id, type: 'reply', ok: true, data: { deregistered: true } });
+        }
         return;
       case 'inventory.sync': {
         const result = await reconcileInventory(

--- a/packages/engine/src/engine/thread.ts
+++ b/packages/engine/src/engine/thread.ts
@@ -48,7 +48,7 @@ export async function postReply(
   const metadata = sanitizeUserMessageMetadata(data.data);
   const sessionRef = requireSessionRefFromMetadata(metadata);
   const createdAt = new Date();
-  const mentionPattern = /(?:^|\s)@(\w+)/g;
+  const mentionPattern = /(?:^|\s)@([\w-]+)/g;
   const mentionedHandles = new Set<string>();
   for (let match = mentionPattern.exec(data.text); match !== null; match = mentionPattern.exec(data.text)) {
     mentionedHandles.add(match[1]);

--- a/packages/engine/src/ports/database.ts
+++ b/packages/engine/src/ports/database.ts
@@ -169,3 +169,17 @@ export async function runAtomicWrites(
   }
   return runSequentially(statements);
 }
+
+/** Normalize the capacity sentinel across SQLite adapters (D1 exposes only a wrapped message).
+ * Keep driver-specific error decoding at this port boundary; engine callers use a stable kind.
+ */
+export function databaseConstraintKind(error: unknown): 'mailbox_capacity' | undefined {
+  const seen = new Set<unknown>();
+  let cause = error;
+  while (cause instanceof Error && !seen.has(cause)) {
+    seen.add(cause);
+    if (/NOT NULL constraint failed: deliveries\.workspace_id/i.test(cause.message)) return 'mailbox_capacity';
+    cause = cause.cause;
+  }
+  return undefined;
+}

--- a/packages/engine/src/routes/__tests__/relayfileInbound.test.ts
+++ b/packages/engine/src/routes/__tests__/relayfileInbound.test.ts
@@ -19,13 +19,14 @@ interface Stack {
 
 const stacks: Stack[] = [];
 
-function makeStack(opts: { kv?: KeyValueStore } = {}): Stack {
+function makeStack(opts: { kv?: KeyValueStore; depthCap?: number } = {}): Stack {
   const runtime = createNodeRuntime({
     dbPath: ':memory:',
     baseUrl: 'http://localhost:0',
     migrate: true,
     config: {
       environment: 'test',
+      ...(opts.depthCap ? { mailbox: { depthCap: opts.depthCap } } : {}),
       relayfileInboundSecret: 'relaycast-master',
     },
     presence: { sweepIntervalMs: 0 },
@@ -70,6 +71,45 @@ class FailingKeyValueStore implements KeyValueStore {
 }
 
 describe('relayfile inbound bridge', () => {
+  it('returns retryable overflow and accepts the same unique event after capacity recovers', async () => {
+    const stack = makeStack({ depthCap: 1 });
+    const ws = await createWorkspace(stack.app, 'inbound-backpressure');
+    const busy = await registerAgent(stack.app, ws.workspaceKey, 'busy');
+    const post = (path: string, token: string, body?: unknown) => stack.app.request(path, {
+      method: 'POST', headers: { 'content-type': 'application/json', authorization: `Bearer ${token}` },
+      ...(body ? { body: JSON.stringify(body) } : {}),
+    });
+    await post('/v1/channels/general/join', busy.token);
+    const targetRes = await post('/v1/integrations/relayfile/inbound-target', ws.workspaceKey,
+      { channel: 'general', provider: 'github', path_glob: '/github/repos/o/r/issues/**' });
+    expect(targetRes.status).toBe(201);
+    const { data: target } = await targetRes.json();
+    const emit = (id: string) => {
+      const path = '/github/repos/o/r/issues/12.json';
+      const body = JSON.stringify({ eventId: id, type: 'file.updated', path, provider: 'github', revision: id,
+        snapshot: { path, contentType: 'application/json', encoding: 'utf-8', content: JSON.stringify({ title: id, body: id, number: 12 }) } });
+      return stack.app.request(target.url, { method: 'POST', body,
+        headers: { ...signedHeaders(target.secret, body), 'X-Relay-Event-Id': id } });
+    };
+    expect((await emit('first')).status).toBe(201);
+    const rejected = await emit('second');
+    expect(rejected.status).toBe(503);
+    expect(rejected.headers.get('Retry-After')).toBe('30');
+    expect(await rejected.json()).toMatchObject({ error: { code: 'mailbox_full' } });
+    const inbox = await stack.app.request('/v1/deliveries', { headers: { authorization: `Bearer ${busy.token}` } });
+    const { data: queued } = await inbox.json();
+    expect(queued).toHaveLength(1);
+    await post(`/v1/deliveries/${queued[0].id}/ack`, busy.token);
+    const retried = await emit('second');
+    expect(retried.status).toBe(201);
+    const { data: accepted } = await retried.json();
+    const duplicate = await emit('second');
+    expect(duplicate.status).toBe(201);
+    expect(await duplicate.json()).toMatchObject({ data: { replayed: true, message_id: accepted.message_id } });
+    const stored = await stack.app.request('/v1/channels/general/messages', { headers: { authorization: `Bearer ${ws.workspaceKey}` } });
+    expect((await stored.json()).data).toHaveLength(2);
+  });
+
   it('provisions a signed relayfile target for a workspace channel', async () => {
     const stack = makeStack();
     const ws = await createWorkspace(stack.app, 'relayfile-target');
@@ -173,6 +213,8 @@ describe('relayfile inbound bridge', () => {
     const target = targetBody.data;
     const event = {
       eventId: 'evt_slack_1',
+      providerEventType: 'message.created',
+      resourceRef: '/slack/channels/C123',
       type: 'file.created',
       path: '/slack/channels/C123/messages/1780607825_485189/meta.json',
       revision: 'rev_1',
@@ -210,6 +252,7 @@ describe('relayfile inbound bridge', () => {
     expect(list.status).toBe(200);
     const messages = await list.json() as { data: Array<{ text: string }> };
     expect(messages.data.filter((message) => message.text.includes('hello from slack'))).toHaveLength(1);
+    expect(messages.data[0]).toMatchObject({ metadata: { provider_event_type: 'message.created', resource_ref: '/slack/channels/C123' } });
   });
 
   it('creates channel deliveries so node/broker agents receive the message', async () => {
@@ -407,4 +450,13 @@ describe('relayfile inbound bridge', () => {
     expect(message?.text).toContain(`${'x'.repeat(1200)}...`);
     expect(message?.text).not.toContain(longBody);
   });
+  it('exposes terminal provider state from a Cloud sync envelope without treating metadata as authority', () => {
+    const payload = { number: 42, state: 'closed', merged: true, title: 'Fix', user: { login: 'author' } };
+    const snapshot = { content: JSON.stringify({ provider: 'github', objectType: 'pull_request', objectId: '42', deleted: false, connectionId: 'connection', payload }) };
+    const message = formatRelayfileEventMessage({ type: 'file.updated', providerEventType: 'pull_request.closed', path: '/github/repos/a/b/pulls/42__fix/meta.json', snapshot }, 'github');
+    expect(message).toMatchObject({ author: 'author', record: payload, text: expect.stringContaining('Fix') });
+    expect(formatRelayfileEventMessage({ type: 'file.updated', path: '/github/42.json', snapshot }, 'github')?.text).toContain('Github update');
+    expect(formatRelayfileEventMessage({ type: 'file.updated', path: '/github/42.json', snapshot: { content: JSON.stringify({ title: 'Ordinary record', payload }) } }, 'github')?.record).toMatchObject({ title: 'Ordinary record', payload });
+  });
+
 });

--- a/packages/engine/src/routes/action.ts
+++ b/packages/engine/src/routes/action.ts
@@ -3,7 +3,7 @@ import { z } from 'zod';
 import { FleetWireJsonValueSchema } from '@relaycast/types';
 import type { AppEnv } from '../env.js';
 import { errorResponse } from '../lib/httpError.js';
-import { requireAuth } from '../middleware/auth.js';
+import { requireAuth, requireSender } from '../middleware/auth.js';
 import { jsonIdempotentOk, parseIdempotencyKey } from '../middleware/idempotency.js';
 import { rateLimit } from '../middleware/rateLimit.js';
 import * as actionEngine from '../engine/action.js';
@@ -299,12 +299,15 @@ actionRoutes.post('/actions/:name/invocations/:id/complete', requireAuth, rateLi
 });
 
 // GET /v1/actions/:name/invocations/:id - get invocation status
-actionRoutes.get('/actions/:name/invocations/:id', requireAuth, rateLimit, async (c) => {
+actionRoutes.get('/actions/:name/invocations/:id', requireSender, rateLimit, async (c) => {
   try {
     const db = c.get('db');
     const workspace = c.get('workspace');
     const result = await actionEngine.getInvocation(db, workspace.id, c.req.param('name'), c.req.param('id'));
-    if (!result) {
+    // Served providers need their delegated broker's terminal spawn result.
+    // This does not grant node principals general workspace invocation access.
+    const node = c.get('node');
+    if (!result || (node && (result.action_name !== 'spawn' || result.dispatched_node_id !== node.id))) {
       return jsonNotFound(c, 'invocation_not_found', 'Invocation not found');
     }
     return jsonOk(c, result);

--- a/packages/engine/src/routes/agent.ts
+++ b/packages/engine/src/routes/agent.ts
@@ -47,6 +47,7 @@ const skillSchema = z.object({
 const capabilitiesSchema = z.record(z.string(), z.unknown());
 
 const registerAgentSchema = z.object({
+  auto_join_general: z.boolean().optional(),
   name: z.string().min(1),
   type: AgentTypeSchema.optional(),
   persona: z.string().optional(),
@@ -262,6 +263,7 @@ agentRoutes.post(
         metadata,
         skills,
         capabilities,
+        auto_join_general: autoJoinGeneral,
         recovery_proof_hash: recoveryProofHash,
         work_unit_id: workUnitId,
       } = parsed.data;
@@ -276,6 +278,7 @@ agentRoutes.post(
         persona,
         metadata: nextMetadata,
         capabilities,
+        autoJoinGeneral,
         recoveryProofHash,
         workUnitId,
       });

--- a/packages/engine/src/routes/channel.ts
+++ b/packages/engine/src/routes/channel.ts
@@ -1,7 +1,7 @@
 import { Hono } from 'hono';
 import { z } from 'zod';
 import type { AppEnv } from '../env.js';
-import { requireAuth, requireAgentToken, requireWorkspaceRead } from '../middleware/auth.js';
+import { requireAuth, requireAgentToken, requireWorkspaceRead, requireWorkspaceKey } from '../middleware/auth.js';
 import { rateLimit } from '../middleware/rateLimit.js';
 import * as channelEngine from '../engine/channel.js';
 import { fanoutToChannel, fanoutToWorkspace } from './fanout.js';
@@ -556,3 +556,12 @@ channelRoutes.post(
     }
   },
 );
+
+// Workspace owners provision routing without rotating or borrowing the recipient's token.
+channelRoutes.post('/agents/:name/subscription-channel', requireWorkspaceKey, rateLimit, async (c) => {
+  try {
+    return jsonOk(c, await channelEngine.ensureAgentSubscriptionChannel(c.get('db'), c.get('workspace').id, c.req.param('name')));
+  } catch (err: unknown) {
+    return errorResponse(c, err);
+  }
+});

--- a/packages/engine/src/routes/inboundWebhook.ts
+++ b/packages/engine/src/routes/inboundWebhook.ts
@@ -1,3 +1,4 @@
+import { buildMessageCreatedEventData } from '../engine/deliveryWire.js';
 import { Hono } from 'hono';
 import { z } from 'zod';
 import type { AppEnv } from '../env.js';
@@ -143,7 +144,8 @@ inboundWebhookRoutes.post('/hooks/:webhookId', async (c) => {
     const { workspace_id, channel_id, agent_id, _deliveries, _delivery_rejections, ...responseData } = result;
 
     const eventData = { ...responseData, id: responseData.message_id, channel_id, agent_id };
-    runInBackground(c, routeDeliveryOutcomes(c, _deliveries, 'message.created', eventData, { workspaceId: workspace_id }), 'route webhook deliveries');
+    const messageEventData = buildMessageCreatedEventData(eventData, { channelName: result.channel, fromName: result.author });
+    runInBackground(c, routeDeliveryOutcomes(c, _deliveries, 'message.created', messageEventData, { workspaceId: workspace_id }), 'route webhook deliveries');
     if (channel_id) {
       runInBackground(
         c,

--- a/packages/engine/src/routes/inboundWebhook.ts
+++ b/packages/engine/src/routes/inboundWebhook.ts
@@ -1,13 +1,15 @@
 import { Hono } from 'hono';
 import { z } from 'zod';
 import type { AppEnv } from '../env.js';
-import { errorResponse } from '../lib/httpError.js';
+import { asCodedError, errorResponse } from '../lib/httpError.js';
 import { requireWorkspaceKey } from '../middleware/auth.js';
 import { rateLimit } from '../middleware/rateLimit.js';
+import { resolveMailboxConfig } from '../engine/mailboxConfig.js';
 import * as inboundWebhookEngine from '../engine/inboundWebhook.js';
 import * as triggerEngine from '../engine/trigger.js';
 import * as channelEngine from '../engine/channel.js';
 import { fanoutToChannel } from './fanout.js';
+import { routeDeliveryOutcomes } from './deliveryRouting.js';
 import { runInBackground } from './background.js';
 import { sendWebhookEvent } from './webhookOutbox.js';
 import { emitServerEvent } from '../lib/serverTelemetry.js';
@@ -133,13 +135,15 @@ inboundWebhookRoutes.post('/hooks/:webhookId', async (c) => {
         author: author ?? source,
         payload: (payload && typeof payload === 'object') ? payload as Record<string, unknown> : undefined,
       },
+      { mailbox: (workspaceId) => resolveMailboxConfig(c.get('engine').config, workspaceId) },
     );
     if (!result) {
       return jsonNotFound(c, 'webhook_not_found', 'Webhook not found or inactive');
     }
-    const { workspace_id, channel_id, agent_id, ...responseData } = result;
+    const { workspace_id, channel_id, agent_id, _deliveries, _delivery_rejections, ...responseData } = result;
 
-    const eventData = { ...responseData, channel_id };
+    const eventData = { ...responseData, id: responseData.message_id, channel_id, agent_id };
+    runInBackground(c, routeDeliveryOutcomes(c, _deliveries, 'message.created', eventData, { workspaceId: workspace_id }), 'route webhook deliveries');
     if (channel_id) {
       runInBackground(
         c,
@@ -205,6 +209,7 @@ inboundWebhookRoutes.post('/hooks/:webhookId', async (c) => {
 
     return jsonCreated(c, responseData);
   } catch (err: unknown) {
+    if (asCodedError(err).code === 'mailbox_full') c.header('Retry-After', '30');
     return errorResponse(c, err);
   }
 });

--- a/packages/engine/src/routes/relayfileInbound.ts
+++ b/packages/engine/src/routes/relayfileInbound.ts
@@ -29,6 +29,12 @@ const createTargetSchema = z.object({
   path_glob: z.string().trim().min(1),
 });
 
+const providerRecordEnvelopeSchema = z.object({
+  provider: z.string(), objectType: z.string(), objectId: z.string(),
+  deleted: z.boolean(), connectionId: z.string(),
+  payload: z.record(z.string(), z.unknown()),
+});
+
 const relayfileSnapshotSchema = z.object({
   path: z.string().optional(),
   contentType: z.string().optional(),
@@ -44,6 +50,8 @@ const relayfileEventSchema = z.object({
   revision: z.string().optional(),
   origin: z.string().optional(),
   provider: z.string().optional(),
+  providerEventType: z.string().optional(),
+  resourceRef: z.string().optional(),
   correlationId: z.string().optional(),
   timestamp: z.string().optional(),
   contentHash: z.string().optional(),
@@ -67,6 +75,8 @@ interface RelayfileEventPublic {
   revision?: string;
   origin?: string;
   provider?: string;
+  providerEventType?: string;
+  resourceRef?: string;
   correlationId?: string;
   timestamp?: string;
   contentHash?: string;
@@ -196,7 +206,7 @@ relayfileInboundRoutes.post('/integrations/relayfile/inbound/:workspaceId/:chann
       actorId: 'relayfile-inbound',
       scope: `relayfile-inbound:${channelId}`,
       key: deliveryEventId,
-      fingerprint: JSON.stringify({ path: event.path, revision: event.revision, contentHash: event.contentHash }),
+      fingerprint: JSON.stringify({ path: event.path, revision: event.revision, contentHash: event.contentHash, providerEventType: event.providerEventType, resourceRef: event.resourceRef }),
       kv: c.get('engine').kv,
       requireKv: true,
       ttlSeconds: IDEMPOTENCY_TTL_SECONDS,
@@ -213,11 +223,15 @@ relayfileInboundRoutes.post('/integrations/relayfile/inbound/:workspaceId/:chann
             revision: event.revision,
             eventId: deliveryEventId,
             provider,
+            ...(event.providerEventType ? { provider_event_type: event.providerEventType } : {}),
+            ...(event.resourceRef ? { resource_ref: event.resourceRef } : {}),
             contentHash: event.contentHash,
           },
           provider,
           path: event.path,
           event: event.type,
+          ...(event.providerEventType ? { provider_event_type: event.providerEventType } : {}),
+          ...(event.resourceRef ? { resource_ref: event.resourceRef } : {}),
           record: message.record,
         },
       }, { mailbox }),
@@ -273,6 +287,10 @@ relayfileInboundRoutes.post('/integrations/relayfile/inbound/:workspaceId/:chann
     return jsonCreated(c, { replayed: result.replayed, message_id: result.data.message_id });
   } catch (err) {
     const code = (err as Error & { code?: string }).code;
+    if (code === 'mailbox_full') {
+      c.header('Retry-After', '30');
+      return jsonError(c, 'mailbox_full', 'A recipient mailbox is full; retry this event', 503);
+    }
     if (code === 'idempotency_in_progress') {
       return jsonOk(c, { skipped: 'duplicate_in_progress' });
     }
@@ -351,12 +369,17 @@ export async function verifyRelayfileSignature(
 }
 
 export function formatRelayfileEventMessage(event: RelayfileEventPublic, provider: string): { text: string; author: string; record: unknown } | null {
-  const record = parseSnapshotRecord(event.snapshot);
+  const stored = parseSnapshotRecord(event.snapshot);
+  const envelope = providerRecordEnvelopeSchema.safeParse(stored);
+  // Cloud's sync writer stores canonical records in a provider envelope.
+  // Unwrap only that complete shape; an ordinary record's payload property
+  // is data. Authenticated event semantics still come exclusively from event.
+  const record = envelope.success && envelope.data.provider === provider ? envelope.data.payload : stored;
   const author = recordAuthor(record) ?? provider;
   const title = recordTitle(record);
   const body = recordBody(record);
   const providerLabel = provider.charAt(0).toUpperCase() + provider.slice(1);
-  const lines = [`${providerLabel} update`];
+  const lines = [event.providerEventType ? `${providerLabel} ${event.providerEventType}` : `${providerLabel} update`];
   if (title) lines.push(title);
   if (body && body !== title) lines.push(body);
   lines.push(`Relayfile path: ${event.path}`);

--- a/packages/types/src/__tests__/sdk-openapi-sync.test.ts
+++ b/packages/types/src/__tests__/sdk-openapi-sync.test.ts
@@ -51,6 +51,8 @@ const NON_SDK_OPENAPI_PATHS = new Set([
   // Operator-only, one-time recovery for legacy registrations. Agent SDKs do
   // not expose it because normal registration establishes the verifier.
   '/v1/agents/{param}/legacy-identity',
+  // Workspace-owner subscription provisioning, called by the Relay integration CLI.
+  '/v1/agents/{param}/subscription-channel',
 ]);
 
 const CORE_SDK_PATHS = new Set([


### PR DESCRIPTION
Backports the reviewed GitHub subscription delivery changes from #387 onto the production `release/8.5.2` maintenance line. The current Cloud host depends on `RetentionCursorStore`, `cursorStore`, and `wsBacklogLimit`, which mainline 8.7.0 does not support. A direct mainline upgrade also requires unapplied 0048–0052 schema changes.

This backport keeps production's schema-free retention, bounded WebSocket redrive, and active-expiry recovery unchanged. It adds identity-scoped subscription recipients, exact hyphenated mentions, confirmed node-owned spawn status, atomic mailbox backpressure and membership cleanup.

The engine consumes already-published `@relaycast/types@8.7.0`. Its source differs from maintenance types only by the two optional `auto_join_general` fields, so no new types release or maintenance publish-workflow change is needed. a2a remains 8.5.2.

Validation: engine build and all 898 tests pass. Migration files, `retention.ts`, `rowidRetention.ts`, and `routes/deliveryRouting.ts` are byte-identical to the maintenance parent. Independent compatibility review recommended this schema-free path; final backport review is pending.

Release plan: publish engine-only `8.5.2-hotfix.4` under `alpha` using the existing maintenance workflow, verify artifact integrity, then pin it and published types8.7.0 in relaycast-cloud#106 rebased onto current production. No new migration, capacity override, mainline rollback, or latest-tag change is part of this rollout.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core message fanout, spawn placement, and inbound integration atomicity; mistakes could mis-route deliveries or drop/replay events, though behavior is heavily covered by new conformance tests.
> 
> **Overview**
> Backports GitHub-style **subscription delivery** and related engine behavior onto the maintenance line without changing schema-free retention or migration paths.
> 
> **Subscription & agents:** Workspace owners can provision **`POST /v1/agents/{name}/subscription-channel`** — an idempotent, identity-bound `agent-events-*` route where only that agent may be a member; recreated names get new channels. Registration and node **`agent.register`** accept **`auto_join_general: false`** for isolated workers (recovery keeps existing memberships). Agent removal invalidates channel membership caches from the actual delete transaction.
> 
> **Mentions & delivery:** Mentions now resolve **full hyphenated handles** (shared parser for live send and replay); thread replies use the same rules. **Relayfile** and **raw inbound webhooks** create durable channel deliveries, route them like normal messages, and on **full mailboxes** roll back the whole event with **503 `mailbox_full`** and **`Retry-After: 30`** (no partial commits). Relayfile preserves **`providerEventType` / `resourceRef`** in metadata and unwraps Cloud sync envelopes for display only.
> 
> **Fleet / spawn:** Nodes may **read spawn invocation status** only for invocations dispatched to their own node. **`verify_ready: true`** fails with **`spawn_target_unavailable`** when the chosen provider is not live; inventory reconciliation honors only top-level **`verify_ready`**. Nonempty **`target_node`** uses capacity placement even when a legacy workspace-global **`spawn`** action exists (ACL still applies). **`agent.deregister`** with an **`id`** gets a correlated **reply** after teardown.
> 
> Docs/OpenAPI/changelogs bump the unreleased section to **Minor**; engine depends on **`@relaycast/types@8.7.0`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aea586ac95555b4faa1cdf64fa46d70c724e317f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/AgentWorkforce/relaycast/pull/414?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

