### PR TITLE
fix(engine): restore scheduled maintenance compatibility

### DIFF
--- a/.agentworkforce/trajectories/completed/2026-09/traj_n99tgaiqqynd.trace.json
+++ b/.agentworkforce/trajectories/completed/2026-09/traj_n99tgaiqqynd.trace.json
@@ -1,0 +1,181 @@
+{
+  "version": "1.0.0",
+  "id": "7325b2df-94a5-482a-b16a-3f6538a1b2ee",
+  "timestamp": "2026-09-10T10:36:02.555Z",
+  "trajectory": "traj_n99tgaiqqynd",
+  "files": [
+    {
+      "path": ".agentworkforce/trajectories/active/traj_n99tgaiqqynd/trajectory.json",
+      "conversations": [
+        {
+          "contributor": {
+            "type": "ai"
+          },
+          "ranges": [
+            {
+              "start_line": 1,
+              "end_line": 62,
+              "revision": "7bb763980ee363aede4b700369ff6637b5e4a4e0"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "path": "CHANGELOG.md",
+      "conversations": [
+        {
+          "contributor": {
+            "type": "ai"
+          },
+          "ranges": [
+            {
+              "start_line": 16,
+              "end_line": 26,
+              "revision": "7bb763980ee363aede4b700369ff6637b5e4a4e0"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "path": "packages/engine/CHANGELOG.md",
+      "conversations": [
+        {
+          "contributor": {
+            "type": "ai"
+          },
+          "ranges": [
+            {
+              "start_line": 7,
+              "end_line": 17,
+              "revision": "7bb763980ee363aede4b700369ff6637b5e4a4e0"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "path": "packages/engine/src/__tests__/conformance/delivery.test.ts",
+      "conversations": [
+        {
+          "contributor": {
+            "type": "ai"
+          },
+          "ranges": [
+            {
+              "start_line": 1528,
+              "end_line": 1569,
+              "revision": "7bb763980ee363aede4b700369ff6637b5e4a4e0"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "path": "packages/engine/src/engine/__tests__/maintenanceApiCompatibility.test.ts",
+      "conversations": [
+        {
+          "contributor": {
+            "type": "ai"
+          },
+          "ranges": [
+            {
+              "start_line": 1,
+              "end_line": 114,
+              "revision": "7bb763980ee363aede4b700369ff6637b5e4a4e0"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "path": "packages/engine/src/engine/retention.ts",
+      "conversations": [
+        {
+          "contributor": {
+            "type": "ai"
+          },
+          "ranges": [
+            {
+              "start_line": 5,
+              "end_line": 11,
+              "revision": "7bb763980ee363aede4b700369ff6637b5e4a4e0"
+            },
+            {
+              "start_line": 30,
+              "end_line": 52,
+              "revision": "7bb763980ee363aede4b700369ff6637b5e4a4e0"
+            },
+            {
+              "start_line": 150,
+              "end_line": 155,
+              "revision": "7bb763980ee363aede4b700369ff6637b5e4a4e0"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "path": "packages/engine/src/engine/rowidRetention.ts",
+      "conversations": [
+        {
+          "contributor": {
+            "type": "ai"
+          },
+          "ranges": [
+            {
+              "start_line": 1,
+              "end_line": 230,
+              "revision": "7bb763980ee363aede4b700369ff6637b5e4a4e0"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "path": "packages/engine/src/index.ts",
+      "conversations": [
+        {
+          "contributor": {
+            "type": "ai"
+          },
+          "ranges": [
+            {
+              "start_line": 92,
+              "end_line": 98,
+              "revision": "7bb763980ee363aede4b700369ff6637b5e4a4e0"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "path": "packages/engine/src/routes/deliveryRouting.ts",
+      "conversations": [
+        {
+          "contributor": {
+            "type": "ai"
+          },
+          "ranges": [
+            {
+              "start_line": 510,
+              "end_line": 523,
+              "revision": "7bb763980ee363aede4b700369ff6637b5e4a4e0"
+            },
+            {
+              "start_line": 552,
+              "end_line": 565,
+              "revision": "7bb763980ee363aede4b700369ff6637b5e4a4e0"
+            },
+            {
+              "start_line": 591,
+              "end_line": 597,
+              "revision": "7bb763980ee363aede4b700369ff6637b5e4a4e0"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/.agentworkforce/trajectories/completed/2026-09/traj_n99tgaiqqynd/summary.md
+++ b/.agentworkforce/trajectories/completed/2026-09/traj_n99tgaiqqynd/summary.md
@@ -1,0 +1,40 @@
+# Trajectory: Reconcile Relaycast production maintenance APIs into main
+
+> **Status:** ✅ Completed
+> **Task:** Relaycast#415
+> **Confidence:** 90%
+> **Started:** September 10, 2026 at 12:32 PM
+> **Completed:** September 10, 2026 at 12:36 PM
+
+---
+
+## Summary
+
+Restored host-owned schema-free retention cursors and bounded WS redrive for Relaycast #415.
+
+**Approach:** Standard approach
+
+---
+
+## Key Decisions
+
+### Added an opt-in host cursor retention mode beside the 8.8 index-backed default
+- **Chose:** Added an opt-in host cursor retention mode beside the 8.8 index-backed default
+- **Reasoning:** Relaycast-cloud needs production's schema-free API while self-hosted 8.8 users retain durable database cursors and scheduled expiry semantics.
+
+---
+
+## Chapters
+
+### 1. Work
+*Agent: default*
+
+- Added an opt-in host cursor retention mode beside the 8.8 index-backed default: Added an opt-in host cursor retention mode beside the 8.8 index-backed default
+- Engine, SDK/types, release, and full lint suites passed; actionlint reports pre-existing workflow warnings outside this diff.
+
+---
+
+## Artifacts
+
+**Commits:** 7bb76398
+**Files changed:** 9

--- a/.agentworkforce/trajectories/completed/2026-09/traj_n99tgaiqqynd/trajectory.json
+++ b/.agentworkforce/trajectories/completed/2026-09/traj_n99tgaiqqynd/trajectory.json
@@ -1,0 +1,82 @@
+{
+  "id": "traj_n99tgaiqqynd",
+  "version": 1,
+  "task": {
+    "title": "Reconcile Relaycast production maintenance APIs into main",
+    "source": {
+      "system": "plain",
+      "id": "Relaycast#415"
+    }
+  },
+  "status": "completed",
+  "startedAt": "2026-09-10T10:32:31.408Z",
+  "completedAt": "2026-09-10T10:36:02.485Z",
+  "agents": [
+    {
+      "name": "default",
+      "role": "lead",
+      "joinedAt": "2026-09-10T10:35:27.002Z"
+    }
+  ],
+  "chapters": [
+    {
+      "id": "chap_gug9oygglej9",
+      "title": "Work",
+      "agentName": "default",
+      "startedAt": "2026-09-10T10:35:27.002Z",
+      "endedAt": "2026-09-10T10:36:02.485Z",
+      "events": [
+        {
+          "ts": 1789036527003,
+          "type": "decision",
+          "content": "Added an opt-in host cursor retention mode beside the 8.8 index-backed default: Added an opt-in host cursor retention mode beside the 8.8 index-backed default",
+          "raw": {
+            "question": "Added an opt-in host cursor retention mode beside the 8.8 index-backed default",
+            "chosen": "Added an opt-in host cursor retention mode beside the 8.8 index-backed default",
+            "alternatives": [],
+            "reasoning": "Relaycast-cloud needs production's schema-free API while self-hosted 8.8 users retain durable database cursors and scheduled expiry semantics."
+          },
+          "significance": "high"
+        },
+        {
+          "ts": 1789036527291,
+          "type": "reflection",
+          "content": "Engine, SDK/types, release, and full lint suites passed; actionlint reports pre-existing workflow warnings outside this diff.",
+          "raw": {
+            "confidence": 0.84
+          },
+          "significance": "high",
+          "tags": [
+            "confidence:0.84"
+          ]
+        }
+      ]
+    }
+  ],
+  "retrospective": {
+    "summary": "Restored host-owned schema-free retention cursors and bounded WS redrive for Relaycast #415.",
+    "approach": "Standard approach",
+    "confidence": 0.9
+  },
+  "commits": [
+    "7bb76398"
+  ],
+  "filesChanged": [
+    ".agentworkforce/trajectories/active/traj_n99tgaiqqynd/trajectory.json",
+    "CHANGELOG.md",
+    "packages/engine/CHANGELOG.md",
+    "packages/engine/src/__tests__/conformance/delivery.test.ts",
+    "packages/engine/src/engine/__tests__/maintenanceApiCompatibility.test.ts",
+    "packages/engine/src/engine/retention.ts",
+    "packages/engine/src/engine/rowidRetention.ts",
+    "packages/engine/src/index.ts",
+    "packages/engine/src/routes/deliveryRouting.ts"
+  ],
+  "projectId": "AgentWorkforce/relaycast",
+  "tags": [],
+  "_trace": {
+    "startRef": "0fbb999e1768415c41239e2f14b7d14b92aaf9b9",
+    "endRef": "7bb763980ee363aede4b700369ff6637b5e4a4e0",
+    "traceId": "7325b2df-94a5-482a-b16a-3f6538a1b2ee"
+  }
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,11 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 Packages without a separate changelog are covered by the cross-package notes below.
 
-## [Unreleased]
+## [Unreleased - Patch]
+
+### Fixed
+
+- Engine scheduled maintenance again supports host-owned retention cursors and bounded websocket backlog redrive, allowing hosted deployments to retain schema-free recovery behavior.
 
 ## [8.8.0] - 2026-09-10
 

--- a/packages/engine/CHANGELOG.md
+++ b/packages/engine/CHANGELOG.md
@@ -7,7 +7,11 @@ See the [root changelog](../../CHANGELOG.md) for cross-package release highlight
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [Unreleased - Patch]
+
+### Fixed
+
+- `pruneExpired` accepts a host-owned `cursorStore` for bounded schema-free retention without the engine cursor table; scheduled node redrive accepts `wsBacklogLimit` per agent.
 
 ## [8.8.0] - 2026-09-10
 

--- a/packages/engine/src/__tests__/conformance/delivery.test.ts
+++ b/packages/engine/src/__tests__/conformance/delivery.test.ts
@@ -1564,6 +1564,38 @@ describe('durable delivery api', () => {
     expect(remaining).toEqual({ status: 'delivered' });
   });
 
+  it.each([1.5, Number.NaN])('normalizes invalid ws backlog limits before the SQL LIMIT (%s)', async (wsBacklogLimit) => {
+    const ws = await createWorkspace(stack.app, `mailbox-ws-sweep-limit-${String(wsBacklogLimit)}`);
+    const alice = await registerAgent(stack.app, ws.workspaceKey, 'alice');
+    const node = await enrollAndAttachNode(ws, { cursorHandshake: true });
+    const bob = await registerViaNode(node, 'bob');
+    for (const text of ['one', 'two']) {
+      const post = await stack.app.request('/v1/channels/general/messages', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json', authorization: `Bearer ${alice.token}` },
+        body: JSON.stringify({ text }),
+      });
+      expect(post.status).toBe(201);
+    }
+    await waitForAssertion(() => expect(node.sock.ofType('deliver')).toHaveLength(2));
+
+    const db = stack.runtime.deps.db;
+    const rowsForBob = and(eq(deliveries.workspaceId, ws.workspaceId), eq(deliveries.agentId, bob.agentId));
+    await db.update(deliveries).set({
+      status: 'queued', nextAttemptAt: null, dispatchAttempts: 0, deliveredAt: null, lastDispatchError: null,
+    }).where(rowsForBob);
+    const before = node.sock.ofType('deliver').length;
+
+    await expect(sweepDueNodeDeliveries(stack.runtime.deps, { now: new Date(), wsBacklogLimit })).resolves.toBe(2);
+    const redriven = node.sock.ofType('deliver').slice(before);
+    expect(redriven.map((frame) => frame.seq)).toEqual(Number.isNaN(wsBacklogLimit) ? [1, 2] : [1]);
+    const remaining = await db.select({ seq: deliveries.seq, status: deliveries.status })
+      .from(deliveries).where(rowsForBob).orderBy(deliveries.seq);
+    expect(remaining).toEqual(Number.isNaN(wsBacklogLimit)
+      ? [{ seq: 1, status: 'delivered' }, { seq: 2, status: 'delivered' }]
+      : [{ seq: 1, status: 'delivered' }, { seq: 2, status: 'queued' }]);
+  });
+
   it('sweep stops a ws agent backlog at the first undeliverable seq (node connected, agent not ready)', async () => {
     // The node is connected but the agent is not delivery-ready (cursor
     // negotiation pending after a reconnect). The group must stop at seq 1 —

--- a/packages/engine/src/__tests__/conformance/delivery.test.ts
+++ b/packages/engine/src/__tests__/conformance/delivery.test.ts
@@ -1528,6 +1528,42 @@ describe('durable delivery api', () => {
     expect(row2.status).toBe('delivered');
   });
 
+  it('caps one ws agent backlog per scheduled sweep without reordering or failing deferred rows', async () => {
+    const ws = await createWorkspace(stack.app, 'mailbox-ws-sweep-backlog-limit');
+    const alice = await registerAgent(stack.app, ws.workspaceKey, 'alice');
+    const node = await enrollAndAttachNode(ws, { cursorHandshake: true });
+    const bob = await registerViaNode(node, 'bob');
+    for (const text of ['one', 'two', 'three']) {
+      const post = await stack.app.request('/v1/channels/general/messages', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json', authorization: `Bearer ${alice.token}` },
+        body: JSON.stringify({ text }),
+      });
+      expect(post.status).toBe(201);
+    }
+    await waitForAssertion(() => expect(node.sock.ofType('deliver')).toHaveLength(3));
+
+    const db = stack.runtime.deps.db;
+    const rowsForBob = and(eq(deliveries.workspaceId, ws.workspaceId), eq(deliveries.agentId, bob.agentId));
+    await db.update(deliveries).set({
+      status: 'queued', nextAttemptAt: null, dispatchAttempts: 0, deliveredAt: null, lastDispatchError: null,
+    }).where(rowsForBob);
+    const before = node.sock.ofType('deliver').length;
+
+    expect(await sweepDueNodeDeliveries(stack.runtime.deps, { now: new Date(), wsBacklogLimit: 2 })).toBe(3);
+    expect(node.sock.ofType('deliver').slice(before).map(frame => frame.seq)).toEqual([1, 2]);
+    const firstPass = await db.select({ seq: deliveries.seq, status: deliveries.status })
+      .from(deliveries).where(rowsForBob).orderBy(deliveries.seq);
+    expect(firstPass).toEqual([
+      { seq: 1, status: 'delivered' }, { seq: 2, status: 'delivered' }, { seq: 3, status: 'queued' },
+    ]);
+
+    expect(await sweepDueNodeDeliveries(stack.runtime.deps, { now: new Date(Date.now() + 1_000) })).toBe(1);
+    const [remaining] = await db.select({ status: deliveries.status }).from(deliveries)
+      .where(and(rowsForBob, eq(deliveries.seq, 3)));
+    expect(remaining).toEqual({ status: 'delivered' });
+  });
+
   it('sweep stops a ws agent backlog at the first undeliverable seq (node connected, agent not ready)', async () => {
     // The node is connected but the agent is not delivery-ready (cursor
     // negotiation pending after a reconnect). The group must stop at seq 1 —

--- a/packages/engine/src/engine/__tests__/maintenanceApiCompatibility.test.ts
+++ b/packages/engine/src/engine/__tests__/maintenanceApiCompatibility.test.ts
@@ -91,6 +91,33 @@ describe('scheduled-maintenance API compatibility', () => {
     expect(vi.mocked(f.cursorStore.save)).toHaveBeenCalled();
   });
 
+  it.each([
+    {},
+    { version: 1 },
+    { next: 0, positions: {}, highs: {} },
+    { version: 1, next: 0, tables: { deliveries: { cursor: 'legacy-rowid' } } },
+  ])('resets malformed host cursor state safely: %j', async (saved) => {
+    const f = fixture();
+    const old = Math.floor(new Date('2026-01-01T00:00:00Z').getTime() / 1_000);
+    f.sqlite.exec(`
+      INSERT INTO messages(id, workspace_id, channel_id, agent_id, body)
+        VALUES ('message', 'ws', 'channel', 'agent', 'body');
+      INSERT INTO deliveries(id, workspace_id, message_id, agent_id, seq, status, created_at)
+        VALUES ('delivery', 'ws', 'message', 'agent', 1, 'acked', ${old});
+    `);
+    vi.mocked(f.cursorStore.load).mockResolvedValue(saved);
+
+    await expect(pruneExpired(f.db, {
+      cursorStore: f.cursorStore,
+      batchLimit: 2,
+      maxBatches: 1,
+      now: new Date('2026-06-01T00:00:00Z'),
+    })).resolves.toMatchObject({ deliveries: 1 });
+    expect(f.sqlite.prepare("SELECT count(*) AS n FROM deliveries").get()).toEqual({ n: 0 });
+    expect(vi.mocked(f.cursorStore.save)).toHaveBeenCalled();
+    expect(f.state()).toMatchObject({ version: 1, tables: {} });
+  });
+
   it('reclaims long-expired active deliveries only when explicitly enabled', async () => {
     const f = fixture();
     const now = new Date('2026-06-01T00:00:00Z');

--- a/packages/engine/src/engine/__tests__/maintenanceApiCompatibility.test.ts
+++ b/packages/engine/src/engine/__tests__/maintenanceApiCompatibility.test.ts
@@ -1,0 +1,114 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { drizzle } from 'drizzle-orm/better-sqlite3';
+import { getSqliteDb, runMigrations, type SqliteDbHandle } from '../../adapters/node/database.js';
+import * as schema from '../../db/schema.js';
+import {
+  pruneExpired,
+  sweepDueNodeDeliveries,
+  type PruneOptions,
+  type RetentionCursorStore,
+  type RowidRetentionState,
+} from '../../index.js';
+import type { EngineDb } from '../../ports/database.js';
+
+const handles: SqliteDbHandle[] = [];
+afterEach(() => { for (const handle of handles.splice(0)) handle.sqlite.close(); vi.restoreAllMocks(); });
+
+function fixture() {
+  const handle = getSqliteDb(':memory:');
+  handles.push(handle);
+  runMigrations(handle);
+  handle.sqlite.exec(`
+    INSERT INTO workspaces(id, name, api_key_hash) VALUES ('ws', 'workspace', 'key');
+    INSERT INTO agents(id, workspace_id, name, token_hash) VALUES ('agent', 'ws', 'agent', 'token');
+    INSERT INTO channels(id, workspace_id, name) VALUES ('channel', 'ws', 'general');
+  `);
+  const queries: Array<{ sql: string; params: unknown[] }> = [];
+  const db = drizzle(handle.sqlite, {
+    schema,
+    logger: { logQuery: (sql, params) => queries.push({ sql, params }) },
+  }) as unknown as EngineDb;
+  let state: RowidRetentionState | undefined;
+  const cursorStore: RetentionCursorStore = {
+    load: vi.fn(async () => structuredClone(state)),
+    save: vi.fn(async (next) => { state = structuredClone(next); }),
+  };
+  return { ...handle, db, queries, cursorStore, state: () => state };
+}
+
+// This is deliberately the exact public shape used by relaycast-cloud's
+// scheduledMaintenance entrypoint. It protects the engine package boundary
+// without importing or modifying the cloud repository.
+function scheduledMaintenanceCallShape(cursorStore: RetentionCursorStore) {
+  const retention = {
+    batchLimit: 200,
+    maxBatches: 5,
+    defaults: { messageTtlDays: 30 },
+    cursorStore,
+    maxDurationMs: 10_000,
+  } satisfies PruneOptions;
+  const redrive = {
+    limit: 50,
+    wsBacklogLimit: 25,
+  } satisfies NonNullable<Parameters<typeof sweepDueNodeDeliveries>[1]>;
+  return { retention, redrive };
+}
+
+describe('scheduled-maintenance API compatibility', () => {
+  it('accepts the current cloud retention and redrive call shape', () => {
+    const { cursorStore } = fixture();
+    expect(scheduledMaintenanceCallShape(cursorStore)).toMatchObject({
+      retention: { cursorStore, maxDurationMs: 10_000 },
+      redrive: { limit: 50, wsBacklogLimit: 25 },
+    });
+  });
+
+  it('uses the host cursor store for bounded, resumable retention without touching maintenance_cursors', async () => {
+    const f = fixture();
+    const old = Math.floor(new Date('2026-01-01T00:00:00Z').getTime() / 1_000);
+    const message = f.sqlite.prepare("INSERT INTO messages(id, workspace_id, channel_id, agent_id, body) VALUES (?, 'ws', 'channel', 'agent', 'body')");
+    const delivery = f.sqlite.prepare("INSERT INTO deliveries(id, workspace_id, message_id, agent_id, seq, status, created_at) VALUES (?, 'ws', ?, 'agent', ?, 'acked', ?)");
+    for (let n = 1; n <= 5; n++) {
+      const id = String(n);
+      message.run(id);
+      delivery.run('delivery-' + id, id, n, old);
+    }
+
+    const opts: PruneOptions = {
+      cursorStore: f.cursorStore,
+      batchLimit: 2,
+      maxBatches: 1,
+      now: new Date('2026-06-01T00:00:00Z'),
+    };
+    await pruneExpired(f.db, opts);
+    expect(f.state()?.tables.deliveries?.cursor).toBeDefined();
+    expect(f.sqlite.prepare("SELECT count(*) AS n FROM maintenance_cursors WHERE id = 'retention-v1'").get()).toEqual({ n: 0 });
+    expect(f.queries.some(query => query.sql.includes('FROM deliveries NOT INDEXED') && query.sql.includes('WITH page AS MATERIALIZED'))).toBe(true);
+
+    await pruneExpired(f.db, opts);
+    await pruneExpired(f.db, opts);
+    expect(f.sqlite.prepare("SELECT count(*) AS n FROM deliveries").get()).toEqual({ n: 0 });
+    expect(vi.mocked(f.cursorStore.save)).toHaveBeenCalled();
+  });
+
+  it('reclaims long-expired active deliveries only when explicitly enabled', async () => {
+    const f = fixture();
+    const now = new Date('2026-06-01T00:00:00Z');
+    const expired = Math.floor(now.getTime() / 1_000) - 8 * 86_400;
+    f.sqlite.exec(`
+      INSERT INTO messages(id, workspace_id, channel_id, agent_id, body) VALUES ('message', 'ws', 'channel', 'agent', 'body');
+      INSERT INTO deliveries(id, workspace_id, message_id, agent_id, seq, status, expires_at)
+      VALUES ('queued', 'ws', 'message', 'agent', 1, 'queued', ${expired});
+    `);
+
+    await expect(pruneExpired(f.db, {
+      cursorStore: f.cursorStore,
+      activeExpiryRecovery: true,
+      expiredDeliveryGraceDays: 7,
+      maxBatches: 1,
+      now,
+    })).resolves.toMatchObject({ deliveries: 1 });
+    expect(f.sqlite.prepare("SELECT id FROM deliveries WHERE id = 'queued'").get()).toBeUndefined();
+    expect(f.queries.some(query => query.sql.includes('idx_deliveries_active_expiry'))).toBe(true);
+  });
+});

--- a/packages/engine/src/engine/delivery.ts
+++ b/packages/engine/src/engine/delivery.ts
@@ -828,7 +828,12 @@ export async function fetchQueuedWsBacklogEvents(
   agentId: string,
   opts: { now?: Date; limit?: number } = {},
 ): Promise<RoutableDeliveryEvent[]> {
-  const limit = Math.min(Math.max(opts.limit ?? 200, 1), 500);
+  // SQLite LIMIT accepts only a finite integer. Match the bounded redrive
+  // option's existing semantics: floor fractions, clamp positive values, and
+  // use the safe default for NaN, infinities, or omitted limits.
+  const limit = Number.isFinite(opts.limit)
+    ? Math.min(Math.max(Math.floor(opts.limit!), 1), 500)
+    : 200;
   const now = opts.now ?? new Date();
   const nowSeconds = Math.floor(now.getTime() / 1000);
 

--- a/packages/engine/src/engine/retention.ts
+++ b/packages/engine/src/engine/retention.ts
@@ -5,6 +5,7 @@ import type { EffectiveMessageRetention } from '@relaycast/types';
 import type { getDb } from '../db/index.js';
 import { workspaces } from '../db/schema.js';
 import { snowflakeIdLowerBound } from './snowflake.js';
+import { pruneRowidPages, type RetentionCursorStore } from './rowidRetention.js';
 
 type Db = ReturnType<typeof getDb>;
 
@@ -29,12 +30,23 @@ export interface RetentionDefaults {
 }
 
 export interface PruneOptions {
+  /**
+   * Host-owned durable state for schema-free, rowid-bounded recovery. Supplying
+   * this avoids the engine maintenance-cursors table; callers must serialize it.
+   */
+  cursorStore?: RetentionCursorStore;
   /** Stop starting candidate pages after this elapsed budget (default 10s, capped at 30s). */
   maxDurationMs?: number;
   /** Max candidate rows examined per table per batch. Default/cap 200. */
   batchLimit?: number;
   /** Max candidate batches per table per call. Default/cap 5; durable cursors resume on the next call. */
   maxBatches?: number;
+  /** Active queued/delivered expiry recovery is opt-in and defaults to a 7-day grace window. */
+  expiredDeliveryGraceDays?: number;
+  /** Opt in to bounded, indexed cleanup of active deliveries past their expiry grace window. */
+  activeExpiryRecovery?: boolean;
+  /** Maximum active-expiry recovery batches (capped at four). */
+  activeExpiryRecoveryMaxBatches?: number;
   /** Clock override for tests. */
   now?: Date;
   /** Deployment-wide TTL fallbacks; see {@link RetentionDefaults}. */
@@ -138,5 +150,6 @@ export function afterSnowflake(column: SQLiteColumn, cursor: string): SQL {
 
 /** Bounded, resumable retention; preserves TTL overrides and event high-water marks. */
 export async function pruneExpired(db: Db, opts: PruneOptions = {}): Promise<PruneResult> {
+  if (opts.cursorStore) return pruneRowidPages(db, { ...opts, cursorStore: opts.cursorStore });
   return pruneBounded(db, opts);
 }

--- a/packages/engine/src/engine/rowidRetention.ts
+++ b/packages/engine/src/engine/rowidRetention.ts
@@ -1,0 +1,230 @@
+import { sql } from 'drizzle-orm';
+import { z } from 'zod';
+import type { EngineDb } from '../ports/database.js';
+import type { WorkspaceRetentionSettings } from '../db/schema.js';
+import type { PruneOptions, PruneResult, RetentionDefaults } from './retention.js';
+import { snowflakeIdLowerBound } from './snowflake.js';
+
+const safeRowid = z.number().int().min(Number.MIN_SAFE_INTEGER).max(Number.MAX_SAFE_INTEGER);
+const stateSchema = z.object({
+  version: z.literal(1),
+  next: z.number().int().min(0).max(4),
+  tables: z.record(z.string(), z.object({ cursor: safeRowid.optional(), high: safeRowid.optional() })),
+});
+export type RowidRetentionState = z.infer<typeof stateSchema>;
+
+/**
+ * Host-owned durable state for the schema-free retention path. Hosts must
+ * serialize maintenance calls for a database, and `save` must resolve only
+ * after the checkpoint is durable. This path creates no engine table or index.
+ */
+export interface RetentionCursorStore {
+  load(): Promise<unknown>;
+  save(state: RowidRetentionState): Promise<void>;
+}
+
+type Candidate = {
+  _rowid: number;
+  id: string;
+  workspace_id: string;
+  created_at: number;
+  expires_at: number | null;
+  seq: number;
+  message_id: string;
+  agent_id: string;
+  status: string;
+  retention: string | null;
+  eligible: number;
+};
+type Table = {
+  name: string;
+  result: keyof PruneResult;
+  columns: string;
+  setting?: keyof WorkspaceRetentionSettings;
+  fallback?: keyof RetentionDefaults;
+  snowflake?: boolean;
+  guard: string;
+};
+
+const SETTLED_DELIVERIES = "deliveries.status IN ('acked', 'failed', 'dead_lettered')";
+const DEFAULT_EXPIRED_DELIVERY_GRACE_DAYS = 7;
+const MAX_ACTIVE_EXPIRY_RECOVERY_BATCHES = 4;
+const ACTIVE_EXPIRY_RECOVERY_DELETE_LIMIT = 1_000;
+const ROWID_PAGE_LIMIT = 200;
+const ROWID_MAX_BATCHES_PER_TABLE = 5;
+const ROWID_DELETE_CHUNK_SIZE = 10;
+
+const tables: Table[] = [
+  { name: 'messages', result: 'messages', columns: 'id, workspace_id',
+    setting: 'message_ttl_days', fallback: 'messageTtlDays', snowflake: true,
+    guard: 'NOT EXISTS (SELECT 1 FROM messages replies WHERE replies.thread_id = messages.id)' },
+  { name: 'deliveries', result: 'deliveries', columns: 'id, workspace_id, created_at, status, expires_at',
+    setting: 'delivery_ttl_days', fallback: 'deliveryTtlDays', guard: SETTLED_DELIVERIES },
+  { name: 'message_logs', result: 'messageLogs', columns: 'id, workspace_id',
+    setting: 'message_log_ttl_days', fallback: 'messageLogTtlDays', snowflake: true, guard: '1' },
+  { name: 'workspace_events', result: 'workspaceEvents', columns: 'workspace_id, seq, created_at',
+    setting: 'workspace_event_ttl_days', fallback: 'workspaceEventTtlDays',
+    guard: 'EXISTS (SELECT 1 FROM workspace_events hw WHERE hw.workspace_id = workspace_events.workspace_id AND hw.seq > workspace_events.seq LIMIT 1)' },
+  { name: 'read_receipts', result: 'readReceipts', columns: 'message_id, agent_id',
+    guard: 'NOT EXISTS (SELECT 1 FROM messages m WHERE m.id = read_receipts.message_id)' },
+];
+
+/** Worst-case statement count for one cursor-store invocation, below D1's 1000-query ceiling. */
+export const ROWID_RETENTION_D1_QUERY_CEILING = tables.length * (
+  1 + ROWID_MAX_BATCHES_PER_TABLE + ROWID_MAX_BATCHES_PER_TABLE * Math.ceil(ROWID_PAGE_LIMIT / ROWID_DELETE_CHUNK_SIZE)
+) + MAX_ACTIVE_EXPIRY_RECOVERY_BATCHES;
+
+async function recoverExpiredActiveDeliveries(
+  db: EngineDb,
+  nowMs: number,
+  graceDays: number,
+  maxBatches: number,
+): Promise<number> {
+  const cutoffSeconds = Math.floor((nowMs - Math.max(0, Math.floor(graceDays * 86_400_000))) / 1_000);
+  const batches = bounded(maxBatches, MAX_ACTIVE_EXPIRY_RECOVERY_BATCHES, MAX_ACTIVE_EXPIRY_RECOVERY_BATCHES);
+  let deleted = 0;
+  for (let batch = 0; batch < batches; batch++) {
+    // This is the pre-existing global active-expiry index from migration 0031;
+    // the outer predicate repeats every condition so extension/status races are safe.
+    const changed = await db.all<{ id: string }>(sql`
+      DELETE FROM deliveries
+      WHERE status IN ('queued', 'delivered')
+        AND expires_at IS NOT NULL AND expires_at < ${cutoffSeconds}
+        AND id IN (
+          SELECT id FROM deliveries INDEXED BY idx_deliveries_active_expiry
+          WHERE status IN ('queued', 'delivered')
+            AND expires_at IS NOT NULL AND expires_at < ${cutoffSeconds}
+          ORDER BY expires_at, id LIMIT ${ACTIVE_EXPIRY_RECOVERY_DELETE_LIMIT}
+        )
+      RETURNING id
+    `);
+    deleted += changed.length;
+    if (changed.length < ACTIVE_EXPIRY_RECOVERY_DELETE_LIMIT) break;
+  }
+  return deleted;
+}
+
+function bounded(value: number | undefined, fallback: number, maximum: number): number {
+  return value !== undefined && Number.isFinite(value)
+    ? Math.max(1, Math.min(maximum, Math.floor(value)))
+    : fallback;
+}
+
+function isExpired(row: Candidate, table: Table, defaults: Required<RetentionDefaults>, nowMs: number): boolean {
+  if (!table.setting || !table.fallback) return true;
+  const settings = row.retention ? JSON.parse(row.retention) as WorkspaceRetentionSettings : {};
+  const days = settings[table.setting] === undefined ? defaults[table.fallback] : settings[table.setting];
+  if (days == null || !Number.isFinite(days) || days <= 0) return false;
+  const cutoff = nowMs - days * 86_400_000;
+  if (!Number.isFinite(cutoff)) return false;
+  if (!table.snowflake) return row.created_at * 1_000 < cutoff;
+  const bound = snowflakeIdLowerBound(cutoff);
+  return row.id.length < bound.length || (row.id.length === bound.length && row.id < bound);
+}
+
+/**
+ * Schema-free recovery mode. It pages by SQLite rowid before policy and
+ * eligibility filtering, so retained history cannot turn a bounded run into a
+ * full scan. A saved high-water mark makes each traversal finite under writes.
+ */
+export async function pruneRowidPages(
+  db: EngineDb,
+  opts: PruneOptions & { cursorStore: RetentionCursorStore },
+): Promise<PruneResult> {
+  const nowMs = (opts.now ?? new Date()).getTime();
+  if (!Number.isFinite(nowMs)) throw new Error('Invalid retention clock');
+  const limit = bounded(opts.batchLimit, ROWID_PAGE_LIMIT, ROWID_PAGE_LIMIT);
+  const pageBudget = bounded(opts.maxBatches, ROWID_MAX_BATCHES_PER_TABLE, ROWID_MAX_BATCHES_PER_TABLE) * tables.length;
+  const deadline = Date.now() + bounded(opts.maxDurationMs, 10_000, 30_000);
+  const defaults: Required<RetentionDefaults> = {
+    messageTtlDays: null,
+    deliveryTtlDays: 90,
+    messageLogTtlDays: 90,
+    workspaceEventTtlDays: 30,
+    ...Object.fromEntries(Object.entries(opts.defaults ?? {}).filter(([, value]) => value !== undefined)),
+  };
+  const saved = await opts.cursorStore.load();
+  const state: RowidRetentionState = saved == null
+    ? { version: 1, next: 0, tables: {} }
+    : stateSchema.parse(saved);
+  const save = () => opts.cursorStore.save(structuredClone(state));
+  const result: PruneResult = { messages: 0, deliveries: 0, messageLogs: 0, readReceipts: 0, workspaceEvents: 0 };
+  const finished = new Set<number>();
+
+  // Active expiry is opt-in because it intentionally skips delivery.failed
+  // fanout; normal scheduled expiry remains the default notification path.
+  if (opts.activeExpiryRecovery === true) {
+    result.deliveries += await recoverExpiredActiveDeliveries(
+      db,
+      nowMs,
+      opts.expiredDeliveryGraceDays ?? DEFAULT_EXPIRED_DELIVERY_GRACE_DAYS,
+      opts.activeExpiryRecoveryMaxBatches ?? MAX_ACTIVE_EXPIRY_RECOVERY_BATCHES,
+    );
+  }
+
+  for (let step = 0; step < pageBudget && Date.now() < deadline; step++) {
+    const index = state.next;
+    state.next = (index + 1) % tables.length;
+    if (finished.has(index)) continue;
+    const table = tables[index]!;
+    await save(); // fairness is durable before an admitted page
+    const position = state.tables[table.name] ??= {};
+    if (Date.now() >= deadline) break;
+    if (position.high === undefined) {
+      const [last] = await db.all<{ _rowid: number }>(sql`
+        SELECT rowid AS _rowid FROM ${sql.raw(table.name)} NOT INDEXED ORDER BY rowid DESC LIMIT 1
+      `);
+      if (!last) {
+        delete state.tables[table.name];
+        finished.add(index);
+        await save();
+        continue;
+      }
+      position.high = safeRowid.parse(last._rowid);
+    }
+    if (Date.now() >= deadline) break;
+    const page = await db.all<Candidate>(sql`
+      WITH page AS MATERIALIZED (
+        SELECT rowid AS _rowid, ${sql.raw(table.columns)} FROM ${sql.raw(table.name)} NOT INDEXED
+        WHERE rowid <= ${position.high}
+          ${position.cursor === undefined ? sql`` : sql`AND rowid > ${position.cursor}`}
+        ORDER BY rowid LIMIT ${limit}
+      ) SELECT page.*, ${sql.raw(table.guard.replaceAll(table.name + '.', 'page.'))} AS eligible,
+        ${table.setting ? sql`w.retention` : sql`NULL`} AS retention
+      FROM page ${table.setting ? sql`LEFT JOIN workspaces w ON w.id = page.workspace_id` : sql``}
+      ORDER BY page._rowid
+    `);
+    for (const row of page) safeRowid.parse(row._rowid);
+    const removable = page.filter(row => row.eligible && isExpired(row, table, defaults, nowMs));
+    for (let offset = 0; offset < removable.length; offset += ROWID_DELETE_CHUNK_SIZE) {
+      if (Date.now() >= deadline) {
+        await save();
+        return result;
+      }
+      const chunk = removable.slice(offset, offset + ROWID_DELETE_CHUNK_SIZE);
+      const guards = chunk.map(row => {
+        const identity = table.result === 'workspaceEvents'
+          ? sql`workspace_id = ${row.workspace_id} AND seq = ${row.seq}`
+          : table.result === 'readReceipts'
+            ? sql`message_id = ${row.message_id} AND agent_id = ${row.agent_id}`
+            : sql`id = ${row.id} AND workspace_id = ${row.workspace_id}`;
+        const policy = table.setting ? sql`AND (SELECT retention FROM workspaces WHERE id = ${row.workspace_id}) IS ${row.retention}` : sql``;
+        const created = table.setting && !table.snowflake ? sql`AND created_at = ${row.created_at}` : sql``;
+        const status = table.result === 'deliveries' ? sql`AND status = ${row.status}` : sql``;
+        return sql`(rowid = ${row._rowid} AND ${identity} ${policy} ${created} ${status})`;
+      });
+      const deleted = await db.all(sql`DELETE FROM ${sql.raw(table.name)} NOT INDEXED
+        WHERE (${sql.join(guards, sql` OR `)}) AND ${sql.raw(table.guard)} RETURNING 1`);
+      result[table.result] += deleted.length;
+    }
+    if (page.length < limit || page.at(-1)?._rowid === position.high) {
+      delete state.tables[table.name];
+      finished.add(index);
+    } else {
+      position.cursor = page.at(-1)!._rowid;
+    }
+    await save();
+    if (finished.size === tables.length) break;
+  }
+  return result;
+}

--- a/packages/engine/src/engine/rowidRetention.ts
+++ b/packages/engine/src/engine/rowidRetention.ts
@@ -74,6 +74,7 @@ export const ROWID_RETENTION_D1_QUERY_CEILING = tables.length * (
   1 + ROWID_MAX_BATCHES_PER_TABLE + ROWID_MAX_BATCHES_PER_TABLE * Math.ceil(ROWID_PAGE_LIMIT / ROWID_DELETE_CHUNK_SIZE)
 ) + MAX_ACTIVE_EXPIRY_RECOVERY_BATCHES;
 
+/** Delete only long-expired active deliveries through the existing bounded index. */
 async function recoverExpiredActiveDeliveries(
   db: EngineDb,
   nowMs: number,
@@ -104,12 +105,14 @@ async function recoverExpiredActiveDeliveries(
   return deleted;
 }
 
+/** Clamp an optional maintenance budget to a positive, finite row count. */
 function bounded(value: number | undefined, fallback: number, maximum: number): number {
   return value !== undefined && Number.isFinite(value)
     ? Math.max(1, Math.min(maximum, Math.floor(value)))
     : fallback;
 }
 
+/** Evaluate one candidate against its workspace retention policy and clock. */
 function isExpired(row: Candidate, table: Table, defaults: Required<RetentionDefaults>, nowMs: number): boolean {
   if (!table.setting || !table.fallback) return true;
   const settings = row.retention ? JSON.parse(row.retention) as WorkspaceRetentionSettings : {};
@@ -144,9 +147,15 @@ export async function pruneRowidPages(
     ...Object.fromEntries(Object.entries(opts.defaults ?? {}).filter(([, value]) => value !== undefined)),
   };
   const saved = await opts.cursorStore.load();
-  const state: RowidRetentionState = saved == null
-    ? { version: 1, next: 0, tables: {} }
-    : stateSchema.parse(saved);
+  // Cursor documents are advisory checkpoints owned by the host. A stale,
+  // partial, or legacy document must not take scheduled retention offline, and
+  // must never be trusted to construct a delete predicate. Restarting from an
+  // empty state is safe because every delete below rechecks row identity and
+  // current policy before mutating anything.
+  const parsed = saved == null ? undefined : stateSchema.safeParse(saved);
+  const state: RowidRetentionState = parsed?.success
+    ? parsed.data
+    : { version: 1, next: 0, tables: {} };
   const save = () => opts.cursorStore.save(structuredClone(state));
   const result: PruneResult = { messages: 0, deliveries: 0, messageLogs: 0, readReceipts: 0, workspaceEvents: 0 };
   const finished = new Set<number>();

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -92,6 +92,7 @@ export {
   DEFAULT_WORKSPACE_EVENT_TTL_DAYS,
 } from './engine/retention.js';
 export type { PruneOptions, PruneResult, RetentionDefaults } from './engine/retention.js';
+export type { RetentionCursorStore, RowidRetentionState } from './engine/rowidRetention.js';
 export type { WorkspaceRetentionSettings } from './db/schema.js';
 
 // Whole-workspace expiry is opt-in at creation and uses only the stored,

--- a/packages/engine/src/routes/deliveryRouting.ts
+++ b/packages/engine/src/routes/deliveryRouting.ts
@@ -510,8 +510,14 @@ async function redriveWsBacklogForAgent(
   ctx: RoutingContext,
   agentId: string,
   now: Date,
+  wsBacklogLimit: number | undefined,
 ): Promise<void> {
-  const backlog = await deliveryEngine.fetchQueuedWsBacklogEvents(ctx.db, ctx.workspaceId, agentId, { now });
+  const backlog = await deliveryEngine.fetchQueuedWsBacklogEvents(
+    ctx.db,
+    ctx.workspaceId,
+    agentId,
+    { now, limit: wsBacklogLimit },
+  );
   if (backlog.length === 0) return;
 
   const backlogDeliveries = backlog.map((event) => event.delivery);
@@ -546,10 +552,14 @@ async function redriveWsBacklogForAgent(
  */
 export async function sweepDueNodeDeliveries(
   engine: EngineDeps,
-  opts: { workspaceId?: string; now?: Date; limit?: number } = {},
+  opts: { workspaceId?: string; now?: Date; limit?: number; wsBacklogLimit?: number } = {},
 ): Promise<number> {
   const now = opts.now ?? new Date();
-  const due = await deliveryEngine.fetchDueNodeDeliveryEvents(engine.db, { ...opts, now });
+  const due = await deliveryEngine.fetchDueNodeDeliveryEvents(engine.db, {
+    workspaceId: opts.workspaceId,
+    limit: opts.limit,
+    now,
+  });
 
   const httpPushEvents: typeof due = [];
   const wsAgents: { workspaceId: string; agentId: string }[] = [];
@@ -581,6 +591,7 @@ export async function sweepDueNodeDeliveries(
         { db: engine.db, workspaceId: agent.workspaceId, engine },
         agent.agentId,
         now,
+        opts.wsBacklogLimit,
       )
     )),
   ];


### PR DESCRIPTION
Closes #415

## Summary
- restore the public `RetentionCursorStore` and `PruneOptions.cursorStore` contract with an opt-in, host-owned, rowid-bounded retention path that needs no new engine migration
- preserve the current 8.8 index-backed retention and expiry paths; opt-in active-expiry recovery uses the existing global expiry index
- add `wsBacklogLimit` to scheduled node redrive while preserving per-agent ordering and later drain behavior
- add engine API/behavior coverage, including the current relaycast-cloud scheduled-maintenance call shape without changing relaycast-cloud

## Validation
- `npm run -w @relaycast/engine typecheck`
- `npm run -w @relaycast/engine lint`
- `npm run -w @relaycast/engine test` (958 tests)
- `npm run -w @relaycast/types test` (209 tests)
- `npm run -w @relaycast/sdk test` (467 tests)
- `npm run test:release`
- `npm run lint`
- Veto diff review: PASS (code 96/100; no security or secrets findings)

`actionlint` was run; it reports existing warnings in untouched workflows.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/AgentWorkforce/relaycast/pull/416?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds an alternate retention deletion path and changes scheduled WS redrive batching; mistakes could affect data lifecycle or delivery ordering, though the default index-backed retention path is unchanged without `cursorStore`.
> 
> **Overview**
> Restores **scheduled maintenance compatibility** for hosted deployments (Relaycast #415) without changing the default 8.8 self-host path.
> 
> **Retention:** `pruneExpired` gains an opt-in `cursorStore` on `PruneOptions`. When set, pruning uses new **rowid-paged, host-owned** state (`rowidRetention.ts`) instead of the engine `maintenance_cursors` table—resumable deletes with malformed cursor documents reset safely. Optional **`activeExpiryRecovery`** reclaims long-expired `queued`/`delivered` rows via the existing active-expiry index. Public types `RetentionCursorStore` and `RowidRetentionState` are exported from the package entry.
> 
> **Delivery redrive:** `sweepDueNodeDeliveries` accepts **`wsBacklogLimit`** to cap how many queued websocket frames are redriven per agent per sweep while keeping ascending `seq` order; `fetchQueuedWsBacklogEvents` normalizes invalid limits for SQLite `LIMIT`.
> 
> Coverage adds **`maintenanceApiCompatibility.test.ts`** (relaycast-cloud call shape) and conformance tests for backlog caps and limit normalization. Changelogs note the fix; `.agentworkforce` trajectory artifacts are bookkeeping only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f1a644527c5f7566fb76c7c6699c40485642c1b3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->