### PR TITLE
fix(sdk-rust): honor registration Retry-After

### DIFF
--- a/.agentworkforce/trajectories/completed/2026-09/traj_26eywxjmijuy/summary.md
+++ b/.agentworkforce/trajectories/completed/2026-09/traj_26eywxjmijuy/summary.md
@@ -1,0 +1,31 @@
+# Trajectory: Document Rust registration retry cooldown helpers
+
+> **Status:** ✅ Completed
+> **Confidence:** 98%
+> **Started:** September 10, 2026 at 04:57 PM
+> **Completed:** September 10, 2026 at 04:58 PM
+
+---
+
+## Summary
+
+Added concise rustdoc to the private registration cooldown helpers, resolving the CodeRabbit docstring coverage warning.
+
+**Approach:** Standard approach
+
+---
+
+## Key Decisions
+
+### Added rustdoc for both helpers flagged by CodeRabbit
+- **Chose:** Added rustdoc for both helpers flagged by CodeRabbit
+- **Reasoning:** The docs state the observable cap/fallback and cached-deadline behavior without broadening the implementation.
+
+---
+
+## Chapters
+
+### 1. Work
+*Agent: default*
+
+- Added rustdoc for both helpers flagged by CodeRabbit: Added rustdoc for both helpers flagged by CodeRabbit

--- a/.agentworkforce/trajectories/completed/2026-09/traj_26eywxjmijuy/trajectory.json
+++ b/.agentworkforce/trajectories/completed/2026-09/traj_26eywxjmijuy/trajectory.json
@@ -1,0 +1,53 @@
+{
+  "id": "traj_26eywxjmijuy",
+  "version": 1,
+  "task": {
+    "title": "Document Rust registration retry cooldown helpers"
+  },
+  "status": "completed",
+  "startedAt": "2026-09-10T14:57:44.212Z",
+  "completedAt": "2026-09-10T14:58:32.365Z",
+  "agents": [
+    {
+      "name": "default",
+      "role": "lead",
+      "joinedAt": "2026-09-10T14:58:30.218Z"
+    }
+  ],
+  "chapters": [
+    {
+      "id": "chap_752rm4tqu6pc",
+      "title": "Work",
+      "agentName": "default",
+      "startedAt": "2026-09-10T14:58:30.218Z",
+      "endedAt": "2026-09-10T14:58:32.365Z",
+      "events": [
+        {
+          "ts": 1789052310219,
+          "type": "decision",
+          "content": "Added rustdoc for both helpers flagged by CodeRabbit: Added rustdoc for both helpers flagged by CodeRabbit",
+          "raw": {
+            "question": "Added rustdoc for both helpers flagged by CodeRabbit",
+            "chosen": "Added rustdoc for both helpers flagged by CodeRabbit",
+            "alternatives": [],
+            "reasoning": "The docs state the observable cap/fallback and cached-deadline behavior without broadening the implementation."
+          },
+          "significance": "high"
+        }
+      ]
+    }
+  ],
+  "retrospective": {
+    "summary": "Added concise rustdoc to the private registration cooldown helpers, resolving the CodeRabbit docstring coverage warning.",
+    "approach": "Standard approach",
+    "confidence": 0.98
+  },
+  "commits": [],
+  "filesChanged": [],
+  "projectId": "AgentWorkforce/relaycast",
+  "tags": [],
+  "_trace": {
+    "startRef": "8edc3cdbb7854846bcbb0563afb79912345d5102",
+    "endRef": "8edc3cdbb7854846bcbb0563afb79912345d5102"
+  }
+}

--- a/.agentworkforce/trajectories/completed/2026-09/traj_fn1qd11avbv8/summary.md
+++ b/.agentworkforce/trajectories/completed/2026-09/traj_fn1qd11avbv8/summary.md
@@ -1,0 +1,36 @@
+# Trajectory: Fix Rust registration Retry-After cooldown handling
+
+> **Status:** ✅ Completed
+> **Confidence:** 92%
+> **Started:** September 10, 2026 at 04:43 PM
+> **Completed:** September 10, 2026 at 04:43 PM
+
+---
+
+## Summary
+
+Rust registration now honors bounded server Retry-After cooldowns, preserves the 60-second malformed-header fallback, and schedules retries from the same cached cooldown.
+
+**Approach:** Standard approach
+
+---
+
+## Key Decisions
+
+### Registration cooldowns use the parsed Retry-After value, capped at five minutes
+- **Chose:** Registration cooldowns use the parsed Retry-After value, capped at five minutes
+- **Reasoning:** The hosted gateway sends a short authoritative delay; keeping a cap prevents malformed or hostile headers from blocking an agent indefinitely, while absent or malformed values retain the fail-closed 60-second fallback.
+
+### Retry scheduling consumes the active cached cooldown
+- **Chose:** Retry scheduling consumes the active cached cooldown
+- **Reasoning:** Using the cache as the source of truth prevents the fixed two-second retry sleep from producing local Blocked attempts before the server-directed cooldown expires.
+
+---
+
+## Chapters
+
+### 1. Work
+*Agent: default*
+
+- Registration cooldowns use the parsed Retry-After value, capped at five minutes: Registration cooldowns use the parsed Retry-After value, capped at five minutes
+- Retry scheduling consumes the active cached cooldown: Retry scheduling consumes the active cached cooldown

--- a/.agentworkforce/trajectories/completed/2026-09/traj_fn1qd11avbv8/trajectory.json
+++ b/.agentworkforce/trajectories/completed/2026-09/traj_fn1qd11avbv8/trajectory.json
@@ -1,0 +1,65 @@
+{
+  "id": "traj_fn1qd11avbv8",
+  "version": 1,
+  "task": {
+    "title": "Fix Rust registration Retry-After cooldown handling"
+  },
+  "status": "completed",
+  "startedAt": "2026-09-10T14:43:14.126Z",
+  "completedAt": "2026-09-10T14:43:54.175Z",
+  "agents": [
+    {
+      "name": "default",
+      "role": "lead",
+      "joinedAt": "2026-09-10T14:43:16.330Z"
+    }
+  ],
+  "chapters": [
+    {
+      "id": "chap_x96iv6q8a5az",
+      "title": "Work",
+      "agentName": "default",
+      "startedAt": "2026-09-10T14:43:16.330Z",
+      "endedAt": "2026-09-10T14:43:54.175Z",
+      "events": [
+        {
+          "ts": 1789051396331,
+          "type": "decision",
+          "content": "Registration cooldowns use the parsed Retry-After value, capped at five minutes: Registration cooldowns use the parsed Retry-After value, capped at five minutes",
+          "raw": {
+            "question": "Registration cooldowns use the parsed Retry-After value, capped at five minutes",
+            "chosen": "Registration cooldowns use the parsed Retry-After value, capped at five minutes",
+            "alternatives": [],
+            "reasoning": "The hosted gateway sends a short authoritative delay; keeping a cap prevents malformed or hostile headers from blocking an agent indefinitely, while absent or malformed values retain the fail-closed 60-second fallback."
+          },
+          "significance": "high"
+        },
+        {
+          "ts": 1789051398486,
+          "type": "decision",
+          "content": "Retry scheduling consumes the active cached cooldown: Retry scheduling consumes the active cached cooldown",
+          "raw": {
+            "question": "Retry scheduling consumes the active cached cooldown",
+            "chosen": "Retry scheduling consumes the active cached cooldown",
+            "alternatives": [],
+            "reasoning": "Using the cache as the source of truth prevents the fixed two-second retry sleep from producing local Blocked attempts before the server-directed cooldown expires."
+          },
+          "significance": "high"
+        }
+      ]
+    }
+  ],
+  "retrospective": {
+    "summary": "Rust registration now honors bounded server Retry-After cooldowns, preserves the 60-second malformed-header fallback, and schedules retries from the same cached cooldown.",
+    "approach": "Standard approach",
+    "confidence": 0.92
+  },
+  "commits": [],
+  "filesChanged": [],
+  "projectId": "AgentWorkforce/relaycast",
+  "tags": [],
+  "_trace": {
+    "startRef": "6416a5aaceef9d82e521e86a5fea5eb27750e748",
+    "endRef": "6416a5aaceef9d82e521e86a5fea5eb27750e748"
+  }
+}

--- a/packages/sdk-rust/CHANGELOG.md
+++ b/packages/sdk-rust/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
 - `RelayError::retry_after_ms()` exposes the authoritative server delay for exact-release overload handling.
 - Retryable HTTP failures retain the final status, API error, request metadata, and attempt count after retries are exhausted.
 - Retried 5xx responses honor a bounded `Retry-After` delay.
+- Agent registration now honors bounded server `Retry-After` cooldowns and waits for that same cooldown before retrying.
 
 ### Changed
 

--- a/packages/sdk-rust/Cargo.toml
+++ b/packages/sdk-rust/Cargo.toml
@@ -25,6 +25,7 @@ urlencoding = "2.1"
 
 [dev-dependencies]
 tokio-test = "0.4"
+tokio = { version = "1.0", features = ["test-util"] }
 mockito = "1.5"
 wiremock = "0.6"
 tempfile = "3.19"

--- a/packages/sdk-rust/src/registration.rs
+++ b/packages/sdk-rust/src/registration.rs
@@ -18,6 +18,10 @@ const DEFAULT_REGISTRATION_COOLDOWN_SECS: u64 = 60;
 const MAX_REGISTRATION_COOLDOWN_SECS: u64 = 300;
 const DEFAULT_REGISTRATION_RETRY_BACKOFF: Duration = Duration::from_secs(2);
 
+/// Resolve a local registration cooldown from the server's parsed `Retry-After` delay.
+///
+/// Valid delays are capped to avoid an unbounded local block; absent or
+/// malformed headers retain the fail-closed default cooldown.
 fn registration_cooldown_duration(retry_after_ms: Option<u64>) -> Duration {
     retry_after_ms
         .map(Duration::from_millis)
@@ -200,6 +204,11 @@ impl AgentRegistrationClient {
         lock_unpoisoned(&self.registration_cooldowns).remove(trimmed);
     }
 
+    /// Select the next retry delay, preferring the active cached cooldown.
+    ///
+    /// The cached deadline prevents a retry from reaching the server before a
+    /// known rate-limit window expires. Error metadata is only a fallback when
+    /// concurrent invalidation has removed that deadline.
     fn registration_retry_delay(
         &self,
         agent_name: &str,

--- a/packages/sdk-rust/src/registration.rs
+++ b/packages/sdk-rust/src/registration.rs
@@ -3,14 +3,27 @@
 use std::collections::HashMap;
 use std::path::Path;
 use std::sync::{Arc, Mutex, MutexGuard};
-use std::time::{Duration, Instant};
+use std::time::Duration;
 
 use thiserror::Error;
+use tokio::time::Instant;
 
 use crate::error::RelayError;
 use crate::{AgentClient, CreateAgentRequest, RelayCast};
 
 const DEFAULT_REGISTRATION_COOLDOWN_SECS: u64 = 60;
+// A valid Retry-After is the server's scheduling instruction, but retaining a
+// cooldown indefinitely would let a broken or hostile intermediary pin an
+// agent locally. Keep the same bounded-wait principle as the HTTP client.
+const MAX_REGISTRATION_COOLDOWN_SECS: u64 = 300;
+const DEFAULT_REGISTRATION_RETRY_BACKOFF: Duration = Duration::from_secs(2);
+
+fn registration_cooldown_duration(retry_after_ms: Option<u64>) -> Duration {
+    retry_after_ms
+        .map(Duration::from_millis)
+        .map(|delay| delay.min(Duration::from_secs(MAX_REGISTRATION_COOLDOWN_SECS)))
+        .unwrap_or(Duration::from_secs(DEFAULT_REGISTRATION_COOLDOWN_SECS))
+}
 
 fn lock_unpoisoned<T>(mutex: &Mutex<T>) -> MutexGuard<'_, T> {
     match mutex.lock() {
@@ -187,6 +200,20 @@ impl AgentRegistrationClient {
         lock_unpoisoned(&self.registration_cooldowns).remove(trimmed);
     }
 
+    fn registration_retry_delay(
+        &self,
+        agent_name: &str,
+        error: &AgentRegistrationError,
+    ) -> Duration {
+        // Rate-limit retries must consume the cache entry made by the failed
+        // registration. Falling back to the error's rounded display value is
+        // only for concurrent invalidation; it must not permit a premature
+        // request while a known cooldown is still active.
+        self.registration_block_remaining(agent_name)
+            .or_else(|| registration_retry_after_secs(error).map(Duration::from_secs))
+            .unwrap_or(DEFAULT_REGISTRATION_RETRY_BACKOFF)
+    }
+
     /// Register a **new** agent and return its token.
     ///
     /// Registration is create-only as of engine 8.2.0 (#349): a name already
@@ -272,10 +299,11 @@ impl AgentRegistrationClient {
                 code,
                 request_id,
                 attempts,
-                ..
+                retry_after_ms,
             }) => {
-                let retry_after_secs = DEFAULT_REGISTRATION_COOLDOWN_SECS;
-                let blocked_until = Instant::now() + Duration::from_secs(retry_after_secs);
+                let cooldown = registration_cooldown_duration(retry_after_ms);
+                let retry_after_secs = cooldown.as_secs();
+                let blocked_until = Instant::now() + cooldown;
                 lock_unpoisoned(&self.registration_cooldowns)
                     .insert(trimmed_name.to_string(), blocked_until);
                 Err(AgentRegistrationError::RateLimited {
@@ -365,7 +393,7 @@ pub async fn retry_agent_registration(
         match client.register_agent_token(agent_name, cli_hint).await {
             Ok(token) => return Ok(token),
             Err(error) if registration_is_retryable(&error) && attempt < MAX_ATTEMPTS - 1 => {
-                tokio::time::sleep(Duration::from_secs(2)).await;
+                tokio::time::sleep(client.registration_retry_delay(agent_name, &error)).await;
             }
             Err(error) if registration_is_retryable(&error) => {
                 return Err(AgentRegistrationRetryOutcome::RetryableExhausted(error));
@@ -380,11 +408,14 @@ pub async fn retry_agent_registration(
 mod tests {
     use super::{
         format_registration_error, normalize_cli, registration_cli_from_hint,
-        registration_is_retryable, registration_retry_after_secs, AgentRegistrationClient,
-        AgentRegistrationError,
+        registration_cooldown_duration, registration_is_retryable, registration_retry_after_secs,
+        retry_agent_registration, AgentRegistrationClient, AgentRegistrationError,
+        DEFAULT_REGISTRATION_COOLDOWN_SECS, MAX_REGISTRATION_COOLDOWN_SECS,
     };
     use crate::{RelayCast, RelayCastOptions};
     use serde_json::json;
+    use std::time::Duration;
+    use tokio::time::{advance, Instant};
     use wiremock::matchers::{body_string_contains, header, method, path};
     use wiremock::{Mock, MockServer, ResponseTemplate};
 
@@ -615,20 +646,22 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn register_agent_token_sets_cooldown_on_rate_limit() {
+    async fn register_agent_token_uses_server_retry_after_for_rate_limit_cooldown() {
         let server = MockServer::start().await;
         let relay =
             RelayCast::new(RelayCastOptions::new("rk_live_test").with_base_url(server.uri()))
                 .expect("relay init");
         let client = AgentRegistrationClient::new(relay, "claude");
 
-        let rate_limited = ResponseTemplate::new(429).set_body_json(json!({
-            "ok": false,
-            "error": {
-                "code": "rate_limited",
-                "message": "too many requests"
-            }
-        }));
+        let rate_limited = ResponseTemplate::new(429)
+            .insert_header("retry-after", "2")
+            .set_body_json(json!({
+                "ok": false,
+                "error": {
+                    "code": "workspace_busy",
+                    "message": "workspace is busy"
+                }
+            }));
 
         Mock::given(method("POST"))
             .and(path("/v1/agents"))
@@ -644,11 +677,143 @@ mod tests {
         match error {
             AgentRegistrationError::RateLimited {
                 retry_after_secs, ..
-            } => assert_eq!(retry_after_secs, 60),
+            } => assert_eq!(retry_after_secs, 2),
             other => panic!("unexpected error variant: {other:?}"),
         }
 
         assert!(client.registration_block_remaining("worker-c").is_some());
+    }
+
+    #[tokio::test]
+    async fn register_agent_token_uses_safe_fallback_for_malformed_retry_after() {
+        let server = MockServer::start().await;
+        let relay =
+            RelayCast::new(RelayCastOptions::new("rk_live_test").with_base_url(server.uri()))
+                .expect("relay init");
+        let client = AgentRegistrationClient::new(relay, "claude");
+
+        Mock::given(method("POST"))
+            .and(path("/v1/agents"))
+            .respond_with(
+                ResponseTemplate::new(429)
+                    .insert_header("retry-after", "not-a-delay")
+                    .set_body_json(json!({
+                        "ok": false,
+                        "error": {
+                            "code": "workspace_busy",
+                            "message": "workspace is busy"
+                        }
+                    })),
+            )
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let error = client
+            .register_agent_token("worker-malformed", None)
+            .await
+            .expect_err("expected rate-limited error");
+        match error {
+            AgentRegistrationError::RateLimited {
+                retry_after_secs, ..
+            } => assert_eq!(retry_after_secs, DEFAULT_REGISTRATION_COOLDOWN_SECS),
+            other => panic!("unexpected error variant: {other:?}"),
+        }
+        assert!(client
+            .registration_block_remaining("worker-malformed")
+            .is_some());
+    }
+
+    #[test]
+    fn registration_cooldown_preserves_valid_delay_and_bounds_it() {
+        assert_eq!(
+            registration_cooldown_duration(Some(2_000)),
+            Duration::from_secs(2)
+        );
+        assert_eq!(
+            registration_cooldown_duration(None),
+            Duration::from_secs(DEFAULT_REGISTRATION_COOLDOWN_SECS)
+        );
+        assert_eq!(
+            registration_cooldown_duration(Some((MAX_REGISTRATION_COOLDOWN_SECS + 1) * 1_000)),
+            Duration::from_secs(MAX_REGISTRATION_COOLDOWN_SECS)
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn registration_retry_timer_uses_cached_cooldown_without_premature_retry() {
+        let relay = RelayCast::new(RelayCastOptions::new("rk_live_test")).expect("relay init");
+        let client = AgentRegistrationClient::new(relay, "claude");
+        let agent_name = "worker-timer";
+        super::lock_unpoisoned(&client.registration_cooldowns).insert(
+            agent_name.to_string(),
+            Instant::now() + Duration::from_secs(2),
+        );
+        let error = AgentRegistrationError::RateLimited {
+            agent_name: agent_name.to_string(),
+            retry_after_secs: 1,
+            detail: "429".to_string(),
+        };
+
+        // The active cache wins over a stale error display value, so a retry
+        // cannot escape a known cooldown early.
+        let delay = client.registration_retry_delay(agent_name, &error);
+        assert_eq!(delay, Duration::from_secs(2));
+        let sleep = tokio::time::sleep(delay);
+        tokio::pin!(sleep);
+        assert!(!sleep.as_mut().is_elapsed());
+
+        advance(Duration::from_secs(1)).await;
+        assert!(!sleep.as_mut().is_elapsed());
+        advance(Duration::from_secs(1)).await;
+        sleep.as_mut().await;
+    }
+
+    #[tokio::test]
+    async fn retry_registration_retries_immediately_when_server_authorizes_zero_delay() {
+        let server = MockServer::start().await;
+        let relay =
+            RelayCast::new(RelayCastOptions::new("rk_live_test").with_base_url(server.uri()))
+                .expect("relay init");
+        let client = AgentRegistrationClient::new(relay, "claude");
+
+        Mock::given(method("POST"))
+            .and(path("/v1/agents"))
+            .respond_with(
+                ResponseTemplate::new(429)
+                    .insert_header("retry-after", "0")
+                    .set_body_json(json!({
+                        "ok": false,
+                        "error": {
+                            "code": "workspace_busy",
+                            "message": "workspace is busy"
+                        }
+                    })),
+            )
+            .up_to_n_times(1)
+            .expect(1)
+            .mount(&server)
+            .await;
+        Mock::given(method("POST"))
+            .and(path("/v1/agents"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "ok": true,
+                "data": {
+                    "id": "a_worker_retry",
+                    "name": "worker-retry",
+                    "token": "at_live_retry",
+                    "status": "online",
+                    "created_at": "2026-09-10T00:00:00.000Z"
+                }
+            })))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let token = retry_agent_registration(&client, "worker-retry", None)
+            .await
+            .expect("server-authorized immediate retry should reach the server");
+        assert_eq!(token, "at_live_retry");
     }
 
     #[test]


### PR DESCRIPTION
Fixes #419

## Summary

- use `RelayError::Api.retry_after_ms` for 429 registration cooldowns, capped at five minutes
- retain the 60-second fail-closed fallback for absent or malformed headers
- schedule retry attempts from the active cached cooldown instead of adding a fixed sleep
- add deterministic timer, header/fallback/cap, and retry-path coverage

## Verification

- `cargo test --manifest-path packages/sdk-rust/Cargo.toml`
- `cargo build --manifest-path packages/sdk-rust/Cargo.toml`
- `cargo clippy --manifest-path packages/sdk-rust/Cargo.toml -- -D warnings`
- `rustfmt --edition 2021 --check packages/sdk-rust/src/registration.rs`
- Veto diff review: PASS (code 96/100; security 97/100; no secrets findings)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes client-side rate-limit and retry timing for agent registration; behavior is bounded and well-tested but affects production retry patterns under 429 responses.
> 
> **Overview**
> **Rust agent registration** now derives local rate-limit cooldowns from the server’s parsed `Retry-After` (`retry_after_ms` on 429), with a **five-minute cap** and the existing **60-second** fallback when the header is missing or invalid.
> 
> **Retry scheduling** no longer uses a fixed two-second sleep: `retry_agent_registration` waits via `registration_retry_delay`, which prefers the **cached cooldown deadline** so retries do not hit the API before the block expires (still falls back to error metadata or a 2s default when the cache is cleared).
> 
> Cooldown timing uses **`tokio::time::Instant`** for consistency with async sleeps. The changelog records the fix; dev tests add `tokio` `test-util` and cover header parsing, cap/fallback, cached-delay behavior, and immediate retry when `Retry-After: 0`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit abae562d920ef79c7577763d65f8850298c66a3d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->