### PR TITLE
fix(engine): bounded node-list SQL pushdown, live/history selector, cursor pagination

### DIFF
--- a/.agentworkforce/trajectories/completed/2026-09/traj_qcx6fywepk3d.trace.json
+++ b/.agentworkforce/trajectories/completed/2026-09/traj_qcx6fywepk3d.trace.json
@@ -1,0 +1,74 @@
+{
+  "version": "1.0.0",
+  "id": "2ecdadb7-66b0-4228-8a8b-4f1d8f3b41c6",
+  "timestamp": "2026-09-11T00:45:46.975Z",
+  "trajectory": "traj_qcx6fywepk3d",
+  "files": [
+    {
+      "path": "packages/engine/CHANGELOG.md",
+      "conversations": [
+        {
+          "contributor": {
+            "type": "ai"
+          },
+          "ranges": [
+            {
+              "start_line": 11,
+              "end_line": 17,
+              "revision": "20571bf9379db893f0fbcf96593bda8288a9caaf"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "path": "packages/engine/src/__tests__/conformance/nodeListBoundedHistory.test.ts",
+      "conversations": [
+        {
+          "contributor": {
+            "type": "ai"
+          },
+          "ranges": [
+            {
+              "start_line": 294,
+              "end_line": 512,
+              "revision": "20571bf9379db893f0fbcf96593bda8288a9caaf"
+            },
+            {
+              "start_line": 608,
+              "end_line": 624,
+              "revision": "20571bf9379db893f0fbcf96593bda8288a9caaf"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "path": "packages/engine/src/engine/node.ts",
+      "conversations": [
+        {
+          "contributor": {
+            "type": "ai"
+          },
+          "ranges": [
+            {
+              "start_line": 2060,
+              "end_line": 2066,
+              "revision": "20571bf9379db893f0fbcf96593bda8288a9caaf"
+            },
+            {
+              "start_line": 2074,
+              "end_line": 2085,
+              "revision": "20571bf9379db893f0fbcf96593bda8288a9caaf"
+            },
+            {
+              "start_line": 2098,
+              "end_line": 2118,
+              "revision": "20571bf9379db893f0fbcf96593bda8288a9caaf"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/.agentworkforce/trajectories/completed/2026-09/traj_qcx6fywepk3d/summary.md
+++ b/.agentworkforce/trajectories/completed/2026-09/traj_qcx6fywepk3d/summary.md
@@ -1,0 +1,38 @@
+# Trajectory: Repair Relaycast PR 424 at HEAD c73e2d88489137ed9caa1711e329deef895cf035
+
+> **Status:** ✅ Completed
+> **Confidence:** 90%
+> **Started:** September 11, 2026 at 02:32 AM
+> **Completed:** September 11, 2026 at 02:45 AM
+
+---
+
+## Summary
+
+Fixed final Veto P1 for PR 424: visibleActiveAgentCounts bound agentNodeBindings.nodeId via inArray, expanding to one D1 bind parameter per visible node id and exceeding the 100-parameter ceiling on the history and legacy observer paths. Replaced with a json_each IN-subquery bound as a single JSON-array parameter, mirroring the existing agentIds filter. Added regressions covering 500+ node ids and 500 authorized agent ids asserting bounded parameter counts and no N+1. Full engine (1009 tests) and SDK suites, typecheck, and lint pass.
+
+**Approach:** Standard approach
+
+---
+
+## Key Decisions
+
+### Replaced inArray(nodeId, nodeIds) with a JSON-array json_each IN-subquery in visibleActiveAgentCounts
+- **Chose:** Replaced inArray(nodeId, nodeIds) with a JSON-array json_each IN-subquery in visibleActiveAgentCounts
+- **Reasoning:** inArray expands to one bind parameter per node id, exceeding D1's 100-parameter ceiling for large history pages/legacy observer requests; json_each keeps the bind count constant regardless of cardinality, consistent with the existing agentIds pattern
+
+---
+
+## Chapters
+
+### 1. Work
+*Agent: default*
+
+- Replaced inArray(nodeId, nodeIds) with a JSON-array json_each IN-subquery in visibleActiveAgentCounts: Replaced inArray(nodeId, nodeIds) with a JSON-array json_each IN-subquery in visibleActiveAgentCounts
+
+---
+
+## Artifacts
+
+**Commits:** 20571bf9, 783acdf0
+**Files changed:** 3

--- a/.agentworkforce/trajectories/completed/2026-09/traj_qcx6fywepk3d/trajectory.json
+++ b/.agentworkforce/trajectories/completed/2026-09/traj_qcx6fywepk3d/trajectory.json
@@ -1,0 +1,61 @@
+{
+  "id": "traj_qcx6fywepk3d",
+  "version": 1,
+  "task": {
+    "title": "Repair Relaycast PR 424 at HEAD c73e2d88489137ed9caa1711e329deef895cf035"
+  },
+  "status": "completed",
+  "startedAt": "2026-09-11T00:32:14.754Z",
+  "completedAt": "2026-09-11T00:45:46.893Z",
+  "agents": [
+    {
+      "name": "default",
+      "role": "lead",
+      "joinedAt": "2026-09-11T00:45:05.947Z"
+    }
+  ],
+  "chapters": [
+    {
+      "id": "chap_3rq9421k9mm7",
+      "title": "Work",
+      "agentName": "default",
+      "startedAt": "2026-09-11T00:45:05.947Z",
+      "endedAt": "2026-09-11T00:45:46.893Z",
+      "events": [
+        {
+          "ts": 1789087505948,
+          "type": "decision",
+          "content": "Replaced inArray(nodeId, nodeIds) with a JSON-array json_each IN-subquery in visibleActiveAgentCounts: Replaced inArray(nodeId, nodeIds) with a JSON-array json_each IN-subquery in visibleActiveAgentCounts",
+          "raw": {
+            "question": "Replaced inArray(nodeId, nodeIds) with a JSON-array json_each IN-subquery in visibleActiveAgentCounts",
+            "chosen": "Replaced inArray(nodeId, nodeIds) with a JSON-array json_each IN-subquery in visibleActiveAgentCounts",
+            "alternatives": [],
+            "reasoning": "inArray expands to one bind parameter per node id, exceeding D1's 100-parameter ceiling for large history pages/legacy observer requests; json_each keeps the bind count constant regardless of cardinality, consistent with the existing agentIds pattern"
+          },
+          "significance": "high"
+        }
+      ]
+    }
+  ],
+  "retrospective": {
+    "summary": "Fixed final Veto P1 for PR 424: visibleActiveAgentCounts bound agentNodeBindings.nodeId via inArray, expanding to one D1 bind parameter per visible node id and exceeding the 100-parameter ceiling on the history and legacy observer paths. Replaced with a json_each IN-subquery bound as a single JSON-array parameter, mirroring the existing agentIds filter. Added regressions covering 500+ node ids and 500 authorized agent ids asserting bounded parameter counts and no N+1. Full engine (1009 tests) and SDK suites, typecheck, and lint pass.",
+    "approach": "Standard approach",
+    "confidence": 0.9
+  },
+  "commits": [
+    "20571bf9",
+    "783acdf0"
+  ],
+  "filesChanged": [
+    "packages/engine/CHANGELOG.md",
+    "packages/engine/src/__tests__/conformance/nodeListBoundedHistory.test.ts",
+    "packages/engine/src/engine/node.ts"
+  ],
+  "projectId": "AgentWorkforce/relaycast",
+  "tags": [],
+  "_trace": {
+    "startRef": "c73e2d88489137ed9caa1711e329deef895cf035",
+    "endRef": "20571bf9379db893f0fbcf96593bda8288a9caaf",
+    "traceId": "2ecdadb7-66b0-4228-8a8b-4f1d8f3b41c6"
+  }
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 Packages without a separate changelog are covered by the cross-package notes below.
 
-## [Unreleased - Patch]
+## [Unreleased - Minor]
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,11 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 Packages without a separate changelog are covered by the cross-package notes below.
 
-## [Unreleased]
+## [Unreleased - Patch]
+
+### Fixed
+
+- `GET /v1/nodes` no longer fetches a workspace's entire node history to serve a default listing: `name`, `capability`, and a new `status` liveness selector are now pushed into SQL, and `status=online` returns only fresh-heartbeat live nodes. An explicit `history=true` mode adds bounded, non-truncating cursor pagination for reading full history (e.g. `--all`). `active_agents` is now flagged with `active_agents_stale` once a node is offline, so a frozen historical count is never presented as current occupancy. (Fixes [#422](https://github.com/AgentWorkforce/relaycast/issues/422))
 
 ## [8.8.0] - 2026-09-10
 

--- a/README.md
+++ b/README.md
@@ -676,10 +676,25 @@ send its SHA-256 hash as `expected_token_hash`; Relaycast then rejects a stale
 release with `agent_release_generation_conflict` before dispatch or completion,
 so a same-name takeover is left untouched.
 
+`GET /nodes` pushes `capability`, `name`, and a liveness `status` selector
+into its SQL query instead of fetching the full roster and filtering in JS.
+Without `history`, the response stays the legacy bare array every existing
+caller already handles; `status=online` is the server-filtered live-Fleet
+path a default listing should use, since it never reads or returns
+history no matter how many dead rows a workspace has accumulated.
+`history=true` switches to a bounded, paginated contract
+(`{ nodes, next_cursor }`, paged with `cursor`/`limit`) for an explicit full
+read (e.g. `--all`): it visits and returns every matching row exactly once,
+with no silent truncation, however large the retained history is. Each
+entry's `active_agents` is authoritative live occupancy only while `live` is
+`true`; once a node goes offline, `active_agents` is a frozen historical
+value and `active_agents_stale` is `true` — callers must not present it as
+current capacity.
+
 Fleet node presence is also published to workspace-key observer streams as the
 ephemeral `node.online`, `node.heartbeat`, and `node.offline` events. Each
 carries a `node` payload matching the `GET /nodes` roster entry (capabilities,
-tags, `load`, `active_agents`/`max_agents`, `handlers_live`,
+tags, `load`, `active_agents`/`active_agents_stale`/`max_agents`, `handlers_live`,
 `last_heartbeat_at`), so a single event fully refreshes a node's row.
 `load` is normalized managed-agent capacity utilization and remains `null`
 unless a direct node, or every constituent provider of a broker node,

--- a/docs/relay-cli-422-companion-change.md
+++ b/docs/relay-cli-422-companion-change.md
@@ -1,0 +1,61 @@
+# Companion change needed in the Relay CLI repo for #422
+
+This repository (`relaycast`/`@relaycast/engine` + `@relaycast/sdk`) now exposes
+the server-side pieces `AgentWorkforce/relay#1689` needs, but per scope this PR
+does **not** touch the Relay CLI repository (`AgentWorkforce/relay`,
+`packages/cli/src/cli/commands/fleet.ts`). That repo needs its own follow-up
+PR making these two calls.
+
+## What changed here
+
+- `GET /v1/nodes?status=online` now pushes the liveness selector into SQL and
+  returns only fresh-heartbeat live nodes — the same shape (`data: [...]`)
+  Relay already parses, just without the offline/history rows.
+- `GET /v1/nodes?history=true&cursor=&limit=` returns
+  `{ nodes: [...], next_cursor }`, a bounded page of the full roster (any
+  status), ordered by `id`, that never truncates: keep paging while
+  `next_cursor` is non-null.
+- Every roster entry now carries `active_agents_stale` (`true` once a node is
+  offline). `active_agents` on an offline row is frozen history, not current
+  occupancy.
+- `@relaycast/sdk`: `relay.nodes.list({ status: 'online' })` for the live path;
+  `relay.nodes.listHistory({ cursor, limit })` for bounded, paginated history.
+
+## Required Relay CLI change (`packages/cli/src/cli/commands/fleet.ts`)
+
+1. **Default `fleet nodes` / `fleet agent list`** (today, per the issue, calls
+   `relay.nodes.list()` unfiltered and hides `offline`/non-fleet rows locally):
+   change the default call to `relay.nodes.list({ status: 'online' })` (or the
+   equivalent raw `GET /v1/nodes?status=online`). Drop the local
+   `6294 offline or non-fleet records hidden` message for the default path —
+   it should no longer be true, since the server never returns those rows.
+   Keep any remaining local capability/name filtering; those params still work
+   unchanged (now pushed into SQL server-side).
+
+2. **`--all` (explicit history)**: replace the single unbounded
+   `relay.nodes.list()` call with a loop over `relay.nodes.listHistory()`,
+   following `nextCursor` until it is `null`:
+
+   ```ts
+   const rows: NodeRosterEntry[] = [];
+   let cursor: string | null | undefined;
+   do {
+     const page = await relay.nodes.listHistory({ cursor, limit: 200 });
+     rows.push(...page.nodes);
+     cursor = page.nextCursor;
+   } while (cursor);
+   ```
+
+   This bounds each request/response instead of the previous single
+   6,298-row / ~3 MB fetch, while still returning every row to `--all` with no
+   truncation.
+
+3. **`active_agents` display**: when rendering `--all`/history rows, use
+   `node.activeAgentsStale` to avoid presenting a frozen offline count as
+   current occupancy — e.g. render it as `active_agents (stale)` or omit it,
+   rather than as a live number.
+
+None of this requires a Relaycast API version bump gate: `status`, `history`,
+`cursor`, `limit`, and `active_agents_stale` are additive query parameters and
+an additive response field, so an unmodified Relay CLI keeps working exactly
+as before against this engine version.

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1103,6 +1103,10 @@ components:
           description: Normalized managed-agent capacity utilization. Null unless a direct node, or every constituent provider of a broker node, explicitly reports a genuine measurement.
         active_agents:
           type: integer
+          description: Managed-agent occupancy. Authoritative only while `live` is true; once a node goes offline this is a frozen historical value — see `active_agents_stale`.
+        active_agents_stale:
+          type: boolean
+          description: True whenever `live` is false, meaning `active_agents` is frozen history, not current occupancy.
         max_agents:
           type: integer
           minimum: 0
@@ -4980,7 +4984,21 @@ paths:
                 $ref: '#/components/schemas/ErrorResponse'
     get:
       summary: List nodes
-      description: List delivery nodes in the workspace, optionally filtered by capability or name. Observer tokens require `nodes:read`; agent filters constrain active-agent details.
+      description: >
+        List delivery nodes in the workspace, optionally filtered by capability, name,
+        or liveness. `capability`, `name`, and `status` are evaluated in SQL, not
+        fetched in full and filtered afterward. Without `history`, the response is a
+        bare array (the legacy, unpaginated shape every existing caller already
+        handles); `status=online` is the server-filtered live-Fleet path a default
+        `fleet nodes` call should use, since it never reads or returns history no
+        matter how large the workspace's roster has grown. `history=true` switches to
+        a bounded, paginated contract (`{ nodes, next_cursor }`) for an explicit full
+        read (e.g. `--all`): `cursor`/`limit` page through every matching row exactly
+        once, with no silent truncation, however many historical rows are retained.
+        Each entry's `active_agents` is authoritative live occupancy only while
+        `live` is `true`; once a node goes offline its `active_agents` is frozen
+        history and `active_agents_stale` is `true`. Observer tokens require
+        `nodes:read`; agent filters constrain active-agent details.
       tags:
         - Nodes
       security:
@@ -4998,9 +5016,35 @@ paths:
           required: false
           schema:
             type: string
+        - name: status
+          in: query
+          required: false
+          description: Pushes a liveness predicate into SQL. `online` is fresh-heartbeat live nodes; `offline` is everything else.
+          schema:
+            type: string
+            enum: [online, offline]
+        - name: history
+          in: query
+          required: false
+          description: Switches the response to the bounded `{ nodes, next_cursor }` pagination contract.
+          schema:
+            type: boolean
+        - name: cursor
+          in: query
+          required: false
+          description: Resume point from a previous page's `next_cursor`. Only meaningful with `history=true`.
+          schema:
+            type: string
+        - name: limit
+          in: query
+          required: false
+          description: Page size, clamped server-side to a fixed maximum. Only meaningful with `history=true`.
+          schema:
+            type: integer
+            minimum: 1
       responses:
         '200':
-          description: Node roster
+          description: Node roster — a bare array by default, or `{ nodes, next_cursor }` when `history=true`.
           content:
             application/json:
               schema:

--- a/packages/engine/CHANGELOG.md
+++ b/packages/engine/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+### Fixed
+
+- `listNodes`/`GET /v1/nodes` push `name`, `capability`, and a new `status` (`online`/`offline`) liveness selector into SQL instead of fetching the whole workspace roster and filtering in JS. `history=true` adds a bounded, non-truncating cursor pagination contract (`{ nodes, next_cursor }`, paged via `cursor`/`limit`, capped at 500/page) for explicit full-history reads. Without `history`, the response stays the legacy bare array. Roster entries add `active_agents_stale` (true once a node is offline) so `active_agents` is never read back as authoritative current occupancy. Added `idx_nodes_status_heartbeat` to keep the live-selection query indexed.
+
 ## [8.8.0] - 2026-09-10
 
 ### Added

--- a/packages/engine/CHANGELOG.md
+++ b/packages/engine/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ### Fixed
 
-- `listNodes`/`GET /v1/nodes` push `name`, `capability`, and a new `status` (`online`/`offline`) liveness selector into SQL instead of fetching the whole workspace roster and filtering in JS. `history=true` adds a bounded, non-truncating cursor pagination contract (`{ nodes, next_cursor }`, paged via `cursor`/`limit`, capped at 500/page) for explicit full-history reads. Without `history`, the response stays the legacy bare array. Roster entries add `active_agents_stale` (true once a node is offline) so `active_agents` is never read back as authoritative current occupancy. Added `idx_nodes_status_heartbeat` to keep the live-selection query indexed.
+- `listNodes`/`GET /v1/nodes` push `name`, `capability`, and a new `status` (`online`/`offline`) liveness selector into SQL instead of fetching the whole workspace roster and filtering in JS. `history=true` adds a bounded, non-truncating cursor pagination contract (`{ nodes, next_cursor }`, paged via `cursor`/`limit`, capped at 500/page) for explicit full-history reads. Without `history`, the response stays the legacy bare array. Roster entries add `active_agents_stale` (true once a node is offline) so `active_agents` is never read back as authoritative current occupancy. Added `idx_nodes_status_heartbeat` to keep the live-selection query indexed. An observer token's authorized `active_agents` count is computed with bounded, JSON-array-bound SQL joins instead of one `inArray`/`IN (...)` bind per visible node id, keeping every roster query under D1's 100-parameter limit regardless of page size or history/legacy path.
 
 ## [8.8.0] - 2026-09-10
 

--- a/packages/engine/CHANGELOG.md
+++ b/packages/engine/CHANGELOG.md
@@ -7,7 +7,7 @@ See the [root changelog](../../CHANGELOG.md) for cross-package release highlight
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [Unreleased - Minor]
 
 ### Fixed
 

--- a/packages/engine/src/__tests__/conformance/nodeListBoundedHistory.test.ts
+++ b/packages/engine/src/__tests__/conformance/nodeListBoundedHistory.test.ts
@@ -294,6 +294,90 @@ describe('observer-authorized node history pagination (#422 follow-up)', () => {
     expect(maxQueriesPerPage).toBeLessThan(10);
   });
 
+  it('handles high-cardinality observer authorization without exceeding bind limits or skipping interleaved rows', async () => {
+    const ws = await createWorkspace(stack.app, 'observer-history-wide-ws');
+    const allowedAgents = await Promise.all(
+      Array.from({ length: 140 }, async (_, i) => registerAgent(stack.app, ws.workspaceKey, `observer-wide-allowed-${i}`)),
+    );
+    const hidden = await registerAgent(stack.app, ws.workspaceKey, 'observer-wide-hidden');
+
+    const db = stack.runtime.deps.db;
+    const now = new Date();
+    const authorizedNames: string[] = [];
+    const hiddenNames: string[] = [];
+    for (let i = 0; i < 24; i++) {
+      const id = `node_obs_wide_${ws.workspaceId}_${String(i).padStart(4, '0')}`;
+      const name = `wide-${i}`;
+      const allowed = i % 2 === 0;
+      await db.insert(nodes).values({
+        id,
+        workspaceId: ws.workspaceId,
+        name,
+        tokenHash: `obs-wide-token-hash-${ws.workspaceId}-${i}`,
+        status: 'offline',
+        createdAt: now,
+      });
+      await db.insert(agentNodeBindings).values({
+        id: `anb_obs_wide_${ws.workspaceId}_${i}`,
+        workspaceId: ws.workspaceId,
+        agentId: allowed ? allowedAgents[i % allowedAgents.length].agentId : hidden.agentId,
+        nodeId: id,
+        status: 'active',
+      });
+      if (allowed) authorizedNames.push(name); else hiddenNames.push(name);
+    }
+
+    const observerToken = await createObserverToken(
+      ws.workspaceKey,
+      allowedAgents.map((agent) => agent.agentId),
+    );
+
+    const sqlite = stack.runtime.handle.sqlite;
+    const originalPrepare = sqlite.prepare.bind(sqlite);
+    const seenNames: string[] = [];
+    const seenIds = new Set<string>();
+    let cursor: string | null = null;
+    let pages = 0;
+    let maxQueriesPerPage = 0;
+    do {
+      const url = new URL('http://test/v1/nodes');
+      url.searchParams.set('history', 'true');
+      url.searchParams.set('limit', '4');
+      if (cursor) url.searchParams.set('cursor', cursor);
+
+      let queryCount = 0;
+      sqlite.prepare = ((sqlText: string) => {
+        queryCount++;
+        return originalPrepare(sqlText);
+      }) as typeof sqlite.prepare;
+      let res: Response;
+      try {
+        res = await stack.app.request(url.pathname + '?' + url.searchParams.toString(), {
+          headers: { authorization: `Bearer ${observerToken}` },
+        });
+      } finally {
+        sqlite.prepare = originalPrepare;
+      }
+      maxQueriesPerPage = Math.max(maxQueriesPerPage, queryCount);
+
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as { data: { nodes: Array<{ id: string; name: string }>; next_cursor: string | null } };
+      for (const node of body.data.nodes) {
+        if (!node.name.startsWith('wide-')) continue;
+        expect(hiddenNames).not.toContain(node.name);
+        expect(seenIds.has(node.id)).toBe(false);
+        seenIds.add(node.id);
+        seenNames.push(node.name);
+      }
+      cursor = body.data.next_cursor;
+      pages++;
+      expect(pages).toBeLessThan(50);
+    } while (cursor);
+
+    expect(new Set(seenNames)).toEqual(new Set(authorizedNames));
+    expect(maxQueriesPerPage).toBeLessThan(10);
+  });
+
   it('returns no rows and a null next_cursor when the observer is authorized for nothing on the page', async () => {
     const ws = await createWorkspace(stack.app, 'observer-history-empty-ws');
     const allowed = await registerAgent(stack.app, ws.workspaceKey, 'observer-allowed-agent-2');
@@ -394,5 +478,18 @@ describe('capability filter tolerates legacy/malformed capability shapes (#422 f
     });
     expect(noMatch.status).toBe(200);
     expect(((await noMatch.json()) as { data: Array<{ name: string }> }).data).toEqual([]);
+  });
+
+  it('treats malformed top-level capability JSON as empty instead of raising json_each errors', async () => {
+    const ws = await createWorkspace(stack.app, 'capability-top-level-malformed-ws');
+    await seedNode(ws, 'node_cap_bad_top_level', 'bad-top-level-node', 'not-json' as never);
+    await seedNode(ws, 'node_cap_good_top_level', 'good-top-level-node', ['read']);
+
+    const res = await stack.app.request('/v1/nodes?capability=read', {
+      headers: { authorization: `Bearer ${ws.workspaceKey}` },
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { data: Array<{ name: string }> };
+    expect(body.data.map((n) => n.name)).toEqual(['good-top-level-node']);
   });
 });

--- a/packages/engine/src/__tests__/conformance/nodeListBoundedHistory.test.ts
+++ b/packages/engine/src/__tests__/conformance/nodeListBoundedHistory.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
-import { nodes } from '../../db/schema.js';
-import { makeNodeStack, createWorkspace, type TestStack } from './harness.js';
+import { agentNodeBindings, agents, nodes } from '../../db/schema.js';
+import { makeNodeStack, createWorkspace, registerAgent, type TestStack } from './harness.js';
 
 /**
  * Regression for #422: `GET /v1/nodes` read every historical row in a
@@ -92,7 +92,7 @@ describe('bounded node list with thousands of historical rows (#422)', () => {
         )
         .all(ws.workspaceId, Date.now(), Date.now() - 45_000),
     );
-    expect(plan).toContain('idx_nodes_status');
+    expect(plan).toContain('idx_nodes_status_heartbeat');
   });
 
   it('returns only the offline subset for status=offline, still scoped to this workspace', async () => {
@@ -160,5 +160,239 @@ describe('bounded node list with thousands of historical rows (#422)', () => {
     const body = (await roster.json()) as { data: unknown };
     expect(Array.isArray(body.data)).toBe(true);
     expect((body.data as unknown[]).length).toBe(historyRows.length + liveRows.length);
+  });
+});
+
+/**
+ * Regression for the observer-scoped follow-up to #422: an observer token's
+ * `agent_ids` filter must be pushed into the same SQL query that computes the
+ * page and `next_cursor` — not applied client-of-the-DB, one `listNodeAgents`
+ * query per roster row, after a page already fixed which rows and which
+ * cursor to return. Getting this wrong can (a) leak a hidden node's id via
+ * `next_cursor`, (b) skip an authorized row or stop paging early once hidden
+ * rows are filtered back out of an already-fixed page, and (c) costs one
+ * query per node on a page instead of a bounded number of queries per page.
+ */
+describe('observer-authorized node history pagination (#422 follow-up)', () => {
+  let stack: TestStack;
+  beforeEach(() => { stack = makeNodeStack(); });
+  afterEach(async () => { await stack.close(); });
+
+  async function createObserverToken(workspaceKey: string, agentIds: string[]) {
+    const res = await stack.app.request('/v1/observer-tokens', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', authorization: `Bearer ${workspaceKey}` },
+      body: JSON.stringify({
+        name: 'node-roster-observer',
+        scopes: ['nodes:read'],
+        filters: { agent_ids: agentIds },
+      }),
+    });
+    expect(res.status).toBe(201);
+    const body = (await res.json()) as { data: { token: string } };
+    return body.data.token;
+  }
+
+  /** Seed `count` nodes, alternating an active binding to `allowedAgentId` (authorized/visible)
+   * and `hiddenAgentId` (unauthorized/hidden) so pages mix both in an interleaved order. */
+  async function seedInterleavedNodes(
+    ws: { workspaceId: string },
+    count: number,
+    allowedAgentId: string,
+    hiddenAgentId: string,
+  ): Promise<{ authorizedNames: string[]; hiddenNames: string[] }> {
+    const db = stack.runtime.deps.db;
+    const now = new Date();
+    const authorizedNames: string[] = [];
+    const hiddenNames: string[] = [];
+    for (let i = 0; i < count; i++) {
+      const id = `node_obs_${ws.workspaceId}_${String(i).padStart(4, '0')}`;
+      const name = `obs-${i}`;
+      const authorized = i % 2 === 0;
+      await db.insert(nodes).values({
+        id,
+        workspaceId: ws.workspaceId,
+        name,
+        tokenHash: `obs-token-hash-${ws.workspaceId}-${i}`,
+        status: 'offline',
+        createdAt: now,
+      });
+      await db.insert(agentNodeBindings).values({
+        id: `anb_obs_${ws.workspaceId}_${i}`,
+        workspaceId: ws.workspaceId,
+        agentId: authorized ? allowedAgentId : hiddenAgentId,
+        nodeId: id,
+        status: 'active',
+      });
+      if (authorized) authorizedNames.push(name); else hiddenNames.push(name);
+    }
+    return { authorizedNames, hiddenNames };
+  }
+
+  it('never leaks a hidden node into the page or next_cursor, and visits every authorized row exactly once across pages', async () => {
+    const ws = await createWorkspace(stack.app, 'observer-history-paged-ws');
+    const allowed = await registerAgent(stack.app, ws.workspaceKey, 'observer-allowed-agent');
+    const hidden = await registerAgent(stack.app, ws.workspaceKey, 'observer-hidden-agent');
+    const { authorizedNames, hiddenNames } = await seedInterleavedNodes(ws, 20, allowed.agentId, hidden.agentId);
+    const observerToken = await createObserverToken(ws.workspaceKey, [allowed.agentId]);
+
+    const sqlite = stack.runtime.handle.sqlite;
+    const originalPrepare = sqlite.prepare.bind(sqlite);
+
+    const seenIds = new Set<string>();
+    const seenNames: string[] = [];
+    let cursor: string | null = null;
+    let pages = 0;
+    let maxQueriesPerPage = 0;
+    do {
+      const url = new URL('http://test/v1/nodes');
+      url.searchParams.set('history', 'true');
+      url.searchParams.set('limit', '3');
+      if (cursor) url.searchParams.set('cursor', cursor);
+
+      let queryCount = 0;
+      sqlite.prepare = ((sqlText: string) => {
+        queryCount++;
+        return originalPrepare(sqlText);
+      }) as typeof sqlite.prepare;
+      let res: Response;
+      try {
+        res = await stack.app.request(url.pathname + '?' + url.searchParams.toString(), {
+          headers: { authorization: `Bearer ${observerToken}` },
+        });
+      } finally {
+        sqlite.prepare = originalPrepare;
+      }
+      maxQueriesPerPage = Math.max(maxQueriesPerPage, queryCount);
+
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as {
+        data: { nodes: Array<{ id: string; name: string }>; next_cursor: string | null };
+      };
+      for (const node of body.data.nodes) {
+        // registerAgent implicitly creates its own direct node with an active
+        // self-binding; scope these assertions to the `obs-*` fixture nodes.
+        if (!node.name.startsWith('obs-')) continue;
+        expect(hiddenNames).not.toContain(node.name); // never returned
+        expect(seenIds.has(node.id)).toBe(false); // no duplicate visits across pages
+        seenIds.add(node.id);
+        seenNames.push(node.name);
+      }
+      cursor = body.data.next_cursor;
+      pages++;
+      expect(pages).toBeLessThan(50); // guard against non-termination
+    } while (cursor);
+
+    // Every authorized row visited exactly once; no hidden row ever surfaced,
+    // and `next_cursor` never stalled before every authorized row was reached.
+    expect(new Set(seenNames)).toEqual(new Set(authorizedNames));
+    expect(pages).toBeGreaterThan(1); // actually exercised multi-page pagination
+
+    // Bounded per-page query cost: a fixed small number of queries regardless
+    // of how many rows are on the page, not one `listNodeAgents`-style query
+    // per roster row (which would scale with the 3-row page/20-row workspace).
+    expect(maxQueriesPerPage).toBeLessThan(10);
+  });
+
+  it('returns no rows and a null next_cursor when the observer is authorized for nothing on the page', async () => {
+    const ws = await createWorkspace(stack.app, 'observer-history-empty-ws');
+    const allowed = await registerAgent(stack.app, ws.workspaceKey, 'observer-allowed-agent-2');
+    const hidden = await registerAgent(stack.app, ws.workspaceKey, 'observer-hidden-agent-2');
+    await seedInterleavedNodes(ws, 6, allowed.agentId, hidden.agentId);
+    // Authorized for an agent with no bindings at all: nothing should be visible.
+    const stranger = await registerAgent(stack.app, ws.workspaceKey, 'observer-stranger-agent-2');
+    const observerToken = await createObserverToken(ws.workspaceKey, [stranger.agentId]);
+
+    const res = await stack.app.request('/v1/nodes?history=true&limit=3', {
+      headers: { authorization: `Bearer ${observerToken}` },
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { data: { nodes: Array<{ name: string }>; next_cursor: string | null } };
+    // The stranger's own implicit direct node is visible (self-binding), but
+    // none of the seeded `obs-*` fixture nodes are — the observer has no
+    // authorized binding to either the allowed or hidden fixture agent.
+    expect(body.data.nodes.filter((node) => node.name.startsWith('obs-'))).toEqual([]);
+    expect(body.data.next_cursor).toBeNull();
+  });
+});
+
+/**
+ * Regression: `?capability=` pushes a `json_each`/`json_extract` EXISTS
+ * clause into SQL. `json_extract` raises SQLite's `malformed JSON` error when
+ * evaluated against a legacy/primitive string capability array element (a
+ * bare string like `read` is not itself valid JSON, unlike a quoted `"read"`)
+ * — that shape is exactly what a plain-string capability list produces once
+ * `json_each` unwraps the array. The condition must never let SQLite try
+ * `json_extract` on a non-object element.
+ */
+describe('capability filter tolerates legacy/malformed capability shapes (#422 follow-up)', () => {
+  let stack: TestStack;
+  beforeEach(() => { stack = makeNodeStack(); });
+  afterEach(async () => { await stack.close(); });
+
+  async function seedNode(ws: { workspaceId: string }, id: string, name: string, capabilities: unknown) {
+    const db = stack.runtime.deps.db;
+    await db.insert(nodes).values({
+      id,
+      workspaceId: ws.workspaceId,
+      name,
+      tokenHash: `cap-token-hash-${id}`,
+      status: 'offline',
+      // Bypass the JS-side `normalizeCapabilities` on purpose: this seeds the
+      // exact on-disk shapes a pre-existing/legacy row can carry.
+      capabilities: capabilities as never,
+      createdAt: new Date(),
+    });
+  }
+
+  it('matches legacy plain-string capability arrays without a malformed JSON error', async () => {
+    const ws = await createWorkspace(stack.app, 'capability-legacy-string-ws');
+    await seedNode(ws, 'node_cap_legacy_string', 'legacy-string-node', ['read', 'write']);
+    await seedNode(ws, 'node_cap_object', 'object-node', [{ name: 'read' }]);
+    await seedNode(ws, 'node_cap_other', 'other-node', ['other']);
+
+    const res = await stack.app.request('/v1/nodes?capability=read', {
+      headers: { authorization: `Bearer ${ws.workspaceKey}` },
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { data: Array<{ name: string }> };
+    expect(new Set(body.data.map((n) => n.name))).toEqual(new Set(['legacy-string-node', 'object-node']));
+  });
+
+  it('matches a mixed string/object capability array on either shape without erroring', async () => {
+    const ws = await createWorkspace(stack.app, 'capability-mixed-ws');
+    await seedNode(ws, 'node_cap_mixed', 'mixed-node', ['read', { name: 'write' }]);
+
+    const byString = await stack.app.request('/v1/nodes?capability=read', {
+      headers: { authorization: `Bearer ${ws.workspaceKey}` },
+    });
+    expect(byString.status).toBe(200);
+    expect(((await byString.json()) as { data: Array<{ name: string }> }).data.map((n) => n.name)).toEqual(['mixed-node']);
+
+    const byObjectName = await stack.app.request('/v1/nodes?capability=write', {
+      headers: { authorization: `Bearer ${ws.workspaceKey}` },
+    });
+    expect(byObjectName.status).toBe(200);
+    expect(((await byObjectName.json()) as { data: Array<{ name: string }> }).data.map((n) => n.name)).toEqual(['mixed-node']);
+  });
+
+  it('does not error and matches nothing for a capability array holding non-JSON-object primitives alongside strings', async () => {
+    const ws = await createWorkspace(stack.app, 'capability-malformed-ws');
+    // `true`/`42` are valid JSON scalars (unlike a bare unquoted string) but
+    // are still not objects, so `$.name` must never be extracted from them.
+    await seedNode(ws, 'node_cap_scalars', 'scalars-node', ['keep-me', true, 42, null]);
+
+    const res = await stack.app.request('/v1/nodes?capability=keep-me', {
+      headers: { authorization: `Bearer ${ws.workspaceKey}` },
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { data: Array<{ name: string }> };
+    expect(body.data.map((n) => n.name)).toEqual(['scalars-node']);
+
+    const noMatch = await stack.app.request('/v1/nodes?capability=nonexistent', {
+      headers: { authorization: `Bearer ${ws.workspaceKey}` },
+    });
+    expect(noMatch.status).toBe(200);
+    expect(((await noMatch.json()) as { data: Array<{ name: string }> }).data).toEqual([]);
   });
 });

--- a/packages/engine/src/__tests__/conformance/nodeListBoundedHistory.test.ts
+++ b/packages/engine/src/__tests__/conformance/nodeListBoundedHistory.test.ts
@@ -378,6 +378,135 @@ describe('observer-authorized node history pagination (#422 follow-up)', () => {
     expect(maxQueriesPerPage).toBeLessThan(10);
   });
 
+  /**
+   * Regression: `visibleActiveAgentCounts` used `inArray(agentNodeBindings.nodeId, nodeIds)`,
+   * which binds one SQL parameter per node id. The legacy/default (unfiltered,
+   * unpaginated) observer path can return hundreds of visible nodes in a
+   * single query, and D1 caps a statement at 100 bound parameters — this
+   * would either throw or silently truncate on a real workspace. The fix
+   * binds `nodeIds` as a single JSON-array parameter via `json_each` instead,
+   * so the bind count stays constant no matter how many nodes are visible.
+   */
+  it('computes active-agent counts for 500+ visible nodes on the legacy observer path without exceeding a D1-safe bind count', async () => {
+    const ws = await createWorkspace(stack.app, 'observer-legacy-wide-ws');
+    const allowed = await registerAgent(stack.app, ws.workspaceKey, 'observer-legacy-wide-allowed');
+    const hidden = await registerAgent(stack.app, ws.workspaceKey, 'observer-legacy-wide-hidden');
+
+    const NODE_COUNT = 520;
+    const { authorizedNames } = await seedInterleavedNodes(ws, NODE_COUNT, allowed.agentId, hidden.agentId);
+    const observerToken = await createObserverToken(ws.workspaceKey, [allowed.agentId]);
+
+    const sqlite = stack.runtime.handle.sqlite;
+    const originalPrepare = sqlite.prepare.bind(sqlite);
+    let maxBindParams = 0;
+    let queryCount = 0;
+    sqlite.prepare = ((sqlText: string) => {
+      queryCount++;
+      // Bound JSON-array params never expand into per-element `?` markers,
+      // so every statement's placeholder count stays well under D1's 100
+      // parameter ceiling regardless of NODE_COUNT.
+      const paramCount = (sqlText.match(/\?/g) ?? []).length;
+      maxBindParams = Math.max(maxBindParams, paramCount);
+      return originalPrepare(sqlText);
+    }) as typeof sqlite.prepare;
+
+    let res: Response;
+    try {
+      res = await stack.app.request('/v1/nodes', {
+        headers: { authorization: `Bearer ${observerToken}` },
+      });
+    } finally {
+      sqlite.prepare = originalPrepare;
+    }
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { data: Array<{ name: string; active_agents: number }> };
+    const visibleObsNodes = body.data.filter((n) => n.name.startsWith('obs-'));
+    expect(new Set(visibleObsNodes.map((n) => n.name))).toEqual(new Set(authorizedNames));
+    for (const node of visibleObsNodes) expect(node.active_agents).toBe(1);
+
+    expect(maxBindParams).toBeLessThan(100); // D1 parameter ceiling
+    // No N+1: a small, fixed number of queries regardless of NODE_COUNT
+    // (roster query + one bounded active-agent-counts query, plus setup).
+    expect(queryCount).toBeLessThan(10);
+  });
+
+  it('handles a high-cardinality legacy observer request (500+ authorized agent ids) within a single bounded query', async () => {
+    const ws = await createWorkspace(stack.app, 'observer-legacy-wide-agents-ws');
+    const db = stack.runtime.deps.db;
+    const now = new Date();
+
+    // Insert agent rows directly (bypassing the HTTP registration flow,
+    // which is rate-limited well below 500 requests/test) purely for
+    // fixture speed; only `agentId` needs to round-trip through the
+    // observer token's `agent_ids` filter and the SQL join.
+    const allowedAgentIds = Array.from({ length: 500 }, (_, i) => `agent_obs_legacy_wide_${ws.workspaceId}_${i}`);
+    await db.insert(agents).values(
+      allowedAgentIds.map((id, i) => ({
+        id,
+        workspaceId: ws.workspaceId,
+        name: `observer-legacy-wide-agent-${i}`,
+        tokenHash: `obs-legacy-wide-agent-token-hash-${ws.workspaceId}-${i}`,
+      })),
+    );
+    const hiddenAgentId = `agent_obs_legacy_wide_${ws.workspaceId}_hidden`;
+    await db.insert(agents).values({
+      id: hiddenAgentId,
+      workspaceId: ws.workspaceId,
+      name: 'observer-legacy-wide-agents-hidden',
+      tokenHash: `obs-legacy-wide-agents-hidden-token-hash-${ws.workspaceId}`,
+    });
+
+    const authorizedNames: string[] = [];
+    for (let i = 0; i < 40; i++) {
+      const id = `node_obs_legacy_agents_${ws.workspaceId}_${String(i).padStart(4, '0')}`;
+      const name = `wide-agents-${i}`;
+      const allowed = i % 2 === 0;
+      await db.insert(nodes).values({
+        id,
+        workspaceId: ws.workspaceId,
+        name,
+        tokenHash: `obs-legacy-wide-agents-token-hash-${ws.workspaceId}-${i}`,
+        status: 'offline',
+        createdAt: now,
+      });
+      await db.insert(agentNodeBindings).values({
+        id: `anb_obs_legacy_agents_${ws.workspaceId}_${i}`,
+        workspaceId: ws.workspaceId,
+        agentId: allowed ? allowedAgentIds[i % allowedAgentIds.length] : hiddenAgentId,
+        nodeId: id,
+        status: 'active',
+      });
+      if (allowed) authorizedNames.push(name);
+    }
+
+    const observerToken = await createObserverToken(ws.workspaceKey, allowedAgentIds);
+
+    const sqlite = stack.runtime.handle.sqlite;
+    const originalPrepare = sqlite.prepare.bind(sqlite);
+    let maxBindParams = 0;
+    sqlite.prepare = ((sqlText: string) => {
+      const paramCount = (sqlText.match(/\?/g) ?? []).length;
+      maxBindParams = Math.max(maxBindParams, paramCount);
+      return originalPrepare(sqlText);
+    }) as typeof sqlite.prepare;
+
+    let res: Response;
+    try {
+      res = await stack.app.request('/v1/nodes', {
+        headers: { authorization: `Bearer ${observerToken}` },
+      });
+    } finally {
+      sqlite.prepare = originalPrepare;
+    }
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { data: Array<{ name: string }> };
+    const visible = body.data.filter((n) => n.name.startsWith('wide-agents-'));
+    expect(new Set(visible.map((n) => n.name))).toEqual(new Set(authorizedNames));
+    expect(maxBindParams).toBeLessThan(100);
+  });
+
   it('returns no rows and a null next_cursor when the observer is authorized for nothing on the page', async () => {
     const ws = await createWorkspace(stack.app, 'observer-history-empty-ws');
     const allowed = await registerAgent(stack.app, ws.workspaceKey, 'observer-allowed-agent-2');

--- a/packages/engine/src/__tests__/conformance/nodeListBoundedHistory.test.ts
+++ b/packages/engine/src/__tests__/conformance/nodeListBoundedHistory.test.ts
@@ -1,0 +1,164 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { nodes } from '../../db/schema.js';
+import { makeNodeStack, createWorkspace, type TestStack } from './harness.js';
+
+/**
+ * Regression for #422: `GET /v1/nodes` read every historical row in a
+ * workspace with no status filter, limit, or cursor, then hid offline rows
+ * client-side. On a real workspace this meant fetching 6,298 rows and 3+MB
+ * to show four live nodes.
+ *
+ * This suite seeds thousands of dead historical rows directly (bypassing the
+ * full enroll/heartbeat HTTP flow purely for fixture speed) alongside a
+ * small, deterministic live set, then proves:
+ *   - the default live selection (`status=online`) returns exactly the live
+ *     subset, never more, regardless of how much history exists;
+ *   - explicit history pagination (`history=true`) visits and returns every
+ *     historical row exactly once across pages, with no silent truncation;
+ *   - the legacy unfiltered shape (no `status`/`history`) is preserved for
+ *     existing callers.
+ */
+describe('bounded node list with thousands of historical rows (#422)', () => {
+  let stack: TestStack;
+  beforeEach(() => { stack = makeNodeStack(); });
+  afterEach(async () => { await stack.close(); });
+
+  const HISTORY_ROWS = 4_000;
+  const LIVE_ROWS = 4;
+
+  async function seed(ws: { workspaceId: string }) {
+    const db = stack.runtime.deps.db;
+    const now = Date.now();
+
+    // Thousands of dead historical rows: registered once, long stale.
+    const historyRows = Array.from({ length: HISTORY_ROWS }, (_, i) => ({
+      id: `node_history_${ws.workspaceId}_${String(i).padStart(6, '0')}`,
+      workspaceId: ws.workspaceId,
+      name: `history-${i}`,
+      tokenHash: `history-token-hash-${ws.workspaceId}-${i}`,
+      status: 'offline' as const,
+      // Reported activity while alive; frozen once offline and must not be
+      // read back as current occupancy (active_agents_stale semantics).
+      activeAgents: (i % 3) + 1,
+      lastHeartbeatAt: new Date(now - 10 * 24 * 60 * 60 * 1000 - i),
+      createdAt: new Date(now - 10 * 24 * 60 * 60 * 1000 - i),
+    }));
+    const BATCH = 200;
+    for (let i = 0; i < historyRows.length; i += BATCH) {
+      await db.insert(nodes).values(historyRows.slice(i, i + BATCH));
+    }
+
+    // A handful of live nodes, heartbeated just now.
+    const liveRows = Array.from({ length: LIVE_ROWS }, (_, i) => ({
+      id: `node_live_${ws.workspaceId}_${i}`,
+      workspaceId: ws.workspaceId,
+      name: `live-${i}`,
+      tokenHash: `live-token-hash-${ws.workspaceId}-${i}`,
+      status: 'online' as const,
+      activeAgents: i,
+      lastHeartbeatAt: new Date(now),
+      createdAt: new Date(now),
+    }));
+    await db.insert(nodes).values(liveRows);
+
+    return { historyRows, liveRows };
+  }
+
+  it('visits and returns only the requested live subset by default, never the full history', async () => {
+    const ws = await createWorkspace(stack.app, 'bounded-live-ws');
+    const { liveRows } = await seed(ws);
+
+    const roster = await stack.app.request('/v1/nodes?status=online', {
+      headers: { authorization: `Bearer ${ws.workspaceKey}` },
+    });
+    expect(roster.status).toBe(200);
+    const body = (await roster.json()) as { data: Array<Record<string, unknown>> };
+
+    expect(body.data).toHaveLength(LIVE_ROWS);
+    expect(new Set(body.data.map((n) => n.name))).toEqual(new Set(liveRows.map((r) => r.name)));
+    for (const node of body.data) {
+      expect(node.live).toBe(true);
+      expect(node.status).toBe('online');
+      expect(node.active_agents_stale).toBe(false);
+    }
+
+    // The SQL plan for the live path must seek the (workspace_id, status,
+    // last_heartbeat_at) index, not scan every historical row.
+    const plan = JSON.stringify(
+      stack.runtime.handle.sqlite
+        .prepare(
+          `EXPLAIN QUERY PLAN SELECT * FROM nodes WHERE workspace_id = ? AND status = 'online'
+             AND last_heartbeat_at IS NOT NULL AND last_heartbeat_at <= ? AND last_heartbeat_at >= ?`,
+        )
+        .all(ws.workspaceId, Date.now(), Date.now() - 45_000),
+    );
+    expect(plan).toContain('idx_nodes_status');
+  });
+
+  it('returns only the offline subset for status=offline, still scoped to this workspace', async () => {
+    const ws = await createWorkspace(stack.app, 'bounded-offline-scope-ws');
+    await seed(ws);
+    const otherWs = await createWorkspace(stack.app, 'bounded-offline-other-ws');
+    await seed(otherWs);
+
+    const roster = await stack.app.request('/v1/nodes?status=offline&name=history-0', {
+      headers: { authorization: `Bearer ${ws.workspaceKey}` },
+    });
+    expect(roster.status).toBe(200);
+    const body = (await roster.json()) as { data: Array<Record<string, unknown>> };
+    expect(body.data).toHaveLength(1);
+    expect(body.data[0]).toMatchObject({ name: 'history-0', live: false, active_agents_stale: true });
+  });
+
+  it('pages the full explicit history without gaps, duplicates, or silent truncation', async () => {
+    const ws = await createWorkspace(stack.app, 'bounded-history-page-ws');
+    const { historyRows, liveRows } = await seed(ws);
+    const total = historyRows.length + liveRows.length;
+
+    const seenIds = new Set<string>();
+    const seenNames: string[] = [];
+    let cursor: string | null = null;
+    let pages = 0;
+    do {
+      const url = new URL('http://test/v1/nodes');
+      url.searchParams.set('history', 'true');
+      url.searchParams.set('limit', '250');
+      if (cursor) url.searchParams.set('cursor', cursor);
+      const res = await stack.app.request(url.pathname + '?' + url.searchParams.toString(), {
+        headers: { authorization: `Bearer ${ws.workspaceKey}` },
+      });
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as {
+        data: { nodes: Array<{ id: string; name: string }>; next_cursor: string | null };
+      };
+      expect(body.data.nodes.length).toBeGreaterThan(0);
+      expect(body.data.nodes.length).toBeLessThanOrEqual(250);
+      for (const node of body.data.nodes) {
+        expect(seenIds.has(node.id)).toBe(false); // no duplicate visits across pages
+        seenIds.add(node.id);
+        seenNames.push(node.name);
+      }
+      cursor = body.data.next_cursor;
+      pages++;
+      expect(pages).toBeLessThan(200); // guard against an infinite/non-terminating cursor
+    } while (cursor);
+
+    expect(seenIds.size).toBe(total); // every historical + live row visited exactly once
+    expect(new Set(seenNames)).toEqual(
+      new Set([...historyRows.map((r) => r.name), ...liveRows.map((r) => r.name)]),
+    );
+  });
+
+  it('preserves the legacy unfiltered array shape for existing callers', async () => {
+    const ws = await createWorkspace(stack.app, 'bounded-legacy-ws');
+    const { historyRows, liveRows } = await seed(ws);
+
+    const roster = await stack.app.request('/v1/nodes', {
+      headers: { authorization: `Bearer ${ws.workspaceKey}` },
+    });
+    expect(roster.status).toBe(200);
+    const body = (await roster.json()) as { data: unknown };
+    expect(Array.isArray(body.data)).toBe(true);
+    expect((body.data as unknown[]).length).toBe(historyRows.length + liveRows.length);
+  });
+});

--- a/packages/engine/src/db/migrations/0054_node_status_heartbeat_index.sql
+++ b/packages/engine/src/db/migrations/0054_node_status_heartbeat_index.sql
@@ -1,0 +1,8 @@
+-- #422: GET /v1/nodes now pushes a liveness selector (status=online/offline)
+-- into SQL instead of fetching every historical row and filtering in JS.
+-- The live-node path (status='online') needs its heartbeat freshness check
+-- covered by the same index as the status equality, or it degrades to a
+-- workspace-wide scan on every roster read once a workspace accumulates
+-- thousands of dead rows. No data changes.
+CREATE INDEX IF NOT EXISTS idx_nodes_status_heartbeat
+  ON nodes(workspace_id, status, last_heartbeat_at);

--- a/packages/engine/src/db/schema.ts
+++ b/packages/engine/src/db/schema.ts
@@ -263,6 +263,7 @@ export const nodes = sqliteTable(
     index('idx_nodes_workspace').on(table.workspaceId),
     index('idx_nodes_token').on(table.tokenHash),
     index('idx_nodes_status').on(table.workspaceId, table.status),
+    index('idx_nodes_status_heartbeat').on(table.workspaceId, table.status, table.lastHeartbeatAt),
     index('idx_nodes_workspace_machine').on(table.workspaceId, table.machineId),
     index('idx_nodes_workspace_machine_proven').on(table.workspaceId, table.machineId, table.provenLiveAt),
   ],

--- a/packages/engine/src/engine/node.ts
+++ b/packages/engine/src/engine/node.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 import { invalidateChannelCache } from './cache.js';
-import { and, asc, eq, inArray, isNotNull, isNull, lt, lte, ne, or, sql } from 'drizzle-orm';
+import { and, asc, eq, gt, gte, inArray, isNotNull, isNull, lt, lte, ne, or, sql } from 'drizzle-orm';
 import type {
   FleetAgentRecoverMessage,
   FleetAgentRegisterMessage,
@@ -27,7 +27,7 @@ import { isProviderAgentDeliveryReady, type NodeConnectionRegistry } from '../po
 import { generateId } from './snowflake.js';
 import { assertRegistrableAgentName } from './agent.js';
 import { rotateAgentIdentity } from './agentIdentity.js';
-import { isNodeLive, isReusableForMachineMatch, nodeHasCapacity, nodeHasCapability, NODE_LIVENESS_TTL_MS } from './placement.js';
+import { isNodeLive, isReusableForMachineMatch, nodeHasCapacity, NODE_LIVENESS_TTL_MS } from './placement.js';
 import {
   DEFAULT_PROVIDER_NAME,
   capabilityKind,
@@ -136,8 +136,8 @@ function requestId(message: { id?: string }): string {
   return message.id ?? generateId();
 }
 
-function publicNode(row: NodeRow) {
-  const live = isNodeLive(row);
+function publicNode(row: NodeRow, now?: number) {
+  const live = isNodeLive(row, now);
   return {
     id: row.id,
     name: row.name,
@@ -154,6 +154,13 @@ function publicNode(row: NodeRow) {
     handlers_live: live && row.handlersLive,
     load: row.loadReported ? row.load : null,
     active_agents: row.activeAgents,
+    // `active_agents` is only an authoritative live occupancy count while the
+    // node is proven live within NODE_LIVENESS_TTL_MS. Once a node goes
+    // offline, its last-reported value is frozen history: it can no longer
+    // change and must not be presented as current capacity. Callers that
+    // need current occupancy must check this flag rather than assuming a
+    // non-null `active_agents` means "right now".
+    active_agents_stale: !live,
     max_agents: row.maxAgents,
     last_heartbeat_at: row.lastHeartbeatAt?.toISOString() ?? null,
     created_at: row.createdAt.toISOString(),
@@ -1994,16 +2001,95 @@ export async function reconcileInventory(
   };
 }
 
+/** Default page size for the explicit, bounded node-history cursor contract. */
+export const NODE_LIST_HISTORY_DEFAULT_LIMIT = 100;
+/** Hard cap on a single history page, regardless of caller-requested `limit`. */
+export const NODE_LIST_HISTORY_MAX_LIMIT = 500;
+
+export interface ListNodesFilters {
+  capability?: string;
+  name?: string;
+  /**
+   * Selects on computed liveness (persisted `status` plus a fresh heartbeat
+   * within `NODE_LIVENESS_TTL_MS`), pushed into SQL rather than applied after
+   * a full-table fetch. Omitted: no liveness selection (legacy behavior).
+   */
+  status?: 'online' | 'offline';
+  /**
+   * Switches the response to the bounded, paginated history contract:
+   * `{ nodes, nextCursor }` instead of a bare array, ordered by `id` so a
+   * caller can page through every historical row exactly once with no gaps
+   * or silent truncation, however many rows the workspace has retained.
+   */
+  history?: boolean;
+  /** Resume point for `history`: the `id` of the last row already consumed. */
+  cursor?: string | null;
+  /** Page size for `history`, clamped to [1, NODE_LIST_HISTORY_MAX_LIMIT]. */
+  limit?: number;
+}
+
+export interface ListNodesHistoryPage {
+  nodes: ReturnType<typeof publicNode>[];
+  nextCursor: string | null;
+}
+
+/** Pushes a capability match (string or `{ name }` shape) into a SQL EXISTS clause. */
+function capabilityMatchCondition(capability: string) {
+  return sql`EXISTS (SELECT 1 FROM json_each(${nodes.capabilities}) AS cap
+    WHERE cap.value = ${capability} OR json_extract(cap.value, '$.name') = ${capability})`;
+}
+
+/** Liveness predicate mirroring {@link isNodeLive}, pushed into SQL. */
+function livenessCondition(status: 'online' | 'offline', now: Date) {
+  const staleBefore = new Date(now.getTime() - NODE_LIVENESS_TTL_MS);
+  const live = and(
+    eq(nodes.status, 'online'),
+    isNotNull(nodes.lastHeartbeatAt),
+    lte(nodes.lastHeartbeatAt, now),
+    gte(nodes.lastHeartbeatAt, staleBefore),
+  )!;
+  return status === 'online' ? live : or(
+    ne(nodes.status, 'online'),
+    isNull(nodes.lastHeartbeatAt),
+    lt(nodes.lastHeartbeatAt, staleBefore),
+    // A heartbeat clock skewed into the future never counts as live either.
+    gt(nodes.lastHeartbeatAt, now),
+  )!;
+}
+
 export async function listNodes(
   db: Db,
   workspaceId: string,
-  filters: { capability?: string; name?: string } = {},
-) {
-  const rows = await db.select().from(nodes).where(eq(nodes.workspaceId, workspaceId));
-  return rows
-    .filter((node) => !filters.name || node.name === filters.name)
-    .filter((node) => !filters.capability || nodeHasCapability(node, filters.capability))
-    .map(publicNode);
+  filters: ListNodesFilters = {},
+): Promise<ListNodesHistoryPage> {
+  const now = new Date();
+  const conditions = [eq(nodes.workspaceId, workspaceId)];
+  if (filters.name) conditions.push(eq(nodes.name, filters.name));
+  if (filters.capability) conditions.push(capabilityMatchCondition(filters.capability));
+  if (filters.status) conditions.push(livenessCondition(filters.status, now));
+
+  if (!filters.history) {
+    // Legacy/default shape: a bare array, unpaginated, matching every caller
+    // that predates the history/status selector. `name`/`capability`/`status`
+    // are still evaluated in SQL instead of after a full-table fetch.
+    const rows = await db.select().from(nodes).where(and(...conditions));
+    return { nodes: rows.map((row) => publicNode(row, now.getTime())), nextCursor: null };
+  }
+
+  if (filters.cursor) conditions.push(gt(nodes.id, filters.cursor));
+  const limit = Math.min(
+    Math.max(1, filters.limit ?? NODE_LIST_HISTORY_DEFAULT_LIMIT),
+    NODE_LIST_HISTORY_MAX_LIMIT,
+  );
+  const rows = await db
+    .select()
+    .from(nodes)
+    .where(and(...conditions))
+    .orderBy(asc(nodes.id))
+    .limit(limit + 1);
+  const page = rows.slice(0, limit);
+  const nextCursor = rows.length > limit ? page[page.length - 1].id : null;
+  return { nodes: page.map((row) => publicNode(row, now.getTime())), nextCursor };
 }
 
 export async function getPublicNode(db: Db, workspaceId: string, name: string) {

--- a/packages/engine/src/engine/node.ts
+++ b/packages/engine/src/engine/node.ts
@@ -2060,7 +2060,7 @@ export interface ListNodesHistoryPage {
  * to match primitive capabilities exactly as before.
  */
 function capabilityMatchCondition(capability: string) {
-  return sql`EXISTS (SELECT 1 FROM json_each(${nodes.capabilities}) AS cap
+  return sql`EXISTS (SELECT 1 FROM json_each(CASE WHEN json_valid(${nodes.capabilities}) THEN ${nodes.capabilities} ELSE '[]' END) AS cap
     WHERE cap.value = ${capability}
        OR (json_valid(cap.value) AND json_extract(cap.value, '$.name') = ${capability}))`;
 }
@@ -2074,12 +2074,12 @@ function capabilityMatchCondition(capability: string) {
  */
 function observerNodeVisibilityCondition(agentIds: string[]) {
   if (agentIds.length === 0) return sql`0`;
-  const values = sql.join(agentIds.map((id) => sql`${id}`), sql`, `);
   return sql`EXISTS (
     SELECT 1 FROM ${agentNodeBindings} AS b
+    JOIN json_each(${JSON.stringify(agentIds)}) AS allowed
+      ON allowed.value = b.agent_id
     WHERE b.node_id = ${nodes.id}
       AND b.status = 'active'
-      AND b.agent_id IN (${values})
   )`;
 }
 
@@ -2105,7 +2105,7 @@ async function visibleActiveAgentCounts(
       eq(agentNodeBindings.workspaceId, workspaceId),
       eq(agentNodeBindings.status, 'active'),
       inArray(agentNodeBindings.nodeId, nodeIds),
-      inArray(agentNodeBindings.agentId, agentIds),
+      sql`${agentNodeBindings.agentId} IN (SELECT value FROM json_each(${JSON.stringify(agentIds)}))`,
     ))
     .groupBy(agentNodeBindings.nodeId);
   for (const row of rows) counts.set(row.nodeId, Number(row.count));

--- a/packages/engine/src/engine/node.ts
+++ b/packages/engine/src/engine/node.ts
@@ -2098,13 +2098,20 @@ async function visibleActiveAgentCounts(
 ): Promise<Map<string, number>> {
   const counts = new Map<string, number>();
   if (nodeIds.length === 0 || agentIds.length === 0) return counts;
+  // Both `nodeIds` and `agentIds` are bound as single JSON-array parameters
+  // (via `json_each`) rather than expanded through `inArray`/`IN (...)`,
+  // which would otherwise emit one bind parameter per id. A history page or
+  // a high-cardinality legacy (unpaginated) observer request can carry
+  // hundreds of node ids, and D1 caps a statement at 100 bound parameters —
+  // two JSON binds keep this query's parameter count constant regardless of
+  // how many nodes or agents are being counted.
   const rows = await db
     .select({ nodeId: agentNodeBindings.nodeId, count: sql<number>`count(*)` })
     .from(agentNodeBindings)
     .where(and(
       eq(agentNodeBindings.workspaceId, workspaceId),
       eq(agentNodeBindings.status, 'active'),
-      inArray(agentNodeBindings.nodeId, nodeIds),
+      sql`${agentNodeBindings.nodeId} IN (SELECT value FROM json_each(${JSON.stringify(nodeIds)}))`,
       sql`${agentNodeBindings.agentId} IN (SELECT value FROM json_each(${JSON.stringify(agentIds)}))`,
     ))
     .groupBy(agentNodeBindings.nodeId);

--- a/packages/engine/src/engine/node.ts
+++ b/packages/engine/src/engine/node.ts
@@ -2026,6 +2026,22 @@ export interface ListNodesFilters {
   cursor?: string | null;
   /** Page size for `history`, clamped to [1, NODE_LIST_HISTORY_MAX_LIMIT]. */
   limit?: number;
+  /**
+   * Restricts the result to nodes with at least one active binding to one of
+   * these agent ids — the SQL-pushed form of an observer token's `agent_ids`
+   * filter. Applied as a WHERE condition alongside `name`/`capability`/`status`,
+   * *before* the cursor/limit page is computed, so:
+   *   - a hidden node's id is never selected into the page, let alone into
+   *     `nextCursor` — an observer can't learn a hidden node's id or presence
+   *     by watching the cursor advance past it;
+   *   - the page-then-filter ordering can't shrink a page's visible count
+   *     below `limit` while still reporting more rows exist, and can't stop
+   *     paging while an authorized row beyond the current page is unvisited —
+   *     the authorization predicate is part of what "the next row" means.
+   * An empty array (as opposed to undefined) is a real, deliberate filter
+   * that authorizes nothing.
+   */
+  observerAgentIds?: string[];
 }
 
 export interface ListNodesHistoryPage {
@@ -2033,10 +2049,67 @@ export interface ListNodesHistoryPage {
   nextCursor: string | null;
 }
 
-/** Pushes a capability match (string or `{ name }` shape) into a SQL EXISTS clause. */
+/**
+ * Pushes a capability match (string or `{ name }` shape) into a SQL EXISTS
+ * clause. `cap.value` is only a valid `json_extract` target when the array
+ * element is itself a JSON object; a legacy/primitive string element (the
+ * common shape) is not valid JSON on its own (e.g. `read` vs `"read"`), and
+ * `json_extract` raises `malformed JSON` if evaluated against it. Gate the
+ * object-shape branch behind `json_valid` so `AND` short-circuits before
+ * `json_extract` ever sees a bare string, leaving the string-equality branch
+ * to match primitive capabilities exactly as before.
+ */
 function capabilityMatchCondition(capability: string) {
   return sql`EXISTS (SELECT 1 FROM json_each(${nodes.capabilities}) AS cap
-    WHERE cap.value = ${capability} OR json_extract(cap.value, '$.name') = ${capability})`;
+    WHERE cap.value = ${capability}
+       OR (json_valid(cap.value) AND json_extract(cap.value, '$.name') = ${capability}))`;
+}
+
+/**
+ * Pushes an observer token's `agent_ids` filter into a SQL EXISTS clause: a
+ * node is visible only if it has at least one *active* binding to one of the
+ * authorized agent ids. `agentIds: []` (filter present but empty) matches no
+ * node, mirroring `observerAllowsAgent`'s fail-closed behavior for an empty
+ * allow-list rather than falling open.
+ */
+function observerNodeVisibilityCondition(agentIds: string[]) {
+  if (agentIds.length === 0) return sql`0`;
+  const values = sql.join(agentIds.map((id) => sql`${id}`), sql`, `);
+  return sql`EXISTS (
+    SELECT 1 FROM ${agentNodeBindings} AS b
+    WHERE b.node_id = ${nodes.id}
+      AND b.status = 'active'
+      AND b.agent_id IN (${values})
+  )`;
+}
+
+/**
+ * Active-agent counts for a page of nodes, scoped to an observer's
+ * authorized agent ids, in one query — not one `listNodeAgents` query per
+ * node. Used to override each visible node's `active_agents` with the count
+ * the observer is actually authorized to see (mirrors the prior per-node
+ * `filterNodeAgentsForObserver(...).length` behavior).
+ */
+async function visibleActiveAgentCounts(
+  db: Db,
+  workspaceId: string,
+  nodeIds: string[],
+  agentIds: string[],
+): Promise<Map<string, number>> {
+  const counts = new Map<string, number>();
+  if (nodeIds.length === 0 || agentIds.length === 0) return counts;
+  const rows = await db
+    .select({ nodeId: agentNodeBindings.nodeId, count: sql<number>`count(*)` })
+    .from(agentNodeBindings)
+    .where(and(
+      eq(agentNodeBindings.workspaceId, workspaceId),
+      eq(agentNodeBindings.status, 'active'),
+      inArray(agentNodeBindings.nodeId, nodeIds),
+      inArray(agentNodeBindings.agentId, agentIds),
+    ))
+    .groupBy(agentNodeBindings.nodeId);
+  for (const row of rows) counts.set(row.nodeId, Number(row.count));
+  return counts;
 }
 
 /** Liveness predicate mirroring {@link isNodeLive}, pushed into SQL. */
@@ -2067,13 +2140,25 @@ export async function listNodes(
   if (filters.name) conditions.push(eq(nodes.name, filters.name));
   if (filters.capability) conditions.push(capabilityMatchCondition(filters.capability));
   if (filters.status) conditions.push(livenessCondition(filters.status, now));
+  // Observer authorization is a WHERE condition, evaluated in the same query
+  // as every other filter and therefore before pagination/cursor computation
+  // below — a hidden node is excluded from row selection entirely, so it can
+  // never land in `nextCursor`, and cursor advancement always tracks "the
+  // next authorized row" rather than "the next row, authorized or not".
+  if (filters.observerAgentIds) conditions.push(observerNodeVisibilityCondition(filters.observerAgentIds));
 
   if (!filters.history) {
     // Legacy/default shape: a bare array, unpaginated, matching every caller
     // that predates the history/status selector. `name`/`capability`/`status`
     // are still evaluated in SQL instead of after a full-table fetch.
     const rows = await db.select().from(nodes).where(and(...conditions));
-    return { nodes: rows.map((row) => publicNode(row, now.getTime())), nextCursor: null };
+    const page = rows.map((row) => publicNode(row, now.getTime()));
+    if (!filters.observerAgentIds) return { nodes: page, nextCursor: null };
+    const counts = await visibleActiveAgentCounts(db, workspaceId, rows.map((row) => row.id), filters.observerAgentIds);
+    return {
+      nodes: page.map((node) => ({ ...node, active_agents: counts.get(node.id) ?? 0 })),
+      nextCursor: null,
+    };
   }
 
   if (filters.cursor) conditions.push(gt(nodes.id, filters.cursor));
@@ -2089,7 +2174,13 @@ export async function listNodes(
     .limit(limit + 1);
   const page = rows.slice(0, limit);
   const nextCursor = rows.length > limit ? page[page.length - 1].id : null;
-  return { nodes: page.map((row) => publicNode(row, now.getTime())), nextCursor };
+  const publicPage = page.map((row) => publicNode(row, now.getTime()));
+  if (!filters.observerAgentIds) return { nodes: publicPage, nextCursor };
+  const counts = await visibleActiveAgentCounts(db, workspaceId, page.map((row) => row.id), filters.observerAgentIds);
+  return {
+    nodes: publicPage.map((node) => ({ ...node, active_agents: counts.get(node.id) ?? 0 })),
+    nextCursor,
+  };
 }
 
 export async function getPublicNode(db: Db, workspaceId: string, name: string) {

--- a/packages/engine/src/routes/node.ts
+++ b/packages/engine/src/routes/node.ts
@@ -101,7 +101,7 @@ function strictExternalUrl(c: Parameters<typeof jsonError>[0]): boolean {
   return environment !== 'test';
 }
 
-type NodeRosterEntry = Awaited<ReturnType<typeof nodeEngine.listNodes>>[number];
+type NodeRosterEntry = Awaited<ReturnType<typeof nodeEngine.listNodes>>['nodes'][number];
 type NodeAgentBinding = NonNullable<Awaited<ReturnType<typeof nodeEngine.listNodeAgents>>>[number];
 type ObserverContext = ReturnType<typeof getObserverTokenFromContext>;
 
@@ -191,21 +191,49 @@ async function enrollNode(c: Context<AppEnv>, data: z.infer<typeof createNodeSch
   }
 }
 
-// GET /v1/nodes?capability=&name= - node roster
+const nodeStatusSchema = z.enum(['online', 'offline']);
+
+// GET /v1/nodes?capability=&name=&status=&history=&cursor=&limit= - node roster
+//
+// Default (no `history`): a bare array, matching every caller written before
+// this selector existed. `status=online` (or `offline`) now pushes a
+// liveness predicate into SQL instead of fetching the whole table and
+// filtering in JS — this is the server-filtered live-Fleet path a default
+// `fleet nodes` call should use so it never downloads history.
+//
+// `history=true`: switches to the bounded, paginated contract
+// (`{ nodes, next_cursor }`) for an explicit full-roster read (`--all`).
+// `cursor`/`limit` page through it without silent truncation, however many
+// historical rows the workspace has retained.
 nodeRoutes.get('/nodes', requireWorkspaceRead('nodes:read'), rateLimit, async (c) => {
   try {
     const db = c.get('db');
     const workspace = c.get('workspace');
-    const result = await nodeEngine.listNodes(db, workspace.id, {
+    const statusRaw = c.req.query('status');
+    if (statusRaw !== undefined && !nodeStatusSchema.safeParse(statusRaw).success) {
+      return jsonError(c, 'invalid_request', "status must be 'online' or 'offline'", 400);
+    }
+    const history = c.req.query('history') === 'true';
+    const limitRaw = c.req.query('limit');
+    const limit = limitRaw !== undefined ? Number(limitRaw) : undefined;
+    if (limit !== undefined && (!Number.isInteger(limit) || limit < 1)) {
+      return jsonError(c, 'invalid_request', 'limit must be a positive integer', 400);
+    }
+    const page = await nodeEngine.listNodes(db, workspace.id, {
       capability: c.req.query('capability'),
       name: c.req.query('name'),
+      status: statusRaw as 'online' | 'offline' | undefined,
+      history,
+      cursor: c.req.query('cursor') ?? null,
+      limit,
     });
-    return jsonOk(c, await filterNodesForObserver(
+    const visible = await filterNodesForObserver(
       db,
       workspace.id,
       getObserverTokenFromContext(c),
-      result,
-    ));
+      page.nodes,
+    );
+    return jsonOk(c, history ? { nodes: visible, next_cursor: page.nextCursor } : visible);
   } catch (err: unknown) {
     return errorResponse(c, err);
   }

--- a/packages/engine/src/routes/node.ts
+++ b/packages/engine/src/routes/node.ts
@@ -101,7 +101,6 @@ function strictExternalUrl(c: Parameters<typeof jsonError>[0]): boolean {
   return environment !== 'test';
 }
 
-type NodeRosterEntry = Awaited<ReturnType<typeof nodeEngine.listNodes>>['nodes'][number];
 type NodeAgentBinding = NonNullable<Awaited<ReturnType<typeof nodeEngine.listNodeAgents>>>[number];
 type ObserverContext = ReturnType<typeof getObserverTokenFromContext>;
 
@@ -113,22 +112,10 @@ function filterNodeAgentsForObserver(observer: ObserverContext, bindings: NodeAg
   return bindings.filter((binding) => observerAllowsAgent(observer, binding.agent_id));
 }
 
-async function filterNodesForObserver(
-  db: Parameters<typeof nodeEngine.listNodes>[0],
-  workspaceId: string,
-  observer: ObserverContext,
-  roster: NodeRosterEntry[],
-): Promise<NodeRosterEntry[]> {
-  if (!observerHasAgentFilter(observer)) return roster;
-  const visible: NodeRosterEntry[] = [];
-  for (const node of roster) {
-    const bindings = await nodeEngine.listNodeAgents(db, workspaceId, node.name);
-    const visibleBindings = bindings ? filterNodeAgentsForObserver(observer, bindings) : [];
-    if (visibleBindings.length > 0) {
-      visible.push({ ...node, active_agents: visibleBindings.length });
-    }
-  }
-  return visible;
+/** The observer's authorized agent ids, or `undefined` when unfiltered/absent. */
+function observerAgentIdsFilter(observer: ObserverContext): string[] | undefined {
+  if (!observer) return undefined;
+  return normalizeObserverFilters(observer.filters).agent_ids;
 }
 
 // POST /v1/nodes - enroll or rotate a node token (workspace-key only)
@@ -226,14 +213,13 @@ nodeRoutes.get('/nodes', requireWorkspaceRead('nodes:read'), rateLimit, async (c
       history,
       cursor: c.req.query('cursor') ?? null,
       limit,
+      // Pushed into the same SQL query as every other filter, so hidden nodes
+      // are excluded from row selection before the page/cursor is computed —
+      // see `observerNodeVisibilityCondition` — instead of one
+      // `listNodeAgents` query per roster row followed by an app-side filter.
+      observerAgentIds: observerAgentIdsFilter(getObserverTokenFromContext(c)),
     });
-    const visible = await filterNodesForObserver(
-      db,
-      workspace.id,
-      getObserverTokenFromContext(c),
-      page.nodes,
-    );
-    return jsonOk(c, history ? { nodes: visible, next_cursor: page.nextCursor } : visible);
+    return jsonOk(c, history ? { nodes: page.nodes, next_cursor: page.nextCursor } : page.nodes);
   } catch (err: unknown) {
     return errorResponse(c, err);
   }

--- a/packages/sdk-typescript/CHANGELOG.md
+++ b/packages/sdk-typescript/CHANGELOG.md
@@ -7,7 +7,7 @@ See the [root changelog](../../CHANGELOG.md) for cross-package release highlight
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [Unreleased - Minor]
 
 ### Added
 

--- a/packages/sdk-typescript/CHANGELOG.md
+++ b/packages/sdk-typescript/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+### Added
+
+- `nodes.list()` accepts `status: 'online' | 'offline'` to select on the engine's server-filtered liveness query instead of fetching the full roster. `NodeRosterEntry.activeAgentsStale` is `true` whenever `live` is `false`, so a frozen historical occupancy count is never treated as current.
+- `nodes.listHistory()` reads the bounded, paginated `history=true` contract (`{ nodes, nextCursor }`) for an explicit full-roster read without silent truncation, however many rows the workspace has retained.
+
 ## [8.8.0] - 2026-09-10
 
 ### Changed

--- a/packages/sdk-typescript/src/__tests__/relay.test.ts
+++ b/packages/sdk-typescript/src/__tests__/relay.test.ts
@@ -846,6 +846,149 @@ describe('RelayCast', () => {
   });
 
   describe('nodes', () => {
+    it('list() with status builds the query and camelizes stale roster fields', async () => {
+      const { RelayCast } = await import('../relay.js');
+      const relay = new RelayCast({ apiKey: 'rk_live_test123' });
+
+      mockFetch.mockImplementation(() => mockResponse([
+        {
+          id: 'node_1',
+          name: 'node-one',
+          kind: 'ws',
+          role: 'direct',
+          machine_id: null,
+          delivery_adapter: 'ws',
+          delivery: null,
+          capabilities: [],
+          tags: [],
+          version: '1.0.0',
+          status: 'offline',
+          live: false,
+          handlers_live: false,
+          load: null,
+          active_agents: 3,
+          active_agents_stale: true,
+          max_agents: 5,
+          last_heartbeat_at: '2026-09-10T00:00:00.000Z',
+          created_at: '2026-09-01T00:00:00.000Z',
+        },
+      ]));
+
+      const result = await relay.nodes.list({ status: 'offline' });
+
+      const [url, init] = mockFetch.mock.calls[0]!;
+      expect(url).toBe('https://cast.agentrelay.com/v1/nodes?status=offline');
+      expect(init.method).toBe('GET');
+      expect(result).toEqual([
+        expect.objectContaining({
+          id: 'node_1',
+          name: 'node-one',
+          activeAgents: 3,
+          activeAgentsStale: true,
+          lastHeartbeatAt: '2026-09-10T00:00:00.000Z',
+        }),
+      ]);
+    });
+
+    it('list() with capability and name filters builds the combined query', async () => {
+      const { RelayCast } = await import('../relay.js');
+      const relay = new RelayCast({ apiKey: 'rk_live_test123' });
+
+      mockFetch.mockImplementation(() => mockResponse([]));
+      await relay.nodes.list({ capability: 'gpu', name: 'node/one', status: 'online' });
+
+      const [url] = mockFetch.mock.calls[0]!;
+      const requested = new URL(String(url));
+      expect(requested.pathname).toBe('/v1/nodes');
+      expect(requested.searchParams.get('capability')).toBe('gpu');
+      expect(requested.searchParams.get('name')).toBe('node/one');
+      expect(requested.searchParams.get('status')).toBe('online');
+    });
+
+    it('list() omits query params entirely when no filters are given', async () => {
+      const { RelayCast } = await import('../relay.js');
+      const relay = new RelayCast({ apiKey: 'rk_live_test123' });
+
+      mockFetch.mockImplementation(() => mockResponse([]));
+      await relay.nodes.list();
+
+      const [url] = mockFetch.mock.calls[0]!;
+      expect(url).toBe('https://cast.agentrelay.com/v1/nodes');
+    });
+
+    it('listHistory() sets history=true, forwards cursor/limit, and maps next_cursor to nextCursor', async () => {
+      const { RelayCast } = await import('../relay.js');
+      const relay = new RelayCast({ apiKey: 'rk_live_test123' });
+
+      mockFetch.mockImplementation(() => mockResponse({
+        nodes: [
+          {
+            id: 'node_2',
+            name: 'node-two',
+            kind: 'http_push',
+            role: 'broker',
+            machine_id: 'machine_1',
+            delivery_adapter: 'http_push',
+            delivery: null,
+            capabilities: [],
+            tags: [],
+            version: '1.0.0',
+            status: 'offline',
+            live: false,
+            handlers_live: false,
+            load: null,
+            active_agents: 2,
+            active_agents_stale: true,
+            max_agents: 10,
+            last_heartbeat_at: '2026-09-09T00:00:00.000Z',
+            created_at: '2026-09-01T00:00:00.000Z',
+          },
+        ],
+        next_cursor: 'cursor_abc',
+      }));
+
+      const result = await relay.nodes.listHistory({
+        capability: 'gpu',
+        name: 'node',
+        status: 'offline',
+        cursor: 'cursor_prev',
+        limit: 50,
+      });
+
+      const requested = new URL(String(mockFetch.mock.calls[0]?.[0]));
+      expect(requested.pathname).toBe('/v1/nodes');
+      expect(requested.searchParams.get('history')).toBe('true');
+      expect(requested.searchParams.get('capability')).toBe('gpu');
+      expect(requested.searchParams.get('name')).toBe('node');
+      expect(requested.searchParams.get('status')).toBe('offline');
+      expect(requested.searchParams.get('cursor')).toBe('cursor_prev');
+      expect(requested.searchParams.get('limit')).toBe('50');
+
+      expect(result).toEqual({
+        nodes: [
+          expect.objectContaining({
+            id: 'node_2',
+            activeAgents: 2,
+            activeAgentsStale: true,
+          }),
+        ],
+        nextCursor: 'cursor_abc',
+      });
+    });
+
+    it('listHistory() maps a null next_cursor to a null nextCursor', async () => {
+      const { RelayCast } = await import('../relay.js');
+      const relay = new RelayCast({ apiKey: 'rk_live_test123' });
+
+      mockFetch.mockImplementation(() => mockResponse({ nodes: [], next_cursor: null }));
+
+      const result = await relay.nodes.listHistory();
+
+      const [url] = mockFetch.mock.calls[0]!;
+      expect(url).toBe('https://cast.agentrelay.com/v1/nodes?history=true');
+      expect(result).toEqual({ nodes: [], nextCursor: null });
+    });
+
     it('delete() URL-encodes the node name, forwards force, and returns cascade details', async () => {
       const { RelayCast } = await import('../relay.js');
       const relay = new RelayCast({ apiKey: 'rk_live_test123' });

--- a/packages/sdk-typescript/src/relay.ts
+++ b/packages/sdk-typescript/src/relay.ts
@@ -71,6 +71,8 @@ import type {
   DeleteNodeOptions,
   DeleteNodeResponse,
   NodeAgentBinding,
+  NodeHistoryPage,
+  NodeHistoryQuery,
   NodeListQuery,
   NodeRosterEntry,
   Trigger,
@@ -977,6 +979,21 @@ export class RelayCast {
       const params: Record<string, string> = {};
       if (query?.capability) params.capability = query.capability;
       if (query?.name) params.name = query.name;
+      if (query?.status) params.status = query.status;
+      return this.client.get('/v1/nodes', params);
+    },
+
+    // Explicit, bounded pagination contract for reading history (e.g. `--all`
+    // in the Relay CLI): pages through every matching row exactly once, no
+    // matter how many the workspace has retained, without silent truncation.
+    // Compatible callers keep using `list()`, which never returns this shape.
+    listHistory: (query?: NodeHistoryQuery): Promise<NodeHistoryPage> => {
+      const params: Record<string, string> = { history: 'true' };
+      if (query?.capability) params.capability = query.capability;
+      if (query?.name) params.name = query.name;
+      if (query?.status) params.status = query.status;
+      if (query?.cursor) params.cursor = query.cursor;
+      if (query?.limit !== undefined) params.limit = String(query.limit);
       return this.client.get('/v1/nodes', params);
     },
 

--- a/packages/sdk-typescript/src/types.ts
+++ b/packages/sdk-typescript/src/types.ts
@@ -347,6 +347,13 @@ export interface NodeRosterEntry {
   /** Managed-agent capacity utilization in [0,1], or null when unreported. */
   load: number | null;
   activeAgents: number;
+  /**
+   * `activeAgents` is only an authoritative live occupancy count while
+   * `live` is true. Once a node goes offline its last-reported value is
+   * frozen history — it cannot change and must not be read as current
+   * capacity. `true` whenever `live` is `false`.
+   */
+  activeAgentsStale: boolean;
   maxAgents: number;
   lastHeartbeatAt: string | null;
   createdAt: string;
@@ -416,6 +423,31 @@ export interface BindAgentToNodeRequest {
 export interface NodeListQuery {
   capability?: string;
   name?: string;
+  /**
+   * Pushed into the roster's SQL query. Omitted: unfiltered by liveness
+   * (legacy default). `'online'` is the server-filtered live-Fleet path —
+   * it never reads or returns history, however large the workspace's
+   * roster has grown. `'offline'` selects everything else and, without
+   * `history`, is not paginated: prefer {@link RelayClient.nodes.listHistory}
+   * for a bounded read of a large dead roster.
+   */
+  status?: 'online' | 'offline';
+}
+
+export interface NodeHistoryQuery {
+  capability?: string;
+  name?: string;
+  status?: 'online' | 'offline';
+  /** Resume point from a previous page's `nextCursor`. Omit to start from the beginning. */
+  cursor?: string | null;
+  /** Page size, clamped server-side to a fixed maximum. */
+  limit?: number;
+}
+
+export interface NodeHistoryPage {
+  nodes: NodeRosterEntry[];
+  /** Pass back as `cursor` to fetch the next page; `null` once every row has been visited. */
+  nextCursor: string | null;
 }
 
 export interface Trigger {


### PR DESCRIPTION
Fixes #422

## Summary

`GET /v1/nodes` fetched every historical node row in a workspace with no status filter, limit, or cursor, then filtered `name`/`capability` in JS. On a real workspace this meant 6,298 rows / ~3 MB fetched to show 4 live nodes.

## Changes

- **SQL pushdown**: `name`, `capability` (via a `json_each`/`json_extract` `EXISTS` clause, matching both string and `{ name }` capability shapes), and a new `status` liveness selector are all evaluated in SQL (`packages/engine/src/engine/node.ts`), not fetched wholesale and filtered in JS.
- **Live/history selector**: `status=online` pushes the same freshness predicate as `isNodeLive` (persisted `status='online'` + heartbeat within `NODE_LIVENESS_TTL_MS`) into SQL — the server-filtered live-Fleet path a default `fleet nodes` call should use.
- **Bounded cursor pagination for explicit history**: `history=true&cursor=&limit=` returns `{ nodes, next_cursor }`, keyset-paginated by `id`, capped at 500/page, guaranteed to visit and return every matching row exactly once with no silent truncation.
- **Compatibility**: without `history`, `GET /v1/nodes` keeps returning the legacy bare array — every existing caller (SDK, tests) is unaffected. The new paginated envelope is only returned when a caller opts in via `history=true`.
- **Stale offline `active_agents` semantics**: every roster entry now carries `active_agents_stale` (`true` whenever the node isn't currently live). `active_agents` on an offline row is documented as frozen history, never presented as current occupancy.
- **Index**: added `idx_nodes_status_heartbeat` (`workspace_id, status, last_heartbeat_at`) so the live-selection query stays indexed as history grows (migration `0054_node_status_heartbeat_index.sql`).
- **SDK** (`@relaycast/sdk`): `nodes.list({ status })` for the live path (still returns `NodeRosterEntry[]`); new `nodes.listHistory({ cursor, limit })` for the bounded paginated contract. `NodeRosterEntry.activeAgentsStale` added.
- **Docs**: `openapi.yaml`, `README.md`, and package changelogs (`CHANGELOG.md`, `packages/engine/CHANGELOG.md`, `packages/sdk-typescript/CHANGELOG.md`) updated to match.

## Regression evidence

`packages/engine/src/__tests__/conformance/nodeListBoundedHistory.test.ts` seeds 4,000 dead historical rows + 4 live rows directly in SQLite and proves:
- `status=online` returns exactly the 4 live nodes, never the history, and its query plan uses `idx_nodes_status` (no full scan).
- `status=offline` stays scoped to the requesting workspace even when another workspace holds the same-shaped history.
- `history=true` pagination visits and returns all 4,004 rows exactly once, in bounded 250-row pages, with no duplicates and no gaps (loop guarded against non-termination).
- The legacy unfiltered call still returns the full bare array (compat).

## Verification

- `npm run typecheck` — engine, sdk-typescript: clean.
- `npm run lint` — engine, sdk-typescript: clean.
- `npx vitest run` — engine: 87 files / 1000 tests passed (including the new regression and all existing node/observer/provider suites). sdk-typescript: 23 files / 467 tests passed.
- `npx turbo lint test build --filter=@relaycast/engine --filter=@relaycast/sdk` — all green.
- `git diff` reviewed; `package-lock.json` churn from local `npm install`/native-module rebuild reverted before commit (not part of this change).

## Compatibility

- `GET /v1/nodes` default response shape (bare array) is unchanged for every existing caller.
- `capability`/`name` query params behave identically, just evaluated server-side now.
- New: `status`, `history`, `cursor`, `limit` query params and `active_agents_stale`/paginated-envelope response additions are purely additive.
- SDK: `nodes.list()` signature/behavior unchanged aside from the new optional `status` filter; `nodes.listHistory()` is a new, separate method — no breaking change to any existing SDK consumer.

## Companion Relay CLI work (not in this PR — different repo)

Full details in `docs/relay-cli-422-companion-change.md`. Summary for `AgentWorkforce/relay`, `packages/cli/src/cli/commands/fleet.ts`:
1. Default `fleet nodes` / `fleet agent list` should call `relay.nodes.list({ status: 'online' })` instead of the unfiltered `list()`, and drop the local "N offline or non-fleet records hidden" message (no longer true — the server never returns those rows).
2. `--all` should loop `relay.nodes.listHistory({ cursor, limit })` until `nextCursor` is `null`, instead of one unbounded `list()` call.
3. History/`--all` rendering should use `activeAgentsStale` to avoid showing a frozen offline count as current occupancy.

None of this requires a version gate — the engine's new params/fields are additive, so an unmodified Relay CLI keeps working unchanged.

## Not done here (by design/scope)

- No merge, publish, or deploy performed.
- Relay CLI repository not touched (companion change documented only).

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/AgentWorkforce/relaycast/pull/424?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

