### PR TITLE
fix: preserve subscription hotfix behavior in engine releases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ Packages without a separate changelog are covered by the cross-package notes bel
 
 ## [Unreleased - Patch]
 
+- Prevent recipient self-invitations from restoring a released subscription membership.
+
 ### Fixed
 
 - Durable message replay preserves exact hyphenated mentions and webhook display names, and raw webhook deliveries use the same payload shape as live messages.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,12 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 Packages without a separate changelog are covered by the cross-package notes below.
 
-## [Unreleased]
+## [Unreleased - Patch]
+
+### Fixed
+
+- Durable message replay preserves exact hyphenated mentions and webhook display names, and raw webhook deliveries use the same payload shape as live messages.
+- Subscription joins cannot recreate membership for an agent released during the request.
 
 ## [8.9.0] - 2026-09-11
 

--- a/packages/engine/CHANGELOG.md
+++ b/packages/engine/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased - Patch]
 
+- Prevent recipient self-invitations from restoring a released subscription membership.
+
 ### Fixed
 
 - Durable message replay preserves exact hyphenated mentions and webhook display names, and raw webhook deliveries use the same payload shape as live messages.

--- a/packages/engine/CHANGELOG.md
+++ b/packages/engine/CHANGELOG.md
@@ -7,7 +7,12 @@ See the [root changelog](../../CHANGELOG.md) for cross-package release highlight
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [Unreleased - Patch]
+
+### Fixed
+
+- Durable message replay preserves exact hyphenated mentions and webhook display names, and raw webhook deliveries use the same payload shape as live messages.
+- Subscription joins cannot recreate membership for an agent released during the request.
 
 ## [8.9.0] - 2026-09-11
 

--- a/packages/engine/src/__tests__/conformance/delivery.test.ts
+++ b/packages/engine/src/__tests__/conformance/delivery.test.ts
@@ -1904,6 +1904,55 @@ describe('durable delivery api', () => {
     ]);
   });
 
+  it('preserves hyphenated mentions through node reconnect replay', async () => {
+    const ws = await createWorkspace(stack.app, 'mention-replay');
+    const alice = await registerAgent(stack.app, ws.workspaceKey, 'alice');
+    const node = await enrollAndAttachNode(ws);
+    const bob = await registerViaNode(node, 'build-reviewer_2');
+    const response = await stack.app.request('/v1/channels/general/messages', {
+      method: 'POST', headers: { 'content-type': 'application/json', authorization: `Bearer ${alice.token}` },
+      body: JSON.stringify({ text: '@build-reviewer_2 ping @build-reviewer_2 email@example.com \\@escaped' }),
+    });
+    expect(response.status).toBe(201);
+    await stack.settle();
+    const live = latestDeliverOfType(node.sock, 'message.created');
+    expect(live.payload).toMatchObject({ data: { mentions: ['build-reviewer_2'] } });
+    await node.handle.handleClose();
+    const reconnected = await enrollAndAttachNode(ws, { id: node.id, name: node.name });
+    await reconnected.handle.handleMessage(JSON.stringify({ v: 1, type: 'inventory.sync',
+      agents: [{ agent_id: bob.agentId, name: 'build-reviewer_2', session_ref: 'sess-build-reviewer_2' }] }));
+    await stack.settle();
+    expect(latestDeliverOfType(reconnected.sock, 'message.created').payload).toEqual(live.payload);
+  });
+
+  it('normalizes a live raw-hook delivery for node recipients', async () => {
+    const ws = await createWorkspace(stack.app, 'raw-hook-wire');
+    const node = await enrollAndAttachNode(ws);
+    const recipient = await registerViaNode(node, 'hook-recipient');
+    const created = await stack.app.request('/v1/webhooks', { method: 'POST',
+      headers: { 'content-type': 'application/json', authorization: `Bearer ${ws.workspaceKey}` },
+      body: JSON.stringify({ channel: 'general' }) });
+    expect(created.status).toBe(201);
+    const { data: hook } = await created.json();
+    const response = await stack.app.request(`/v1/hooks/${hook.webhook_id}`, { method: 'POST',
+      headers: { 'content-type': 'application/json', authorization: `Bearer ${hook.token}` },
+      body: JSON.stringify({ text: 'provider event', author: 'GitHub' }) });
+    expect(response.status).toBe(201);
+    await stack.settle();
+    expect(latestDeliverOfType(node.sock, 'message.created').payload).toMatchObject({
+      type: 'message.created', data: { channel_name: 'general', from_name: 'GitHub', text: 'provider event' },
+    });
+    await node.handle.handleClose();
+    const reconnected = await enrollAndAttachNode(ws, { id: node.id, name: node.name });
+    await reconnected.handle.handleMessage(JSON.stringify({ v: 1, type: 'inventory.sync',
+      agents: [{ agent_id: recipient.agentId, name: 'hook-recipient', session_ref: 'sess-hook-recipient' }] }));
+    await stack.settle();
+    expect(latestDeliverOfType(reconnected.sock, 'message.created').payload).toMatchObject({
+      type: 'message.created', data: { channel_name: 'general', from_name: 'GitHub', text: 'provider event' },
+    });
+
+  });
+
   it('redelivers a DM with the same deliver payload after broker death/reconnect', async () => {
     const ws = await createWorkspace(stack.app, 'mailbox-node-redeliver-dm');
     const alice = await registerAgent(stack.app, ws.workspaceKey, 'alice');

--- a/packages/engine/src/__tests__/conformance/subscriptionChannel.test.ts
+++ b/packages/engine/src/__tests__/conformance/subscriptionChannel.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { channelMembers, channels } from '../../db/schema.js';
 import { generateId } from '../../engine/snowflake.js';
 import { deleteAgent } from '../../engine/agent.js';
-import { createChannel, getChannel, joinChannel, leaveChannel, ensureAgentSubscriptionChannel } from '../../engine/channel.js';
+import { createChannel, getChannel, joinChannel, inviteAgent, leaveChannel, ensureAgentSubscriptionChannel } from '../../engine/channel.js';
 import type { EngineDb, TransactionCapability } from '../../ports/database.js';
 import { makeNodeStack, createWorkspace, registerAgent, type TestStack } from './harness.js';
 
@@ -78,6 +78,40 @@ describe('agent subscription channels', () => {
     });
     try {
       await expect(joinChannel(db, ws.workspaceId, channel.name, target.agentId)).rejects.toMatchObject({ code: 'agent_not_found' });
+      expect((await getChannel(db, ws.workspaceId, channel.name)).members).toHaveLength(0);
+    } finally { hook.mockRestore(); }
+  });
+
+  it('does not recreate membership when release races a recipient self-invitation', async () => {
+    const ws = await createWorkspace(stack.app, 'release-racing-invite');
+    const target = await registerAgent(stack.app, ws.workspaceKey, 'racing-invite-target');
+    const db = stack.runtime.deps.db;
+    const channel = await ensureAgentSubscriptionChannel(db, ws.workspaceId, 'racing-invite-target');
+    const original = db.select.bind(db);
+    let reads = 0;
+    let released = false;
+    // Hold the real invitee lookup result, then release before the membership lookup.
+    // All SQL, lifecycle cleanup, and the invitation itself use the actual engine.
+    const wrap = (query: object): object => new Proxy(query, {
+      get(object, key) {
+        const value = Reflect.get(object, key, object);
+        if (key === 'then') return (resolve: (rows: unknown) => unknown, reject: (error: unknown) => unknown) =>
+          Promise.resolve(object).then(async rows => {
+            await deleteAgent(db, ws.workspaceId, 'racing-invite-target');
+            released = true;
+            return rows;
+          }).then(resolve, reject);
+        return typeof value === 'function' ? (...args: unknown[]) => wrap(value.apply(object, args)) : value;
+      },
+    });
+    const hook = vi.spyOn(db, 'select').mockImplementation(((...args: Parameters<typeof original>) => {
+      const query = original(...args);
+      return ++reads === 3 ? wrap(query) : query;
+    }) as typeof db.select);
+    try {
+      await expect(inviteAgent(db, ws.workspaceId, channel.name, target.agentId, 'racing-invite-target'))
+        .rejects.toMatchObject({ code: 'agent_not_found' });
+      expect(released).toBe(true);
       expect((await getChannel(db, ws.workspaceId, channel.name)).members).toHaveLength(0);
     } finally { hook.mockRestore(); }
   });

--- a/packages/engine/src/__tests__/conformance/subscriptionChannel.test.ts
+++ b/packages/engine/src/__tests__/conformance/subscriptionChannel.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { channelMembers, channels } from '../../db/schema.js';
 import { generateId } from '../../engine/snowflake.js';
 import { deleteAgent } from '../../engine/agent.js';
-import { createChannel, getChannel, joinChannel, ensureAgentSubscriptionChannel } from '../../engine/channel.js';
+import { createChannel, getChannel, joinChannel, leaveChannel, ensureAgentSubscriptionChannel } from '../../engine/channel.js';
 import type { EngineDb, TransactionCapability } from '../../ports/database.js';
 import { makeNodeStack, createWorkspace, registerAgent, type TestStack } from './harness.js';
 
@@ -52,6 +52,33 @@ describe('agent subscription channels', () => {
     });
     try {
       await expect(ensureAgentSubscriptionChannel(db, ws.workspaceId, 'racing-recipient')).rejects.toMatchObject({ code: 'agent_not_found' });
+    } finally { hook.mockRestore(); }
+  });
+
+  it('rejects a released recipient joining its old subscription channel', async () => {
+    const ws = await createWorkspace(stack.app, 'released-join');
+    const target = await registerAgent(stack.app, ws.workspaceKey, 'released-join-target');
+    const db = stack.runtime.deps.db;
+    const channel = await ensureAgentSubscriptionChannel(db, ws.workspaceId, 'released-join-target');
+    await deleteAgent(db, ws.workspaceId, 'released-join-target');
+    await expect(joinChannel(db, ws.workspaceId, channel.name, target.agentId)).rejects.toMatchObject({ code: 'agent_not_found' });
+    expect((await getChannel(db, ws.workspaceId, channel.name)).members).toHaveLength(0);
+  });
+
+  it('prevents release racing a subscription join from recreating membership', async () => {
+    const ws = await createWorkspace(stack.app, 'release-racing-join');
+    const target = await registerAgent(stack.app, ws.workspaceKey, 'racing-join-target');
+    const db = stack.runtime.deps.db;
+    const channel = await ensureAgentSubscriptionChannel(db, ws.workspaceId, 'racing-join-target');
+    await leaveChannel(db, ws.workspaceId, channel.name, target.agentId);
+    const original = db.run.bind(db);
+    const hook = vi.spyOn(db, 'run').mockImplementationOnce(async query => {
+      await deleteAgent(db, ws.workspaceId, 'racing-join-target');
+      return original(query);
+    });
+    try {
+      await expect(joinChannel(db, ws.workspaceId, channel.name, target.agentId)).rejects.toMatchObject({ code: 'agent_not_found' });
+      expect((await getChannel(db, ws.workspaceId, channel.name)).members).toHaveLength(0);
     } finally { hook.mockRestore(); }
   });
 

--- a/packages/engine/src/engine/channel.ts
+++ b/packages/engine/src/engine/channel.ts
@@ -329,11 +329,19 @@ export async function joinChannel(
     return { channel: channelName, agent_id: agentId, already_member: true };
   }
 
-  await db.insert(channelMembers).values({
-    channelId: channel.id,
-    agentId,
-    role: 'member',
-  });
+  if (channel.name.startsWith(SUBSCRIPTION_CHANNEL_PREFIX)) {
+    // Serialize the liveness check with release's membership removal.
+    await db.run(sql`INSERT INTO channel_members (channel_id, agent_id, role)
+      SELECT ${channel.id}, id, 'member' FROM agents
+      WHERE id = ${agentId} AND workspace_id = ${workspaceId} AND status != 'released'
+      ON CONFLICT DO NOTHING`);
+    const [recipient] = await db.select({ id: agents.id }).from(channelMembers)
+      .innerJoin(agents, eq(agents.id, channelMembers.agentId))
+      .where(and(eq(channelMembers.channelId, channel.id), eq(agents.id, agentId), ne(agents.status, 'released'))).limit(1);
+    if (!recipient) throw codedError('Subscription recipient was released', 'agent_not_found', 404);
+  } else {
+    await db.insert(channelMembers).values({ channelId: channel.id, agentId, role: 'member' });
+  }
 
   await invalidateChannelCache(workspaceId, channelName);
 

--- a/packages/engine/src/engine/channel.ts
+++ b/packages/engine/src/engine/channel.ts
@@ -288,6 +288,18 @@ export async function archiveChannel(db: Db, workspaceId: string, name: string) 
   return true;
 }
 
+async function insertLiveSubscriptionMember(db: Db, workspaceId: string, channelId: string, agentId: string) {
+  // Serialize the liveness check with release's membership removal.
+  await db.run(sql`INSERT INTO channel_members (channel_id, agent_id, role)
+    SELECT ${channelId}, id, 'member' FROM agents
+    WHERE id = ${agentId} AND workspace_id = ${workspaceId} AND status != 'released'
+    ON CONFLICT DO NOTHING`);
+  const [recipient] = await db.select({ id: agents.id }).from(channelMembers)
+    .innerJoin(agents, eq(agents.id, channelMembers.agentId))
+    .where(and(eq(channelMembers.channelId, channelId), eq(agents.id, agentId), ne(agents.status, 'released'))).limit(1);
+  if (!recipient) throw codedError('Subscription recipient was released', 'agent_not_found', 404);
+}
+
 export async function joinChannel(
   db: Db,
   workspaceId: string,
@@ -330,15 +342,7 @@ export async function joinChannel(
   }
 
   if (channel.name.startsWith(SUBSCRIPTION_CHANNEL_PREFIX)) {
-    // Serialize the liveness check with release's membership removal.
-    await db.run(sql`INSERT INTO channel_members (channel_id, agent_id, role)
-      SELECT ${channel.id}, id, 'member' FROM agents
-      WHERE id = ${agentId} AND workspace_id = ${workspaceId} AND status != 'released'
-      ON CONFLICT DO NOTHING`);
-    const [recipient] = await db.select({ id: agents.id }).from(channelMembers)
-      .innerJoin(agents, eq(agents.id, channelMembers.agentId))
-      .where(and(eq(channelMembers.channelId, channel.id), eq(agents.id, agentId), ne(agents.status, 'released'))).limit(1);
-    if (!recipient) throw codedError('Subscription recipient was released', 'agent_not_found', 404);
+    await insertLiveSubscriptionMember(db, workspaceId, channel.id, agentId);
   } else {
     await db.insert(channelMembers).values({ channelId: channel.id, agentId, role: 'member' });
   }
@@ -485,11 +489,15 @@ export async function inviteAgent(
     );
 
   if (!existing) {
-    await db.insert(channelMembers).values({
-      channelId: channel.id,
-      agentId: invitee.id,
-      role: 'member',
-    });
+    if (channel.name.startsWith(SUBSCRIPTION_CHANNEL_PREFIX)) {
+      await insertLiveSubscriptionMember(db, workspaceId, channel.id, invitee.id);
+    } else {
+      await db.insert(channelMembers).values({
+        channelId: channel.id,
+        agentId: invitee.id,
+        role: 'member',
+      });
+    }
     await invalidateChannelCache(workspaceId, channelName);
   }
 

--- a/packages/engine/src/engine/delivery.ts
+++ b/packages/engine/src/engine/delivery.ts
@@ -1,3 +1,4 @@
+import { parseMessageMentions } from './mentions.js';
 import { eq, and, not, asc, isNull, inArray, notInArray, lte, gt, sql, getTableColumns, type SQL } from 'drizzle-orm';
 import type { getDb } from '../db/index.js';
 import { deliveries, messages, agents, readReceipts, channelMembers, channels, dmConversations } from '../db/schema.js';
@@ -6,7 +7,7 @@ import { runAtomic } from '../ports/database.js';
 import type { NodeConnectionRegistry } from '../ports/realtime.js';
 import { isProviderAgentDeliveryReady } from '../ports/realtime.js';
 import { buildDeliverFrame, buildDeliverPayload, buildMessageCreatedEventData, buildThreadReplyEventData, buildDmReceivedEventData, buildGroupDmReceivedEventData } from './deliveryWire.js';
-import { publicMessageMetadata } from './messageMetadata.js';
+import { displayAgentName, publicMessageMetadata } from './messageMetadata.js';
 import { toIso } from '../lib/serialize.js';
 import { readNodeRedriveCandidates } from './nodeRedriveCandidates.js';
 import { fetchAttachmentsBatch, type AttachmentRow } from './attachments.js';
@@ -553,7 +554,7 @@ function buildRoutableDeliveryEvent(
   row: PendingDeliveryRow,
   attachments: AttachmentRow[],
 ): { eventType: string; eventData: Record<string, unknown> } {
-  const senderName = row.senderAgentName ?? 'unknown';
+  const senderName = displayAgentName(row.metadata as Record<string, unknown> | null, row.senderAgentName);
   const injectionMode = row.delivery.mode === 'next-tool-call' ? 'steer' : 'wait';
   // Thread replies route as `thread.reply` in the live path even inside a DM /
   // group DM (see routes/thread.ts fanout), so a missed thread reply must
@@ -634,7 +635,7 @@ function buildRoutableDeliveryEvent(
     };
   }
 
-  const mentions = [...row.body.matchAll(/@(\w+)/g)].map((match) => match[1]);
+  const mentions = parseMessageMentions(row.body);
   return {
     eventType,
     eventData: buildMessageCreatedEventData({

--- a/packages/engine/src/engine/mentions.ts
+++ b/packages/engine/src/engine/mentions.ts
@@ -1,0 +1,4 @@
+/** Shared by live delivery and durable replay; emails and escaped handles are not mentions. */
+export function parseMessageMentions(text: string): string[] {
+  return [...new Set([...text.matchAll(/(?:^|\s)@([\w-]+)/g)].map(match => match[1]))];
+}

--- a/packages/engine/src/engine/message.ts
+++ b/packages/engine/src/engine/message.ts
@@ -1,3 +1,4 @@
+import { parseMessageMentions } from './mentions.js';
 import { eq, and, sql, isNull, lt, gt, inArray } from 'drizzle-orm';
 import type { getDb } from '../db/index.js';
 import { messages, agents, reactions, readReceipts, messageAttachments } from '../db/schema.js';
@@ -34,12 +35,7 @@ export async function postMessage(
   const startedAtMs = Date.now();
   const messageId = generateId();
 
-  // Parse @mentions from text without treating email domains as handles.
-  const mentionPattern = /(?:^|\s)@([\w-]+)/g;
-  const mentionedHandles = new Set<string>();
-  for (let match = mentionPattern.exec(data.text); match !== null; match = mentionPattern.exec(data.text)) {
-    mentionedHandles.add(match[1]);
-  }
+  const mentionedHandles = new Set(parseMessageMentions(data.text));
 
   const metadata = sanitizeUserMessageMetadata(data.data);
   const sessionRef = requireSessionRefFromMetadata(metadata);

--- a/packages/engine/src/routes/inboundWebhook.ts
+++ b/packages/engine/src/routes/inboundWebhook.ts
@@ -1,3 +1,4 @@
+import { buildMessageCreatedEventData } from '../engine/deliveryWire.js';
 import { Hono } from 'hono';
 import { z } from 'zod';
 import type { AppEnv } from '../env.js';
@@ -143,7 +144,8 @@ inboundWebhookRoutes.post('/hooks/:webhookId', async (c) => {
     const { workspace_id, channel_id, agent_id, _deliveries, _delivery_rejections, ...responseData } = result;
 
     const eventData = { ...responseData, id: responseData.message_id, channel_id, agent_id };
-    runInBackground(c, routeDeliveryOutcomes(c, _deliveries, 'message.created', eventData, { workspaceId: workspace_id }), 'route webhook deliveries');
+    const messageEventData = buildMessageCreatedEventData(eventData, { channelName: result.channel, fromName: result.author });
+    runInBackground(c, routeDeliveryOutcomes(c, _deliveries, 'message.created', messageEventData, { workspaceId: workspace_id }), 'route webhook deliveries');
     if (channel_id) {
       runInBackground(
         c,


### PR DESCRIPTION
Engine 8.9.0 omits subscription protections already present in deployed 8.5.2-hotfix.4. A replayed `@chief-agent` becomes `chief`, email domains become mentions, and an authenticated join racing a release can recreate membership for the released identity. Raw webhook deliveries also lose the canonical live payload conversion and replay display attribution.

Restore the shared exact mention parser across live messages and durable replay, normalize raw webhook message events, retain trusted webhook display names through reconnect, and guard subscription joins with a conditional live-recipient insert plus post-write check. These are the existing hotfix protections, composed onto current main; no SQL migrations or maintenance bounds change.

Validation:
- Added regression cases first: four failures on released source; a separate reconnect-display case also failed before its fix.
- All 1,048 engine tests pass, including 75 delivery/subscription conformance cases; engine TypeScript build passes.
- Independent review's actual-API/SQLite diagnostic reproduces both P1s on the immutable 8.9.0 package and passes against this compiled source: exact mentions in redrive/backlog, trusted display author, and HTTP join returning 404 with zero memberships after release.

Independent exact-head review is pending. After reviewed merge this needs a new immutable patch release and an updated relaycast-cloud #105 package pin. Hosted rollout remains held for the separate four-migration growth/cost approval and real Nango-to-chief acceptance; these local tests do not satisfy those gates.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/AgentWorkforce/relaycast/pull/427?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes delivery replay payloads and subscription membership writes on agent release races; behavior is narrowly scoped but affects routing and identity lifecycle correctness.
> 
> **Overview**
> Restores **8.5.2-hotfix** protections on current main: durable replay and live sends now share **`parseMessageMentions`**, so hyphenated handles stay intact and email addresses are not treated as mentions.
> 
> **Durable redrive** also uses **`displayAgentName`** for sender attribution, and **raw inbound webhooks** build **`message.created`** payloads through **`buildMessageCreatedEventData`** so node deliveries match live wire shape (including reconnect replay).
> 
> **Subscription channels** route **`join`** and **`invite`** through **`insertLiveSubscriptionMember`**: membership is inserted only for non-**released** agents, with a follow-up check that fails with **`agent_not_found`** if release wins the race—including recipient self-invitation—so released identities cannot be re-added to their route.
> 
> Changelogs note an upcoming patch release; conformance tests cover mention replay, webhook wire normalization, and release-vs-join/invite races.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bcfbcf2778407a2486708dd4a28176bd1bbfbb3c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->