### PR TITLE
fix: backport authenticated node admission without schema changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@ Packages without a separate changelog are covered by the cross-package notes bel
 
 ### Fixed
 
+- Node registration confirms the authenticated provider admission contract on the production maintenance engine without adding database migrations.
+
 - Thread replies resolve full hyphenated mentions; subscription setup rejects recipients released during membership creation.
 - Verified spawn checks the selected provider heartbeat, and inventory reconciliation honors only canonical `verify_ready` input. Empty explicit targets retain legacy spawn routing.
 

--- a/README.md
+++ b/README.md
@@ -803,6 +803,17 @@ presence-only for node-hosted agents (the node binding is left intact so the
 still-running session keeps its deliveries); pass `{ deregister: true }` to follow the
 full `agent.deregister` teardown path that re-homes the agent to its direct node.
 
+The authenticated `node.register` acknowledgement may include
+`registration_contract: "relay:node-registration-v1"`. This is authored by the
+server, independently of `accepted_capabilities`, and is emitted only when the
+adapter confirms the connection's provider binding. It guarantees create-only
+`agent.register`, exact request-ID echo, authenticated provider and origin-node
+assignment, `auto_join_general: false`, and `expected_token_hash` enforcement on
+`POST /v1/agents/release`. Missing or unknown contracts do not establish support.
+Clients must correlate the acknowledgement to this connection and its expected
+provider before admitting fresh identities. Registration is not idempotent: a
+lost reply still requires retained ownership or name quarantine, not a retry.
+
 Broker nodes can negotiate restart-safe delivery cursor recovery by including
 `{ "name": "relay:delivery-cursor-v1", "kind": "capacity" }` in every
 `node.register`. Relaycast then adds the authoritative `delivery_ack_seq` for the

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -11,6 +11,16 @@ info:
     - Success: `{ ok: true, data: ... }`
     - Error: `{ ok: false, error: { code, message } }`
 
+    Authenticated node-control admission: the `node.register` WebSocket reply can
+    include `registration_contract: "relay:node-registration-v1"` when the adapter
+    confirms the connection's provider binding. This server-authored contract
+    guarantees create-only agent registration, exact request-ID echo,
+    authenticated provider/origin assignment, optional general-channel isolation,
+    and `expected_token_hash` enforcement on `POST /v1/agents/release`. It is
+    independent of client-advertised capabilities. Missing/unknown values do not
+    establish support; clients must validate the current connection and provider.
+    Lost registration replies are not safe to retry automatically.
+
     Telemetry attribution (optional, all requests):
 
     Clients may declare who is driving a request so server-side product

--- a/packages/engine/CHANGELOG.md
+++ b/packages/engine/CHANGELOG.md
@@ -20,6 +20,8 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ### Fixed
 
+- Node registration confirms the authenticated provider admission contract on the production maintenance engine without adding database migrations.
+
 - Thread replies resolve full hyphenated mentions; subscription setup rejects recipients released during membership creation.
 - Verified spawn checks the selected provider heartbeat, and inventory reconciliation honors only canonical `verify_ready` input. Empty explicit targets retain legacy spawn routing.
 

--- a/packages/engine/src/__tests__/conformance/nodeRegistrationContract.test.ts
+++ b/packages/engine/src/__tests__/conformance/nodeRegistrationContract.test.ts
@@ -1,0 +1,72 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { eq } from 'drizzle-orm';
+import { agents, channelMembers } from '../../db/schema.js';
+import { makeNodeStack, createWorkspace, FakeSocket, type TestStack } from './harness.js';
+
+describe('authenticated node registration contract', () => {
+  let stack: TestStack;
+  beforeEach(() => { stack = makeNodeStack(); });
+  afterEach(async () => { vi.restoreAllMocks(); await stack?.close(); });
+
+  async function connect() {
+    const ws = await createWorkspace(stack.app, 'registration-contract');
+    const enrolled = await stack.app.request('/v1/nodes', {
+      method: 'POST',
+      headers: { authorization: `Bearer ${ws.workspaceKey}`, 'content-type': 'application/json' },
+      body: JSON.stringify({ node_id: 'contract-node', name: 'contract-node', role: 'broker',
+        capabilities: [], max_agents: 4, tags: [], version: 'test' }),
+    });
+    expect(enrolled.status).toBe(201);
+    const socket = new FakeSocket();
+    const handle = stack.runtime.realtime.attachNodeSocket(ws.workspaceId, 'contract-node', socket);
+    const send = (frame: Record<string, unknown>) => handle.handleMessage(JSON.stringify({ v: 1, ...frame }));
+    const register = () => send({ id: 'node-request', type: 'node.register', node_id: 'contract-node',
+      name: 'contract-node', provider: { name: 'broker', instance_id: 'contract-instance' },
+      capabilities: [{ name: 'relay:node-registration-v1', kind: 'action' }], max_agents: 4,
+      tags: [], version: 'test', resume_cursor: null });
+    return { ws, socket, send, register };
+  }
+
+  it('announces server semantics and honors them through node create and guarded HTTP release', async () => {
+    const { ws, socket, send, register } = await connect();
+    await register();
+    expect(socket.ofType('reply').find(frame => frame.id === 'node-request')).toMatchObject({
+      data: { provider: { name: 'broker', instance_id: 'contract-instance' },
+        registration_contract: 'relay:node-registration-v1' },
+    });
+    await send({ id: 'create-request', type: 'agent.register', name: 'contract-worker', auto_join_general: false });
+    const reply = socket.ofType('reply').find(frame => frame.id === 'create-request') as
+      { data: { agent_id: string; token: string; name: string } };
+    expect(reply.data).toMatchObject({ name: 'contract-worker', agent_id: expect.any(String), token: expect.any(String) });
+    const [owned] = await stack.runtime.handle.db.select().from(agents).where(eq(agents.id, reply.data.agent_id));
+    expect(owned).toMatchObject({ providerName: 'broker', originNodeId: 'contract-node' });
+    expect(await stack.runtime.handle.db.select().from(channelMembers).where(eq(channelMembers.agentId, owned.id))).toEqual([]);
+    await send({ id: 'duplicate-request', type: 'agent.register', name: 'contract-worker' });
+    expect(socket.ofType('error').find(frame => frame.id === 'duplicate-request')).toMatchObject({ code: 'agent_already_exists' });
+    const rejected = await stack.app.request('/v1/agents/release', {
+      method: 'POST',
+      headers: { authorization: `Bearer ${ws.workspaceKey}`, 'content-type': 'application/json' },
+      body: JSON.stringify({ name: 'contract-worker', expected_token_hash: '0'.repeat(64) }),
+    });
+    expect(rejected.status).toBe(409);
+    expect(await rejected.json()).toMatchObject({ error: { code: 'agent_release_generation_conflict' } });
+    expect(await stack.runtime.handle.db.select().from(agents).where(eq(agents.id, owned.id))).toEqual([owned]);
+    expect(socket.ofType('action.invoke')).toEqual([]);
+  });
+
+  it('does not announce support when the adapter cannot resolve the authenticated provider', async () => {
+    const { socket, register } = await connect();
+    vi.spyOn(stack.runtime.realtime, 'providerNameForConnection').mockReturnValue(undefined);
+    await register();
+    const reply = socket.ofType('reply').find(frame => frame.id === 'node-request') as { data: Record<string, unknown> };
+    expect(reply.data).not.toHaveProperty('registration_contract');
+  });
+  it('omits the contract when the matching provider has no live attachment', async () => {
+    const { socket, register } = await connect();
+    vi.spyOn(stack.runtime.realtime, 'isProviderAttached').mockReturnValue(false);
+    await register();
+    const reply = socket.ofType('reply').find(frame => frame.id === 'node-request') as { data: Record<string, unknown> };
+    expect(reply.data).not.toHaveProperty('registration_contract');
+  });
+
+});

--- a/packages/engine/src/engine/node.ts
+++ b/packages/engine/src/engine/node.ts
@@ -2204,6 +2204,13 @@ export async function handleNodeControlMessage(args: HandleNodeControlMessageArg
             ...registered.node,
             provider: registered.provider,
             accepted_capabilities: acceptance,
+            // Backport the server contract while retaining the deployed maintenance
+            // dependencies and schema. Client capability echoes are not proof.
+            ...(args.connectionId
+              && args.registry.providerNameForConnection?.(args.connectionId) === provider.name
+              && args.registry.isProviderAttached?.(args.workspaceId, args.nodeId, provider.name)
+              ? { registration_contract: 'relay:node-registration-v1' }
+              : {}),
           },
         });
         // The node row is already persisted online, so emit the durable


### PR DESCRIPTION
Backport the authenticated node-registration acknowledgement onto the deployed 8.5.2 maintenance engine. Brokers can verify create-only registration, provider/origin binding, channel isolation and guarded identity cleanup without promoting the unrelated 8.9 database migrations.

The acknowledgement is emitted only when this connection resolves to the registered provider and the adapter confirms its live attachment. It is server-authored and request-correlated; echoed client capabilities do not establish support. The maintenance implementation uses the same literal wire contract while preserving its already-published dependencies.

Validation:
- Added contract tests first: one failed on the unchanged maintenance branch. All three contract controls now pass, along with delivery/subscription conformance (76 total).
- All 905 engine tests pass; TypeScript build passes.
- Compared all 644 `dist` files with immutable deployed `8.5.2-hotfix.4`: no additions/removals; only `engine/node.js` and its two generated maps differ. All migration files and maintenance/subscription implementations remain byte-identical.
- The real compiled broker plus this local engine passes provider admission, authoritative origin, isolated channels, duplicate refusal, guarded release, failed-spawn cleanup and DM delivery. This is local diagnostic evidence, not Nango/chief acceptance.

Exact-head independent review is pending. After reviewed merge, use the existing maintenance-branch workflow to publish only engine `8.5.2-hotfix.5` to `alpha`, then pin and validate the hosted consumer through its normal PR/CI deployment. No workflow/gate changes, mainline version rollback, direct production SQL, or migration approval reuse is proposed. Mainline regression correction continues separately in #427.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/AgentWorkforce/relaycast/pull/428?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes authenticated node admission signaling on a security-sensitive fleet path, but the wire change is additive, strictly gated on live provider attachment, and covered by new conformance tests with no schema changes.
> 
> **Overview**
> Backports **server-authored** `registration_contract: "relay:node-registration-v1"` on successful **`node.register`** replies for the deployed maintenance engine, **without database migrations**.
> 
> The field is added only when the realtime adapter confirms the connection’s provider binding (`providerNameForConnection` matches the registered provider and `isProviderAttached` is true). Client-advertised capabilities are explicitly **not** treated as proof of support.
> 
> Documentation in **README**, **openapi.yaml**, and changelogs describes what the contract promises (create-only `agent.register`, provider/origin binding, optional general-channel isolation, guarded `expected_token_hash` release) and that missing contracts or lost replies must not be blindly retried.
> 
> New **conformance tests** assert the contract is announced and honored end-to-end, and that it is omitted when the provider cannot be resolved or is not live.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 246bf6461bd3259e04c234ec296dac64ea0d3874. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->