### PR TITLE
fix(engine): prevent released subscription invitation races

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ Packages without a separate changelog are covered by the cross-package notes bel
 
 ## [Unreleased - Minor]
 
+- Prevent recipient self-invitations from restoring a released subscription membership.
+
 ### Added
 
 - Node credentials can read their own dispatched spawn results, allowing served fleet actions to confirm broker readiness with node-scoped authority.

--- a/packages/engine/CHANGELOG.md
+++ b/packages/engine/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased - Minor]
 
+- Prevent recipient self-invitations from restoring a released subscription membership.
+
 ### Added
 
 - Node credentials can read status for spawn invocations dispatched to their own node, so served providers can await confirmed broker readiness without workspace credentials.

--- a/packages/engine/src/__tests__/conformance/subscriptionChannel.test.ts
+++ b/packages/engine/src/__tests__/conformance/subscriptionChannel.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { channelMembers, channels } from '../../db/schema.js';
 import { generateId } from '../../engine/snowflake.js';
 import { deleteAgent } from '../../engine/agent.js';
-import { createChannel, getChannel, joinChannel, leaveChannel, ensureAgentSubscriptionChannel } from '../../engine/channel.js';
+import { createChannel, getChannel, joinChannel, inviteAgent, leaveChannel, ensureAgentSubscriptionChannel } from '../../engine/channel.js';
 import type { EngineDb, TransactionCapability } from '../../ports/database.js';
 import { makeNodeStack, createWorkspace, registerAgent, type TestStack } from './harness.js';
 
@@ -78,6 +78,40 @@ describe('agent subscription channels', () => {
     });
     try {
       await expect(joinChannel(db, ws.workspaceId, channel.name, target.agentId)).rejects.toMatchObject({ code: 'agent_not_found' });
+      expect((await getChannel(db, ws.workspaceId, channel.name)).members).toHaveLength(0);
+    } finally { hook.mockRestore(); }
+  });
+
+  it('does not recreate membership when release races a recipient self-invitation', async () => {
+    const ws = await createWorkspace(stack.app, 'release-racing-invite');
+    const target = await registerAgent(stack.app, ws.workspaceKey, 'racing-invite-target');
+    const db = stack.runtime.deps.db;
+    const channel = await ensureAgentSubscriptionChannel(db, ws.workspaceId, 'racing-invite-target');
+    const original = db.select.bind(db);
+    let reads = 0;
+    let released = false;
+    // Hold the real invitee lookup result, then release before the membership lookup.
+    // All SQL, lifecycle cleanup, and the invitation itself use the actual engine.
+    const wrap = (query: object): object => new Proxy(query, {
+      get(object, key) {
+        const value = Reflect.get(object, key, object);
+        if (key === 'then') return (resolve: (rows: unknown) => unknown, reject: (error: unknown) => unknown) =>
+          Promise.resolve(object).then(async rows => {
+            await deleteAgent(db, ws.workspaceId, 'racing-invite-target');
+            released = true;
+            return rows;
+          }).then(resolve, reject);
+        return typeof value === 'function' ? (...args: unknown[]) => wrap(value.apply(object, args)) : value;
+      },
+    });
+    const hook = vi.spyOn(db, 'select').mockImplementation(((...args: Parameters<typeof original>) => {
+      const query = original(...args);
+      return ++reads === 3 ? wrap(query) : query;
+    }) as typeof db.select);
+    try {
+      await expect(inviteAgent(db, ws.workspaceId, channel.name, target.agentId, 'racing-invite-target'))
+        .rejects.toMatchObject({ code: 'agent_not_found' });
+      expect(released).toBe(true);
       expect((await getChannel(db, ws.workspaceId, channel.name)).members).toHaveLength(0);
     } finally { hook.mockRestore(); }
   });

--- a/packages/engine/src/engine/channel.ts
+++ b/packages/engine/src/engine/channel.ts
@@ -288,6 +288,18 @@ export async function archiveChannel(db: Db, workspaceId: string, name: string) 
   return true;
 }
 
+async function insertLiveSubscriptionMember(db: Db, workspaceId: string, channelId: string, agentId: string) {
+  // Serialize the liveness check with release's membership removal.
+  await db.run(sql`INSERT INTO channel_members (channel_id, agent_id, role)
+    SELECT ${channelId}, id, 'member' FROM agents
+    WHERE id = ${agentId} AND workspace_id = ${workspaceId} AND status != 'released'
+    ON CONFLICT DO NOTHING`);
+  const [recipient] = await db.select({ id: agents.id }).from(channelMembers)
+    .innerJoin(agents, eq(agents.id, channelMembers.agentId))
+    .where(and(eq(channelMembers.channelId, channelId), eq(agents.id, agentId), ne(agents.status, 'released'))).limit(1);
+  if (!recipient) throw codedError('Subscription recipient was released', 'agent_not_found', 404);
+}
+
 export async function joinChannel(
   db: Db,
   workspaceId: string,
@@ -330,15 +342,7 @@ export async function joinChannel(
   }
 
   if (channel.name.startsWith(SUBSCRIPTION_CHANNEL_PREFIX)) {
-    // Serialize the liveness check with release's membership removal.
-    await db.run(sql`INSERT INTO channel_members (channel_id, agent_id, role)
-      SELECT ${channel.id}, id, 'member' FROM agents
-      WHERE id = ${agentId} AND workspace_id = ${workspaceId} AND status != 'released'
-      ON CONFLICT DO NOTHING`);
-    const [recipient] = await db.select({ id: agents.id }).from(channelMembers)
-      .innerJoin(agents, eq(agents.id, channelMembers.agentId))
-      .where(and(eq(channelMembers.channelId, channel.id), eq(agents.id, agentId), ne(agents.status, 'released'))).limit(1);
-    if (!recipient) throw codedError('Subscription recipient was released', 'agent_not_found', 404);
+    await insertLiveSubscriptionMember(db, workspaceId, channel.id, agentId);
   } else {
     await db.insert(channelMembers).values({ channelId: channel.id, agentId, role: 'member' });
   }
@@ -485,11 +489,15 @@ export async function inviteAgent(
     );
 
   if (!existing) {
-    await db.insert(channelMembers).values({
-      channelId: channel.id,
-      agentId: invitee.id,
-      role: 'member',
-    });
+    if (channel.name.startsWith(SUBSCRIPTION_CHANNEL_PREFIX)) {
+      await insertLiveSubscriptionMember(db, workspaceId, channel.id, invitee.id);
+    } else {
+      await db.insert(channelMembers).values({
+        channelId: channel.id,
+        agentId: invitee.id,
+        role: 'member',
+      });
+    }
     await invalidateChannelCache(workspaceId, channelName);
   }
 


### PR DESCRIPTION
A subscription recipient can race its own invitation against release: the invitation sees a live identity before release, then recreates the membership after release removes it. Subsequent webhooks can queue unreachable deliveries.

Reuse the conditional live-recipient insert and post-write check for subscription invitations as well as joins. Ordinary invitations retain their existing behavior. This is the maintenance backport of the correction in #427; it follows #428 before the prospective engine 8.5.2-hotfix.5 publication. No migrations, dependencies or release workflow change.

Validation: the regression uses real SQL and actual lifecycle deletion, fails on the prior source, and passes after the correction (17 subscription tests). Full engine suite: 906 passed across 79 files; TypeScript build passes. Clean compilation against immutable hotfix.4 changes only channel.js, node.js and their generated maps; all 50 migration files and dependencies are unchanged. Independent Finn review is in progress. Real Nango-to-chief acceptance is tracked separately and remains unproven.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Narrows subscription membership writes on the delivery-critical invite/join path; scope is limited to prefixed subscription channels with no schema changes.
> 
> **Overview**
> Fixes a race where a **subscription recipient’s self-invitation** could run ahead of **agent release**: the invite path used an unconditional membership insert, so release could drop the row and the invite could recreate it, leaving webhook deliveries queued for a released identity.
> 
> The change **extracts** `insertLiveSubscriptionMember` and uses it for subscription channels in **`inviteAgent`** as well as **`joinChannel`**. Membership is inserted only when the agent row is still non-`released`, then verified after write; otherwise the call fails with `agent_not_found`. Ordinary channel invites are unchanged.
> 
> Changelog entries document the behavior, and a conformance test simulates release interleaving with `inviteAgent` on a subscription channel.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 14b4d5edfb23c16874e0337b17446fb55a8ef171. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->